### PR TITLE
Add --focus tests to review command for LLM-generated test quality

### DIFF
--- a/plugins/wicked-engineering/commands/review.md
+++ b/plugins/wicked-engineering/commands/review.md
@@ -143,7 +143,7 @@ Evaluate each pattern with examples from code.
 **tests**: Test quality and value
 ```python
 Task(
-    subagent_type="wicked-engineering:senior-engineer",
+    subagent_type="wicked-qe:code-analyzer",
     prompt="""Evaluate test quality. Fewer, higher-quality tests beat many low-value ones.
 
 ## Target


### PR DESCRIPTION
LLM-generated tests often produce low-value assertions that test their own inputs back (e.g. assert user.name == "alice"). Add test quality evaluation using the heuristic "what product bug would make this fail?" to flag tautological, mock-heavy, and implementation-mirroring tests.

Also strengthens the general review to catch these patterns without --focus.