### PR TITLE
fix: wg-check specialist schema + CP verb safety + crew:start wording

### DIFF
--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -74,7 +74,7 @@ Parse the JSON response to get `project_dir` for later use.
    ```
    You can use built-in archetypes (content-heavy, ui-heavy, api-backend, infrastructure-framework, data-pipeline, mobile-app, ml-ai, compliance-regulated, monorepo-platform, real-time) OR define new ones dynamically.
 
-5. **Store archetype hints** in project.json as `archetype_hints` for reuse at checkpoints.
+5. **Store archetype hints** via phase_manager update as `archetype_hints` for reuse at checkpoints (do NOT write project.json directly — use the update command in step 5.5).
 
 ### 5.5 Analyze Input with Smart Decisioning
 
@@ -163,7 +163,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" {name} update \
 
 Every crew project should be tracked as a kanban initiative. This provides visibility in the kanban board and dashboards.
 
-**Goal**: store both the initiative *name* and *UUID* in project.json so session_start can reconnect without a kanban round-trip.
+**Goal**: store both the initiative *name* and *UUID* via phase_manager update so session_start can reconnect without a kanban round-trip.
 
 1. **Look up existing initiative by name**. If wicked-kanban is installed:
    ```bash
@@ -230,7 +230,7 @@ Example output:
 ### Task Lifecycle
 - Staleness detection: 30 minutes
 - Recovery mode: automatic
-- Override mechanism: available via project.json
+- Override mechanism: available via phase_manager update
 
 ### Next Step
 Run `/wicked-garden:crew:execute` to begin the clarify phase.


### PR DESCRIPTION
## Summary

- **#87**: Rewrote specialist.json validation in `/wg-check` to match actual schema structure (`{"plugin": "name", "specialists": [{name, role, ...}]}`) instead of the assumed `{"specialist": {name, role}}` single-object path. Now iterates `.specialists[]?.role` array and validates each role.
- **#88**: Added CP integration smoke test section (check 9b) that restricts testing to GET-safe verbs only (`list`, `get`, `stats`), preventing 405/400 false failures from POST-only endpoints like `create`, `search`, `traverse`.
- **#90**: Fixed 3 instances in `crew:start` where wording implied direct `project.json` file writes — all now reference `phase_manager update` as the canonical write path.

Closes #87, closes #88, closes #90

## Test plan

- [ ] Run `/wg-check` on a plugin with specialist.json to verify schema validation passes
- [ ] Run `/wg-check --full` to verify CP smoke test only hits GET-safe verbs
- [ ] Verify crew:start no longer references direct project.json writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)