### PR TITLE
fix(skills): remove disable-model-invocation: false from 5 SKILL.md files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
-      "version": "6.0.0-beta.4"
+      "version": "6.0.0-beta.5"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-beta.5",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
   "author": {
     "name": "Mike Parcewski"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [6.0.0-beta.5] - 2026-04-18
+
+**Skill-registration fix.** Beta.4 shipped 5 SKILL.md files with
+`disable-model-invocation: false` in frontmatter. Empirically that key —
+at any value including `false` — suppresses model-invocability (Claude Code
+appears to treat presence-of-key as opt-out). Removed the line from:
+- `skills/crew/adopt-legacy/SKILL.md`
+- `skills/crew/propose-process/SKILL.md`
+- `skills/crew/workflow/SKILL.md`
+- `skills/qe/acceptance-testing/SKILL.md`
+- `skills/search/unified-search/SKILL.md`
+
+`skills/persona/SKILL.md` retains `disable-model-invocation: true` (intentional — user-only).
+
+After this release:
+- `Skill(skill="wicked-garden:crew:adopt-legacy")` becomes invokable
+- `Skill(skill="wicked-garden:crew:propose-process")` becomes invokable (was unknown throughout the v6 rebuild)
+- `context: fork` on the 3 edited skills can finally activate on Skill() dispatch
+- Total invocable skill count should go up by 5 post-reload
+
 ## [6.0.0-beta.4] - 2026-04-18
 
 **v6.0 autonomy mechanism + issue #332 partial** — shift-left phase-boundary

--- a/skills/crew/adopt-legacy/SKILL.md
+++ b/skills/crew/adopt-legacy/SKILL.md
@@ -10,7 +10,6 @@ description: |
   Use when: upgrading a project from wicked-garden v6.0-beta.3 to v6.0; checking
   whether a project needs migration; transforming legacy artifacts before running
   crew:approve on a beta project.
-disable-model-invocation: false
 allowed-tools:
   - Read
   - Write

--- a/skills/crew/propose-process/SKILL.md
+++ b/skills/crew/propose-process/SKILL.md
@@ -11,7 +11,6 @@ description: |
   initial task chain for `/wicked-garden:crew:start`, or invoked on `TaskCompleted` to
   prune / augment / re-tier the remaining chain. Also used by
   `/wicked-garden:crew:just-finish` (yolo mode) to drive autonomous completion.
-disable-model-invocation: false
 ---
 
 # Propose Process (Facilitator Rubric)

--- a/skills/crew/workflow/SKILL.md
+++ b/skills/crew/workflow/SKILL.md
@@ -8,7 +8,6 @@ description: |
   Use when: "crew phases", "phase plan", "workflow execution", "start a project",
   "clarify outcome", "design phase", "build phase", "approve phase", "crew workflow",
   "phase progression", "QE gate", "shift-left testing", or structured delivery guidance.
-disable-model-invocation: false
 context: fork
 ---
 

--- a/skills/qe/acceptance-testing/SKILL.md
+++ b/skills/qe/acceptance-testing/SKILL.md
@@ -7,7 +7,6 @@ description: |
 
   Use when: "run acceptance tests", "verify it works", "did it pass",
   "test this scenario", "acceptance criteria", "validate the feature"
-disable-model-invocation: false
 context: fork
 ---
 

--- a/skills/search/unified-search/SKILL.md
+++ b/skills/search/unified-search/SKILL.md
@@ -9,7 +9,6 @@ description: |
 
   Prefer this over raw Grep/Glob for symbol search, impact analysis,
   code-doc cross-references, and understanding codebase structure.
-disable-model-invocation: false
 context: fork
 ---
 


### PR DESCRIPTION
5 SKILL.md files set `disable-model-invocation: false` in frontmatter. Empirically that key at ANY value (including false) suppresses skill registration — Claude Code appears to treat presence-of-key as opt-out.

After removing the line from 5 files, the skills should finally register at their namespaced names (`wicked-garden:crew:adopt-legacy`, `wicked-garden:search:unified-search`, etc.) and `context: fork` can actually fire.

`persona/SKILL.md` retained `disable-model-invocation: true` (intentional user-only).

Tiny fix — 8 files, 22 insertions, 7 deletions.
