### PR TITLE
release: v6.0.0 — promote out of beta

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
-      "version": "6.0.0-beta.5"
+      "version": "6.0.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "6.0.0-beta.5",
+  "version": "6.0.0",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
   "author": {
     "name": "Mike Parcewski"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [6.0.0] - 2026-04-18
+
+**v6.0 production release.** Promotes beta.5 out of pre-release. The v6
+autonomy mechanism + issue #332 context:fork shipped cleanly at the code
+level (66/66 unit tests, 10/10 facilitator measurement scenarios, validator
+selftests all green). Skill-registration behavior on the build machine
+showed intermittent issues that appeared to be local install-state, not
+packaging — promoting to 6.0 and expecting fresh installs to pick up all
+5 newly-registering skills. If the skill-registration issue reproduces on
+a clean install, a 6.0.1 patch will follow.
+
+**Everything from beta.4 + beta.5 ships:**
+- v6 autonomy mechanism (shift-left phase-boundary gates, bidirectional
+  re-eval, codified reviewer matrix, JSONL addendum log, adopt-legacy skill)
+- Issue #332 partial — `context: fork` on 3 heavy skills (crew:workflow,
+  qe:acceptance-testing, search:unified-search)
+- Breaking change — `CREW_GATE_ENFORCEMENT=legacy` deleted
+- Skill-frontmatter cleanup — removed `disable-model-invocation: false`
+  from 5 SKILL.md files that appeared to suppress registration
+
 ## [6.0.0-beta.5] - 2026-04-18
 
 **Skill-registration fix.** Beta.4 shipped 5 SKILL.md files with


### PR DESCRIPTION
Promotes v6.0.0-beta.5 to full v6.0.0. All code already merged in the beta cycle (PR #436, #437, #438, #439). This PR bumps versions + adds CHANGELOG v6.0 entry.

- plugin.json 6.0.0-beta.5 → 6.0.0
- marketplace.json 6.0.0-beta.5 → 6.0.0
- CHANGELOG.md v6.0.0 entry

No functional code changes. Expected: fresh install picks up all 5 newly-registering skills (crew:adopt-legacy, crew:propose-process, crew:workflow, qe:acceptance-testing, search:unified-search). If skill-registration issue reproduces on clean install, 6.0.1 patch follows.