### PR TITLE
fix(kanban): use _python.sh shim in _trigger_mem_write (#384)

### DIFF
--- a/scripts/kanban/kanban.py
+++ b/scripts/kanban/kanban.py
@@ -661,8 +661,9 @@ class KanbanStore:
         }
 
         try:
+            shim = Path(plugin_root) / "scripts" / "_python.sh"
             subprocess.run(
-                ["python3", f"{plugin_root}/scripts/mem/store.py"],
+                ["sh", str(shim), f"{plugin_root}/scripts/mem/store.py"],
                 input=json.dumps(payload),
                 text=True,
                 timeout=5,


### PR DESCRIPTION
## Summary

- Fixes #384
- `KanbanStore._trigger_mem_write()` was calling `subprocess.run(["python3", ...])` directly, violating the cross-platform rule in CLAUDE.md
- Replaced with `["sh", str(shim), ...]` using `Path(plugin_root) / "scripts" / "_python.sh"` — the standard cross-platform Python resolver used throughout the plugin

## Changes

- `scripts/kanban/kanban.py`: one-line fix in `_trigger_mem_write`, adds `shim` variable using already-imported `Path`

## Test plan

- [ ] Verify `_trigger_mem_write` still fires after a task status update (smoke test on macOS)
- [ ] Confirm no remaining bare `python3` subprocess calls in `scripts/kanban/` (grep shows only shebangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)