### PR TITLE
feat(skills): context: fork for heavy workflow skills (#332)

### DIFF
--- a/skills/acceptance-testing/SKILL.md
+++ b/skills/acceptance-testing/SKILL.md
@@ -8,6 +8,7 @@ description: |
   Use when: "run acceptance tests", "verify it works", "did it pass",
   "test this scenario", "acceptance criteria", "validate the feature"
 context: fork
+agent: test-designer
 ---
 
 # Acceptance Testing

--- a/skills/engineering/debugging/SKILL.md
+++ b/skills/engineering/debugging/SKILL.md
@@ -7,6 +7,8 @@ description: |
   Use when: "debug this error", "why is this failing", "root cause analysis",
   "fix this bug", "investigate crash", "stack trace", "not working"
 portability: portable
+context: fork
+agent: debugger
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: ["**/*.log", "**/error*.ts", "**/error*.py", "**/*debug*"]

--- a/skills/jam/SKILL.md
+++ b/skills/jam/SKILL.md
@@ -8,6 +8,7 @@ description: |
 
   Use when: "brainstorm this", "explore ideas", "get different perspectives",
   "focus group", "what do you think about", "pros and cons"
+context: fork
 ---
 
 # Brainstorming Skill


### PR DESCRIPTION
## Summary

Adds `context: fork` frontmatter to heavy-workflow skills so Claude Code launches them as subagents with their own context window, returning only final output to main. Also binds a verified agent where a matching specialist exists. Keeps quick skills (mem, status, help) inline.

Closes #332

## Changes (frontmatter only — no body edits)

| Skill | Change | Agent binding |
|---|---|---|
| `skills/acceptance-testing/SKILL.md` | already had `context: fork`; added `agent` | `test-designer` (closest real agent; `acceptance-test-executor` does not exist) |
| `skills/engineering/debugging/SKILL.md` | added `context: fork` + `agent` | `debugger` (verified in `agents/engineering/debugger.md`) |
| `skills/jam/SKILL.md` | added `context: fork` | none (per issue — jam uses its own council orchestration) |

## Skills listed in issue but missing on disk

The issue's table uses command-style names (`crew:execute`, `qe:acceptance`, etc.) that don't all map to existing SKILL.md files. Per issue instructions ("Do not add `context: fork` to a skill that doesn't exist on disk. Report missing ones instead"), the following were NOT modified because no matching skill file exists:

- `crew:execute` — no `skills/crew/execute/SKILL.md`. The `/wicked-garden:crew:execute` command exists, but it dispatches crew agents; no dedicated skill. The existing `skills/workflow/SKILL.md` (crew phase engine) already has `context: fork`.
- `crew:just-finish` — no matching SKILL.md. The autonomy logic lives in `skills/crew/adaptive/SKILL.md` (which is smaller/advisory — leaving inline).
- `qe:acceptance` — mapped to `skills/acceptance-testing/SKILL.md` (top-level, single-skill domain).
- `qe:automate` — no `skills/qe/automate/SKILL.md`. The `test-automation-engineer` agent exists but there's no corresponding skill file to modify.
- `search:index` — no matching skill file.
- `search:quality` — no matching skill file.
- `engineering:debug` — mapped to `skills/engineering/debugging/SKILL.md`.
- `jam:brainstorm` — mapped to `skills/jam/SKILL.md` (single-skill domain, skill name is `brainstorming`).

## Judgment calls

- **`qe:acceptance` → `test-designer`**: issue suggested `acceptance-test-executor` or `test-designer`. Only `test-designer` exists in `agents/qe/`, so bound that.
- **`jam` no binding**: issue said "none — default". The jam skill internally dispatches `agents/jam/facilitator.md` and `agents/jam/council.md` across multiple personas, so a single binding would be wrong. Omitted `agent:`.
- **Skills already forked** (`skills/workflow`, `skills/unified-search`, `skills/acceptance-testing`): verified — this PR only extends the pattern.

## Validation

```
python3 -c "import yaml,pathlib; [yaml.safe_load(open(p).read().split('---')[1]) for p in pathlib.Path('skills').rglob('SKILL.md')]"
```

All 88 SKILL.md frontmatter blocks parse as valid YAML. The three modified frontmatter blocks were double-checked.

## Test plan

- [ ] Confirm `context: fork` is recognized by Claude Code skill loader (no warnings in `/wg-check`)
- [ ] Invoke `/wicked-garden:engineering:debug` and verify it launches as a subagent with `debugger` binding
- [ ] Invoke `/wicked-garden:jam:brainstorm` and confirm fork behavior; council/facilitator personas still dispatch correctly
- [ ] Invoke `/wicked-garden:qe:acceptance` and confirm fork + test-designer binding is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)