### PR TITLE
feat(jam): bus emit points + synthesis-trigger consumer (#409)

### DIFF
--- a/WICKED_GARDEN_BUS_EVENTS.md
+++ b/WICKED_GARDEN_BUS_EVENTS.md
@@ -62,6 +62,12 @@ These fields are **stripped automatically** by `_bus.py` before emission:
 | `wicked.experiment.concluded` | `delivery.experiment` | A/B experiment concluded with results |
 | `wicked.rollout.decided` | `delivery.rollout` | Rollout go/no-go decision made |
 
+### Facts
+
+| Event Type | Subdomain | Description |
+|------------|-----------|-------------|
+| `wicked.fact.extracted` | `facts` | Structured fact extracted from conversation (consumed by wicked-brain auto-memorize) |
+
 ### Jam
 
 | Event Type | Subdomain | Description |
@@ -69,6 +75,7 @@ These fields are **stripped automatically** by `_bus.py` before emission:
 | `wicked.council.voted` | `jam.council` | Council evaluation completed with model votes |
 | `wicked.persona.contributed` | `jam.persona` | Persona contributed a perspective in a brainstorm round |
 | `wicked.session.started` | `jam.session` | Brainstorm or council session started |
+| `wicked.session.synthesis_ready` | `jam.session` | All expected Round 1 personas contributed or timeout elapsed — facilitator may synthesize |
 | `wicked.session.synthesized` | `jam.session` | Session synthesis completed |
 
 ### Platform

--- a/agents/jam/council.md
+++ b/agents/jam/council.md
@@ -168,9 +168,9 @@ Each model's response becomes one entry:
 
 If `save_transcript.py` is unavailable, skip transcript storage silently.
 
-After synthesis, emit to wicked-bus:
+After synthesis, emit to wicked-bus. Payload rule: IDs + counts + outcomes only (no raw model text, no full prompts). `agreement_ratio` is a float in `[0.0, 1.0]`.
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.council.voted '{"session_id":"{session_id}","topic":"{topic}","models_count":{N},"agreement_ratio":{R}}' 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.council.voted '{"session_id":"{session_id}","models_count":{N},"agreement_ratio":{R}}' 2>/dev/null || true
 ```
 
 ### 7. Synthesize Three-Stage Output

--- a/agents/jam/facilitator.md
+++ b/agents/jam/facilitator.md
@@ -194,17 +194,26 @@ EventStore.append(
 
 If event emission fails, skip silently — it is supplementary, not required.
 
-Also emit to wicked-bus (additive — both EventStore and bus):
+Also emit to wicked-bus (additive — both EventStore and bus).
 
-At session start:
+**Payload rules**: IDs + counts + outcomes only — never persona dialogue, thinking text, or full prompts. Truncate any `topic` field to the first 80 characters before emitting.
+
+At session start (emit `expected_persona_count` so the synthesis-trigger consumer knows when Round 1 is complete):
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.session.started '{"session_id":"{session_id}","topic":"{topic}","persona_count":{N}}' 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.session.started '{"session_id":"{session_id}","topic":"{topic_truncated_80}","persona_count":{N},"expected_persona_count":{N}}' 2>/dev/null || true
+```
+
+After each Round 1 persona contributes (fire once per persona; Round 2 and beyond must NOT emit this event):
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.persona.contributed '{"session_id":"{session_id}","persona_name":"{persona_name}","round":1,"expected_persona_count":{N}}' 2>/dev/null || true
 ```
 
 After synthesis:
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.session.synthesized '{"session_id":"{session_id}","topic":"{topic}","insight_count":{N},"duration_secs":{D}}' 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.session.synthesized '{"session_id":"{session_id}","insight_count":{N},"duration_secs":{D}}' 2>/dev/null || true
 ```
+
+`expected_persona_count` equals the number of personas chosen in step 2 (Persona Assembly). Record it in the jam session object when the session is first created so downstream consumers can resolve it even if they missed the started event.
 
 ### 4. Synthesis
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -81,6 +81,11 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "jam.session",
         "description": "Session synthesis completed",
     },
+    "wicked.session.synthesis_ready": {
+        "domain": "wicked-garden",
+        "subdomain": "jam.session",
+        "description": "All expected Round 1 personas contributed or timeout elapsed — facilitator may synthesize",
+    },
     "wicked.council.voted": {
         "domain": "wicked-garden",
         "subdomain": "jam.council",

--- a/scripts/_bus_consumers.json
+++ b/scripts/_bus_consumers.json
@@ -41,6 +41,14 @@
       "description": "Generates scenario scaffolding when build phase completes",
       "module": "scripts/qe/_bus_consumers.py",
       "added": "2026-04-18"
+    },
+    {
+      "id": "jam:synthesis-trigger",
+      "event_filter": "wicked.persona.contributed",
+      "domain": "jam",
+      "description": "Emits wicked.session.synthesis_ready when all Round 1 personas have contributed or 120s elapsed",
+      "module": "scripts/jam/_bus_consumers.py",
+      "added": "2026-04-17"
     }
   ]
 }

--- a/scripts/jam/_bus_consumers.py
+++ b/scripts/jam/_bus_consumers.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+jam/_bus_consumers.py — Bus event consumers for the jam domain.
+
+Synthesis-trigger consumer: tracks per-session Round 1 persona contributions
+and emits `wicked.session.synthesis_ready` when either:
+  - contribution count for a session reaches its `expected_persona_count`, OR
+  - 120 seconds have elapsed since the last contribution for that session.
+
+Poll-on-invoke pattern — callable from jam commands (or any startup hook) to
+drain pending events. Fails open: bus errors never propagate.
+
+Round 1 only: contributions with round != 1 are ignored so Round 2 sequential
+persona dialogue is not interfered with.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+logger = logging.getLogger("wicked-jam.bus-consumers")
+
+# Timeout: if no new contribution arrives within this window, mark synthesis ready.
+_SYNTHESIS_TIMEOUT_SECONDS = 120.0
+
+# Default expected persona count when the session object lacks one. 4 matches the
+# /wicked-garden:jam:quick default; full brainstorms typically override via the
+# session record.
+_DEFAULT_EXPECTED_PERSONAS = 4
+
+# Ledger file tracking per-session contribution state. Separate from the global
+# _bus_processed.json ledger because we track *per-session aggregate*, not
+# per-event idempotency.
+_JAM_LEDGER_FILE = os.path.join(
+    os.path.expanduser("~"),
+    ".something-wicked", "wicked-garden", "local",
+    "wicked-jam", "_synthesis_tracker.json",
+)
+
+
+def _load_tracker() -> Dict[str, Dict[str, Any]]:
+    """Load the per-session tracker. Returns {session_id: {...}}."""
+    try:
+        with open(_JAM_LEDGER_FILE, "r") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_tracker(tracker: Dict[str, Dict[str, Any]]) -> None:
+    """Persist the tracker. Fails open."""
+    try:
+        os.makedirs(os.path.dirname(_JAM_LEDGER_FILE), exist_ok=True)
+        with open(_JAM_LEDGER_FILE, "w") as f:
+            json.dump(tracker, f)
+    except OSError:
+        pass  # fail open
+
+
+def _lookup_expected_persona_count(session_id: str) -> Optional[int]:
+    """Look up expected_persona_count from the jam session record, if present."""
+    try:
+        from _domain_store import DomainStore
+        ds = DomainStore("wicked-jam")
+        sessions = ds.list("sessions") or []
+        for s in sessions:
+            if s.get("id") == session_id or s.get("session_id") == session_id:
+                n = s.get("expected_persona_count")
+                if isinstance(n, int) and n > 0:
+                    return n
+        return None
+    except Exception:
+        return None
+
+
+def _resolve_expected(session_id: str, tracker_entry: Dict[str, Any]) -> int:
+    """Return expected_persona_count, preferring tracker → store → default."""
+    n = tracker_entry.get("expected_persona_count")
+    if isinstance(n, int) and n > 0:
+        return n
+    looked = _lookup_expected_persona_count(session_id)
+    if looked:
+        return looked
+    return _DEFAULT_EXPECTED_PERSONAS
+
+
+def _emit_synthesis_ready(
+    session_id: str,
+    received: int,
+    expected: int,
+    reason: str,
+    chain_id: Optional[str],
+) -> None:
+    """Emit wicked.session.synthesis_ready. Fails open."""
+    try:
+        from _bus import emit_event
+        emit_event(
+            "wicked.session.synthesis_ready",
+            {
+                "session_id": session_id,
+                "received_count": received,
+                "expected_count": expected,
+                "reason": reason,  # "all_received" | "timeout"
+            },
+            chain_id=chain_id,
+        )
+    except Exception as e:
+        logger.debug(f"synthesis_ready emit failed (non-blocking): {e}")
+
+
+def process_pending_events(now: Optional[float] = None) -> List[str]:
+    """Poll wicked.persona.contributed events, track per-session counts, and emit
+    wicked.session.synthesis_ready once a session reaches expected count or times out.
+
+    Returns list of action strings (for logging / tests).
+    `now` override enables deterministic testing; real calls pass None.
+    """
+    actions: List[str] = []
+    now_ts = time.time() if now is None else now
+
+    try:
+        from _bus import poll_pending, ack_events
+    except Exception as e:
+        logger.debug(f"bus import failed (non-blocking): {e}")
+        return actions
+
+    try:
+        events = poll_pending(event_type_prefix="wicked.persona.") or []
+
+        tracker = _load_tracker()
+        max_event_id = 0
+        changed = False
+
+        for event in events:
+            event_id = event.get("event_id", 0)
+            if isinstance(event_id, int) and event_id > max_event_id:
+                max_event_id = event_id
+
+            if event.get("event_type") != "wicked.persona.contributed":
+                continue
+
+            payload = event.get("payload") or {}
+            session_id = payload.get("session_id")
+            if not session_id:
+                continue
+
+            # Round 1 only — Round 2 sequential dialogue must not be triggered.
+            round_num = payload.get("round", 1)
+            try:
+                round_num = int(round_num)
+            except (TypeError, ValueError):
+                round_num = 1
+            if round_num != 1:
+                continue
+
+            metadata = event.get("metadata") or {}
+            chain_id = metadata.get("chain_id")
+
+            entry = tracker.get(session_id) or {
+                "received_count": 0,
+                "last_contribution_ts": now_ts,
+                "processed_event_ids": [],
+                "ready_emitted": False,
+                "chain_id": None,
+                "expected_persona_count": None,
+            }
+
+            # Per-event idempotency inside this session's ledger entry
+            processed_ids = entry.get("processed_event_ids") or []
+            if event_id and event_id in processed_ids:
+                continue
+
+            entry["received_count"] = int(entry.get("received_count", 0)) + 1
+            entry["last_contribution_ts"] = now_ts
+            if event_id:
+                processed_ids.append(event_id)
+                # Cap ledger size — last 64 ids per session is plenty for Round 1.
+                entry["processed_event_ids"] = processed_ids[-64:]
+            if chain_id and not entry.get("chain_id"):
+                entry["chain_id"] = chain_id
+            # Allow first-contribution emitter to seed expected count via payload.
+            if not entry.get("expected_persona_count"):
+                n = payload.get("expected_persona_count")
+                if isinstance(n, int) and n > 0:
+                    entry["expected_persona_count"] = n
+
+            tracker[session_id] = entry
+            changed = True
+
+            if not entry.get("ready_emitted"):
+                expected = _resolve_expected(session_id, entry)
+                if entry["received_count"] >= expected:
+                    _emit_synthesis_ready(
+                        session_id,
+                        received=entry["received_count"],
+                        expected=expected,
+                        reason="all_received",
+                        chain_id=entry.get("chain_id"),
+                    )
+                    entry["ready_emitted"] = True
+                    actions.append(
+                        f"synthesis_ready emitted for {session_id} "
+                        f"({entry['received_count']}/{expected}, all_received)"
+                    )
+
+        # Timeout sweep — any session with unemitted readiness whose last
+        # contribution is older than the timeout gets flushed.
+        for session_id, entry in list(tracker.items()):
+            if entry.get("ready_emitted"):
+                continue
+            last = float(entry.get("last_contribution_ts") or 0.0)
+            if last <= 0:
+                continue
+            if (now_ts - last) >= _SYNTHESIS_TIMEOUT_SECONDS:
+                received = int(entry.get("received_count", 0))
+                if received <= 0:
+                    continue
+                expected = _resolve_expected(session_id, entry)
+                _emit_synthesis_ready(
+                    session_id,
+                    received=received,
+                    expected=expected,
+                    reason="timeout",
+                    chain_id=entry.get("chain_id"),
+                )
+                entry["ready_emitted"] = True
+                tracker[session_id] = entry
+                changed = True
+                actions.append(
+                    f"synthesis_ready emitted for {session_id} "
+                    f"({received}/{expected}, timeout)"
+                )
+
+        # Prune emitted sessions older than 24h to bound ledger growth.
+        cutoff = now_ts - 86400
+        pruned = {
+            sid: e for sid, e in tracker.items()
+            if not (e.get("ready_emitted") and float(e.get("last_contribution_ts") or 0.0) < cutoff)
+        }
+        if len(pruned) != len(tracker):
+            tracker = pruned
+            changed = True
+
+        if changed:
+            _save_tracker(tracker)
+
+        if max_event_id > 0:
+            ack_events(max_event_id)
+
+    except Exception as e:
+        logger.debug(f"jam bus consumer error (non-blocking): {e}")
+
+    return actions
+
+
+if __name__ == "__main__":
+    # Manual invocation for testing / debug:
+    #   python3 scripts/jam/_bus_consumers.py
+    logging.basicConfig(level=logging.INFO)
+    results = process_pending_events()
+    for line in results:
+        print(line)


### PR DESCRIPTION
## Summary

Wire the jam domain into wicked-bus and enable parallel Round 1 persona execution via a new synthesis-trigger consumer.

Closes #409 (parent #404).

- **4 emit points** wired in facilitator.md / council.md agent prompts: `wicked.session.started` (now carries `expected_persona_count` + 80-char-truncated topic), `wicked.persona.contributed` (new, Round 1 only — per persona), `wicked.session.synthesized`, `wicked.council.voted` (topic dropped, IDs + counts only).
- **New Core event** `wicked.session.synthesis_ready` added to `BUS_EVENT_MAP`; catalog regenerated.
- **Synthesis-trigger consumer** at `scripts/jam/_bus_consumers.py` — poll-on-invoke pattern mirroring `scripts/smaht/_bus_consumers.py`. Tracks per-session Round 1 contributions in `~/.something-wicked/.../wicked-jam/_synthesis_tracker.json`. Emits `wicked.session.synthesis_ready` when `received_count >= expected_persona_count` (reason `all_received`) or 120 s elapse after the last contribution (reason `timeout`). Round 2 events are ignored so sequential persona dialogue is untouched.
- **Registered** in `scripts/_bus_consumers.json` — 5/8 consumer slots used.
- **Fails open** everywhere: missing bus, DomainStore, or session record never propagate. stdlib-only. No Tier-3 content ever lands on the bus (deny-list still enforced upstream in `_bus._sanitize_payload`).

## Test plan

- [x] Module imports cleanly under `python3 -m py_compile` and via `sys.path.insert(0, 'scripts')`.
- [x] `BUS_EVENT_MAP['wicked.session.synthesis_ready']` is present with `subdomain=jam.session`.
- [x] `scripts/_bus_consumers.json` parses and registers `jam:synthesis-trigger`.
- [x] Unit-style integration test with mocked `poll_pending` / `ack_events` / `emit_event` confirms:
  - 4 contributions for `expected=4` emits `synthesis_ready` with `reason=all_received`.
  - Round 2 contributions are skipped.
  - Partial count + 121 s idle emits `synthesis_ready` with `reason=timeout`.
  - Replaying the same `event_id` does not double-count (per-session idempotency).
- [x] `WICKED_BUS_DISABLED=1 python3 scripts/jam/_bus_consumers.py` returns `[]` with no exceptions.
- [ ] End-to-end: run `/wicked-garden:jam:quick` with wicked-bus live, verify 4 `wicked.persona.contributed` events fire and a single `wicked.session.synthesis_ready` arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)