### PR TITLE
fix(smaht): tighten synthesize gate + add scope validation step (#391)

### DIFF
--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -320,7 +320,7 @@ def _suggest_discovery(prompt: str, state) -> str | None:
 # Complexity + risk scoring (inline, no API calls, no external imports)
 # ---------------------------------------------------------------------------
 
-_SYNTHESIS_THRESHOLD = 0.25  # complexity >= this OR is_risky → trigger synthesis
+_SYNTHESIS_THRESHOLD = 0.40  # complexity >= this OR is_risky → trigger synthesis
 
 _DEEP_WORK_SIGNALS = frozenset({
     "implement", "architecture", "design", "refactor", "migrate",
@@ -406,18 +406,18 @@ def _build_synthesis_directive(prompt: str, complexity: float, is_risky: bool, s
     except Exception:
         pass
 
-    # Encode args for the skill (simple key=value pairs)
+    # Encode args as JSON so the skill can unambiguously parse all fields,
+    # including turns_summary which is itself pipe-separated internally.
     import json as _json
-    args_parts = [
-        f"complexity={complexity:.2f}",
-        f"risk={'true' if is_risky else 'false'}",
-    ]
+    args_dict = {
+        "complexity": round(complexity, 2),
+        "risk": is_risky,
+        "prompt": prompt[:500],
+    }
     if turns_summary:
-        args_parts.append(f"turns={turns_summary[:300]}")
-    # Prompt last (may contain special chars)
-    args_parts.append(f"prompt={prompt[:500]}")
+        args_dict["turns"] = turns_summary[:300]
 
-    args_str = " | ".join(args_parts)
+    args_str = _json.dumps(args_dict)
 
     return (
         "[Context Assembly] This prompt requires deep context synthesis.\n"
@@ -775,10 +775,11 @@ def main():
 
             # Synthesize when:
             # - Router says compound/ambiguous (slow) AND has real content (not near-HOT)
-            # - Low confidence AND long enough to have real intent (> 8 words)
+            # - Low confidence AND meaningful inline complexity (>= 0.40) — word count alone
+            #   is not a reliable signal; a long but simple clarification should not fire
             # - Risky keywords (need verification regardless of length)
             # - Inline heuristics exceed threshold AND > 8 words
-            _low_confidence = (_r.analysis.confidence < 0.60) and (_word_count > 8)
+            _low_confidence = (_r.analysis.confidence < 0.60) and (complexity >= 0.40)
             _should_synthesize = (
                 not _is_near_hot
                 and (

--- a/skills/smaht/synthesize/SKILL.md
+++ b/skills/smaht/synthesize/SKILL.md
@@ -17,11 +17,11 @@ You received this skill because the hook determined this prompt needs deep conte
 
 ## Arguments (from hook)
 
-Parse from the `args` string:
+Args are passed as a JSON string. Parse with `json.loads(args)`:
 - `prompt`: the user's original prompt
 - `complexity`: float 0–1 (hook scoring)
 - `risk`: bool — high-risk keywords detected
-- `turns`: recent session turns summary (condensed)
+- `turns`: recent session turns summary (condensed, may be absent on first turn)
 
 ## Budget (based on complexity + risk)
 
@@ -31,6 +31,27 @@ Parse from the `args` string:
 | 0.5–0.7   | no   | 1      | 3              |
 | > 0.7     | any  | 2      | 4              |
 | any       | yes  | 2      | 3              |
+
+## Step 0: Scope Validation
+
+Before running the full synthesis loop, validate that this prompt actually warrants agentic synthesis. Parse `complexity` and `risk` from the skill args (both provided as JSON fields).
+
+Run these 3 quick checks against the user's prompt:
+
+1. **Novel / complex intent** — Is the prompt asking for something genuinely new or complex (not a clarification, follow-up, or simple yes/no)? Short rephrasing of the prior turn, confirmations ("is this right?", "looks good?"), and single-word continuations ("yes", "proceed") do NOT pass this check.
+2. **Cross-domain or multi-step reasoning** — Does answering require synthesizing knowledge across multiple systems, domains, or layers? Single-file questions or direct factual lookups do NOT pass this check.
+3. **Risk flag** — Is `risk` true (destructive/production-affecting keywords detected by the hook)?
+
+**Decision**:
+- **0 of 3 pass** → Exit early. Output exactly:
+
+  ```
+  [Scope Check: LOW — routing to fast path]
+  ```
+
+  Then stop. Do NOT produce a context briefing or proceed to Step 1.
+
+- **1 or more pass** → Proceed to Step 1 below.
 
 ## Step 1: Facilitator — What do I need to know?
 
@@ -58,6 +79,7 @@ curl -s -X POST http://localhost:4242/api \
   -H "Content-Type: application/json" \
   -d '{"action":"search","params":{"query":"QUERY_TERMS","limit":5}}'
 ```
+If curl fails (brain server not running), fall back to Grep/Glob on the project files directly.
 
 **Recent events** (what changed recently):
 ```bash
@@ -66,7 +88,7 @@ curl -s -X POST http://localhost:4242/api \
   -d '{"action":"search","params":{"query":"QUERY_TERMS event created","limit":3}}'
 ```
 
-Each agent returns: what it found (or "nothing relevant").
+Each agent returns: what it found (or "nothing relevant — brain unavailable, searched files directly").
 
 ## Step 3: Facilitator — Is this sufficient?
 


### PR DESCRIPTION
## Summary

- Raises `_SYNTHESIS_THRESHOLD` from 0.25 to 0.40 in `hooks/scripts/prompt_submit.py`
- Changes `_low_confidence` guard to require BOTH low router confidence (< 0.60) AND meaningful inline complexity (>= 0.40) — replaces the previous word-count-only gate that was too broad
- Adds **Step 0: Scope Validation** to `skills/smaht/synthesize/SKILL.md` as an in-skill early-exit for any prompts that slip past the hook gate

## Problem

The synthesize path was firing on routine prompts — simple clarifications and short follow-ups over 8 words with low router confidence would trigger the full agentic synthesis loop, wasting tokens and adding latency.

Root causes:
1. `_low_confidence = (confidence < 0.60) and (word_count > 8)` — word count is not a meaningful complexity signal on its own
2. `_SYNTHESIS_THRESHOLD = 0.25` — inline heuristic fires on almost any signal match

## Verification

Traced all requested test prompts against new logic:

| Prompt | Expected | Result |
|--------|----------|--------|
| `"is this how it's working now?"` | no fire | complexity=0.0, no threshold met |
| `"lets brainstorm what it should be"` | no fire | near-HOT guard (6 words, no tech signals) |
| `"yes"` | no fire | near-HOT guard |
| `"explain the architecture of the smaht pipeline and compare it to the brain adapter approach"` | fires | complexity=0.40, explain+architecture+compare signals |
| `"how does the router decide between fast and slow path and what are the tradeoffs"` | fires | complexity=0.40, how-does+tradeoff signals |

## Test plan

- [ ] Verify short clarification prompts no longer inject synthesis directive in hook output
- [ ] Verify architecture/explain/compare prompts still trigger synthesis
- [ ] Verify `[Scope Check: LOW — routing to fast path]` output on borderline prompts that pass the hook but fail Step 0 in the skill

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)