### PR TITLE
fix: skill content fixes — specialist names, trigger phrases, redundant sections

### DIFF
--- a/skills/agentic/agentic-patterns/SKILL.md
+++ b/skills/agentic/agentic-patterns/SKILL.md
@@ -130,15 +130,6 @@ Avoid these combinations:
 - **Autonomous + Tight Coordination:** Defeats the purpose of autonomy
 - **Deep Hierarchies + Reflection:** Exponential token cost
 
-## When to Use
-
-Trigger phrases indicating you need this skill:
-- "How should I structure my multi-agent system?"
-- "What architecture pattern fits my use case?"
-- "Why is my agent system slow/buggy/expensive?"
-- "Should agents work independently or together?"
-- "How do I coordinate multiple agents?"
-
 ## Quick Start
 
 1. Identify if task is decomposable (subtasks?) or atomic

--- a/skills/agentic/context-engineering/SKILL.md
+++ b/skills/agentic/context-engineering/SKILL.md
@@ -169,16 +169,6 @@ See `refs/cost-models.md` for detailed cost calculation and budgeting strategies
 4. **Set token budgets:** Hard limits per agent/session
 5. **Monitor token usage:** Track and optimize high-cost agents
 
-## When to Use
-
-Trigger phrases indicating you need this skill:
-- "Token costs are too high"
-- "Running into context limits"
-- "Responses are slow"
-- "How do I manage conversation history?"
-- "What should agents remember?"
-- "How to optimize for cost?"
-
 ## References
 
 - `refs/optimization-techniques.md` - Detailed optimization strategies with code examples

--- a/skills/crew/workflow/SKILL.md
+++ b/skills/crew/workflow/SKILL.md
@@ -38,18 +38,18 @@ Each phase has: Clear deliverables, specialist engagement based on signals, appr
 
 | Signal | Keywords | Specialists |
 |--------|----------|-------------|
-| Security | auth, encrypt, token, jwt | devsecops, compliance |
-| Performance | scale, optimize, cache | appeng, qe |
-| Product | user, feature, story | product, strategy |
-| Compliance | SOC2, HIPAA, audit | compliance |
+| Security | auth, encrypt, token, jwt | platform, compliance |
+| Performance | scale, optimize, cache | engineering, qe |
+| Product | user, feature, story | product |
+| Compliance | SOC2, HIPAA, audit | platform |
 | Ambiguity | maybe, should we, options | jam |
-| Complexity | integration, migrate, refactor | pmo, arch |
+| Complexity | integration, migrate, refactor | delivery, engineering |
 
 ### Complexity Scoring (0-7)
 
 - 0-2: Simple → Built-in agents only
 - 3-4: Moderate → Core specialists
-- 5-7: Complex → All relevant + PMO
+- 5-7: Complex → All relevant + delivery
 
 ## Specialist Engagement
 
@@ -62,9 +62,9 @@ Crew discovers specialists via `specialist.json` in each plugin.
 | Specialist | Fallback |
 |------------|----------|
 | jam | facilitator |
-| qe, strategy | reviewer |
-| arch | researcher |
-| appeng, devsecops | implementer |
+| qe, product | reviewer |
+| engineering (arch) | researcher |
+| engineering, platform | implementer |
 
 ## Phase Details
 
@@ -76,22 +76,22 @@ Crew discovers specialists via `specialist.json` in each plugin.
 ### Design
 **Goal**: Architect the solution
 **Deliverables**: Architecture docs, pattern identification, technical approach
-**Specialists**: strategy, arch, appeng
+**Specialists**: product, engineering
 
 ### QE (Quality Engineering)
 **Goal**: Define test strategy before building
 **Deliverables**: Test scenarios, risk assessment, edge cases
-**Specialists**: qe, devsecops (if security signals)
+**Specialists**: qe, platform (if security signals)
 
 ### Build
 **Goal**: Implement the solution
 **Deliverables**: Working implementation, progress tracking, tests passing
-**Specialists**: appeng, devsecops (if infra)
+**Specialists**: engineering, platform (if infra)
 
 ### Review
 **Goal**: Multi-perspective validation
 **Deliverables**: Review findings, recommendations, sign-off
-**Specialists**: strategy, qe, compliance (if regulated)
+**Specialists**: product, qe, platform (if regulated)
 
 ## Project Lifecycle
 

--- a/skills/engineering/debugging/SKILL.md
+++ b/skills/engineering/debugging/SKILL.md
@@ -10,14 +10,6 @@ description: |
 
 Systematic debugging, root cause analysis, and error investigation.
 
-## When to Use
-
-- Investigating errors or bugs
-- Diagnosing unexpected behavior
-- Performance issues
-- Production incidents
-- User says "debug", "error", "why is this broken", "not working"
-
 ## Debugging Approach
 
 ### 1. Understand the Problem

--- a/skills/engineering/engineering/SKILL.md
+++ b/skills/engineering/engineering/SKILL.md
@@ -4,19 +4,14 @@ description: |
   Senior engineering guidance on code quality, architecture patterns, and
   best practices. Use for implementation planning, code review, or general
   engineering questions about maintainability and design.
+
+  Use when: "review this code", "how should I implement", "is this good practice",
+  "code quality", "refactor", "clean up", "best practice", "design pattern"
 ---
 
 # Engineering Skill
 
 Provide senior engineering guidance on code quality, architecture, and implementation.
-
-## When to Use
-
-- Planning implementation approach
-- Reviewing code for quality and maintainability
-- Evaluating architecture decisions
-- Debugging complex issues
-- User says "review this code", "how should I implement", "is this good practice"
 
 ## What This Skill Does
 

--- a/skills/product/ux-review/SKILL.md
+++ b/skills/product/ux-review/SKILL.md
@@ -114,22 +114,6 @@ Works with:
 | Build | A11y + UI consistency | A11y Expert + UI Reviewer |
 | Review | Comprehensive review | All experts |
 
-## When to Use
-
-**Use wicked-product when:**
-- Designing user-facing features
-- Implementing UI components
-- Need accessibility compliance
-- Want to validate user needs
-- Reviewing visual design
-- Auditing existing interfaces
-
-**Skip wicked-product when:**
-- Pure backend/API work
-- Infrastructure changes
-- No user interaction
-- Internal tooling (unless specifically requested)
-
 ## Quick Checks
 
 For fast feedback:

--- a/skills/qe/qe-strategy/SKILL.md
+++ b/skills/qe/qe-strategy/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: qe-strategy
-description: >
+description: |
   Shift-left QE analysis with quality gates.
   Generate test scenarios, assess risks, create test plans, and automate test generation.
   Enables faster delivery through early quality validation.
+
+  Use when: "test strategy", "quality gate", "test scenarios", "shift-left testing",
+  "generate test plan", "what should we test", "test coverage", "risk assessment"
 ---
 
 # QE Strategy

--- a/skills/smaht/context-assembly/SKILL.md
+++ b/skills/smaht/context-assembly/SKILL.md
@@ -1,19 +1,16 @@
 ---
 name: context-assembly
-description: Intelligent context gathering from wicked-garden sources. Use when resuming projects, researching background, or needing decisions and brainstorms from mem, jam, kanban, search, and crew.
+description: |
+  Intelligent context gathering from wicked-garden sources.
+  Assembles relevant context from mem, jam, kanban, search, and crew before responding.
+
+  Use when: "context briefing", "gather background", "what do we know about",
+  "resume where we left off", "catch me up", "what happened before"
 ---
 
 # Context Assembly
 
 Gather relevant context before responding using wicked-smaht v2's tiered hybrid architecture.
-
-## When to Use
-
-Use context assembly when:
-- Starting work on a complex topic
-- Resuming a previous conversation or project
-- Needing background on decisions, brainstorms, or code
-- Switching between projects or phases
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Resolves #128, #129, #130

- Update stale specialist shorthand names in crew/workflow SKILL.md to match current specialist.json roles
- Add `Use when:` trigger phrases to 3 skills missing them (qe-strategy, context-assembly, engineering)
- Remove redundant "When to Use" body sections from 6 skills that duplicate frontmatter triggers

## Changes

| File | Change |
|------|--------|
| `skills/crew/workflow/SKILL.md` | `appeng`→`engineering`, `devsecops`→`platform`, `pmo`→`delivery` |
| `skills/qe/qe-strategy/SKILL.md` | Add trigger phrases, fix `>` to `\|` scalar |
| `skills/smaht/context-assembly/SKILL.md` | Add trigger phrases, remove body duplicate |
| `skills/engineering/engineering/SKILL.md` | Add trigger phrases, remove body duplicate |
| `skills/engineering/debugging/SKILL.md` | Remove body duplicate |
| `skills/agentic/context-engineering/SKILL.md` | Remove body duplicate |
| `skills/agentic/agentic-patterns/SKILL.md` | Remove body duplicate |
| `skills/product/ux-review/SKILL.md` | Remove body duplicate |

## Test Plan

- [x] All 8 modified skills remain under 200-line limit (87-175 lines)
- [x] Specialist names match `.claude-plugin/specialist.json` roles
- [x] Trigger phrases follow `Use when:` convention in YAML frontmatter

---
Generated with [Claude Code](https://claude.com/claude-code)