### PR TITLE
release: v6.0.0-beta.3 — v6 reliability drop (closes #431, #432, #433, #434)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
-      "version": "6.0.0-beta.2"
+      "version": "6.0.0-beta.3"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0-beta.3",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
   "author": {
     "name": "Mike Parcewski"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [6.0.0-beta.3] - 2026-04-18
+
+**v6 reliability drop** — bundles #430 (shipped in beta.2.1 via #436) plus
+four reliability hardening items surfaced during the first live v6 dogfoods.
+Focus: the v6 happy path should work without surprise in a fresh install
+session.
+
+### Added
+
+- **Critical-skill smoke test (#434)** — `hooks/scripts/bootstrap.py` now
+  checks that `skills/crew/propose-process/SKILL.md` exists on disk at session
+  start. When present, emits a `[Skills]` briefing note telling Claude how to
+  handle "Unknown skill" errors (run `/reload-plugins`). When missing, flags
+  the plugin install as incomplete. Turns a cryptic class of errors into a
+  diagnostic path.
+- **Emission verifier (#432)** — new `scripts/crew/verify_chain_emission.py`
+  + Step 8.5 in `commands/crew/start.md`. After the task chain is emitted,
+  compares native task count (filtered by chain_id) against the plan's
+  `tasks[]`. Mismatches are surfaced with missing-title hints, not silently
+  ignored.
+- **Current-chain helper (#431)** — new `scripts/crew/current_chain.py` reads
+  native tasks by `metadata.chain_id`, summarizes counts by status, and
+  discovers evidence manifests under `phases/*/evidence/`. Wired into the
+  facilitator re-eval directive in `hooks/scripts/prompt_submit.py` so the
+  re-eval call has real data instead of prose "figure it out."
+
+### Changed
+
+- **Brain storage hardening (#433)** — `commands/crew/start.md` Step 10 now
+  retries once, writes a `.pending-brain-store.json` sentinel on failure, and
+  surfaces a WARNING to the user instead of failing silently. Added a new
+  Step 0.5 to `commands/crew/execute.md` that flushes the sentinel on the
+  next crew invocation when the brain becomes reachable.
+
+### Fixed
+
+- Diagnostic for the v6 plugin-cache-stale gotcha that bit the first two live
+  `crew:start` invocations. Not a registry query (hooks can't do that) — just
+  a filesystem check that turns silence into an actionable hint.
+
 ## [6.0.0-beta.2] - 2026-04-18
 
 **v6 cutover fixes** surfaced during the first live dogfood of `crew:start`

--- a/commands/crew/execute.md
+++ b/commands/crew/execute.md
@@ -24,6 +24,22 @@ for a in actions: print(f'[bus] {a}')
 
 If any actions are reported, briefly mention them to the user before proceeding.
 
+### 0.5 Flush Pending Brain-Store Sentinel (issue #433)
+
+If the current project directory contains `.pending-brain-store.json` (written by
+`crew:start` Step 10 when wicked-brain was unreachable), attempt to flush it now:
+
+1. Read and parse the sentinel JSON.
+2. Invoke `Skill(skill="wicked-brain:memory", args={"action": "store", ...})` with
+   the queued fields.
+3. On success: delete the sentinel, mention to the user
+   `[brain] Flushed queued crew:start decision for {slug}`.
+4. On failure: update `attempts` on the sentinel and leave it in place. Mention
+   `[brain] Sentinel flush attempt {N} failed — will retry next run`. Do NOT block
+   execute.
+
+Silently skip if the sentinel is absent. Fail-open on parse errors.
+
 ### 1. Load Project State
 
 Load current project state via phase_manager:

--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -196,6 +196,22 @@ Use **parallel TaskCreate calls** when the chain has multiple tasks with no
 inter-dependencies within a phase. `blockedBy` captures the DAG, so downstream
 tasks wait on upstream ones regardless of creation order.
 
+### 8.5 Verify Emission (issue #432)
+
+After all TaskCreate calls, verify that every plan task has a corresponding
+native task record:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verify_chain_emission.py" \
+  "${project_dir}/process-plan.json" "{slug}.root"
+```
+
+- **Exit 0**: all plan tasks emitted. Continue to Step 9.
+- **Exit 1**: count mismatch. The validator prints the delta + likely-missing
+  titles to stderr. Surface the output to the user, offer to re-emit the
+  missing tasks (you can pick the missing titles straight from the plan JSON),
+  and only advance to Step 9 after the counts match. Do NOT silently ignore.
+
 ### 9. Persist Plan Metadata on Project
 
 Store the facilitator-derived fields on the crew project record so `status` /
@@ -222,8 +238,28 @@ Skill(
 )
 ```
 
-Fail-open: if the brain is unavailable, skip silently. The plan file is the system
-of record; brain storage is an enhancement.
+**Failure handling (issue #433)** — brain storage is best-effort but not silent:
+
+1. If the skill call raises, retry ONCE (most brain failures are transient connection blips).
+2. If the retry also fails, write a sentinel at `${project_dir}/.pending-brain-store.json` with:
+   ```json
+   {
+     "title": "crew:start facilitator plan for {slug}",
+     "type": "decision",
+     "content": "<same content that was passed to the failed call>",
+     "tags": ["crew", "facilitator", "process-plan", "{slug}"],
+     "importance": 6,
+     "queued_at": "<ISO 8601 timestamp>",
+     "attempts": 2
+   }
+   ```
+   A later `/wicked-garden:crew:execute` (or any future crew command) should check
+   for this sentinel and flush it if the brain is now reachable.
+3. Surface a WARNING to the user — do NOT fail silently. Example:
+   > `[crew:start] wicked-brain unreachable after 2 attempts — plan decision queued at .pending-brain-store.json. Future sessions may produce divergent plans until this is flushed.`
+
+The plan file (`process-plan.md` + `process-plan.json`) remains the system of record;
+the sentinel is a recovery mechanism for the brain-as-prior-source path.
 
 ### 11. Report to User
 

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -623,6 +623,49 @@ def _probe_onedrive_path() -> str | None:
     return None
 
 
+# Critical v6 skills — if these files exist on disk under the plugin root
+# but a Skill() call fails with "Unknown skill", the plugin cache is stale
+# and needs `/reload-plugins`. Issue #434.
+_CRITICAL_V6_SKILLS = (
+    "skills/crew/propose-process/SKILL.md",
+)
+
+
+def _check_critical_skills() -> str | None:
+    """Verify critical v6 skill files are present in the plugin root.
+
+    Claude Code's skill registry is cached at plugin-install time. When the
+    plugin ships a new skill mid-version, the cache lags until the user runs
+    `/reload-plugins`. We can't query the live registry from a hook — but we
+    can check the files exist on disk and emit a diagnostic directive so an
+    "Unknown skill" error surfaces a fix path instead of being cryptic.
+
+    Returns a directive string (shown in the briefing) when any critical skill
+    is missing from disk, OR a 1-liner when all files are present that tells
+    Claude how to handle a cache-stale Skill() failure. Fails open on errors.
+    """
+    try:
+        plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        if not plugin_root:
+            return None
+        root = Path(plugin_root)
+        missing = [s for s in _CRITICAL_V6_SKILLS if not (root / s).exists()]
+        if missing:
+            return (
+                "[Skills] Critical v6 skill files are missing from the plugin root:\n"
+                + "\n".join(f"  - {s}" for s in missing)
+                + "\nThe plugin install is incomplete. Reinstall with "
+                "`claude plugin install wicked-garden --scope project`."
+            )
+        return (
+            "[Skills] Critical v6 skills are present on disk. "
+            "If Skill() returns 'Unknown skill: wicked-garden:crew:*', the plugin "
+            "cache is stale — run `/reload-plugins` once, then retry."
+        )
+    except Exception:
+        return None  # fail open — never block bootstrap
+
+
 def _suggest_commands_for_project() -> str | None:
     """Detect project type from files in cwd and suggest 2-3 relevant commands.
 
@@ -831,6 +874,11 @@ def main():
         dangerous_mode = _detect_dangerous_mode()
         if state is not None:
             state.update(dangerous_mode=dangerous_mode)
+
+        # 7c.1. Critical v6 skill smoke-test (issue #434)
+        skills_note = _check_critical_skills()
+        if skills_note:
+            mode_notes.append(skills_note)
 
         # 7d. Check wicked-brain dependency (required, not optional)
         brain_available, brain_note = _check_brain_dependency()

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -560,6 +560,31 @@ def _check_brain_gate(prompt: str) -> None:
         )
 
 
+def _assemble_current_chain(chain_id: str) -> dict | None:
+    """Invoke scripts/crew/current_chain.py to assemble re-eval context.
+
+    Returns the assembled dict (tasks + counts + evidence manifests) or None on
+    any failure. Used by the re-eval directive so Claude has real data to feed
+    into propose-process instead of being told to 'figure it out'. Issue #431.
+    """
+    try:
+        import subprocess
+        plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        if not plugin_root:
+            return None
+        script = Path(plugin_root) / "scripts" / "crew" / "current_chain.py"
+        if not script.exists():
+            return None
+        python_shim = Path(plugin_root) / "scripts" / "_python.sh"
+        cmd = ["sh", str(python_shim), str(script), chain_id]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=3)
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except Exception:
+        return None  # fail-open — directive still fires without the data
+
+
 def _consume_facilitator_reeval(state) -> str | None:
     """v6 Gate 3 (#428): emit facilitator re-eval directive if flag is set.
 
@@ -572,6 +597,10 @@ def _consume_facilitator_reeval(state) -> str | None:
     Hooks cannot run the skill themselves (stdlib-only); this function just
     surfaces the directive.
 
+    Issue #431: augments the directive with a structured ``current_chain`` dict
+    so the re-eval call has real data (task states, counts, evidence) rather
+    than prose "figure it out."
+
     Fail-open: returns None on any error.
     """
     if state is None:
@@ -583,12 +612,31 @@ def _consume_facilitator_reeval(state) -> str | None:
         # Clear flag BEFORE returning so a handler failure still produces a
         # single-shot emission — not an infinite loop.
         state.update(facilitator_reeval_due=False, facilitator_reeval_chain=None)
+
+        # Issue #431: assemble structured current_chain data for the re-eval.
+        chain_data = _assemble_current_chain(chain_id) if chain_id != "unknown" else None
+        chain_block = ""
+        if chain_data:
+            counts = chain_data.get("counts", {})
+            chain_block = (
+                "\n\nCurrent chain snapshot (feed into propose-process `current_chain` arg):\n"
+                f"- tasks: {counts.get('total', 0)} total "
+                f"({counts.get('completed', 0)} completed, "
+                f"{counts.get('in_progress', 0)} in_progress, "
+                f"{counts.get('pending', 0)} pending, "
+                f"{counts.get('blocked', 0)} blocked)\n"
+                f"- evidence manifests discovered: {len(chain_data.get('evidence_manifests', []))}\n"
+                f"- full data available via: `sh ${{CLAUDE_PLUGIN_ROOT}}/scripts/_python.sh "
+                f"${{CLAUDE_PLUGIN_ROOT}}/scripts/crew/current_chain.py {chain_id} --pretty`"
+            )
+
         return (
             f"[Facilitator re-evaluation due] Chain `{chain_id}` had a task completion — "
             f"before addressing the user's prompt, invoke "
             f"`wicked-garden:crew:propose-process` in re-evaluation mode on this chain. "
             f"Update the process-plan.md and emit any task mutations "
             f"(prune, augment, re-tier) as TaskUpdate/TaskCreate calls with reasoning."
+            f"{chain_block}"
         )
     except Exception:
         # Best-effort clear on error to avoid repeating directive in a tight loop

--- a/scripts/crew/current_chain.py
+++ b/scripts/crew/current_chain.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assemble the current_chain input for facilitator re-evaluation mode.
+
+Usage:
+    current_chain.py <chain-id> [--project-dir PATH] [--pretty]
+
+Reads native task JSON files under ${CLAUDE_CONFIG_DIR:-~/.claude}/tasks/,
+filters to those whose metadata.chain_id matches, and emits a structured dict
+suitable for passing as the ``current_chain`` input to the
+``wicked-garden:crew:propose-process`` skill in re-evaluate mode.
+
+Output shape:
+    {
+      "chain_id": "<chain>",
+      "tasks": [
+        {"id", "title", "status", "phase", "event_type",
+         "evidence_required", "blockedBy"}
+      ],
+      "counts": {"pending", "in_progress", "completed", "blocked", "total"},
+      "evidence_manifests": [<list of paths discovered under project_dir>]
+    }
+
+When --project-dir is provided, the script looks under ``phases/*/evidence/``
+and surfaces any manifest-like files (report.md, *.json, *.txt).
+
+Zero external dependencies — stdlib only. Safe to invoke from shell or a hook.
+
+Issue #431.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+_TERMINAL = {"completed", "blocked"}
+_EVIDENCE_HINTS = ("report.md", ".json", ".txt", "-results.", "manifest")
+
+
+def _tasks_dir() -> Path:
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR") or str(Path.home() / ".claude")
+    return Path(config_dir) / "tasks"
+
+
+def _collect_tasks(chain_id: str) -> list[dict]:
+    """Return task dicts whose metadata.chain_id matches."""
+    root = _tasks_dir()
+    if not root.exists():
+        return []
+    out = []
+    for task_file in root.rglob("*.json"):
+        try:
+            data = json.loads(task_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        meta = data.get("metadata") or {}
+        if meta.get("chain_id") != chain_id:
+            continue
+        out.append({
+            "id": data.get("id") or task_file.stem,
+            "title": data.get("subject") or data.get("title") or "<untitled>",
+            "status": data.get("status") or "unknown",
+            "phase": meta.get("phase"),
+            "event_type": meta.get("event_type"),
+            "evidence_required": meta.get("evidence_required") or [],
+            "blockedBy": data.get("blockedBy") or [],
+        })
+    return out
+
+
+def _count_by_status(tasks: list[dict]) -> dict:
+    counts = {"pending": 0, "in_progress": 0, "completed": 0, "blocked": 0, "total": len(tasks)}
+    for t in tasks:
+        status = t.get("status", "pending")
+        if status in counts:
+            counts[status] += 1
+    return counts
+
+
+def _discover_evidence(project_dir: Path) -> list[str]:
+    """List evidence-manifest-looking files under phases/*/evidence/."""
+    out = []
+    if not project_dir.exists():
+        return out
+    for phase_dir in (project_dir / "phases").glob("*"):
+        evidence_dir = phase_dir / "evidence"
+        if not evidence_dir.is_dir():
+            continue
+        for item in evidence_dir.rglob("*"):
+            if not item.is_file():
+                continue
+            name = item.name.lower()
+            if any(hint in name for hint in _EVIDENCE_HINTS):
+                out.append(str(item.relative_to(project_dir)))
+    return sorted(out)
+
+
+def assemble(chain_id: str, project_dir: Path | None = None) -> dict:
+    tasks = _collect_tasks(chain_id)
+    result = {
+        "chain_id": chain_id,
+        "tasks": tasks,
+        "counts": _count_by_status(tasks),
+        "evidence_manifests": [],
+    }
+    if project_dir is not None:
+        result["evidence_manifests"] = _discover_evidence(project_dir)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble current_chain data for re-eval.")
+    parser.add_argument("chain_id", help="Chain id to scan for (e.g. {slug}.root)")
+    parser.add_argument("--project-dir", help="Optional crew project dir for evidence discovery")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve() if args.project_dir else None
+    data = assemble(args.chain_id, project_dir)
+    indent = 2 if args.pretty else None
+    sys.stdout.write(json.dumps(data, indent=indent, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/crew/verify_chain_emission.py
+++ b/scripts/crew/verify_chain_emission.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Verify TaskCreate emission matched the facilitator plan's tasks[].
+
+Usage:
+    verify_chain_emission.py <path-to-plan.json> <chain-id>
+
+Scans native task JSON files under ${CLAUDE_CONFIG_DIR:-~/.claude}/tasks/ for
+tasks whose metadata.chain_id matches the given chain_id, then compares the
+count to the length of tasks[] in the plan file.
+
+Exit codes:
+    0 — counts match, all plan tasks have a native task
+    1 — mismatch (prints delta to stderr), or plan unreadable
+
+Zero external dependencies — stdlib only. Safe to run from a shell hook.
+
+Issue #432.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _tasks_dir() -> Path:
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR") or str(Path.home() / ".claude")
+    return Path(config_dir) / "tasks"
+
+
+def _count_tasks_with_chain(chain_id: str) -> tuple[int, list[str]]:
+    """Return (count, titles) of tasks whose metadata.chain_id matches."""
+    root = _tasks_dir()
+    if not root.exists():
+        return (0, [])
+    count = 0
+    titles = []
+    for task_file in root.rglob("*.json"):
+        try:
+            data = json.loads(task_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        meta = data.get("metadata") or {}
+        if meta.get("chain_id") == chain_id:
+            count += 1
+            titles.append(data.get("subject") or data.get("title") or "<untitled>")
+    return (count, titles)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify TaskCreate emission matches plan tasks[].")
+    parser.add_argument("plan_path", help="Path to process-plan.json")
+    parser.add_argument("chain_id", help="Expected chain_id (e.g. {slug}.root)")
+    args = parser.parse_args()
+
+    try:
+        plan = json.loads(Path(args.plan_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"ERROR: cannot read plan — {exc}\n")
+        sys.exit(1)
+
+    plan_tasks = plan.get("tasks") or []
+    expected = len(plan_tasks)
+
+    actual, actual_titles = _count_tasks_with_chain(args.chain_id)
+
+    if actual == expected:
+        sys.stdout.write(f"OK: {actual}/{expected} tasks emitted for chain {args.chain_id}\n")
+        sys.exit(0)
+
+    delta = expected - actual
+    sys.stderr.write(
+        f"MISMATCH: plan has {expected} tasks, {actual} emitted for chain {args.chain_id} "
+        f"(delta={delta:+d})\n"
+    )
+    plan_titles = [t.get("title", "<untitled>") for t in plan_tasks]
+    missing_titles = [t for t in plan_titles if t not in actual_titles]
+    if missing_titles:
+        sys.stderr.write("Likely missing:\n")
+        for title in missing_titles:
+            sys.stderr.write(f"  - {title}\n")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Bundles four v6 reliability hardening items surfaced during the first live v6 dogfoods. Goal: the happy path works without surprise in a fresh-install session.

## What ships

### #434 — Critical-skill smoke test (`hooks/scripts/bootstrap.py`)
Checks `skills/crew/propose-process/SKILL.md` exists on disk at session start. Emits a `[Skills]` briefing note telling Claude how to handle "Unknown skill" errors (run `/reload-plugins`). When missing, flags the plugin install as incomplete. Turns the cryptic class of errors that bit this session's first two `crew:start` runs into a diagnostic path.

### #432 — Emission verifier (`scripts/crew/verify_chain_emission.py` + Step 8.5)
After the task chain is emitted, compares native task count (filtered by `metadata.chain_id`) against the plan's `tasks[]`. Mismatches surface with missing-title hints. Not silent drops.

### #431 — Current-chain helper (`scripts/crew/current_chain.py`)
Reads native tasks by `metadata.chain_id`, summarizes counts by status, discovers evidence manifests under `phases/*/evidence/`. Wired into the facilitator re-eval directive in `prompt_submit.py` so the re-eval call has real data instead of prose "figure it out."

### #433 — Brain storage hardening (`commands/crew/start.md` Step 10 + `execute.md` Step 0.5)
Step 10 retries once, writes `.pending-brain-store.json` sentinel on failure, surfaces WARNING to user (not silent). Step 0.5 in execute flushes the sentinel when the brain becomes reachable again.

## Manifests

- `plugin.json` + `marketplace.json` → 6.0.0-beta.3
- `CHANGELOG.md` updated

## Test plan

- [x] `sh scripts/_python.sh scripts/crew/current_chain.py <chain> --pretty` → emits structured JSON
- [x] `sh scripts/_python.sh scripts/crew/verify_chain_emission.py <plan> <chain>` → exit 0 on match, exit 1 with delta on mismatch
- [x] Bootstrap `_check_critical_skills()` returns positive note when skill file present, flags install when missing
- [x] `prompt_submit.py` parses cleanly with new helper + wiring
- [ ] End-to-end dogfood: next `/wicked-garden:crew:start` run should show all four improvements in the wild
- [ ] Reviewer confirms no regressions to existing bootstrap/prompt_submit paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)