### PR TITLE
feat(qe): scenario scaffold consumer on build->test-strategy (#410)

### DIFF
--- a/commands/qe/scenarios.md
+++ b/commands/qe/scenarios.md
@@ -9,6 +9,25 @@ Generate comprehensive test scenarios for a feature, function, or user story. Co
 
 ## Instructions
 
+### 0. Poll Bus Events (poll-on-invoke)
+
+Check for pending bus events before starting work. The QE consumer reacts to
+`wicked.phase.transitioned` (build → test-strategy | review) and writes a
+scenario scaffold under `scripts/qe/scenarios/{project_id}/`. Silently skips
+if bus is unavailable.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys; sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts'); sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/qe')
+from _bus_consumers import process_pending_events
+actions = process_pending_events()
+for a in actions: print(f'[bus] {a}')
+" 2>/dev/null || true
+```
+
+If any actions are reported, briefly mention them to the user before proceeding —
+the scaffold path is the starting point for scenario authoring.
+
 ### 1. Parse the Input
 
 Identify what needs scenarios:

--- a/scripts/_bus_consumers.json
+++ b/scripts/_bus_consumers.json
@@ -33,6 +33,14 @@
       "description": "Auto-configures smaht brain adapter when brain is first created",
       "module": "scripts/smaht/_bus_consumers.py",
       "added": "2026-04-13"
+    },
+    {
+      "id": "qe:scenario-scaffold",
+      "event_filter": "wicked.phase.transitioned",
+      "domain": "qe",
+      "description": "Generates scenario scaffolding when build phase completes",
+      "module": "scripts/qe/_bus_consumers.py",
+      "added": "2026-04-18"
     }
   ]
 }

--- a/scripts/qe/_bus_consumers.py
+++ b/scripts/qe/_bus_consumers.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+qe/_bus_consumers.py — Bus event consumers for the qe domain.
+
+Poll-on-invoke pattern: called at command startup before primary logic.
+Each consumer checks the idempotency ledger before acting.
+All consumers fail-open — errors are logged, never raised.
+
+Consumer: qe:scenario-scaffold
+  Subscribes to wicked.phase.transitioned where phase_from == "build"
+  and phase_to ∈ {"test-strategy", "review"}. On match, writes a minimal
+  scenario scaffold markdown file under scripts/qe/scenarios/{project_id}/
+  so the QE test-strategist has a deterministic starting point.
+
+  The scaffold is intentionally skeletal — authorship is the human/agent's
+  job. Idempotent: if the scaffold file already exists, it is not rewritten.
+"""
+
+import json
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Ensure scripts/ is on path so _bus can be imported directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+logger = logging.getLogger("wicked-qe.bus-consumers")
+
+# Phase transitions we care about. Build → {test-strategy | review} covers both
+# phase plans that include a dedicated test-strategy phase and plans that route
+# directly to review (low-complexity projects that skip test-strategy).
+_TRIGGER_PHASE_FROM = "build"
+_TRIGGER_PHASE_TO = frozenset({"test-strategy", "review"})
+
+# Project id must sanitize to a filesystem-safe slug before being used in paths.
+_PROJECT_ID_ALLOWED = re.compile(r"[^a-zA-Z0-9_-]")
+_PROJECT_ID_MAX_LEN = 64
+
+# Scaffold root — sibling of scripts/qe/, keeps generated artifacts out of the
+# marketplace scenarios/ tree which ships as distributable fixtures.
+_SCAFFOLD_ROOT = Path(__file__).resolve().parent / "scenarios"
+
+
+def process_pending_events() -> List[str]:
+    """Poll bus for pending phase transitions and scaffold scenarios on match.
+
+    Called at QE command startup (poll-on-invoke). Returns list of actions
+    taken. Empty list if bus unavailable, no matching events, or scaffolds
+    already exist (idempotent).
+    """
+    actions: List[str] = []
+    try:
+        from _bus import poll_pending, ack_events, is_processed, mark_processed
+
+        events = poll_pending(event_type_prefix="wicked.phase.transitioned")
+        if not events:
+            return actions
+
+        max_event_id = 0
+        for event in events:
+            event_id = event.get("event_id", 0)
+            event_type = event.get("event_type", "")
+            payload = event.get("payload", {}) or {}
+            metadata = event.get("metadata", {}) or {}
+            chain_id = metadata.get("chain_id") or payload.get("chain_id") or ""
+
+            if event_id > max_event_id:
+                max_event_id = event_id
+
+            if event_type != "wicked.phase.transitioned":
+                continue
+
+            phase_from = payload.get("phase_from")
+            phase_to = payload.get("phase_to")
+            if phase_from != _TRIGGER_PHASE_FROM or phase_to not in _TRIGGER_PHASE_TO:
+                continue
+
+            # Idempotency — (event_type, chain_id) matches the crew consumer
+            # shape. Fall back to a composite key when chain_id is absent so
+            # we still dedupe on replay.
+            idem_key = chain_id or f"{payload.get('project_id', '')}:{phase_from}:{phase_to}"
+            if not idem_key:
+                continue
+            if is_processed(event_type, idem_key):
+                continue
+
+            action = _try_scaffold_scenarios(payload, chain_id)
+            # Mark processed even when the scaffold was a no-op (file already
+            # existed or project_id missing) — replaying the same event should
+            # not keep firing.
+            mark_processed(event_type, idem_key)
+            if action:
+                actions.append(action)
+
+        if max_event_id > 0:
+            ack_events(max_event_id)
+
+    except Exception as e:
+        logger.debug(f"QE bus consumer error (non-blocking): {e}")
+
+    return actions
+
+
+def _try_scaffold_scenarios(payload: Dict[str, Any], chain_id: str) -> str:
+    """Write a scenario scaffold for the project, if not already present.
+
+    Returns a human-readable action string on success, empty string on no-op.
+    """
+    project_id_raw = payload.get("project_id") or ""
+    project_id = _sanitize_project_id(project_id_raw)
+    if not project_id:
+        logger.debug("Scaffold skipped: missing or unsafe project_id")
+        return ""
+
+    try:
+        project_dir = _SCAFFOLD_ROOT / project_id
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        scaffold_path = project_dir / "scenarios-scaffold.md"
+        if scaffold_path.exists():
+            # Idempotent — never overwrite a scaffold a human may have edited.
+            return ""
+
+        content = _render_scaffold(project_id, chain_id)
+        # Write atomically via a temp file in the same directory so a partially
+        # written scaffold is never visible to a concurrent reader.
+        tmp_path = scaffold_path.with_suffix(".md.tmp")
+        tmp_path.write_text(content, encoding="utf-8")
+        tmp_path.replace(scaffold_path)
+
+        # Log a plugin-relative path when possible; fall back to absolute for
+        # any redirected scaffold root (e.g. tests).
+        plugin_root = Path(__file__).resolve().parents[2]
+        try:
+            display_path = scaffold_path.relative_to(plugin_root)
+        except ValueError:
+            display_path = scaffold_path
+        action = f"Scaffolded QE scenarios for {project_id} at {display_path}"
+        logger.info(action)
+        return action
+
+    except Exception as e:
+        logger.debug(f"Scaffold error for {project_id} (non-blocking): {e}")
+        return ""
+
+
+def _sanitize_project_id(project_id: str) -> Optional[str]:
+    """Reduce project_id to a filesystem-safe slug or None.
+
+    Path traversal guard: anything outside [a-zA-Z0-9_-] becomes '-', empty
+    and oversized inputs are rejected.
+    """
+    if not isinstance(project_id, str):
+        return None
+    cleaned = _PROJECT_ID_ALLOWED.sub("-", project_id).strip("-")
+    if not cleaned:
+        return None
+    return cleaned[:_PROJECT_ID_MAX_LEN]
+
+
+def _render_scaffold(project_id: str, chain_id: str) -> str:
+    """Produce the minimal scaffold markdown — headers only, no test content."""
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # JSON-encode values so any embedded quote/backslash survives frontmatter.
+    fm_project = json.dumps(project_id)
+    fm_chain = json.dumps(chain_id or "")
+    fm_generated = json.dumps(generated_at)
+    return (
+        "---\n"
+        f"project_id: {fm_project}\n"
+        f"chain_id: {fm_chain}\n"
+        f"generated_at: {fm_generated}\n"
+        "status: \"scaffold\"\n"
+        "---\n"
+        "\n"
+        f"# QE Scenario Scaffold — {project_id}\n"
+        "\n"
+        "Auto-generated on `build` phase completion. Fill in each section below\n"
+        "with concrete scenarios before advancing the test or review phase.\n"
+        "\n"
+        "## Happy Path\n"
+        "\n"
+        "_Author: describe the nominal, expected-outcome scenarios here._\n"
+        "\n"
+        "## Edge Cases\n"
+        "\n"
+        "_Author: describe boundary, empty, max, and limit scenarios here._\n"
+        "\n"
+        "## Error Conditions\n"
+        "\n"
+        "_Author: describe invalid input, dependency failures, and error paths here._\n"
+    )


### PR DESCRIPTION
## Summary

- Adds `scripts/qe/_bus_consumers.py` — a poll-on-invoke consumer that subscribes to `wicked.phase.transitioned` and, when `phase_from == "build"` and `phase_to in {"test-strategy", "review"}`, writes a minimal scenario markdown scaffold under `scripts/qe/scenarios/{project_id}/scenarios-scaffold.md`.
- Registers `qe:scenario-scaffold` in `scripts/_bus_consumers.json` (5 / 8 slots used).
- Wires `process_pending_events()` into the `/wicked-garden:qe:scenarios` command as step 0, mirroring `commands/crew/execute.md`.
- Scaffold contents: frontmatter (`project_id`, `chain_id`, `generated_at`, `status: "scaffold"`) + three section headers (`## Happy Path`, `## Edge Cases`, `## Error Conditions`) with single author-prompt placeholders. No test logic generated.

## Design notes

- Mirrors the crew consumer shape exactly: `poll_pending(prefix) -> filter -> is_processed -> act -> mark_processed -> ack_events(max_id)`.
- Idempotency key: `(event_type, chain_id)` — same as `scripts/crew/_bus_consumers.py:52-56`. Falls back to `{project_id}:{phase_from}:{phase_to}` when chain_id is absent so bus replays still dedupe.
- Idempotent on filesystem: if `scenarios-scaffold.md` exists the consumer returns no-op without overwriting. Writes atomically via a `.tmp` + `replace()`.
- Path traversal guard: `project_id` is regex-filtered to `[a-zA-Z0-9_-]` and capped at 64 chars before joining into `_SCAFFOLD_ROOT`.
- Fail-open: bus unavailable, import error, or filesystem error all become silent no-ops (debug-logged).
- stdlib-only, no external deps.
- **Out of scope**: no `emit_event()` calls added — the platform+qe emit side remains owned by #412.

## Why phase_to ∈ {test-strategy, review}

`phase_manager.py:1269-1275` emits `phase_to` as `phase_order[index(phase) + 1]`. The crew phase plan puts `test-strategy` after `build` when the project complexity warrants it (≥2), otherwise the next phase is `test` or `review` depending on skips. Catching both `test-strategy` and `review` covers the two real-world adjacencies a successful build can produce.

## Test plan

- [x] Unit-level smoke test run locally: `_sanitize_project_id` rejects `../`, empty, None, oversized; `_render_scaffold` emits all three headers + frontmatter; `_try_scaffold_scenarios` writes the file and is no-op on second call; path-traversal input `../../etc/passwd` sanitizes to `etc-passwd` inside the scaffold root and does not escape it.
- [x] Manifest still valid JSON at 5 / 8 consumers.
- [ ] End-to-end: start a crew project, advance through build, observe scaffold appears under `scripts/qe/scenarios/{project_id}/` the next time `/wicked-garden:qe:scenarios` runs.
- [ ] Confirm with sibling PR (#412) once emit points land that the consumer fires on the real event stream.

Closes #410

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>