### PR TITLE
feat: dynamic schema adaptation via manifest_detail()

### DIFF
--- a/scripts/_storage.py
+++ b/scripts/_storage.py
@@ -45,7 +45,7 @@ from typing import Any
 # Internal import — same scripts/ directory
 sys.path.insert(0, str(Path(__file__).parent))
 from _control_plane import get_client, load_config
-from _schema_adapters import to_cp as _to_cp, from_cp as _from_cp
+from _schema_adapters import to_cp as _to_cp, from_cp as _from_cp, set_cp_client as _set_cp_client
 from _session import SessionState
 
 # ---------------------------------------------------------------------------
@@ -138,6 +138,8 @@ class StorageManager:
         self._mode = self._cfg.get("mode") or "local-install"
         if self._mode not in _VALID_MODES:
             self._mode = "local-install"
+        # Inject CP client into schema adapters for manifest_detail lookups
+        _set_cp_client(self._cp)
 
     # ------------------------------------------------------------------
     # Read operations


### PR DESCRIPTION
## Summary

- StorageManager now auto-adapts payloads for domain/source pairs without a static adapter by fetching CP schemas from `manifest_detail()`
- Dynamic adapters inject required field defaults (type-appropriate: string→"", int→0, array→[], etc.)
- Extra fields not in the CP schema are packed into the overflow property (`metadata`, `payload`, etc.)
- Round-trip safe: `from_cp` unpacks overflow fields back to top-level
- Priority chain: static adapter → dynamic adapter → passthrough (no regressions)
- Schema cache: in-process with 5-minute TTL; negative results also cached

Closes #97

## Changes

| File | Change |
|------|--------|
| `scripts/_schema_adapters.py` | Added `_SchemaCache`, `_parse_schema()`, `_dynamic_to_cp()`, `_dynamic_from_cp()`, `set_cp_client()`, `_get_or_fetch_schema()`. Modified `to_cp()`/`from_cp()` with dynamic fallback. |
| `scripts/_storage.py` | One-line change: inject CP client into adapter module at SM init |

## Test plan

- [x] 9 unit tests pass inline (parse_schema, dynamic_to_cp create/update, dynamic_from_cp, edge cases, static priority, passthrough, end-to-end mock, negative cache)
- [x] Round-trip test: to_cp → from_cp preserves original data
- [x] Hook scripts (post_tool.py, stop.py) compile cleanly
- [x] Static adapters still take priority for registered sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)