### PR TITLE
feat(delivery): wire rollout + experiment bus emits via agent prompts

### DIFF
--- a/agents/delivery/experiment-designer.md
+++ b/agents/delivery/experiment-designer.md
@@ -149,6 +149,18 @@ secondary_metric_achieved {variant, user_id, value}
 - Maximum acceptable risk
 - Resource constraints
 
+### 8.5. Emit Experiment Conclusion
+
+**After the experiment concludes and a winner (or inconclusive result) is determined, emit the event** for cross-domain visibility. The `chain_id` is sourced from session state (`SessionState.active_chain_id`) — use the active crew chain if present, otherwise omit.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.experiment.concluded '{"winner":"variant_a","significance":0.95,"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`winner` must be one of `variant_a`, `variant_b`, or `inconclusive`. `significance` is the observed p-value confidence as a float in `[0.0, 1.0]`.
+
+**Payload rules**: Tier 1 + Tier 2 only. No customer-cohort details, no per-user data, no traffic samples.
+
 ### 9. Update Task
 
 Store experiment design:

--- a/agents/delivery/rollout-manager.md
+++ b/agents/delivery/rollout-manager.md
@@ -148,6 +148,18 @@ Stage 2:
 - T+checkpoints: Progress updates
 - T+complete: Completion summary
 
+### 8.5. Emit Rollout Decision
+
+**After recording a go/no-go decision (or a pause) for the rollout, emit the event** for cross-domain visibility. The `chain_id` is sourced from session state (`SessionState.active_chain_id`) — use the active crew chain if present, otherwise omit.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.rollout.decided '{"decision":"go","traffic_pct":10,"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`decision` must be one of `go`, `no-go`, or `paused`. `traffic_pct` is the integer percentage targeted by the decision (0-100).
+
+**Payload rules**: Tier 1 + Tier 2 only. No customer-cohort details, no per-user data, no traffic samples.
+
 ### 9. Update Task
 
 Track rollout progress:


### PR DESCRIPTION
## Summary

- Adds emit-directive blocks to `agents/delivery/rollout-manager.md` and `agents/delivery/experiment-designer.md` so rollout go/no-go decisions and experiment conclusions publish to the wicked-bus.
- Follows the jam `facilitator.md` / `council.md` precedent — surgical prompt inserts only. No Python, no consumers, no manifest or `scripts/_bus.py` changes.
- Both events (`wicked.rollout.decided`, `wicked.experiment.concluded`) are already registered in `scripts/_bus.py` `BUS_EVENT_MAP`; this wires the agents as producers. `scripts/delivery/` does not exist in v5.1.0 — that's why this was deferred from #412 and the agent-prompt pattern is used.

## Payloads

- `wicked.rollout.decided` — `{"decision":"go|no-go|paused","traffic_pct":N,"chain_id":"{chain_id}"}`
- `wicked.experiment.concluded` — `{"winner":"variant_a|variant_b|inconclusive","significance":0.95,"chain_id":"{chain_id}"}`
- `chain_id` sourced from `SessionState.active_chain_id` (noted in the directives).
- Fail-open (`|| true`). Tier 1 + Tier 2 payloads only — no customer-cohort details, no per-user data, no traffic samples.

## Insertion points

- `agents/delivery/rollout-manager.md` — new section **8.5 Emit Rollout Decision** inserted between section 8 (Communication Plan) and section 9 (Update Task), after the go/no-go decision is recorded.
- `agents/delivery/experiment-designer.md` — new section **8.5 Emit Experiment Conclusion** inserted between section 8 (Define Success Criteria) and section 9 (Update Task), after a winner/inconclusive result is determined.

Closes #423

## Test plan

- [ ] Verify the two agent prompts render and read naturally.
- [ ] Confirm both event types resolve via `scripts/_bus.py` `BUS_EVENT_MAP`.
- [ ] Spot-check a rollout-manager run: the agent emits `wicked.rollout.decided` after a go/no-go is recorded.
- [ ] Spot-check an experiment-designer run: the agent emits `wicked.experiment.concluded` after a winner is determined.
- [ ] Confirm fail-open behavior when `_bus_emit.py` is unavailable (directive uses `|| true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)