### PR TITLE
feat(platform): wire security + compliance bus emits via agent prompts

### DIFF
--- a/agents/platform/auditor.md
+++ b/agents/platform/auditor.md
@@ -317,6 +317,24 @@ TaskUpdate(
 )
 ```
 
+## Bus Events
+
+**After the audit result is finalized** (Overall Status + Certification Readiness determined), emit ONE of the two events below for cross-domain visibility. Emit `wicked.compliance.passed` when Overall Status is `READY`; emit `wicked.compliance.failed` when Overall Status is `NEEDS WORK` or `NOT READY`.
+
+**On pass** (all in-scope controls passing, no P0/P1 gaps):
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.compliance.passed '{"framework":"{soc2|hipaa|gdpr|pci}","checks_passed_count":{N},"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+**On fail** (any failing control or identified gap):
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.compliance.failed '{"framework":"{soc2|hipaa|gdpr|pci}","gap_count":{N},"severity_max":"{critical|high|medium|low}","chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`chain_id` comes from session state — use `SessionState.active_chain_id` if available, else empty string. Substitute at emit time.
+
+**Payload rules**: Tier 1 + Tier 2 only — IDs, counts, severities, enums. NEVER include audit-report contents, evidence file paths, control descriptions, finding text, remediation details, source code, or PII. Fail-open: the `|| true` keeps the agent running when the bus is unavailable.
+
 ## Quality Standards
 
 - Complete control coverage

--- a/agents/platform/compliance-officer.md
+++ b/agents/platform/compliance-officer.md
@@ -247,6 +247,24 @@ TaskUpdate(
 )
 ```
 
+## Bus Events
+
+**After the pass/fail decision is made** (when you set `Status` in the Output Format), emit ONE of the two events below for cross-domain visibility. Emit `wicked.compliance.passed` when Status is `COMPLIANT`; emit `wicked.compliance.failed` when Status is `NEEDS ATTENTION` or `NON-COMPLIANT`.
+
+**On pass** (no P0/P1 gaps, all controls verified):
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.compliance.passed '{"framework":"{soc2|hipaa|gdpr|pci}","checks_passed_count":{N},"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+**On fail** (any gap found):
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.compliance.failed '{"framework":"{soc2|hipaa|gdpr|pci}","gap_count":{N},"severity_max":"{critical|high|medium|low}","chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`chain_id` comes from session state — use `SessionState.active_chain_id` if available, else empty string. Substitute at emit time.
+
+**Payload rules**: Tier 1 + Tier 2 only — IDs, counts, severities, enums. NEVER include finding text, remediation details, source code, compliance-audit contents, control descriptions, file paths, or PII. Fail-open: the `|| true` keeps the agent running when the bus is unavailable.
+
 ## Quality Standards
 
 - Cite specific code locations

--- a/agents/platform/security-engineer.md
+++ b/agents/platform/security-engineer.md
@@ -284,7 +284,12 @@ TaskUpdate(
 
 ## Bus Events
 
-After completing a security review, emit findings to wicked-bus (skip silently if unavailable):
+**After writing each security finding** (one emit per finding), emit the event for cross-domain visibility:
+
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.security.finding_raised '{"severity":"{CRITICAL|HIGH|MEDIUM|LOW}","category":"{CWE category}","finding_count":{N}}' 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" wicked.security.finding_raised '{"severity":"{critical|high|medium|low}","category":"{owasp_top10|secrets|auth|dependency|config}","source_agent":"wicked-garden:platform:security-engineer","chain_id":"{chain_id}"}' 2>/dev/null || true
 ```
+
+`chain_id` comes from session state — use `SessionState.active_chain_id` if available, else empty string. Substitute at emit time.
+
+**Payload rules**: Tier 1 + Tier 2 only — IDs, counts, severities, enums. NEVER include finding text, remediation details, source code, CWE descriptions, file paths, or PII. Fail-open: the `|| true` keeps the agent running when the bus is unavailable.


### PR DESCRIPTION
## Summary

Wires three platform agent prompts to emit bus events at their natural decision points, following the jam precedent exactly (see `agents/jam/facilitator.md`, `agents/jam/council.md`). No Python code, consumers, or bus registration changes — the events already live in `scripts/_bus.py:BUS_EVENT_MAP`. This is purely prompt wiring so LLM-agents emit at the right workflow moments for cross-domain consumers (crew scoring, swarm detection, dashboards).

## Changes

- **`agents/platform/security-engineer.md:285-295`** — replaced the minimal Bus Events stanza with a full jam-style directive for `wicked.security.finding_raised`. Fires once per finding at the moment the agent writes it. Payload: `severity` (critical/high/medium/low), `category` (owasp_top10/secrets/auth/dependency/config), `source_agent`, `chain_id`.
- **`agents/platform/compliance-officer.md:250-266`** — added a new Bus Events section immediately after Task Integration. The natural pass/fail decision point is when the agent sets `Status` in the Output Format (COMPLIANT → `wicked.compliance.passed`; NEEDS ATTENTION/NON-COMPLIANT → `wicked.compliance.failed`). Payloads match the agreed schema: `framework`, `checks_passed_count`/`gap_count`, `severity_max`, `chain_id`.
- **`agents/platform/auditor.md:320-336`** — mirrors the two compliance emits at the audit-result point (Overall Status + Certification Readiness). READY → pass; NEEDS WORK/NOT READY → fail.

## Design notes

- **Fail-open**: every invocation ends in `|| true` — consumers may be offline, emits are advisory.
- **`chain_id` sourcing**: one-line note in each directive points the agent to `SessionState.active_chain_id`, falling back to empty string. The agent substitutes at emit time.
- **Payload discipline**: each block restates the Tier 1 + Tier 2 rule — IDs, counts, severities, enums only. Explicit NEVER list per agent (finding text, remediation details, source code, compliance-audit contents, control descriptions, file paths, PII).
- **Canonical emit point for auditor**: the auditor produces a layered report; the most canonical emit moment is when `Overall Status` is finalized in the Executive Summary (not at individual Controls Tested rows or per-gap). One emit per audit run.

## Scope boundaries (explicit non-changes)

- No changes to `scripts/_bus.py`
- No changes to `scripts/_bus_consumers.json`
- No new Python code
- No consumer wiring
- No restructuring of the three agent prompts — blocks are surgical 10-20 line additions at natural seams

## Test plan

- [ ] Verify all three events still resolve in `scripts/_bus.py:BUS_EVENT_MAP` (confirmed during implementation at lines 111-125).
- [ ] Run the security-engineer agent on a sample target and confirm it emits `wicked.security.finding_raised` once per finding with correct enum values.
- [ ] Run the compliance-officer agent in both pass and fail paths and confirm exactly one of the two events fires.
- [ ] Run the auditor agent end-to-end and confirm a single compliance event fires at the Overall Status decision.
- [ ] Confirm `|| true` keeps all three agents running cleanly when `_bus_emit.py` is absent or the bus is offline.

Closes #422

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>