### PR TITLE
test(scenarios): align 3 stale acceptance scenarios with smaht v2 synthesis path

### DIFF
--- a/scenarios/crew/03-crew-detection.md
+++ b/scenarios/crew/03-crew-detection.md
@@ -1,7 +1,7 @@
 ---
 name: crew-detection
 title: Crew Project Detection During Prompts
-description: Verify crew hints fire for complex prompts, are suppressed when a project is active, and re-fire at complexity=3
+description: Verify crew hints fire for complex prompts, are suppressed when a project is active, and require complexity >= 3
 type: testing
 difficulty: beginner
 estimated_minutes: 8
@@ -10,8 +10,9 @@ estimated_minutes: 8
 # Crew Project Detection During Prompts
 
 This scenario verifies that the crew hint fires when no active project exists and a prompt
-scores complexity >= 2, is suppressed when an active project is in the workspace, and re-fires
-at complexity=3 even after the once-per-session gate has been set.
+scores complexity >= 3 (Router._estimate_complexity 0-3 scale), is suppressed when an active
+project is in the workspace, and does NOT re-fire at complexity=3 when crew_hint_shown=True
+(the once-per-session gate is not bypassed by high complexity — that was the old behaviour).
 
 ## Setup
 
@@ -21,7 +22,11 @@ export TMPDIR=$(mktemp -d)
 
 ## Steps
 
-### 1. Crew hint fires on complex prompt with no active project
+### 1. Crew hint fires on complexity=3 prompt with no active project
+
+The crew hint gate requires `Router._estimate_complexity(prompt) >= 3`. The 0-3 scale awards:
++1 for >80 words, +1 for migration/architecture/refactor keywords, +1 for plan/design/strategy keywords.
+A prompt must score all three to trigger the hint.
 
 ```bash
 cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
@@ -33,7 +38,7 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 }
 EOF
 
-echo '{"prompt": "I need to design and implement a new authentication system with OAuth2 providers, database schema migrations, and changes to three API services", "session_id": "sess-1"}' \
+echo '{"prompt": "Help me plan and architect a complete migration of our monolith to microservices — first design the service boundaries, then implement the first service with full testing and after that build the full data migration pipeline with rollback support", "session_id": "sess-1"}' \
   | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
   | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
@@ -59,7 +64,10 @@ echo '{"prompt": "I need to design and implement a new authentication system wit
 
 **Expected**: `NO_HINT`
 
-### 3. Crew hint re-fires at complexity=3 even when crew_hint_shown=True
+### 3. Crew hint suppressed when crew_hint_shown=True (once per session)
+
+The hint gate checks `crew_hint_shown` and does NOT re-fire at any complexity level.
+Once shown, crew_hint_shown=True suppresses all subsequent hints.
 
 ```bash
 cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
@@ -76,7 +84,7 @@ echo '{"prompt": "Help me plan and architect a complete migration of our monolit
   | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
 
-**Expected**: `HINT_FOUND` (re-fired despite crew_hint_shown=True)
+**Expected**: `NO_HINT` (suppressed by crew_hint_shown=True — once per session, no re-fire)
 
 ### 4. Low-complexity prompt does not trigger hint
 
@@ -120,7 +128,10 @@ else:
 
 **Expected**: `FLAG_SET`
 
-### 6. Regression guard: hint fires at most once per prompt turn
+### 6. Regression guard: hint never appears when crew_hint_shown=True
+
+With crew_hint_shown=True in session state, `crew:start` must never appear in output —
+the once-per-session gate is respected regardless of complexity.
 
 ```bash
 cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
@@ -132,25 +143,26 @@ output=$(echo '{"prompt": "Help me plan and architect a complete migration of ou
   | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print(ctx.count('crew:start'))")
 
 echo "Hint count in output: ${output}"
-[ "${output}" -le 1 ] && echo "SINGLE_HINT_OK" || echo "SPAM_DETECTED"
+[ "${output}" -eq 0 ] && echo "NO_SPAM_OK" || echo "SPAM_DETECTED"
 ```
 
-**Expected**: `SINGLE_HINT_OK`
+**Expected**: `NO_SPAM_OK` (0 crew:start occurrences — gate suppresses all hints once shown)
 
 ## Expected Outcome
 
-The crew hint appears precisely when needed: high-complexity prompts with no active project.
-It is capped at one per prompt turn and respects the workspace-scoped active project detection.
-The re-fire at complexity=3 gives a second nudge for genuinely large requests without spamming.
+The crew hint appears precisely when needed: prompts scoring complexity=3 (all three heuristics:
+>80 words, migration/architecture/refactor keywords, plan/design/strategy keywords) with no active
+project. The hint is gated once per session — crew_hint_shown=True suppresses all subsequent
+hints regardless of complexity. There is no re-fire mechanism.
 
 ## Success Criteria
 
-- [ ] Crew hint present for complex prompt with active_project_id=null
+- [ ] Crew hint present for complexity=3 prompt with active_project_id=null and crew_hint_shown=False
 - [ ] Crew hint absent when active_project_id is set to a project name
-- [ ] Crew hint re-fires at complexity=3 even when crew_hint_shown=True
+- [ ] Crew hint absent when crew_hint_shown=True (no re-fire at any complexity level)
 - [ ] Low-complexity ("fix a typo") prompts produce no hint
 - [ ] crew_hint_shown flag written to session state after first hint
-- [ ] Hint appears at most once per prompt turn (no duplicates)
+- [ ] No crew:start appears in output when crew_hint_shown=True (0 occurrences, not just <=1)
 - [ ] active_project_id (not cp_project_id) is the gate field used
 
 ## Value Demonstrated

--- a/scenarios/crew/04-jam-triggers.md
+++ b/scenarios/crew/04-jam-triggers.md
@@ -1,7 +1,7 @@
 ---
 name: jam-triggers
 title: Jam Session Suggestion Triggers
-description: Verify jam hints fire for ambiguity signals and respect the session gate and path guards
+description: Verify jam hints fire on FAST/SLOW paths only; synthesis-path prompts skip all hints
 type: testing
 difficulty: beginner
 estimated_minutes: 6
@@ -10,9 +10,13 @@ estimated_minutes: 6
 # Jam Session Suggestion Triggers
 
 This scenario verifies that prompts containing exploration and ambiguity signals receive a jam
-session suggestion on FAST and SLOW paths, that the suggestion is suppressed when a jam command
-is already in the prompt, that the one-per-session gate works, and that jam suggestions do not
-compete with active onboarding directives.
+session suggestion on FAST and SLOW paths. Important: prompts that trigger the synthesis path
+(complex + risky or high complexity heuristic score) return early from the hook before any hints
+are appended — jam and crew suggestions are never emitted on the synthesis path.
+
+Jam suggestions fire on FAST/SLOW paths only, the suggestion is suppressed when a jam command
+is already in the prompt, the one-per-session gate prevents repeat suggestions, and jam hints
+do not compete with active onboarding directives.
 
 ## Setup
 
@@ -120,7 +124,11 @@ echo '{"prompt": "What are the tradeoffs between these design options? Compare a
 
 **Expected**: `jam=False onboarding=True`
 
-### 7. Jam and crew hints can coexist
+### 7. Synthesis-path prompts do NOT emit jam or crew hints
+
+Prompts that trigger the synthesis path (high complexity + deep-work signals) cause the hook
+to return early with only the synthesis directive. The jam suggestion and crew hint code is
+never reached. Verify that a clearly synthesis-eligible prompt produces no jam hint.
 
 ```bash
 cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
@@ -135,33 +143,35 @@ EOF
 
 echo '{"prompt": "I need to design and implement a migration strategy — but should we use a strangler fig pattern or big bang? Help me think through the tradeoffs and alternatives across the system architecture", "session_id": "sess-7"}' \
   | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print(f'crew={\"crew:start\" in ctx} jam={\"jam:\" in ctx}')"
+  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); is_synthesis='path=synthesis' in ctx or 'synthesize' in ctx.lower(); has_jam='[Suggestion]' in ctx and 'jam:' in ctx; print(f'synthesis={is_synthesis} jam={has_jam}')"
 ```
 
-**Expected**: `crew=True jam=True`
+**Expected**: `synthesis=True jam=False` (synthesis path returns early; jam hint never appended)
 
 ## Expected Outcome
 
-Jam suggestions fire precisely for prompts with exploration intent, once per session, without
-conflicting with onboarding directives or duplicating existing jam invocations. Crew and jam
-suggestions can coexist in the same context injection.
+Jam suggestions fire precisely for prompts with exploration intent on FAST or SLOW paths, once
+per session, without conflicting with onboarding directives or duplicating existing jam
+invocations. Prompts that trigger the synthesis path (high complexity/risk) return early and
+never reach the jam suggestion code — synthesis and jam are mutually exclusive per prompt turn.
 
 ## Success Criteria
 
-- [ ] Jam suggestion appended for prompts with tradeoffs/options/alternatives
+- [ ] Jam suggestion appended for prompts with tradeoffs/options/alternatives (FAST/SLOW path)
 - [ ] Suggestion names jam:quick or jam:brainstorm (not generic)
 - [ ] No duplicate suggestion when prompt already contains /jam:
 - [ ] jam_hint_shown=True prevents second suggestion
 - [ ] jam_hint_shown flag written to session state after first suggestion
 - [ ] No jam suggestion when onboarding directive is active
-- [ ] Jam and crew suggestions coexist when both conditions are met
+- [ ] Synthesis-path prompts produce no jam hint (synthesis and jam are mutually exclusive)
 
 ## Value Demonstrated
 
-Jam session suggestions were never emitted before this change — the `jam` intent classification
-was used only for FAST-path adapter selection, never for user-facing guidance. Connecting
-ambiguity signals to jam suggestions closes the gap between detecting that a prompt needs
-structured thinking and actually offering the tool for it.
+Jam session suggestions connect ambiguity signals to user-facing guidance. The synthesis path
+intentionally takes priority for high-complexity prompts — users on that path get the full
+synthesis skill invoked before answering, which is more useful than a jam suggestion alone.
+Jam suggestions target the common case: medium-complexity FAST/SLOW path prompts where the user
+would benefit from structured thinking but the request doesn't warrant full synthesis.
 
 ## Cleanup
 

--- a/scenarios/smaht/01-fresh-install.md
+++ b/scenarios/smaht/01-fresh-install.md
@@ -82,7 +82,7 @@ echo "PASS: SessionStart hook script runs without errors"
 ```bash
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir")
 MISSING=0
-for SKILL in agent-browser runtime-exec issue-reporting wickedizer; do
+for SKILL in runtime-exec wickedizer multi-model integration-discovery; do
   if [ -d "$PLUGIN_DIR/skills/$SKILL" ] || [ -f "$PLUGIN_DIR/skills/$SKILL/SKILL.md" ]; then
     echo "  Found: $SKILL"
   else
@@ -153,7 +153,7 @@ echo "PASS: specialist.json valid with multiple specialists"
 - [ ] SessionStart hook fires without errors (no failure notification in Claude Code)
 - [ ] Hook completes within 2 seconds (no timeout)
 - [ ] No setup message, nag, or prompt displayed on session start
-- [ ] Root-level skills discoverable via `/wicked-garden:help`: agent-browser, multi-model, integration-discovery, issue-reporting, runtime-exec, wickedizer
+- [ ] Root-level skills discoverable via `/wicked-garden:help`: multi-model, integration-discovery, runtime-exec, wickedizer
 - [ ] Skills load correctly when queried (frontmatter and content accessible)
 - [ ] Hooks fire silently on session start with no error notifications
 


### PR DESCRIPTION
## Summary

- **`scenarios/crew/03-crew-detection.md`**: Updated crew hint threshold from >= 2 to >= 3 (matching `Router._estimate_complexity` 0-3 scale gate in `prompt_submit.py`). Removed false claim that hint re-fires at complexity=3 when `crew_hint_shown=True` — the gate is once-per-session with no re-fire. Step 6 now asserts 0 occurrences, not `<= 1`.
- **`scenarios/crew/04-jam-triggers.md`**: Step 7 expected `crew=True jam=True` to coexist, but the synthesis path returns early (before hint code) for complex/ambiguous prompts. Updated to assert `synthesis=True, jam=False` and documented the mutual exclusivity in criteria and value sections.
- **`scenarios/smaht/01-fresh-install.md`**: Step 4 checked for `agent-browser` and `issue-reporting` which don't exist on disk. Replaced with actual root-level skills: `runtime-exec`, `wickedizer`, `multi-model`, `integration-discovery`.

## Test plan

- [ ] Run `scenarios/crew/03-crew-detection.md` — verify Steps 1-6 pass with updated expectations
- [ ] Run `scenarios/crew/04-jam-triggers.md` — verify Step 7 now asserts synthesis exclusivity
- [ ] Run `scenarios/smaht/01-fresh-install.md` — verify Step 4 finds all 4 real skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)