### PR TITLE
feat(delivery): persistent process memory + kaizen backlog

### DIFF
--- a/.claude-plugin/gate-policy.json
+++ b/.claude-plugin/gate-policy.json
@@ -155,6 +155,24 @@
         "mode": "parallel",
         "fallback": "senior-engineer"
       }
+    },
+    "uncertainty-gate": {
+      "description": "Blocks addition of new process gates/reviews unless special-cause drift is detected OR the author explicitly flags epistemic uncertainty. Added by issue #447 to prevent reactive over-process on common-cause variation. Evaluated via scripts/delivery/process_memory.py::evaluate_uncertainty_gate. Fails open when scripts/delivery/drift is not importable.",
+      "minimal": {
+        "reviewers": [],
+        "mode": "self-check",
+        "fallback": "facilitator"
+      },
+      "standard": {
+        "reviewers": ["facilitator"],
+        "mode": "sequential",
+        "fallback": "senior-engineer"
+      },
+      "full": {
+        "reviewers": ["facilitator", "risk-assessor"],
+        "mode": "parallel",
+        "fallback": "senior-engineer"
+      }
     }
   }
 }

--- a/commands/delivery/process-health.md
+++ b/commands/delivery/process-health.md
@@ -1,0 +1,64 @@
+---
+description: Surface process memory — kaizen status, unresolved action items, aging alerts
+argument-hint: "[--project name] [--format text|json|both]"
+---
+
+# /wicked-garden:delivery:process-health
+
+Render the persistent process memory for a crew project — kaizen backlog status, unresolved retrospective action items, and aging alerts for items unresolved across two or more sessions. Backs issue #447.
+
+## Arguments
+
+- `--project` (optional): Project name. Defaults to the active crew project.
+- `--format` (optional): `text` (default), `json`, or `both` (json to stderr + text to stdout).
+
+## Instructions
+
+### 1. Resolve the target project
+
+If `--project` is supplied, use it. Otherwise find the active crew project:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json
+```
+
+If neither resolves to a name, abort with an informative message — this command only operates inside a crew project.
+
+### 2. Render the report
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/delivery/process_health.py --project "{project}" --format text
+```
+
+Forward the output verbatim. The report contains:
+
+- Narrative block (if the facilitator has recorded one)
+- Kaizen backlog totals and by-status breakdown
+- Action-item totals and by-status breakdown
+- Aging alerts table (items unresolved for ≥ 2 sessions)
+- Recent gate-pass-rate samples
+- Path to the `process-memory.md` companion artifact
+
+### 3. Suggest follow-up actions
+
+Based on the report, point the user at the right next move:
+
+- Any aging alerts → suggest `/wicked-garden:crew:retro` or direct resolution via the CLI.
+- Kaizen items in `proposed` status older than a week → suggest adopting or rejecting.
+- Empty memory (no kaizen, no action items, no pass-rate samples) → suggest running a retro first.
+
+## Examples
+
+```bash
+# Show process health for the active project
+/wicked-garden:delivery:process-health
+
+# Named project, JSON format
+/wicked-garden:delivery:process-health --project my-feature --format json
+```
+
+## Related
+
+- `/wicked-garden:crew:retro` writes retro findings into the process memory.
+- `/wicked-garden:delivery:setup` configures thresholds this command surfaces.
+- Uncertainty gate is evaluated via `scripts/delivery/process_memory.py uncertainty-gate` when a specialist proposes adding a new process gate.

--- a/scripts/delivery/__init__.py
+++ b/scripts/delivery/__init__.py
@@ -1,0 +1,1 @@
+"""wicked-garden:delivery domain scripts."""

--- a/scripts/delivery/process_health.py
+++ b/scripts/delivery/process_health.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""process_health.py — render the /wicked-garden:delivery:process-health surface.
+
+Collects the facilitator-context dict from ``process_memory`` plus a few
+extra summary rollups (kaizen by status, aging alerts) and prints a
+human-readable report, JSON, or both.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from delivery import process_memory as pm
+
+
+def _rollup(memory: dict) -> dict:
+    """Summarize kaizen + AIs for display."""
+    kaizen = memory.get("kaizen") or []
+    ais = memory.get("action_items") or []
+
+    kaizen_by_status: dict[str, int] = {}
+    for item in kaizen:
+        status = item.get("status") or "unknown"
+        kaizen_by_status[status] = kaizen_by_status.get(status, 0) + 1
+
+    ais_by_status: dict[str, int] = {}
+    for ai in ais:
+        status = ai.get("status") or "unknown"
+        ais_by_status[status] = ais_by_status.get(status, 0) + 1
+
+    aging = [
+        ai
+        for ai in ais
+        if ai.get("status") in ("open", "in-progress")
+        and int(ai.get("age_sessions", 1)) >= pm.AGING_SESSION_THRESHOLD
+    ]
+
+    return {
+        "kaizen_total": len(kaizen),
+        "kaizen_by_status": kaizen_by_status,
+        "action_items_total": len(ais),
+        "action_items_by_status": ais_by_status,
+        "aging_count": len(aging),
+        "aging_items": aging,
+    }
+
+
+def render_report(project: str, memory: dict, rollup: dict) -> str:
+    """Return a human-readable report body."""
+    lines: list[str] = []
+    lines.append(f"# Process Health — {project}")
+    lines.append("")
+    narrative = (memory.get("narrative") or "").strip()
+    if narrative:
+        lines.append("## Narrative")
+        lines.append("")
+        lines.append(narrative)
+        lines.append("")
+
+    lines.append("## Kaizen Backlog")
+    lines.append("")
+    lines.append(f"- Total items: **{rollup['kaizen_total']}**")
+    if rollup["kaizen_by_status"]:
+        status_parts = [
+            f"{status}={count}"
+            for status, count in sorted(rollup["kaizen_by_status"].items())
+        ]
+        lines.append(f"- By status: {', '.join(status_parts)}")
+    lines.append("")
+
+    lines.append("## Action Items")
+    lines.append("")
+    lines.append(f"- Total: **{rollup['action_items_total']}**")
+    if rollup["action_items_by_status"]:
+        status_parts = [
+            f"{status}={count}"
+            for status, count in sorted(rollup["action_items_by_status"].items())
+        ]
+        lines.append(f"- By status: {', '.join(status_parts)}")
+    lines.append("")
+
+    if rollup["aging_count"]:
+        lines.append(
+            f"## Aging Alerts (>= {pm.AGING_SESSION_THRESHOLD} sessions)"
+        )
+        lines.append("")
+        lines.append("| ID | Title | Owner | Age | Status |")
+        lines.append("|----|-------|-------|-----|--------|")
+        for ai in rollup["aging_items"]:
+            lines.append(
+                f"| {ai.get('id', '')} | {ai.get('title', '')} "
+                f"| {ai.get('owner') or '—'} | {ai.get('age_sessions', 1)} "
+                f"| {ai.get('status', '')} |"
+            )
+        lines.append("")
+    else:
+        lines.append("## Aging Alerts")
+        lines.append("")
+        lines.append("_No action items have aged beyond threshold._")
+        lines.append("")
+
+    timeline = memory.get("pass_rate_timeline") or []
+    if timeline:
+        lines.append("## Recent Gate Pass-Rate")
+        lines.append("")
+        for sample in timeline[-5:]:
+            lines.append(
+                f"- {sample.get('recorded_at', '')}: "
+                f"{sample.get('pass_rate', 0.0):.2f} "
+                f"(session {sample.get('session_id') or '—'})"
+            )
+        lines.append("")
+
+    lines.append("## Markdown artifact")
+    lines.append("")
+    lines.append(f"- `{pm._memory_md_path(project)}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render process-health summary for a crew project."
+    )
+    parser.add_argument("--project", required=True)
+    parser.add_argument(
+        "--format",
+        default="text",
+        choices=("text", "json", "both"),
+        help="Output format. 'both' prints JSON to stderr and text to stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    memory = pm.load_memory(args.project)
+    rollup = _rollup(memory)
+    context = pm.facilitator_context(args.project)
+    # Merge rollup into context for JSON consumers.
+    payload = {
+        "project": args.project,
+        "context": context,
+        "rollup": rollup,
+    }
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    report = render_report(args.project, memory, rollup)
+    if args.format == "both":
+        sys.stderr.write(json.dumps(payload, indent=2) + "\n")
+    sys.stdout.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/delivery/process_memory.py
+++ b/scripts/delivery/process_memory.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""process_memory.py — persistent process memory + kaizen backlog (issue #447).
+
+Purpose
+-------
+Process observations and improvement hypotheses evaporate between sessions.
+This module gives every crew project three durable surfaces that survive
+across sessions:
+
+1. ``process-memory.md`` — a living narrative the facilitator reads at every
+   session start (first-class context, not recall-on-demand). Stored in the
+   crew project directory.
+2. **Kaizen backlog** — hypothesis-driven process-improvement items with
+   structured IDs, waste types, uncertainty classification, and status
+   lifecycle (``proposed`` / ``trialing`` / ``adopted`` / ``rejected``).
+3. **Action-item tracking** — retrospective action items get stable ``AI-NNN``
+   IDs and are tracked across sessions; unresolved items ≥2 sessions old
+   surface automatically at planning time.
+
+All three surfaces live in a single JSON file per project so that the
+facilitator can load them with one read:
+
+    <project-dir>/process-memory.json
+
+Additionally a human-readable ``process-memory.md`` companion is rendered on
+every write so users and agents can browse without JSON parsing.
+
+Uncertainty gate
+----------------
+``evaluate_uncertainty_gate()`` is the guardrail that prevents the team from
+bolting on new process gates in response to common-cause variation. Any
+proposed new gate must pass one of:
+
+- The underlying drift is *actionable* (special-cause signal from
+  ``scripts/delivery/drift.classify``), OR
+- The author explicitly flags the uncertainty as ``epistemic`` (we don't
+  know enough) rather than ``aleatoric`` (irreducible variation).
+
+If ``scripts/delivery/drift`` isn't importable yet (PR #452 not merged), the
+gate fails open — we do not block work because a sibling PR hasn't landed.
+The fail-open branch is logged to stderr so reviewers know why the gate
+behaved permissively.
+
+Stdlib-only. No external dependencies. Safe to import from hook scripts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+# Resolve crew project directory helper without creating a circular dep on
+# phase_manager.py (which loads DomainStore, logging config, etc.).
+_SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+try:
+    from _domain_store import get_local_path  # type: ignore
+except Exception:  # pragma: no cover — fallback only triggers in broken envs
+    def get_local_path(domain: str, *subpath: str) -> Path:  # type: ignore[misc]
+        root = Path.home() / ".something-wicked" / "wicked-garden" / "local" / domain
+        for part in subpath:
+            root = root / part
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Lean Muda-derived waste taxonomy — kaizen items are classified by which
+# type of process waste they aim to remove. Using the canonical 8-waste list
+# makes retro observations easier to cluster over time.
+WASTE_TYPES: tuple[str, ...] = (
+    "defects",          # rework, bugs escaping review
+    "overproduction",   # features nobody asked for, extra gates
+    "waiting",          # blocked on review, handoff, toolchain
+    "non-utilized-talent",  # specialists idle or misapplied
+    "transportation",   # excessive context handoff between agents
+    "inventory",        # WIP piling up in one phase
+    "motion",           # switching tools / rereading the same docs
+    "overprocessing",   # rigor above what the work warrants
+)
+
+# Uncertainty classification — borrowed from decision-theory literature.
+# The distinction matters because adding process is only useful against
+# *epistemic* uncertainty (we can learn our way out). Adding process
+# against *aleatoric* uncertainty just adds overhead without removing risk.
+UNCERTAINTY_TYPES: tuple[str, ...] = ("epistemic", "aleatoric")
+
+# Kaizen lifecycle.
+KAIZEN_STATUSES: tuple[str, ...] = ("proposed", "trialing", "adopted", "rejected")
+
+# Action-item lifecycle.
+AI_STATUSES: tuple[str, ...] = ("open", "in-progress", "resolved", "cancelled")
+
+# Aging threshold — action items unresolved for 2+ sessions surface at
+# planning. This is a deliberate choice: 1 session might just be the current
+# work cycle; 2+ means the item is sticking.
+AGING_SESSION_THRESHOLD = 2
+
+# Process-memory JSON + markdown filenames (sit inside the crew project dir).
+MEMORY_JSON_FILENAME = "process-memory.json"
+MEMORY_MD_FILENAME = "process-memory.md"
+
+# Regex for safe project slugs (mirrors phase_manager.is_safe_project_name).
+_SAFE_PROJECT_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KaizenItem:
+    """A hypothesis-driven process-improvement item.
+
+    Fields:
+        id:              ``KZN-NNN`` stable identifier (assigned on creation).
+        title:           One-line summary of the improvement hypothesis.
+        hypothesis:      If-we-do-X-then-Y framing; the thing we'd test.
+        waste_type:      Which Lean waste this aims to reduce.
+        impact:          Rough impact rating (``low`` / ``medium`` / ``high``).
+        effort:          Rough effort rating (``low`` / ``medium`` / ``high``).
+        uncertainty:     ``epistemic`` or ``aleatoric``.
+        status:          See ``KAIZEN_STATUSES``.
+        source_session:  Session ID where this item was first proposed.
+        evidence:        Free-text pointer to the retro / incident that
+                         motivated the idea.
+        decision_notes:  Populated when the uncertainty gate runs.
+        created_at:      ISO timestamp.
+        updated_at:      ISO timestamp.
+    """
+
+    id: str
+    title: str
+    hypothesis: str
+    waste_type: str
+    impact: str = "medium"
+    effort: str = "medium"
+    uncertainty: str = "epistemic"
+    status: str = "proposed"
+    source_session: str = ""
+    evidence: str = ""
+    decision_notes: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class ActionItem:
+    """A retrospective action item that needs tracking across sessions.
+
+    Fields:
+        id:              ``AI-NNN`` stable identifier (assigned on creation).
+        title:           One-line summary.
+        description:     Detail — why this item exists.
+        owner:           Agent or specialist role expected to drive it.
+        status:          See ``AI_STATUSES``.
+        source_session:  Session where the AI originated.
+        last_seen_session:  Session where the AI was last surfaced/updated.
+        age_sessions:    Count of distinct sessions since creation.
+        related_kaizen:  Optional KZN-id link.
+        created_at:      ISO timestamp.
+        updated_at:      ISO timestamp.
+        resolved_at:     ISO timestamp (populated on resolution).
+    """
+
+    id: str
+    title: str
+    description: str = ""
+    owner: str = ""
+    status: str = "open"
+    source_session: str = ""
+    last_seen_session: str = ""
+    age_sessions: int = 1
+    related_kaizen: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+    resolved_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _is_safe_project_name(name: str) -> bool:
+    return bool(name) and bool(_SAFE_PROJECT_RE.match(name))
+
+
+def _project_dir(project: str) -> Path:
+    """Resolve the crew project directory with path-traversal protection.
+
+    Mirrors phase_manager.get_project_dir but avoids importing it (phase
+    manager pulls in DomainStore + logging; this module stays lean so hook
+    scripts can import it).
+    """
+    if not _is_safe_project_name(project):
+        raise ValueError(
+            f"Invalid project name: {project!r}. Must be alphanumeric, "
+            "hyphens, or underscores (max 64 chars)."
+        )
+    base = get_local_path("wicked-crew", "projects")
+    project_dir = (base / project).resolve()
+    # Defense-in-depth: reject any path that escapes the projects root.
+    try:
+        project_dir.relative_to(Path(base).resolve())
+    except ValueError as exc:
+        raise ValueError(f"Invalid project path (traversal blocked): {exc}")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    return project_dir
+
+
+def _memory_json_path(project: str) -> Path:
+    return _project_dir(project) / MEMORY_JSON_FILENAME
+
+
+def _memory_md_path(project: str) -> Path:
+    return _project_dir(project) / MEMORY_MD_FILENAME
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write atomically: temp file + os.replace."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _empty_memory(project: str) -> dict:
+    return {
+        "schema_version": "1.0",
+        "project": project,
+        "created_at": _utc_now(),
+        "updated_at": _utc_now(),
+        # Free-text narrative the facilitator writes at session-end retros.
+        "narrative": "",
+        # Session-pass-rate timeline — newest entry last. Consumed by drift
+        # classifier when the uncertainty gate runs.
+        "pass_rate_timeline": [],
+        # Counters for ID assignment; never reused.
+        "next_kaizen_seq": 1,
+        "next_ai_seq": 1,
+        "kaizen": [],
+        "action_items": [],
+    }
+
+
+def load_memory(project: str) -> dict:
+    """Load the project's process memory, creating an empty shell if absent.
+
+    The shell contains the full schema with empty lists so downstream code
+    doesn't need None-checks. This is the single read point the facilitator
+    uses at session start.
+    """
+    path = _memory_json_path(project)
+    if not path.exists():
+        return _empty_memory(project)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # Corrupted file — don't crash. Treat as empty; a subsequent save()
+        # will overwrite it atomically.
+        print(
+            f"[process_memory] corrupted {path}, re-initializing",
+            file=sys.stderr,
+        )
+        return _empty_memory(project)
+    # Backfill missing fields so older files remain compatible.
+    for key, default in _empty_memory(project).items():
+        data.setdefault(key, default)
+    return data
+
+
+def save_memory(project: str, memory: dict) -> None:
+    """Persist the memory dict + render the markdown companion."""
+    memory["updated_at"] = _utc_now()
+    _atomic_write(
+        _memory_json_path(project),
+        json.dumps(memory, indent=2, sort_keys=False),
+    )
+    _atomic_write(_memory_md_path(project), render_markdown(memory))
+
+
+# ---------------------------------------------------------------------------
+# Kaizen CRUD
+# ---------------------------------------------------------------------------
+
+
+def _next_kaizen_id(memory: dict) -> str:
+    seq = int(memory.get("next_kaizen_seq", 1))
+    memory["next_kaizen_seq"] = seq + 1
+    return f"KZN-{seq:03d}"
+
+
+def add_kaizen(
+    project: str,
+    *,
+    title: str,
+    hypothesis: str,
+    waste_type: str,
+    impact: str = "medium",
+    effort: str = "medium",
+    uncertainty: str = "epistemic",
+    source_session: str = "",
+    evidence: str = "",
+) -> dict:
+    """Append a kaizen item and return it.
+
+    Validates taxonomies before writing so the backlog stays clean.
+    """
+    if waste_type not in WASTE_TYPES:
+        raise ValueError(
+            f"waste_type {waste_type!r} not in {WASTE_TYPES}"
+        )
+    if uncertainty not in UNCERTAINTY_TYPES:
+        raise ValueError(
+            f"uncertainty {uncertainty!r} not in {UNCERTAINTY_TYPES}"
+        )
+    memory = load_memory(project)
+    now = _utc_now()
+    item = KaizenItem(
+        id=_next_kaizen_id(memory),
+        title=title,
+        hypothesis=hypothesis,
+        waste_type=waste_type,
+        impact=impact,
+        effort=effort,
+        uncertainty=uncertainty,
+        status="proposed",
+        source_session=source_session,
+        evidence=evidence,
+        created_at=now,
+        updated_at=now,
+    )
+    memory["kaizen"].append(asdict(item))
+    save_memory(project, memory)
+    return asdict(item)
+
+
+def update_kaizen(project: str, kaizen_id: str, **fields: Any) -> dict | None:
+    """Update mutable fields on a kaizen item. Returns the updated item or None."""
+    memory = load_memory(project)
+    for item in memory["kaizen"]:
+        if item["id"] == kaizen_id:
+            # Guard lifecycle transitions — block unknown statuses.
+            if "status" in fields and fields["status"] not in KAIZEN_STATUSES:
+                raise ValueError(
+                    f"status {fields['status']!r} not in {KAIZEN_STATUSES}"
+                )
+            if "waste_type" in fields and fields["waste_type"] not in WASTE_TYPES:
+                raise ValueError(f"waste_type {fields['waste_type']!r} invalid")
+            if "uncertainty" in fields and fields["uncertainty"] not in UNCERTAINTY_TYPES:
+                raise ValueError(f"uncertainty {fields['uncertainty']!r} invalid")
+            item.update(fields)
+            item["updated_at"] = _utc_now()
+            save_memory(project, memory)
+            return dict(item)
+    return None
+
+
+def list_kaizen(project: str, *, status: str | None = None) -> list[dict]:
+    """List kaizen items, optionally filtered by status."""
+    memory = load_memory(project)
+    items = memory["kaizen"]
+    if status is not None:
+        items = [i for i in items if i.get("status") == status]
+    return list(items)
+
+
+# ---------------------------------------------------------------------------
+# Action-item CRUD + aging
+# ---------------------------------------------------------------------------
+
+
+def _next_ai_id(memory: dict) -> str:
+    seq = int(memory.get("next_ai_seq", 1))
+    memory["next_ai_seq"] = seq + 1
+    return f"AI-{seq:03d}"
+
+
+def add_action_item(
+    project: str,
+    *,
+    title: str,
+    description: str = "",
+    owner: str = "",
+    source_session: str = "",
+    related_kaizen: str = "",
+) -> dict:
+    """Create a tracked retrospective action item."""
+    memory = load_memory(project)
+    now = _utc_now()
+    ai = ActionItem(
+        id=_next_ai_id(memory),
+        title=title,
+        description=description,
+        owner=owner,
+        status="open",
+        source_session=source_session,
+        last_seen_session=source_session,
+        age_sessions=1,
+        related_kaizen=related_kaizen,
+        created_at=now,
+        updated_at=now,
+    )
+    memory["action_items"].append(asdict(ai))
+    save_memory(project, memory)
+    return asdict(ai)
+
+
+def touch_action_item(project: str, ai_id: str, session_id: str) -> dict | None:
+    """Record that an AI was surfaced in ``session_id``.
+
+    Increments ``age_sessions`` only when the session differs from the last
+    one we saw — we count *distinct* sessions, not hook invocations.
+    """
+    memory = load_memory(project)
+    for ai in memory["action_items"]:
+        if ai["id"] == ai_id:
+            if session_id and session_id != ai.get("last_seen_session"):
+                ai["age_sessions"] = int(ai.get("age_sessions", 1)) + 1
+                ai["last_seen_session"] = session_id
+            ai["updated_at"] = _utc_now()
+            save_memory(project, memory)
+            return dict(ai)
+    return None
+
+
+def resolve_action_item(
+    project: str, ai_id: str, *, status: str = "resolved"
+) -> dict | None:
+    """Mark an AI resolved (or cancelled). Sets resolved_at."""
+    if status not in AI_STATUSES:
+        raise ValueError(f"status {status!r} not in {AI_STATUSES}")
+    memory = load_memory(project)
+    for ai in memory["action_items"]:
+        if ai["id"] == ai_id:
+            ai["status"] = status
+            ai["updated_at"] = _utc_now()
+            if status in ("resolved", "cancelled"):
+                ai["resolved_at"] = _utc_now()
+            save_memory(project, memory)
+            return dict(ai)
+    return None
+
+
+def list_action_items(
+    project: str, *, status: str | None = None
+) -> list[dict]:
+    """List action items, optionally filtered by status."""
+    memory = load_memory(project)
+    items = memory["action_items"]
+    if status is not None:
+        items = [i for i in items if i.get("status") == status]
+    return list(items)
+
+
+def aging_action_items(
+    project: str, *, threshold: int = AGING_SESSION_THRESHOLD
+) -> list[dict]:
+    """Return open/in-progress AIs whose age meets or exceeds the threshold.
+
+    This is the call the facilitator makes at session start to surface
+    items that are sticking across multiple sessions.
+    """
+    memory = load_memory(project)
+    return [
+        ai
+        for ai in memory["action_items"]
+        if ai.get("status") in ("open", "in-progress")
+        and int(ai.get("age_sessions", 1)) >= threshold
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pass-rate timeline
+# ---------------------------------------------------------------------------
+
+
+def record_pass_rate(
+    project: str, pass_rate: float, *, session_id: str = ""
+) -> dict:
+    """Append a gate-pass-rate sample to the timeline.
+
+    The timeline feeds ``drift.classify`` when the uncertainty gate runs.
+    Keep the list bounded (newest 50) to avoid unbounded growth.
+    """
+    if not (0.0 <= pass_rate <= 1.0):
+        raise ValueError(f"pass_rate must be in [0, 1], got {pass_rate}")
+    memory = load_memory(project)
+    entry = {
+        "session_id": session_id,
+        "pass_rate": float(pass_rate),
+        "recorded_at": _utc_now(),
+    }
+    memory["pass_rate_timeline"].append(entry)
+    # Bound the timeline — 50 samples is plenty for drift classification.
+    memory["pass_rate_timeline"] = memory["pass_rate_timeline"][-50:]
+    save_memory(project, memory)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty gate
+# ---------------------------------------------------------------------------
+
+
+def _classify_drift(timeline: list[float]) -> dict | None:
+    """Call scripts.delivery.drift.classify if importable; else return None.
+
+    This is the fail-open path documented in the PR. The drift module
+    lives in PR #452 (sibling). Until that merges, we skip the drift
+    check entirely and let the uncertainty flag carry the decision.
+
+    NOTE: The drift module is an expected dependency from PR #452.
+    Until it merges, this helper fails open.
+    """
+    try:
+        # Import lazily — the module may not exist yet in this branch.
+        from delivery import drift as _drift  # type: ignore
+    except Exception:
+        # Surface once, via stderr, so reviewers see the fail-open decision.
+        print(
+            "[process_memory] delivery.drift not importable — "
+            "fail-open on drift classification (PR #452 pending)",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        return _drift.classify(list(timeline))
+    except Exception as exc:  # pragma: no cover — drift shouldn't raise
+        print(
+            f"[process_memory] drift.classify raised {exc!r}; fail-open",
+            file=sys.stderr,
+        )
+        return None
+
+
+def evaluate_uncertainty_gate(
+    project: str,
+    *,
+    proposed_gate_name: str,
+    uncertainty: str = "aleatoric",
+    timeline: list[float] | None = None,
+    session_id: str = "",
+) -> dict:
+    """Decide whether a proposed new process-gate should be allowed.
+
+    A proposed new gate passes when either:
+
+    - ``drift.classify(timeline)["is_actionable"]`` is True (special-cause
+      or >=15% drop — a real signal that warrants more process), OR
+    - ``uncertainty`` is ``"epistemic"`` — the author has explicitly
+      acknowledged that the team is not confident in the cause and needs
+      more process to learn.
+
+    Both conditions are false only when the author is asking for more
+    process to contain aleatoric (irreducible) variation without any
+    special-cause signal. That's the case this gate is meant to block,
+    because more process against aleatoric noise just creates overhead.
+
+    Returns a decision dict that is ALSO recorded as a new kaizen item
+    (``status="proposed"``) so the audit trail is durable.
+
+    Fail-open semantics
+    -------------------
+    If ``drift.classify`` is not importable (PR #452 not merged), the
+    gate treats the drift check as inconclusive and uses only the
+    uncertainty flag. The decision payload notes ``drift_available=False``
+    so downstream reviewers can see why the gate behaved permissively.
+    """
+    if uncertainty not in UNCERTAINTY_TYPES:
+        raise ValueError(f"uncertainty {uncertainty!r} not in {UNCERTAINTY_TYPES}")
+
+    memory = load_memory(project)
+    if timeline is None:
+        timeline = [
+            float(s.get("pass_rate", 0.0))
+            for s in memory.get("pass_rate_timeline", [])
+        ]
+
+    drift_result = _classify_drift(timeline) if timeline else None
+    drift_available = drift_result is not None
+    is_actionable = bool(drift_result.get("is_actionable")) if drift_result else False
+    drift_zone = drift_result.get("zone") if drift_result else "unknown"
+
+    # Decision: pass if EITHER actionable drift OR explicit epistemic flag.
+    passed = is_actionable or uncertainty == "epistemic"
+
+    if passed:
+        if is_actionable:
+            reason = (
+                f"drift classifier flagged {drift_zone!r} zone as actionable — "
+                "adding process is warranted by special-cause signal."
+            )
+        else:
+            reason = (
+                "author flagged uncertainty as epistemic — more process is a "
+                "legitimate learning instrument."
+            )
+    else:
+        reason = (
+            "no special-cause drift detected and uncertainty is aleatoric — "
+            "adding a new gate would add overhead without addressing root cause. "
+            "Consider common-cause remediation (coaching, tooling) instead."
+        )
+
+    decision = {
+        "proposed_gate_name": proposed_gate_name,
+        "passed": passed,
+        "reason": reason,
+        "uncertainty": uncertainty,
+        "drift_available": drift_available,
+        "drift_zone": drift_zone,
+        "drift_is_actionable": is_actionable,
+        "timeline_length": len(timeline),
+        "session_id": session_id,
+        "evaluated_at": _utc_now(),
+    }
+
+    # Record the decision as a kaizen item so it's auditable.
+    kaizen_title = f"Uncertainty gate: {proposed_gate_name} ({'PASS' if passed else 'BLOCK'})"
+    kaizen_notes = json.dumps(decision, indent=2)
+    # Choose waste_type heuristically: blocked gates are overproduction,
+    # passed gates are defect prevention.
+    waste_type = "defects" if passed else "overproduction"
+    add_kaizen(
+        project,
+        title=kaizen_title,
+        hypothesis=(
+            f"Adding a '{proposed_gate_name}' gate will reduce process risk."
+        ),
+        waste_type=waste_type,
+        impact="medium",
+        effort="low",
+        uncertainty=uncertainty,
+        source_session=session_id,
+        evidence=kaizen_notes,
+    )
+    # Find the just-added item and annotate decision_notes for quick recall.
+    memory = load_memory(project)
+    if memory["kaizen"]:
+        memory["kaizen"][-1]["decision_notes"] = kaizen_notes
+        # Auto-reject blocked proposals so they don't clutter "proposed".
+        if not passed:
+            memory["kaizen"][-1]["status"] = "rejected"
+        save_memory(project, memory)
+
+    return decision
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(memory: dict) -> str:
+    """Render the process-memory.md companion document.
+
+    This is the artifact facilitators, reviewers, and humans actually read.
+    It's intentionally compact so it fits into first-class context at
+    session start.
+    """
+    lines: list[str] = []
+    lines.append(f"# Process Memory — {memory.get('project', 'unknown')}")
+    lines.append("")
+    lines.append(f"_Updated {memory.get('updated_at', '')}_")
+    lines.append("")
+
+    narrative = (memory.get("narrative") or "").strip()
+    if narrative:
+        lines.append("## Narrative")
+        lines.append("")
+        lines.append(narrative)
+        lines.append("")
+
+    # Aging action items go FIRST — this is what we want facilitators to
+    # notice immediately when they open the file.
+    aging = [
+        ai
+        for ai in memory.get("action_items", [])
+        if ai.get("status") in ("open", "in-progress")
+        and int(ai.get("age_sessions", 1)) >= AGING_SESSION_THRESHOLD
+    ]
+    if aging:
+        lines.append(f"## Aging Action Items (>= {AGING_SESSION_THRESHOLD} sessions)")
+        lines.append("")
+        lines.append("| ID | Title | Owner | Age | Status |")
+        lines.append("|----|-------|-------|-----|--------|")
+        for ai in aging:
+            lines.append(
+                f"| {ai.get('id', '')} | {ai.get('title', '')} "
+                f"| {ai.get('owner') or '—'} | {ai.get('age_sessions', 1)} "
+                f"| {ai.get('status', '')} |"
+            )
+        lines.append("")
+
+    # All action items (detail table) for completeness.
+    items = memory.get("action_items") or []
+    if items:
+        lines.append("## All Action Items")
+        lines.append("")
+        lines.append("| ID | Title | Status | Age | Owner |")
+        lines.append("|----|-------|--------|-----|-------|")
+        for ai in items:
+            lines.append(
+                f"| {ai.get('id', '')} | {ai.get('title', '')} "
+                f"| {ai.get('status', '')} | {ai.get('age_sessions', 1)} "
+                f"| {ai.get('owner') or '—'} |"
+            )
+        lines.append("")
+
+    kaizen = memory.get("kaizen") or []
+    if kaizen:
+        lines.append("## Kaizen Backlog")
+        lines.append("")
+        lines.append(
+            "| ID | Title | Waste | Impact | Effort | Uncertainty | Status |"
+        )
+        lines.append(
+            "|----|-------|-------|--------|--------|-------------|--------|"
+        )
+        for k in kaizen:
+            lines.append(
+                f"| {k.get('id', '')} | {k.get('title', '')} "
+                f"| {k.get('waste_type', '')} | {k.get('impact', '')} "
+                f"| {k.get('effort', '')} | {k.get('uncertainty', '')} "
+                f"| {k.get('status', '')} |"
+            )
+        lines.append("")
+
+    timeline = memory.get("pass_rate_timeline") or []
+    if timeline:
+        lines.append("## Gate Pass-Rate Timeline (recent)")
+        lines.append("")
+        for sample in timeline[-10:]:
+            lines.append(
+                f"- {sample.get('recorded_at', '')} — "
+                f"{sample.get('pass_rate', 0.0):.2f} "
+                f"(session {sample.get('session_id') or '—'})"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Facilitator context — the one-read-at-session-start surface
+# ---------------------------------------------------------------------------
+
+
+def facilitator_context(project: str) -> dict:
+    """Return the compact dict the facilitator reads at session start.
+
+    Fields are deliberately chosen so the caller can show them inline
+    without further processing. Everything a planner needs to know about
+    open process risk for this project, in one shot.
+    """
+    memory = load_memory(project)
+    aging = [
+        ai
+        for ai in memory.get("action_items", [])
+        if ai.get("status") in ("open", "in-progress")
+        and int(ai.get("age_sessions", 1)) >= AGING_SESSION_THRESHOLD
+    ]
+    proposed_kaizen = [
+        k for k in memory.get("kaizen", []) if k.get("status") == "proposed"
+    ]
+    trialing_kaizen = [
+        k for k in memory.get("kaizen", []) if k.get("status") == "trialing"
+    ]
+    return {
+        "project": project,
+        "narrative": memory.get("narrative", ""),
+        "aging_action_items": aging,
+        "aging_count": len(aging),
+        "open_action_items": len(
+            [a for a in memory.get("action_items", []) if a.get("status") in ("open", "in-progress")]
+        ),
+        "proposed_kaizen": proposed_kaizen,
+        "trialing_kaizen": trialing_kaizen,
+        "kaizen_backlog_size": len(memory.get("kaizen", [])),
+        "pass_rate_timeline_length": len(memory.get("pass_rate_timeline", [])),
+        "markdown_path": str(_memory_md_path(project)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cli() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Persistent process memory + kaizen backlog (issue #447)."
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # show
+    p_show = sub.add_parser("show", help="Show facilitator context JSON.")
+    p_show.add_argument("--project", required=True)
+
+    # render
+    p_render = sub.add_parser("render", help="Print process-memory.md content.")
+    p_render.add_argument("--project", required=True)
+
+    # kaizen-add
+    p_kz = sub.add_parser("kaizen-add", help="Add a kaizen item.")
+    p_kz.add_argument("--project", required=True)
+    p_kz.add_argument("--title", required=True)
+    p_kz.add_argument("--hypothesis", required=True)
+    p_kz.add_argument("--waste-type", required=True, choices=WASTE_TYPES)
+    p_kz.add_argument("--impact", default="medium")
+    p_kz.add_argument("--effort", default="medium")
+    p_kz.add_argument(
+        "--uncertainty", default="epistemic", choices=UNCERTAINTY_TYPES
+    )
+    p_kz.add_argument("--session-id", default="")
+    p_kz.add_argument("--evidence", default="")
+
+    # ai-add
+    p_ai = sub.add_parser("ai-add", help="Add an action item.")
+    p_ai.add_argument("--project", required=True)
+    p_ai.add_argument("--title", required=True)
+    p_ai.add_argument("--description", default="")
+    p_ai.add_argument("--owner", default="")
+    p_ai.add_argument("--session-id", default="")
+
+    # ai-touch
+    p_touch = sub.add_parser(
+        "ai-touch", help="Mark an AI as seen in a session (ages counter)."
+    )
+    p_touch.add_argument("--project", required=True)
+    p_touch.add_argument("--id", required=True)
+    p_touch.add_argument("--session-id", required=True)
+
+    # ai-resolve
+    p_res = sub.add_parser("ai-resolve", help="Resolve an action item.")
+    p_res.add_argument("--project", required=True)
+    p_res.add_argument("--id", required=True)
+    p_res.add_argument(
+        "--status", default="resolved", choices=AI_STATUSES
+    )
+
+    # aging
+    p_age = sub.add_parser(
+        "aging", help="List aging AIs (>= 2 sessions) as JSON."
+    )
+    p_age.add_argument("--project", required=True)
+    p_age.add_argument(
+        "--threshold", type=int, default=AGING_SESSION_THRESHOLD
+    )
+
+    # pass-rate
+    p_pr = sub.add_parser(
+        "record-pass-rate", help="Record a gate-pass-rate sample."
+    )
+    p_pr.add_argument("--project", required=True)
+    p_pr.add_argument("--rate", type=float, required=True)
+    p_pr.add_argument("--session-id", default="")
+
+    # uncertainty-gate
+    p_ug = sub.add_parser(
+        "uncertainty-gate",
+        help="Evaluate whether a proposed new gate should be added.",
+    )
+    p_ug.add_argument("--project", required=True)
+    p_ug.add_argument("--proposed-gate-name", required=True)
+    p_ug.add_argument(
+        "--uncertainty", default="aleatoric", choices=UNCERTAINTY_TYPES
+    )
+    p_ug.add_argument("--session-id", default="")
+
+    args = parser.parse_args()
+
+    if args.cmd == "show":
+        print(json.dumps(facilitator_context(args.project), indent=2))
+        return 0
+
+    if args.cmd == "render":
+        memory = load_memory(args.project)
+        sys.stdout.write(render_markdown(memory))
+        return 0
+
+    if args.cmd == "kaizen-add":
+        item = add_kaizen(
+            args.project,
+            title=args.title,
+            hypothesis=args.hypothesis,
+            waste_type=args.waste_type,
+            impact=args.impact,
+            effort=args.effort,
+            uncertainty=args.uncertainty,
+            source_session=args.session_id,
+            evidence=args.evidence,
+        )
+        print(json.dumps(item, indent=2))
+        return 0
+
+    if args.cmd == "ai-add":
+        ai = add_action_item(
+            args.project,
+            title=args.title,
+            description=args.description,
+            owner=args.owner,
+            source_session=args.session_id,
+        )
+        print(json.dumps(ai, indent=2))
+        return 0
+
+    if args.cmd == "ai-touch":
+        ai = touch_action_item(args.project, args.id, args.session_id)
+        print(json.dumps(ai, indent=2) if ai else json.dumps({"ok": False, "reason": "not found"}))
+        return 0 if ai else 1
+
+    if args.cmd == "ai-resolve":
+        ai = resolve_action_item(args.project, args.id, status=args.status)
+        print(json.dumps(ai, indent=2) if ai else json.dumps({"ok": False, "reason": "not found"}))
+        return 0 if ai else 1
+
+    if args.cmd == "aging":
+        items = aging_action_items(args.project, threshold=args.threshold)
+        print(json.dumps(items, indent=2))
+        return 0
+
+    if args.cmd == "record-pass-rate":
+        entry = record_pass_rate(
+            args.project, args.rate, session_id=args.session_id
+        )
+        print(json.dumps(entry, indent=2))
+        return 0
+
+    if args.cmd == "uncertainty-gate":
+        decision = evaluate_uncertainty_gate(
+            args.project,
+            proposed_gate_name=args.proposed_gate_name,
+            uncertainty=args.uncertainty,
+            session_id=args.session_id,
+        )
+        print(json.dumps(decision, indent=2))
+        return 0 if decision["passed"] else 2
+
+    print(f"Unknown command: {args.cmd}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -181,9 +181,13 @@ Interaction mode (`normal` | `yolo` / `auto_proceed=true` / `/wicked-garden:crew
 
 `scripts/ci/measure_facilitator.py` invokes this rubric in dry-run. With `output=json`, emit one JSON object matching `refs/output-schema.md` instead of creating tasks.
 
+## Process memory (issue #447)
+
+Before Step 3 (factor scoring), read per-project process memory — unresolved retro AIs + open kaizen hypotheses change the plan. See [`refs/process-memory.md`](refs/process-memory.md).
+
 ## Navigation
 
-- [`refs/inputs.md`](refs/inputs.md) — prior-fetch queries, session state reads
+- [`refs/inputs.md`](refs/inputs.md) — prior-fetch queries, session state reads, and [`refs/process-memory.md`](refs/process-memory.md) — persistent process memory + uncertainty gate
 - [`refs/factor-definitions.md`](refs/factor-definitions.md) — the 9 factors + calibration
 - [`refs/specialist-selection.md`](refs/specialist-selection.md) — roster map
 - [`refs/phase-catalog.md`](refs/phase-catalog.md) — phase templates, soft deps

--- a/skills/propose-process/refs/process-memory.md
+++ b/skills/propose-process/refs/process-memory.md
@@ -1,0 +1,69 @@
+# Process memory — first-class context at session start
+
+Issue #447 adds a persistent per-project process memory. The facilitator reads this at every session start so retro observations, kaizen hypotheses, and unresolved action items don't evaporate between sessions.
+
+## Surface
+
+Every crew project has a `process-memory.json` + rendered `process-memory.md` in its project directory:
+
+```
+<project-dir>/process-memory.json    # canonical, machine-readable
+<project-dir>/process-memory.md      # rendered companion, read at session start
+```
+
+The facilitator MUST read `process-memory.md` (or call the context helper) BEFORE scoring factors (Step 3) or selecting phases (Step 5). Observations from prior sessions change the plan — a 3-session-old unresolved action item about flaky tests is a signal that the testability factor needs a higher weight.
+
+## One-shot context read
+
+At session start, fetch the compact dict via:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/delivery/process_memory.py show \
+  --project <project-name>
+```
+
+This returns:
+
+- `narrative` — free-text block written at the most recent retro
+- `aging_action_items` — list of AIs unresolved for >= 2 sessions
+- `aging_count` — integer for quick threshold checks
+- `proposed_kaizen` / `trialing_kaizen` — kaizen items that need attention
+- `kaizen_backlog_size` — total count
+- `pass_rate_timeline_length` — how many samples are available for drift classification
+- `markdown_path` — absolute path to `process-memory.md`
+
+When `aging_count > 0`, surface those items to the user BEFORE creating new tasks. Unresolved process risk from prior sessions takes precedence over novel planning.
+
+## Kaizen backlog
+
+Every process-improvement hypothesis gets a stable `KZN-NNN` ID, a Lean waste classification, impact/effort ratings, and a lifecycle (`proposed` → `trialing` → `adopted` / `rejected`). Waste types match the canonical 8-waste list: defects, overproduction, waiting, non-utilized-talent, transportation, inventory, motion, overprocessing.
+
+When the facilitator notices a process friction point during planning, emit a kaizen item instead of silently absorbing the cost.
+
+## Action items (retro outputs)
+
+Retro action items get `AI-NNN` IDs and are tracked across sessions. The `age_sessions` counter increments whenever the AI is surfaced in a distinct session. At >= 2 sessions unresolved, the item appears in the facilitator's aging list automatically — no manual recall required.
+
+## Uncertainty gate — before adding new process
+
+When a specialist (or the facilitator itself) proposes adding a new gate or review, the proposal MUST pass the uncertainty gate:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/delivery/process_memory.py uncertainty-gate \
+  --project <project-name> \
+  --proposed-gate-name "<slug>" \
+  --uncertainty "epistemic|aleatoric" \
+  --session-id "<session-id>"
+```
+
+Pass condition: **actionable drift** (special-cause signal from `scripts/delivery/drift.classify`) OR **epistemic uncertainty** (the team is explicitly saying "we don't know enough, a gate would help us learn").
+
+Fail condition: common-cause variation + aleatoric uncertainty = more process would just add overhead without addressing root cause.
+
+The decision is recorded as a kaizen item so the audit trail is durable. A blocked proposal is auto-filed as `rejected` in the kaizen backlog.
+
+**Fail-open behavior**: If `scripts/delivery/drift` is not importable yet (PR #452 pending at time of writing), the gate runs with drift classification treated as inconclusive and decides based on the uncertainty flag alone. This is intentional — we don't block work because a sibling PR hasn't landed.

--- a/tests/delivery/test_process_memory.py
+++ b/tests/delivery/test_process_memory.py
@@ -1,0 +1,486 @@
+"""Tests for scripts/delivery/process_memory.py (issue #447).
+
+Coverage:
+- Kaizen CRUD (create, list, update, lifecycle transitions)
+- Action-item CRUD (create, touch, resolve)
+- Aging detection with >= 2-session threshold
+- Uncertainty gate pass/fail with mocked drift.classify responses
+- Uncertainty gate fail-open when drift module is absent
+- Facilitator context one-shot read
+- Markdown rendering
+- Path-traversal protection on project names
+
+Tests run against an isolated tmp-path sandbox so no global state leaks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+# Add scripts/ to sys.path so `from delivery import process_memory` works.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect get_local_path so process memory lives inside tmp_path.
+
+    We patch `_domain_store.get_local_path` AND the copy that
+    process_memory.py imported at module load (via `from _domain_store
+    import get_local_path`). Both names are re-bound so all paths stay
+    inside the sandbox for the duration of the test.
+    """
+    root = tmp_path / "local"
+
+    def _fake_get_local_path(domain: str, *subpath: str) -> Path:
+        p = root / domain
+        for part in subpath:
+            p = p / part
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import _domain_store
+
+    monkeypatch.setattr(_domain_store, "get_local_path", _fake_get_local_path)
+
+    # Re-import process_memory fresh so it picks up the patched helper.
+    # Using reload keeps the module's internal state isolated per test.
+    import importlib
+    from delivery import process_memory as pm
+
+    importlib.reload(pm)
+    monkeypatch.setattr(pm, "get_local_path", _fake_get_local_path)
+    return pm, tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Kaizen CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_add_kaizen_assigns_stable_id_and_timestamps(sandbox):
+    pm, _ = sandbox
+    item = pm.add_kaizen(
+        "proj-a",
+        title="Reduce review churn",
+        hypothesis="Pairing during design reduces rework",
+        waste_type="defects",
+        source_session="sess-1",
+    )
+    assert item["id"] == "KZN-001"
+    assert item["status"] == "proposed"
+    assert item["waste_type"] == "defects"
+    assert item["created_at"]
+    assert item["updated_at"]
+
+    second = pm.add_kaizen(
+        "proj-a",
+        title="Cut build-phase waiting",
+        hypothesis="Async gates unblock",
+        waste_type="waiting",
+    )
+    assert second["id"] == "KZN-002", "IDs must be monotonic within a project"
+
+
+def test_add_kaizen_rejects_invalid_waste_type(sandbox):
+    pm, _ = sandbox
+    with pytest.raises(ValueError):
+        pm.add_kaizen(
+            "proj-a",
+            title="bogus",
+            hypothesis="none",
+            waste_type="not-a-real-waste",
+        )
+
+
+def test_add_kaizen_rejects_invalid_uncertainty(sandbox):
+    pm, _ = sandbox
+    with pytest.raises(ValueError):
+        pm.add_kaizen(
+            "proj-a",
+            title="bogus",
+            hypothesis="none",
+            waste_type="waiting",
+            uncertainty="mystical",
+        )
+
+
+def test_update_kaizen_transitions_status(sandbox):
+    pm, _ = sandbox
+    item = pm.add_kaizen(
+        "proj-a",
+        title="t",
+        hypothesis="h",
+        waste_type="waiting",
+    )
+    updated = pm.update_kaizen("proj-a", item["id"], status="trialing")
+    assert updated["status"] == "trialing"
+    assert updated["updated_at"] >= item["updated_at"]
+
+
+def test_update_kaizen_rejects_unknown_status(sandbox):
+    pm, _ = sandbox
+    item = pm.add_kaizen(
+        "proj-a", title="t", hypothesis="h", waste_type="waiting"
+    )
+    with pytest.raises(ValueError):
+        pm.update_kaizen("proj-a", item["id"], status="frozen")
+
+
+def test_list_kaizen_filters_by_status(sandbox):
+    pm, _ = sandbox
+    a = pm.add_kaizen("proj-a", title="a", hypothesis="h", waste_type="waiting")
+    b = pm.add_kaizen("proj-a", title="b", hypothesis="h", waste_type="defects")
+    pm.update_kaizen("proj-a", b["id"], status="adopted")
+
+    proposed = pm.list_kaizen("proj-a", status="proposed")
+    adopted = pm.list_kaizen("proj-a", status="adopted")
+    assert [i["id"] for i in proposed] == [a["id"]]
+    assert [i["id"] for i in adopted] == [b["id"]]
+
+
+# ---------------------------------------------------------------------------
+# Action-item CRUD + aging
+# ---------------------------------------------------------------------------
+
+
+def test_add_action_item_assigns_monotonic_ids(sandbox):
+    pm, _ = sandbox
+    a = pm.add_action_item("proj-a", title="A", source_session="sess-1")
+    b = pm.add_action_item("proj-a", title="B", source_session="sess-1")
+    assert a["id"] == "AI-001"
+    assert b["id"] == "AI-002"
+    assert a["age_sessions"] == 1
+
+
+def test_touch_action_item_increments_age_on_new_session(sandbox):
+    pm, _ = sandbox
+    ai = pm.add_action_item("proj-a", title="A", source_session="sess-1")
+    # Same session — no increment
+    t1 = pm.touch_action_item("proj-a", ai["id"], "sess-1")
+    assert t1["age_sessions"] == 1
+    # New session — increment
+    t2 = pm.touch_action_item("proj-a", ai["id"], "sess-2")
+    assert t2["age_sessions"] == 2
+    # Another new session — increment again
+    t3 = pm.touch_action_item("proj-a", ai["id"], "sess-3")
+    assert t3["age_sessions"] == 3
+
+
+def test_touch_action_item_unknown_id_returns_none(sandbox):
+    pm, _ = sandbox
+    assert pm.touch_action_item("proj-a", "AI-999", "sess-1") is None
+
+
+def test_resolve_action_item_sets_resolved_at(sandbox):
+    pm, _ = sandbox
+    ai = pm.add_action_item("proj-a", title="A", source_session="sess-1")
+    resolved = pm.resolve_action_item("proj-a", ai["id"])
+    assert resolved["status"] == "resolved"
+    assert resolved["resolved_at"]
+
+
+def test_aging_action_items_surfaces_multi_session_items(sandbox):
+    """Issue #447 acceptance: items >= 2 sessions old surface at planning."""
+    pm, _ = sandbox
+    # Fresh item — should NOT appear
+    pm.add_action_item("proj-a", title="Fresh", source_session="sess-1")
+    # Aging item — touched across two later sessions
+    ai = pm.add_action_item("proj-a", title="Stale", source_session="sess-1")
+    pm.touch_action_item("proj-a", ai["id"], "sess-2")
+
+    aging = pm.aging_action_items("proj-a")
+    ids = [a["id"] for a in aging]
+    assert ai["id"] in ids, "age=2 item must appear in aging list"
+    assert len(aging) == 1, "age=1 item must NOT appear"
+
+
+def test_aging_action_items_excludes_resolved(sandbox):
+    pm, _ = sandbox
+    ai = pm.add_action_item("proj-a", title="A", source_session="sess-1")
+    pm.touch_action_item("proj-a", ai["id"], "sess-2")
+    pm.touch_action_item("proj-a", ai["id"], "sess-3")
+    assert len(pm.aging_action_items("proj-a")) == 1
+
+    pm.resolve_action_item("proj-a", ai["id"])
+    assert pm.aging_action_items("proj-a") == []
+
+
+def test_aging_honors_custom_threshold(sandbox):
+    pm, _ = sandbox
+    ai = pm.add_action_item("proj-a", title="A")
+    pm.touch_action_item("proj-a", ai["id"], "sess-2")
+    pm.touch_action_item("proj-a", ai["id"], "sess-3")
+    # age=3 — under threshold=4, so nothing surfaces
+    assert pm.aging_action_items("proj-a", threshold=4) == []
+    # age=3 — at threshold=3, surfaces
+    assert len(pm.aging_action_items("proj-a", threshold=3)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pass-rate timeline
+# ---------------------------------------------------------------------------
+
+
+def test_record_pass_rate_appends_and_bounds_timeline(sandbox):
+    pm, _ = sandbox
+    # Push 60 samples; internal cap is 50.
+    for i in range(60):
+        pm.record_pass_rate("proj-a", 0.5 + (i % 10) / 20.0, session_id=f"s{i}")
+    memory = pm.load_memory("proj-a")
+    assert len(memory["pass_rate_timeline"]) == 50
+
+
+def test_record_pass_rate_rejects_out_of_range(sandbox):
+    pm, _ = sandbox
+    with pytest.raises(ValueError):
+        pm.record_pass_rate("proj-a", 1.5)
+    with pytest.raises(ValueError):
+        pm.record_pass_rate("proj-a", -0.1)
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty gate
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_drift(
+    monkeypatch: pytest.MonkeyPatch, classify: Callable[[list[float]], dict]
+) -> None:
+    """Inject a synthetic delivery.drift module for the uncertainty-gate tests.
+
+    We don't have the real drift module in this branch (PR #452 pending),
+    so the test shapes the response directly by installing a stub in
+    sys.modules. The stub matches the documented contract.
+    """
+    fake = types.ModuleType("delivery.drift")
+    fake.classify = classify  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "delivery.drift", fake)
+
+
+def test_uncertainty_gate_passes_on_actionable_drift(sandbox, monkeypatch):
+    """Special-cause drift signal → gate passes regardless of uncertainty flag."""
+    pm, _ = sandbox
+
+    def fake_classify(timeline: list[float]) -> dict:
+        return {
+            "zone": "special-cause",
+            "drift": True,
+            "drop_pct": 0.25,
+            "is_actionable": True,
+        }
+
+    _install_fake_drift(monkeypatch, fake_classify)
+    pm.record_pass_rate("proj-a", 0.9, session_id="s1")
+    pm.record_pass_rate("proj-a", 0.6, session_id="s2")
+
+    decision = pm.evaluate_uncertainty_gate(
+        "proj-a",
+        proposed_gate_name="extra-design-review",
+        uncertainty="aleatoric",  # even aleatoric passes when drift is actionable
+        session_id="sess-now",
+    )
+    assert decision["passed"] is True
+    assert decision["drift_available"] is True
+    assert decision["drift_zone"] == "special-cause"
+    # A passing gate is recorded as a proposed kaizen (not rejected).
+    kz = pm.list_kaizen("proj-a")
+    assert kz, "decision must record a kaizen item"
+    assert kz[-1]["status"] == "proposed"
+
+
+def test_uncertainty_gate_blocks_common_cause_aleatoric(sandbox, monkeypatch):
+    """Common-cause + aleatoric = BLOCK. This is the gate's whole point."""
+    pm, _ = sandbox
+
+    def fake_classify(timeline: list[float]) -> dict:
+        return {
+            "zone": "within-control",
+            "drift": False,
+            "drop_pct": 0.02,
+            "is_actionable": False,
+        }
+
+    _install_fake_drift(monkeypatch, fake_classify)
+    pm.record_pass_rate("proj-a", 0.91, session_id="s1")
+    pm.record_pass_rate("proj-a", 0.89, session_id="s2")
+
+    decision = pm.evaluate_uncertainty_gate(
+        "proj-a",
+        proposed_gate_name="extra-design-review",
+        uncertainty="aleatoric",
+        session_id="sess-now",
+    )
+    assert decision["passed"] is False
+    assert "aleatoric" in decision["reason"].lower()
+    # Blocked proposals are auto-marked rejected in the kaizen backlog.
+    kz = pm.list_kaizen("proj-a")
+    assert kz[-1]["status"] == "rejected"
+
+
+def test_uncertainty_gate_passes_on_epistemic_without_drift(sandbox, monkeypatch):
+    """Epistemic uncertainty alone is sufficient — we don't know enough yet."""
+    pm, _ = sandbox
+
+    def fake_classify(timeline: list[float]) -> dict:
+        return {
+            "zone": "within-control",
+            "drift": False,
+            "drop_pct": 0.0,
+            "is_actionable": False,
+        }
+
+    _install_fake_drift(monkeypatch, fake_classify)
+    decision = pm.evaluate_uncertainty_gate(
+        "proj-a",
+        proposed_gate_name="probe-gate",
+        uncertainty="epistemic",
+        session_id="sess-now",
+    )
+    assert decision["passed"] is True
+    assert decision["uncertainty"] == "epistemic"
+
+
+def test_uncertainty_gate_fail_open_when_drift_module_absent(sandbox, monkeypatch):
+    """PR #452 not merged yet — gate must not crash; decides on uncertainty."""
+    pm, _ = sandbox
+    # Ensure the module really is absent.
+    monkeypatch.delitem(sys.modules, "delivery.drift", raising=False)
+
+    # Even without drift, epistemic still passes.
+    d1 = pm.evaluate_uncertainty_gate(
+        "proj-a",
+        proposed_gate_name="probe",
+        uncertainty="epistemic",
+        session_id="sess-x",
+    )
+    assert d1["passed"] is True
+    assert d1["drift_available"] is False
+
+    # And aleatoric alone still blocks — drift absence doesn't flip the semantics.
+    d2 = pm.evaluate_uncertainty_gate(
+        "proj-a",
+        proposed_gate_name="probe-2",
+        uncertainty="aleatoric",
+        session_id="sess-x",
+    )
+    assert d2["passed"] is False
+    assert d2["drift_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# Facilitator context
+# ---------------------------------------------------------------------------
+
+
+def test_facilitator_context_surfaces_aging_ais(sandbox):
+    """Acceptance #447: opening session N surfaces unresolved items from N-1, N-2."""
+    pm, _ = sandbox
+    ai = pm.add_action_item("proj-a", title="Flaky test", source_session="sess-N-2")
+    pm.touch_action_item("proj-a", ai["id"], "sess-N-1")
+    # Now session N — what does the facilitator see?
+    ctx = pm.facilitator_context("proj-a")
+    assert ctx["aging_count"] == 1
+    assert ctx["aging_action_items"][0]["title"] == "Flaky test"
+    assert ctx["markdown_path"].endswith("process-memory.md")
+
+
+def test_facilitator_context_empty_project(sandbox):
+    pm, _ = sandbox
+    ctx = pm.facilitator_context("fresh-proj")
+    assert ctx["aging_count"] == 0
+    assert ctx["kaizen_backlog_size"] == 0
+    assert ctx["pass_rate_timeline_length"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering + persistence
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_rendered_on_every_save(sandbox):
+    pm, _ = sandbox
+    pm.add_kaizen(
+        "proj-a",
+        title="Parallelize reviews",
+        hypothesis="Parallel gate reviewers cut cycle time",
+        waste_type="waiting",
+    )
+    md_path = pm._memory_md_path("proj-a")
+    assert md_path.exists()
+    content = md_path.read_text(encoding="utf-8")
+    assert "Parallelize reviews" in content
+    assert "Kaizen Backlog" in content
+
+
+def test_aging_section_rendered_only_when_items_exist(sandbox):
+    pm, _ = sandbox
+    # Fresh AI — no aging section
+    pm.add_action_item("proj-a", title="Fresh", source_session="s1")
+    md = pm._memory_md_path("proj-a").read_text(encoding="utf-8")
+    assert "Aging Action Items" not in md
+
+    # Age it up
+    ai = pm.list_action_items("proj-a")[0]
+    pm.touch_action_item("proj-a", ai["id"], "s2")
+    md = pm._memory_md_path("proj-a").read_text(encoding="utf-8")
+    assert "Aging Action Items" in md
+
+
+def test_load_memory_backfills_missing_fields(sandbox):
+    """Older memory files missing new keys must load without error."""
+    pm, _ = sandbox
+    path = pm._memory_json_path("proj-old")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Minimal older shape — only project + kaizen
+    path.write_text(
+        json.dumps({"project": "proj-old", "kaizen": []}),
+        encoding="utf-8",
+    )
+    mem = pm.load_memory("proj-old")
+    # Backfilled defaults must be present.
+    assert mem["action_items"] == []
+    assert mem["pass_rate_timeline"] == []
+    assert mem["next_kaizen_seq"] == 1
+
+
+def test_load_memory_recovers_from_corruption(sandbox):
+    pm, _ = sandbox
+    path = pm._memory_json_path("proj-bad")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    # Must not raise — must return a fresh shell.
+    mem = pm.load_memory("proj-bad")
+    assert mem["kaizen"] == []
+
+
+# ---------------------------------------------------------------------------
+# Safety
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_project_name_is_rejected(sandbox):
+    pm, _ = sandbox
+    with pytest.raises(ValueError):
+        pm.add_kaizen(
+            "../escape",
+            title="t",
+            hypothesis="h",
+            waste_type="waiting",
+        )
+    with pytest.raises(ValueError):
+        pm.add_action_item("has spaces", title="t")
+
+
+def test_empty_project_name_is_rejected(sandbox):
+    pm, _ = sandbox
+    with pytest.raises(ValueError):
+        pm.add_kaizen("", title="t", hypothesis="h", waste_type="waiting")


### PR DESCRIPTION
## Summary

Closes #447.

Adds three durable per-project surfaces so retro observations and improvement hypotheses survive across sessions, plus an uncertainty gate that prevents reactive over-process on common-cause variation.

- **`process-memory.json` + rendered `process-memory.md`** per crew project — facilitator reads at every session start as first-class context.
- **Kaizen backlog** with `KZN-NNN` IDs, Lean waste taxonomy (8 canonical types), impact/effort/uncertainty ratings, and a `proposed → trialing → adopted / rejected` lifecycle.
- **Action-item tracking** — retro AIs get `AI-NNN` IDs; aging counter increments per distinct session; items unresolved ≥ 2 sessions surface automatically.
- **Uncertainty gate** — proposed new process gates pass only if the drift classifier flags a special-cause signal OR the author explicitly flags epistemic uncertainty. Decision is recorded as a kaizen item for durable audit.
- **New command** `/wicked-garden:delivery:process-health` surfaces kaizen status, aging alerts, and pass-rate timeline.

## Kaizen backlog schema

```json
{
  "id": "KZN-001",
  "title": "Parallelize design reviews",
  "hypothesis": "Parallel gate reviewers reduce cycle time without hurting rigor",
  "waste_type": "waiting",      // one of the 8 Lean wastes
  "impact": "medium",            // low|medium|high
  "effort": "low",               // low|medium|high
  "uncertainty": "epistemic",    // epistemic|aleatoric
  "status": "proposed",          // proposed|trialing|adopted|rejected
  "source_session": "sess-abc",
  "evidence": "<link or text>",
  "decision_notes": "<uncertainty-gate verdict JSON>",
  "created_at": "...",
  "updated_at": "..."
}
```

## Drift integration (PR #452)

The uncertainty gate consumes `scripts/delivery/drift.classify(timeline)['is_actionable']` per the documented contract in #447. The drift module lands in PR #452. Until it merges, the gate fails open: the drift check is treated as inconclusive and the decision falls back to the uncertainty flag alone. The fail-open choice is logged to stderr so reviewers can see when it happens.

Test `test_uncertainty_gate_fail_open_when_drift_module_absent` covers this exact path.

## Additive-only surfaces (concurrent PR hygiene)

- `.claude-plugin/gate-policy.json` — only adds the `uncertainty-gate` entry; no existing entries touched.
- `skills/propose-process/SKILL.md` — adds a Process-memory section + 1 ref link. SKILL.md stays under the 200-line cap (now 200 exactly).
- New files only under `scripts/delivery/`, `commands/delivery/`, `tests/delivery/`, `skills/propose-process/refs/`. Does not touch #442's `pre_tool.py` or #446's `spec_rubric.py`.

## Test plan

- [x] 27 pytest tests — all green (`pytest tests/delivery/test_process_memory.py`)
- [x] Kaizen CRUD + lifecycle transition validation
- [x] Action-item aging with distinct-session counting (>= 2 threshold)
- [x] Uncertainty gate passes on actionable drift (special-cause signal)
- [x] Uncertainty gate blocks common-cause + aleatoric
- [x] Uncertainty gate passes on epistemic flag alone (no drift)
- [x] Fail-open when `delivery.drift` is not importable
- [x] Facilitator context surfaces aging AIs from sessions N-1 / N-2
- [x] Markdown rendering updates on every save
- [x] Path-traversal rejection on project names
- [x] CLI smoke test: `process_memory.py show`, `process_health.py` render
- [ ] Integration test with real drift module once PR #452 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)