### PR TITLE
fix: resolve 3 UAT failures + address PR #57 review comments

### DIFF
--- a/plugins/wicked-mem/hooks/scripts/prompt_submit.py
+++ b/plugins/wicked-mem/hooks/scripts/prompt_submit.py
@@ -224,11 +224,20 @@ def main():
 
             if not explicit_recall:
                 # For implicit (topical) injection, require at least one
-                # keyword to appear in a memory's tags so we stay precise.
-                memories = [
-                    m for m in memories
-                    if any(kw in (t.lower() for t in m.tags) for kw in keywords)
-                ]
+                # keyword to appear in a memory's tags (or title) so we
+                # stay precise.  Allow substring matches so e.g. keyword
+                # "auth" hits tag "authentication".
+                def _topically_relevant(m):
+                    lowered_tags = [t.lower() for t in m.tags]
+                    title_lower = m.title.lower()
+                    for kw in keywords:
+                        if any(kw in tag for tag in lowered_tags):
+                            return True
+                        if kw in title_lower:
+                            return True
+                    return False
+
+                memories = [m for m in memories if _topically_relevant(m)]
 
             memories = memories[:2]
 

--- a/plugins/wicked-mem/scripts/memory.py
+++ b/plugins/wicked-mem/scripts/memory.py
@@ -488,9 +488,9 @@ class MemoryStore:
             search_paths = [self.base_path / "core"]
             projects_path = self.base_path / "projects"
             if all_projects and projects_path.exists():
-                for project_dir in projects_path.iterdir():
-                    if project_dir.is_dir():
-                        search_paths.append(project_dir)
+                # Search the projects parent dir once (O(1) ripgrep call)
+                # instead of iterating each project subdirectory (O(N)).
+                search_paths.append(projects_path)
             elif self.project:
                 search_paths.append(projects_path / self.project)
 

--- a/plugins/wicked-search/scripts/unified_search.py
+++ b/plugins/wicked-search/scripts/unified_search.py
@@ -218,15 +218,25 @@ class DocumentExtractor:
             r'|^(\d+)\.\s+(.+)$'            # Numbered sections: "1. Title"
         )
 
+        # Common non-heading colon labels that would fragment prose
+        colon_noise = {
+            'note', 'example', 'warning', 'tip', 'info', 'important',
+            'caution', 'see', 'details', 'output', 'input', 'returns',
+            'raises', 'args', 'parameters', 'usage', 'summary',
+        }
+
         for i, line in enumerate(lines):
             stripped = line.strip()
             match = heading_pattern.match(stripped)
 
-            # Also detect "Label:" lines preceded by a blank line
+            # Also detect "Label:" lines preceded by a blank line, but
+            # skip common non-heading labels that would fragment prose.
             colon_heading = None
             if (not match and stripped.endswith(':') and len(stripped) > 3
                     and i > 0 and lines[i - 1].strip() == ''):
-                colon_heading = stripped[:-1].strip()
+                candidate = stripped[:-1].strip()
+                if candidate.lower() not in colon_noise:
+                    colon_heading = candidate
 
             if match or colon_heading:
                 # Save previous section


### PR DESCRIPTION
## Summary

Supersedes #57 — includes the original fixes plus all review feedback addressed.

**Original fixes from #57:**
- wicked-search: Extended `.txt` document indexer regex for numbered sections and colon-label patterns
- wicked-scenarios: Replaced external example.com dependency with local HTML fixture
- wicked-mem: Scoped `store.search()` to core/ + current project; expanded UserPromptSubmit hook for keyword-tag injection

**Review feedback addressed:**
- **prompt_submit.py** — Replaced confusing generator membership check with explicit list-based lookup; extended topical injection to allow substring tag matches (e.g. keyword "auth" matches tag "authentication") and title matching for better recall coverage
- **browser-page-audit.md** — Dynamically allocates a free port instead of hardcoding 8765; adds a curl readiness loop to verify the server is up before running tests
- **memory.py** — Searches the `projects/` parent directory in one ripgrep call (O(1)) instead of iterating each project subdirectory (O(N)) when `all_projects=True`
- **unified_search.py** — Filters common non-heading colon labels (Note:, Example:, Warning:, etc.) to prevent false-positive section splits in document indexing

Closes #50, closes #52, closes #53, supersedes #57

## Test plan

- [ ] Verify `prompt_submit.py` topical injection triggers on substring tag matches
- [ ] Verify browser-page-audit scenario uses dynamic port and waits for readiness
- [ ] Verify `memory.py` search with `--all-projects` uses single ripgrep call
- [ ] Verify document indexer skips "Note:", "Example:" etc. as section headings

https://claude.ai/code/session_01QyC9fZjmcbBaNjzQXKibFB