### PR TITLE
fix(kanban): remove dead 'doing' swimlane from domain_adapter boost_fn (#385)

### DIFF
--- a/scripts/smaht/adapters/domain_adapter.py
+++ b/scripts/smaht/adapters/domain_adapter.py
@@ -60,7 +60,7 @@ _DOMAIN_QUERIES = [
         "project_key": "project_id",
         "title_fn": lambda r: f"[{r.get('swimlane', '?')}] {r.get('name', '')}",
         "summary_fn": lambda r: (r.get("description") or r.get("name") or "")[:200],
-        "boost_fn": lambda r: 0.2 if r.get("swimlane") in ("doing", "in_progress") else 0.0,
+        "boost_fn": lambda r: 0.2 if r.get("swimlane") == "in_progress" else 0.0,
     },
     {
         "domain_name": "wicked-crew",


### PR DESCRIPTION
## Summary
- `domain_adapter.py` had `"doing"` as a valid swimlane in the kanban `boost_fn`, but `"doing"` does not exist in `KanbanStore.DEFAULT_SWIMLANES` or `BOARD_SCHEMAS` — valid IDs are `"todo"`, `"in_progress"`, `"done"`
- Replaced the tuple membership check with a direct equality check against `"in_progress"`, the only live active-work swimlane

## Change
```python
# Before
"boost_fn": lambda r: 0.2 if r.get("swimlane") in ("doing", "in_progress") else 0.0,
# After
"boost_fn": lambda r: 0.2 if r.get("swimlane") == "in_progress" else 0.0,
```

## Test plan
- [ ] Confirm `scripts/kanban/` contains no `"doing"` swimlane references (verified: grep returns empty)
- [ ] Boost correctly fires for `in_progress` tasks and is 0.0 for `todo`/`done`

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)