### PR TITLE
feat(smaht): thread orchestrator output into synthesize directive for SLOW-path prompts

### DIFF
--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -385,8 +385,19 @@ def _score_complexity_and_risk(prompt: str, state) -> tuple[float, bool]:
     return min(complexity, 1.0), is_risky
 
 
-def _build_synthesis_directive(prompt: str, complexity: float, is_risky: bool, state) -> str:
-    """Build the synthesis skill invocation directive for complex/risky prompts."""
+def _build_synthesis_directive(prompt: str, complexity: float, is_risky: bool, state,
+                               context_briefing: str = "") -> str:
+    """Build the synthesis skill invocation directive for complex/risky prompts.
+
+    Args:
+        prompt: The user's original prompt.
+        complexity: Float 0-1 hook scoring.
+        is_risky: Whether high-risk keywords were detected.
+        state: Current session state.
+        context_briefing: Optional orchestrator briefing from SLOW-path pre-run.
+            When provided, the synthesize skill skips cold exploration and uses
+            this as its starting context. Capped at 2000 chars to avoid bloat.
+    """
     # Compact recent turns summary for the skill
     turns_summary = ""
     try:
@@ -416,6 +427,8 @@ def _build_synthesis_directive(prompt: str, complexity: float, is_risky: bool, s
     }
     if turns_summary:
         args_dict["turns"] = turns_summary[:300]
+    if context_briefing:
+        args_dict["context_briefing"] = context_briefing[:2000]
 
     args_str = _json.dumps(args_dict)
 
@@ -757,6 +770,7 @@ def main():
     if not onboarding_directive:
         complexity, is_risky = _score_complexity_and_risk(prompt, state)
         _should_synthesize = False
+        _is_slow_path = False  # tracks whether Router classified this as SLOW
         try:
             from router import Router
             _r = Router(session_topics=list(getattr(state, "topics", None) or [])).route(prompt)
@@ -780,10 +794,11 @@ def main():
             # - Risky keywords (need verification regardless of length)
             # - Inline heuristics exceed threshold AND > 8 words
             _low_confidence = (_r.analysis.confidence < 0.60) and (complexity >= 0.40)
+            _is_slow_path = (_r.path.value == "slow")
             _should_synthesize = (
                 not _is_near_hot
                 and (
-                    (_r.path.value == "slow" and _has_technical)
+                    (_is_slow_path and _has_technical)
                     or is_risky
                     or _low_confidence
                     or (complexity >= _SYNTHESIS_THRESHOLD and _word_count > 8)
@@ -795,7 +810,26 @@ def main():
             _should_synthesize = (complexity >= _SYNTHESIS_THRESHOLD) or is_risky
 
         if _should_synthesize:
-            synthesis_directive = _build_synthesis_directive(prompt, complexity, is_risky, state)
+            # For SLOW-path prompts, run the orchestrator first so the synthesize
+            # skill receives adapter context (brain, kanban, domain events) rather
+            # than starting cold. Fail open: if orchestrator errors, synthesize
+            # without context (original behavior).
+            _context_briefing = ""
+            if _is_slow_path:
+                try:
+                    from orchestrator import Orchestrator
+                    _orch = Orchestrator(session_id=session_id)
+                    _orch_result = _gather_context_sync(_orch, prompt)
+                    if _orch_result and _orch_result.briefing:
+                        _context_briefing = _orch_result.briefing
+                        _log("smaht", "debug", "synthesis.orchestrator_prefetch",
+                             detail={"briefing_len": len(_context_briefing)})
+                except Exception:
+                    pass  # fail open — synthesize without context
+
+            synthesis_directive = _build_synthesis_directive(
+                prompt, complexity, is_risky, state, context_briefing=_context_briefing
+            )
             _log("smaht", "debug", "synthesis.triggered",
                  detail={"complexity": complexity, "risk": is_risky, "turn": turn_count})
             merged = (

--- a/skills/smaht/synthesize/SKILL.md
+++ b/skills/smaht/synthesize/SKILL.md
@@ -22,6 +22,7 @@ Args are passed as a JSON string. Parse with `json.loads(args)`:
 - `complexity`: float 0–1 (hook scoring)
 - `risk`: bool — high-risk keywords detected
 - `turns`: recent session turns summary (condensed, may be absent on first turn)
+- `context_briefing`: pre-assembled adapter context from the orchestrator (present on SLOW-path only, absent on FAST-path or when orchestrator failed). When present, skip cold exploration in Step 1 and use this as the starting context.
 
 ## Budget (based on complexity + risk)
 
@@ -34,7 +35,9 @@ Args are passed as a JSON string. Parse with `json.loads(args)`:
 
 ## Step 0: Scope Validation
 
-Before running the full synthesis loop, validate that this prompt actually warrants agentic synthesis. Parse `complexity` and `risk` from the skill args (both provided as JSON fields).
+Before running the full synthesis loop, validate that this prompt actually warrants agentic synthesis. Parse `complexity`, `risk`, and (if present) `context_briefing` from the skill args (all provided as JSON fields).
+
+If `context_briefing` is present in args, its content can be used to inform all 3 checks below — treat it as verified adapter evidence (kanban state, brain index hits, domain events) rather than re-deriving from scratch.
 
 Run these 3 quick checks against the user's prompt:
 
@@ -55,7 +58,9 @@ Run these 3 quick checks against the user's prompt:
 
 ## Step 1: Facilitator — What do I need to know?
 
-Read the user's prompt and recent turns. Identify 3–5 specific questions:
+**If `context_briefing` is present in args**: Skip the cold exploration phase. Use the provided briefing as your starting context — it already contains adapter output (brain index hits, kanban state, domain events). Proceed directly to Step 3 to assess whether the briefing is sufficient or if targeted follow-up is needed.
+
+**If `context_briefing` is absent**: Read the user's prompt and recent turns. Identify 3–5 specific questions:
 - What concept, file, or system is the user asking about?
 - What past decisions are relevant?
 - What recent changes (events) might affect the answer?


### PR DESCRIPTION
## Summary

- For SLOW-path prompts that trigger the synthesize gate, the orchestrator now runs first and its briefing is passed to the synthesize skill as `context_briefing`
- The synthesize skill uses this pre-assembled context to skip cold exploration (Step 1) and jump straight to sufficiency assessment (Step 3)
- FAST-path synthesis is unchanged; orchestrator call fails open (try/except) so existing behavior is preserved if it errors

## Changes

**`hooks/scripts/prompt_submit.py`**
- Introduced `_is_slow_path` flag (set in the Router try block) to track when Router classified the prompt as SLOW
- In the `if _should_synthesize:` block: when `_is_slow_path` is true, run the orchestrator via the existing `_gather_context_sync()` helper, extract `result.briefing`, and pass it to `_build_synthesis_directive()` as `context_briefing`
- Added `context_briefing: str = ""` parameter to `_build_synthesis_directive()` — appended to args JSON capped at 2000 chars

**`skills/smaht/synthesize/SKILL.md`**
- Added `context_briefing` to the Arguments section
- Step 0: briefing content can inform scope checks as verified adapter evidence
- Step 1: if `context_briefing` present → skip cold exploration, go to Step 3; if absent → existing exploration flow

## Test plan

- [ ] Trigger a SLOW-path prompt (complex, multi-step, technical) — verify `synthesis.orchestrator_prefetch` debug log appears and `context_briefing` is present in the synthesize args
- [ ] Trigger a FAST-path synthesis (risky keyword on short prompt) — verify orchestrator is NOT called (no prefetch log)
- [ ] Set `WICKED_SMAHT_FAIL_INJECT=1` — verify synthesize still fires without context (fail open)
- [ ] Confirm SKILL.md remains under 200 lines (currently 129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)