### PR TITLE
feat(bus): close #407 emit gaps + #414 consumer budget enforcement

### DIFF
--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -18,12 +18,15 @@ Usage:
 """
 
 import json
+import logging
 import os
 import shutil
 import subprocess
 import threading
 import time
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("wicked-garden.bus")
 
 # ---------------------------------------------------------------------------
 # Static event catalog — Phase 1 events only (those with wired consumers).
@@ -523,3 +526,88 @@ def mark_processed(event_type: str, chain_id: str) -> None:
     ledger = {k: v for k, v in ledger.items() if v > cutoff}
 
     _save_ledger(ledger)
+
+
+# ---------------------------------------------------------------------------
+# Consumer registry — static manifest at scripts/_bus_consumers.json.
+# Enforces the max_consumers budget at load time. Does not reject duplicates
+# (idempotent), logs an error when the registered count exceeds the budget.
+# ---------------------------------------------------------------------------
+
+_CONSUMERS_MANIFEST = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "_bus_consumers.json",
+)
+
+
+def load_consumer_registry(
+    manifest_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Load the bus consumer registry and validate it against max_consumers.
+
+    Returns a dict with keys:
+        consumers: list of consumer entries (may be empty on error)
+        max_consumers: int budget (defaults to 8 if absent)
+        registered: int count of consumer entries
+        over_budget: bool — True when registered > max_consumers
+        error: optional str — set when the manifest is missing / malformed
+
+    Fail-open: never raises. A malformed or missing manifest logs an error
+    and returns a registry dict with empty consumers so the bus still boots.
+    Idempotent at load time — duplicate consumer ids are not rejected.
+    """
+    path = manifest_path or _CONSUMERS_MANIFEST
+    result: Dict[str, Any] = {
+        "consumers": [],
+        "max_consumers": 8,
+        "registered": 0,
+        "over_budget": False,
+        "error": None,
+    }
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        result["error"] = f"consumer manifest not found: {path}"
+        logger.debug(result["error"])
+        return result
+    except (json.JSONDecodeError, OSError) as exc:
+        result["error"] = f"consumer manifest malformed: {exc}"
+        logger.error("bus consumer registry: %s", result["error"])
+        return result
+
+    if not isinstance(data, dict):
+        result["error"] = "consumer manifest root is not an object"
+        logger.error("bus consumer registry: %s", result["error"])
+        return result
+
+    consumers = data.get("consumers", [])
+    if not isinstance(consumers, list):
+        result["error"] = "consumer manifest 'consumers' is not a list"
+        logger.error("bus consumer registry: %s", result["error"])
+        consumers = []
+
+    max_budget = data.get("max_consumers", 8)
+    try:
+        max_budget = int(max_budget)
+    except (TypeError, ValueError):
+        max_budget = 8
+
+    registered = len(consumers)
+    over_budget = registered > max_budget
+
+    result.update({
+        "consumers": consumers,
+        "max_consumers": max_budget,
+        "registered": registered,
+        "over_budget": over_budget,
+    })
+
+    if over_budget:
+        logger.error(
+            "bus consumer registry over budget: %d consumers registered, max %d. "
+            "Review %s before adding more consumers.",
+            registered, max_budget, path,
+        )
+
+    return result

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -963,6 +963,37 @@ def _validate_min_gate_score(
     return None
 
 
+def _bump_rework_iteration(project_dir: Path, phase: str) -> int:
+    """Increment the per-phase rework iteration counter and return the new value.
+
+    Persists to phases/<phase>/rework-iterations.json. Fail-open: returns 1 on any
+    read/write error so callers can still emit an event with a plausible count.
+    """
+    iteration_file = project_dir / "phases" / phase / "rework-iterations.json"
+    count = 0
+    try:
+        if iteration_file.exists():
+            data = json.loads(iteration_file.read_text())
+            count = int(data.get("iteration_count", 0))
+    except (json.JSONDecodeError, OSError, ValueError):
+        count = 0  # treat malformed file as fresh
+
+    count += 1
+
+    try:
+        iteration_file.parent.mkdir(parents=True, exist_ok=True)
+        iteration_file.write_text(
+            json.dumps({
+                "iteration_count": count,
+                "updated_at": get_utc_timestamp(),
+            })
+        )
+    except OSError:
+        pass  # fail open: write failure is non-fatal
+
+    return count
+
+
 def _record_gate_override(
     project_dir: Path, phase: str, reason: str, approver: str
 ) -> None:
@@ -1216,6 +1247,21 @@ def approve_phase(
                     "phase": phase,
                     "blocking_reason": gate_result.get("result"),
                 }, chain_id=getattr(state, "chain_id", None))
+                # Rework begins the moment a REJECT verdict is stored.
+                # Bump a per-phase iteration counter (idempotent across reruns)
+                # and fire wicked.rework.triggered alongside the block event.
+                try:
+                    iteration_count = _bump_rework_iteration(
+                        get_project_dir(state.name), phase
+                    )
+                except Exception:
+                    iteration_count = 1  # fail open — still emit with best-effort count
+                emit_event("wicked.rework.triggered", {
+                    "project_id": state.name,
+                    "phase": phase,
+                    "iteration_count": iteration_count,
+                    "chain_id": getattr(state, "chain_id", None),
+                }, chain_id=getattr(state, "chain_id", None))
         except Exception:
             pass  # fail open
 
@@ -1293,7 +1339,28 @@ def approve_phase(
             state.current_phase = next_phase
             return (state, next_phase)
 
-    # No next phase — project is complete
+    # No next phase — project is complete.
+    # Emit wicked.project.completed alongside the final phase transition.
+    try:
+        from _bus import emit_event
+        duration_secs: Optional[float] = None
+        try:
+            created_raw = (state.created_at or "").replace("Z", "+00:00")
+            if created_raw:
+                created_dt = datetime.fromisoformat(created_raw)
+                now_dt = datetime.now(timezone.utc)
+                duration_secs = max(0.0, (now_dt - created_dt).total_seconds())
+        except (ValueError, AttributeError):
+            duration_secs = None  # fail open on malformed timestamps
+        emit_event("wicked.project.completed", {
+            "project_id": state.name,
+            "duration_secs": duration_secs,
+            "chain_id": getattr(state, "chain_id", None),
+            "final_phase": phase,
+        }, chain_id=getattr(state, "chain_id", None))
+    except Exception:
+        pass  # fail open
+
     return (state, None)
 
 

--- a/scripts/platform/observability/health_probe.py
+++ b/scripts/platform/observability/health_probe.py
@@ -7,6 +7,7 @@ Validates all installed plugins against structural contracts:
   3. Cross-plugin subagent_type refs in commands/*.md and agents/*.md
   4. Ghost specialist checks (role, personas, enhances fields)
   5. plugin.json required fields (name, version, description)
+  6. Bus consumer budget (scripts/_bus_consumers.json vs max_consumers)
 
 Exit codes:
   0  healthy — no violations
@@ -438,6 +439,92 @@ def check_specialist(
 
 
 # ---------------------------------------------------------------------------
+# Check 6: Bus consumer budget (scripts/_bus_consumers.json)
+# ---------------------------------------------------------------------------
+
+def check_bus_consumer_budget(
+    plugin_name: str,
+    plugin_root: Path,
+) -> list[dict[str, Any]]:
+    """Validate that registered bus consumers stay within the declared budget.
+
+    Reads plugin_root/scripts/_bus_consumers.json. Flags a warning when
+    registered > max_consumers. Silent (no violation) when the manifest is
+    absent — plugins without bus consumers are not required to ship one.
+    Fail-open: a malformed manifest is reported as a warning, not an error.
+    """
+    violations: list[dict[str, Any]] = []
+    manifest_path = plugin_root / "scripts" / "_bus_consumers.json"
+    if not manifest_path.exists():
+        return violations
+
+    rel_file = _rel_from(manifest_path, plugin_root.parent.parent)
+
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        violations.append(
+            make_violation(
+                plugin=plugin_name,
+                vtype="bus_consumer_budget",
+                severity="warning",
+                message=f"Could not parse _bus_consumers.json: {exc}",
+                file=rel_file,
+            )
+        )
+        return violations
+
+    if not isinstance(data, dict):
+        violations.append(
+            make_violation(
+                plugin=plugin_name,
+                vtype="bus_consumer_budget",
+                severity="warning",
+                message="_bus_consumers.json root is not an object.",
+                file=rel_file,
+            )
+        )
+        return violations
+
+    consumers = data.get("consumers", [])
+    if not isinstance(consumers, list):
+        violations.append(
+            make_violation(
+                plugin=plugin_name,
+                vtype="bus_consumer_budget",
+                severity="warning",
+                message="_bus_consumers.json 'consumers' is not a list.",
+                file=rel_file,
+            )
+        )
+        return violations
+
+    max_budget_raw = data.get("max_consumers", 8)
+    try:
+        max_budget = int(max_budget_raw)
+    except (TypeError, ValueError):
+        max_budget = 8
+
+    registered = len(consumers)
+    if registered > max_budget:
+        violations.append(
+            make_violation(
+                plugin=plugin_name,
+                vtype="bus_consumer_budget",
+                severity="warning",
+                message=(
+                    f"Bus consumer budget exceeded: {registered} consumers "
+                    f"registered, max {max_budget}. Review entries before "
+                    f"adding more."
+                ),
+                file=rel_file,
+            )
+        )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
 # Check 5: plugin.json required fields
 # ---------------------------------------------------------------------------
 
@@ -536,6 +623,11 @@ def probe_plugin(plugin_root: Path, plugins_dir: Path) -> list[dict[str, Any]]:
         violations.extend(
             check_specialist(plugin_name, plugin_root, specialist_json_path)
         )
+
+    # Check 6: bus consumer budget (scripts/_bus_consumers.json)
+    violations.extend(
+        check_bus_consumer_budget(plugin_name, plugin_root)
+    )
 
     return violations
 


### PR DESCRIPTION
## Summary

Two small bus-integration polish gaps — both additive, stdlib-only, fail-open.

- **Closes #407** — wires the two remaining crew emit points in `scripts/crew/phase_manager.py`:
  - `wicked.rework.triggered` fires alongside `wicked.gate.blocked` on REJECT. A per-phase iteration counter persists at `phases/<phase>/rework-iterations.json`.
  - `wicked.project.completed` fires in the `approve_phase` no-next-phase branch, with `duration_secs` derived from `state.created_at`, plus `final_phase` and `chain_id`.
  - Both events are already catalogued in `BUS_EVENT_MAP`, so no catalog regen was needed.

- **Closes #414** — enforces the budget declared in `scripts/_bus_consumers.json`:
  - New `_bus.load_consumer_registry()` reads the manifest, counts consumers, compares against `max_consumers`, and `logger.error`s when over budget. Idempotent at load time (duplicates are not rejected). Malformed or missing manifest → no crash, logs and returns empty.
  - New `check_bus_consumer_budget()` in `scripts/platform/observability/health_probe.py` reports `registered/max` and flags a `warning` violation (via the existing `make_violation(...)` pattern) when over budget. Wired into `probe_plugin` as Check 6.

## Test plan

- [x] AST-parse all three modified files
- [x] Unit-test `_bump_rework_iteration` — counts persist and are per-phase
- [x] Unit-test `check_bus_consumer_budget` — missing/malformed/over-budget/healthy cases
- [x] `tests/crew/test_gate_enforcement.py` — 19/19 pass
- [x] `load_consumer_registry()` against the live manifest reports 4/8, not over budget
- [ ] Follow-up: once a crew project hits REJECT in real use, confirm `wicked.rework.triggered` lands on the bus with the expected payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)