### PR TITLE
feat(bus): platform + qe emit points (#412)

### DIFF
--- a/scripts/qe/registry_store.py
+++ b/scripts/qe/registry_store.py
@@ -108,6 +108,45 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # Emit scenario run event to wicked-bus (additive — fire-and-forget, fail-open).
+    # Result is derived from registry completeness: no missing items = pass, else fail.
+    try:
+        from _bus import emit_event
+        from _session import SessionState
+
+        completeness = registry_data.get("completeness") or {}
+        missing = completeness.get("missing") or []
+        required_count = completeness.get("required_count") or 0
+        captured_count = completeness.get("captured_count") or 0
+
+        result = "pass" if not missing else "fail"
+        # coverage_delta: ratio of captured-to-required as a simple proxy (0.0-1.0).
+        # No prior-run comparison is available at this layer, so delta is reported
+        # as the current completion ratio. Consumers that track diffs should compute
+        # deltas from successive events.
+        if required_count > 0:
+            coverage_delta = round(captured_count / required_count, 3)
+        else:
+            coverage_delta = 0.0
+
+        try:
+            state = SessionState.load()
+            chain_id = getattr(state, "active_chain_id", None) or ""
+        except Exception:
+            chain_id = ""
+
+        emit_event(
+            "wicked.scenario.run",
+            {
+                "scenario_id": args.scenario_slug,
+                "result": result,
+                "coverage_delta": coverage_delta,
+            },
+            chain_id=chain_id,
+        )
+    except Exception:
+        pass  # fail open — bus emit must never break the caller
+
     return 0
 
 


### PR DESCRIPTION
## Summary

Wires the `wicked.scenario.run` bus emit in `scripts/qe/registry_store.py` — the one and only QE Python call site that runs after an acceptance scenario executes (invoked by `wicked-garden:qe:acceptance-test-executor`). Payload follows the WICKED_GARDEN_BUS_EVENTS.md contract:

- `scenario_id` — the scenario slug
- `result` — `pass` when registry `completeness.missing` is empty, else `fail`
- `coverage_delta` — `captured_count / required_count` ratio (0.0-1.0) as a simple proxy, since no prior-run comparison is available at this layer
- `chain_id` (top-level) — read from `SessionState.active_chain_id`, falling back to `""`

Fire-and-forget, fail-open; bus failures never break the caller. Stdlib-only. Tier 1 + Tier 2 payload only — no test output, stack traces, diffs, or source code.

Closes #412

## Skipped emits (no Python call site exists)

Four of the five candidate events don't have canonical Python call sites in v5.0.0:

- **`wicked.security.finding_raised`** — `/wicked-garden:platform:security` and the `security-engineer` agent are entirely markdown-driven. `scripts/platform/` has no security-finding writer (only `prereq_doctor.py` and observability/health/contract runners).
- **`wicked.compliance.passed` / `wicked.compliance.failed`** — `/wicked-garden:platform:compliance` dispatches the `compliance-officer` agent and produces a markdown report; no Python persistence for framework checks exists. `DomainStore("wicked-compliance")` is not used anywhere.
- **`wicked.coverage.changed`** — no Python coverage tracker exists in `scripts/qe/`. (Note: `scripts/crew/traceability.py coverage` tracks requirement-to-test traceability, which is distinct from QE test coverage.)

When the platform domain grows Python persistence for security findings or compliance results, the emit sites can be wired alongside that work in a follow-up.

## Delivery emits deferred

`scripts/delivery/` does not exist in v5.0.0 — the delivery domain is command/agent-only with no Python call sites to emit from. `wicked.rollout.decided` and `wicked.experiment.concluded` stay in the catalog but remain unwired until delivery grows a persistence layer.

## Scope guarantees

- No consumers added (parallel subagent owns QE scaffold consumer #410).
- `scripts/_bus_consumers.json` untouched.
- `scripts/jam/*` untouched.

## Test plan

- [ ] Smoke: run `registry_store.py` with `WICKED_BUS_DISABLED=1` and a sample registry — exits 0, no bus call attempted.
- [ ] Smoke: run with a registry that has `completeness.missing` populated — emit fires with `result="fail"`.
- [ ] Smoke: run with a complete registry — emit fires with `result="pass"` and `coverage_delta=1.0`.
- [ ] Verify via `wicked-bus` CLI that an emitted event carries the correct payload shape and a `chain_id` in metadata.
- [ ] Confirm no regression in the existing DomainStore persistence path.