### PR TITLE
feat(qe): semantic reviewer — spec-to-code alignment verification

### DIFF
--- a/.claude-plugin/gate-policy.json
+++ b/.claude-plugin/gate-policy.json
@@ -137,6 +137,24 @@
         "mode": "parallel",
         "fallback": "senior-engineer"
       }
+    },
+    "semantic-alignment": {
+      "description": "Spec-to-code alignment verification (issue #444). Runs at review-phase gate for complexity >= 3. Extracts numbered AC/FR from clarify-phase specs and classifies each as aligned / divergent / missing against the implementation + test corpora. Missing findings are hard REJECT; divergent findings become gate conditions. Advisory at complexity 0-2. Bypass with CREW_GATE_ENFORCEMENT=legacy.",
+      "minimal": {
+        "reviewers": [],
+        "mode": "advisory",
+        "fallback": "semantic-reviewer"
+      },
+      "standard": {
+        "reviewers": ["semantic-reviewer"],
+        "mode": "sequential",
+        "fallback": "senior-engineer"
+      },
+      "full": {
+        "reviewers": ["semantic-reviewer", "requirements-quality-analyst"],
+        "mode": "parallel",
+        "fallback": "senior-engineer"
+      }
     }
   }
 }

--- a/agents/qe/semantic-reviewer.md
+++ b/agents/qe/semantic-reviewer.md
@@ -1,0 +1,190 @@
+---
+name: semantic-reviewer
+description: |
+  Autonomous post-implementation pass that verifies spec-to-code alignment.
+  Extracts numbered acceptance criteria (AC-*, FR-*, REQ-*) from clarify-phase
+  artifacts (acceptance-criteria.md, objective.md) and emits a structured Gap
+  Report per item with status aligned / divergent / missing. Tests passing !=
+  spec intent satisfied — this agent closes that gap.
+
+  Use when: review-phase gate, post-implementation verification, "does the code
+  actually implement what we specified", spec alignment, divergence detection,
+  complexity >= 3 projects.
+
+  <example>
+  Context: Build phase just completed for a complex authentication feature.
+  user: "Run the review-phase semantic gate for project login-rework."
+  <commentary>Use semantic-reviewer to produce a structured Gap Report per AC
+  before the review phase signs off.</commentary>
+  </example>
+model: sonnet
+effort: medium
+max-turns: 10
+color: magenta
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Semantic Reviewer
+
+You verify that implementation actually satisfies the spec intent captured in
+the clarify phase — per numbered AC / FR. You run AFTER build and test phases,
+as part of the review-phase gate. You are complementary to the traceability
+check in `verification_protocol.py` (which checks that links exist) — you
+check whether the linked code says what the spec says it should.
+
+## Your Contract
+
+**Input**:
+- `phases/clarify/acceptance-criteria.md` (preferred) — numbered AC list
+- `phases/clarify/objective.md` — narrative with FR / REQ mentions
+- Implementation corpus (project dir minus tests)
+- Test corpus (`tests/`, `test/`, `spec/` or filename heuristics)
+
+**Output** — structured Gap Report JSON via `scripts/qe/semantic_review.py`:
+```json
+{
+  "schema_version": "1.0.0",
+  "project": "<name>",
+  "complexity": <int>,
+  "total": <int>,
+  "aligned": <int>, "divergent": <int>, "missing": <int>,
+  "verdict": "APPROVE | CONDITIONAL | REJECT",
+  "score": <0.0-1.0>,
+  "summary": "<one-line>",
+  "findings": [
+    {
+      "id": "AC-1", "description": "...", "source_file": "...",
+      "status": "aligned | divergent | missing",
+      "confidence": <0.0-1.0>,
+      "evidence": ["file/path.py", ...],
+      "reason": "<human explanation>",
+      "expected_constraints": ["3 attempts", "per session"],
+      "matched_constraints": ["3 attempts"],
+      "unmatched_constraints": ["per session"],
+      "in_impl": true, "in_tests": true
+    }
+  ]
+}
+```
+
+## Classification Heuristics
+
+- **Aligned**: AC id referenced in BOTH implementation AND tests, AND keyword
+  overlap between spec description and code context ≥ 35%, AND all concrete
+  constraints (numeric limits, "per session" scope phrases) present in the code.
+- **Divergent**: AC id referenced, BUT at least one of
+  - referenced in only one corpus (impl XOR tests)
+  - concrete spec constraints (e.g. "3 attempts per session") not found near the
+    reference — the code likely implements a close-but-wrong variant
+  - keyword overlap < 35% (implementation mentions the AC id but the
+    surrounding code talks about something else)
+- **Missing**: AC id does not appear anywhere in implementation or tests.
+
+Confidence is higher when we have concrete constraint mismatches (0.85) vs
+only-keyword-overlap drops (0.6).
+
+## Process
+
+### 1. Recall Past Findings
+
+```
+/wicked-garden:mem:recall "semantic review divergence {project_type}"
+```
+
+### 2. Run the Semantic Review CLI
+
+From the project root:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/qe/semantic_review.py" review \
+  --project-dir "${project_dir}" \
+  --project-name "${project_name}" \
+  --complexity "${complexity}" \
+  --output "${project_dir}/phases/review/semantic-gap-report.json"
+```
+
+The CLI exits non-zero when the verdict is REJECT.
+
+### 3. Translate the Report into Gate Conditions
+
+For **every** `divergent` and `missing` finding at complexity >= 3, emit a
+gate condition. Each condition must be resolved (fix code, add test, or
+formally document the deviation) before the review gate advances.
+
+```json
+// conditions-manifest.json (appended to existing manifest)
+{
+  "id": "SEM-AC-1",
+  "description": "AC-1 implementation diverges: spec says '3 attempts per session' but code enforces '3 attempts per request'. Fix: move counter to session scope or update AC.",
+  "verified": false,
+  "source": "semantic-reviewer",
+  "finding_id": "AC-1",
+  "severity": "divergent"
+}
+```
+
+### 4. Update the Task with Findings
+
+```
+TaskUpdate(
+  taskId="{task_id}",
+  description="Append QE findings:
+
+[semantic-reviewer] Spec-to-Code Alignment
+
+**Verdict**: {APPROVE|CONDITIONAL|REJECT}  **Score**: {score} ({aligned}/{total} aligned)
+
+| ID  | Status     | Confidence | Reason                              |
+|-----|------------|------------|-------------------------------------|
+| AC-1 | divergent | 0.85       | constraint 'per session' not found  |
+| AC-2 | aligned   | 0.92       | overlap 78%, both corpora hit       |
+| AC-3 | missing   | 0.90       | no reference in any source file     |
+
+**Recommendation**: {APPROVE / CONDITIONAL gate with N conditions / REJECT}"
+)
+```
+
+### 5. Gate Decision
+
+- `missing > 0` at complexity >= 3 → **REJECT** (hard block)
+- `divergent > 0` at complexity >= 3 → **CONDITIONAL** (manifest required)
+- All aligned → **APPROVE**
+- Complexity < 3 → advisory; never blocking
+
+## When Complexity Is Low
+
+At complexity 0-2, run the same review but treat findings as **advisory
+warnings** in `review-findings.md`, not gate conditions. This matches the
+minimal-rigor tier.
+
+## Bypass
+
+Set `CREW_GATE_ENFORCEMENT=legacy` to skip the semantic gate entirely
+(emergency rollback only — log the bypass in status.md).
+
+## Common Divergence Patterns
+
+Watch for these — they're the classic "tests pass but spec is violated":
+
+1. **Scope drift**: spec says "per session", code implements "per request".
+2. **Limit drift**: spec says "3 attempts", code allows 5.
+3. **Units drift**: spec says "30 seconds", code uses 30 minutes.
+4. **Error-message drift**: spec specifies exact user-visible string, code
+   differs.
+5. **Negation drift**: spec says "MUST NOT X", code implements X conditionally.
+
+All of these produce `unmatched_constraints` entries when the spec uses
+numeric / modal / scope wording.
+
+## Limitations (Honest)
+
+- Heuristics only — no LLM. This catches the cheap 80% of divergences.
+- Overlap scoring can miss rename-heavy refactors (code uses
+  `max_attempts_per_session` but spec says "attempts per session"). The
+  scope-phrase regex catches "per session" literally.
+- Constraint extraction is line-granular — multi-paragraph specs with
+  spread-out constraints can fragment.
+- ADR constraint scanning (`constraints` subcommand) is MVP — it only
+  identifies modal directive lines, it does not verify them against code.
+  Follow-up work: pair each directive with a verification query.

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -918,6 +918,207 @@ def _load_gate_result(project_dir: Path, phase: str) -> Optional[Dict]:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Semantic alignment gate (issue #444)
+#
+# Post-implementation pass that verifies spec-to-code alignment per numbered
+# AC / FR. Runs at the review-phase hook point alongside other review-phase
+# checks (see call site in ``approve_phase``). Complexity-aware: mandatory at
+# complexity >= 3, advisory otherwise.
+#
+# Emergency bypass honoured via CREW_GATE_ENFORCEMENT=legacy env var. The
+# wider v6 enforcement machinery removed the general legacy flag, but this
+# specific gate is new and its own rollback lever is additive — matches the
+# WG_TASK_METADATA escape-hatch pattern for newly-added validators.
+# ---------------------------------------------------------------------------
+
+# Complexity at/above which semantic alignment is MANDATORY (blocking).
+_SEMANTIC_ALIGNMENT_COMPLEXITY_THRESHOLD = 3
+
+
+def _check_semantic_alignment_gate(
+    state: "ProjectState",
+    project_dir: Path,
+    phase: str,
+) -> Tuple[Optional[str], List[str]]:
+    """Run the semantic-alignment check at the review-phase hook point.
+
+    Extracts numbered AC / FR from clarify-phase specs and classifies each as
+    aligned / divergent / missing against the implementation + test corpora.
+
+    Returns a tuple ``(block_reason, warnings)`` where:
+      - ``block_reason`` is non-None when the gate must REJECT phase advance
+        (complexity >= 3 AND at least one MISSING finding). Caller should
+        raise ValueError with this string.
+      - ``warnings`` is a list of non-blocking notes (DIVERGENT or advisory
+        findings) to append to the approve-phase warning list.
+
+    Behaviour matrix::
+
+        complexity >= 3 + missing > 0   -> block_reason set (REJECT)
+        complexity >= 3 + divergent > 0 -> warning + conditions manifest
+                                           appended (CONDITIONAL)
+        complexity >= 3 + all aligned   -> single "APPROVE" warning (info)
+        complexity <  3                 -> advisory warning only; never blocks
+        no spec items found             -> advisory skip
+
+    Respects ``CREW_GATE_ENFORCEMENT=legacy`` — returns (None, []) when set.
+    Fails safe — any exception during analysis becomes a warning, not a block.
+    """
+    # Only runs for the review phase. Caller should pre-check but we
+    # defensively verify here too.
+    if resolve_phase(phase) != "review":
+        return None, []
+
+    # Emergency rollback — honoured for this gate explicitly per issue #444
+    # acceptance ("Respect CREW_GATE_ENFORCEMENT=legacy bypass").
+    if os.environ.get("CREW_GATE_ENFORCEMENT", "").lower() == "legacy":
+        logger.info(
+            "[semantic-alignment] CREW_GATE_ENFORCEMENT=legacy set — "
+            "skipping spec-to-code alignment check."
+        )
+        return None, []
+
+    complexity = int(getattr(state, "complexity_score", 0) or 0)
+    is_mandatory = complexity >= _SEMANTIC_ALIGNMENT_COMPLEXITY_THRESHOLD
+
+    # Resolve project + spec paths defensively — everything must be tolerant
+    # to a project dir without a clarify phase (skip cleanly).
+    clarify_dir = project_dir / "phases" / "clarify"
+    ac_file = clarify_dir / "acceptance-criteria.md"
+    obj_file = clarify_dir / "objective.md"
+
+    if not (ac_file.exists() or obj_file.exists()):
+        # No specs to check — advisory skip.
+        return None, [
+            f"[semantic-alignment] skipped — no clarify-phase specs "
+            f"(acceptance-criteria.md / objective.md) found at {clarify_dir}."
+        ]
+
+    # Import lazily — the script lives under scripts/qe/ and has no
+    # cross-module imports that would trigger at module load time.
+    try:
+        sys.path.insert(
+            0,
+            str(Path(__file__).resolve().parents[1] / "qe"),
+        )
+        import semantic_review  # type: ignore
+    except Exception as exc:  # noqa: BLE001 — fail-safe on ANY import error
+        logger.warning(
+            "[semantic-alignment] import failed (%s) — treating as advisory skip.",
+            exc,
+        )
+        return None, [
+            f"[semantic-alignment] advisory skip — import error: {exc}"
+        ]
+
+    # Run the review, fail-safe on any exception.
+    try:
+        report = semantic_review.review_project(
+            project_dir=project_dir,
+            project_name=state.name,
+            complexity=complexity,
+            ac_file=ac_file if ac_file.exists() else None,
+            objective_file=obj_file if obj_file.exists() else None,
+        )
+    except Exception as exc:  # noqa: BLE001 — see docstring: fail safe.
+        logger.warning(
+            "[semantic-alignment] review raised %s — advisory skip.", exc,
+        )
+        return None, [
+            f"[semantic-alignment] advisory skip — review error: {exc}"
+        ]
+
+    # Persist the report for evidence. Always safe to write even when
+    # aligned so downstream tools have a baseline.
+    try:
+        out_dir = project_dir / "phases" / "review"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / "semantic-gap-report.json"
+        out_path.write_text(
+            json.dumps(semantic_review.report_to_dict(report), indent=2)
+        )
+    except OSError as exc:
+        logger.warning(
+            "[semantic-alignment] could not persist gap report: %s", exc,
+        )
+
+    # Short-circuit when no numbered spec items were found — nothing to check.
+    if report.total == 0:
+        return None, [
+            "[semantic-alignment] skipped — no numbered AC / FR items found "
+            "in clarify-phase specs."
+        ]
+
+    warnings: List[str] = []
+    summary = (
+        f"[semantic-alignment] verdict={report.verdict} "
+        f"score={report.score} aligned={report.aligned} "
+        f"divergent={report.divergent} missing={report.missing} "
+        f"(complexity={complexity}, "
+        f"mandatory={'yes' if is_mandatory else 'no'})"
+    )
+    warnings.append(summary)
+
+    # Add one warning line per non-aligned finding so they surface in approve
+    # output without the caller having to read the JSON.
+    for finding in report.findings:
+        if finding.status == "aligned":
+            continue
+        warnings.append(
+            f"[semantic-alignment] {finding.status.upper()} "
+            f"{finding.id} (conf={finding.confidence:.2f}): {finding.reason}"
+        )
+
+    # Advisory-only at low complexity.
+    if not is_mandatory:
+        return None, warnings
+
+    # Mandatory path: missing => hard REJECT.
+    if report.missing > 0:
+        missing_ids = [f.id for f in report.findings if f.status == "missing"]
+        return (
+            (
+                f"Semantic alignment REJECT: {report.missing} spec item(s) "
+                f"missing from implementation ({', '.join(missing_ids)}). "
+                f"See {project_dir / 'phases' / 'review' / 'semantic-gap-report.json'}. "
+                f"Implement the referenced AC or remove them from the spec "
+                f"before approving, or set CREW_GATE_ENFORCEMENT=legacy to "
+                f"bypass (emergency rollback only)."
+            ),
+            warnings,
+        )
+
+    # Mandatory path: divergent => CONDITIONAL — write conditions so the
+    # existing manifest machinery picks them up on next-phase approve.
+    if report.divergent > 0:
+        try:
+            conditions = [
+                {
+                    "description": (
+                        f"Semantic divergence on {f.id}: {f.reason}"
+                    ),
+                    "source": "semantic-reviewer",
+                    "finding_id": f.id,
+                    "severity": "divergent",
+                }
+                for f in report.findings if f.status == "divergent"
+            ]
+            _write_conditions_manifest(project_dir, phase, conditions)
+            warnings.append(
+                f"[semantic-alignment] {len(conditions)} divergent finding(s) "
+                f"written to conditions manifest — must be resolved before "
+                f"next phase advance."
+            )
+        except OSError as exc:
+            warnings.append(
+                f"[semantic-alignment] divergent findings detected but "
+                f"conditions manifest write failed: {exc}"
+            )
+
+    return None, warnings
+
+
 def _write_conditions_manifest(
     project_dir: Path,
     phase: str,
@@ -1497,6 +1698,18 @@ def approve_phase(
                 "[convergence-verify] %d convergence gate finding(s) for review phase.",
                 len(convergence_findings),
             )
+
+    # Check 0.3 (issue #444): semantic alignment — spec-to-code verification.
+    # Mandatory at complexity >= 3; advisory below. Additive, sits after the
+    # convergence-verify hook (#445).
+    if resolve_phase(phase) == "review":
+        semantic_project_dir = get_project_dir(state.name)
+        sem_block_reason, sem_warnings = _check_semantic_alignment_gate(
+            state, semantic_project_dir, phase,
+        )
+        warnings.extend(sem_warnings)
+        if sem_block_reason:
+            raise ValueError(sem_block_reason)
 
     # Check 1: deliverables for the phase being approved — BLOCKING
     deliverable_issues = _check_phase_deliverables(state, phase)

--- a/scripts/qe/semantic_review.py
+++ b/scripts/qe/semantic_review.py
@@ -1,0 +1,976 @@
+#!/usr/bin/env python3
+"""Semantic reviewer — spec-to-code alignment verification (issue #444).
+
+Autonomous post-implementation pass that extracts numbered acceptance criteria
+(AC-*) and functional requirements (FR-*/REQ-*) from clarify-phase specs
+(``acceptance-criteria.md``, ``objective.md``) and compares them against the
+build-phase implementation corpus plus test results.
+
+Emits a structured Gap Report (JSON) per spec item with ``status`` in
+``{aligned, divergent, missing}``, confidence score, evidence, and reason.
+
+This complements — but does NOT replace — ``verification_protocol.py``
+check #6 (traceability), which verifies existence of req → design → code →
+test chains. Semantic review asks a different question: given the chain
+exists, does the code actually implement what the AC described?
+
+CLI::
+
+    semantic_review.py review \\
+        --project-dir <dir> [--ac-file <path>] [--objective-file <path>] \\
+        [--impl-dir <dir>] [--test-dir <dir>] [--output <json-path>]
+
+    semantic_review.py constraints \\
+        --adr-dir <dir> [--output <json-path>]
+
+Python API::
+
+    from semantic_review import (
+        extract_spec_items, generate_gap_report, extract_adr_constraints,
+    )
+
+Design notes
+------------
+- **Stdlib-only**. No external deps. Cross-platform.
+- **Heuristic-based** — LLM-free. Uses keyword overlap + reference counting
+  and a curated list of ``constraint signals`` (numeric limits, scoping
+  phrases like "per session", modal verbs).
+- **Conservative** on missing — only reports MISSING when the AC identifier
+  literal is absent from both the implementation corpus and the test corpus.
+- **Conservative** on aligned — requires the AC identifier in BOTH corpora
+  AND a minimum keyword overlap with the code context around the reference.
+- **Divergent** — everything else where the AC is referenced but signals
+  don't line up. Confidence score reports how sure we are.
+
+The agent consuming this output (``agents/qe/semantic-reviewer.md``) can
+promote MISSING/DIVERGENT findings to gate conditions when complexity >= 3.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Spec-id extraction — accept AC-*, FR-*, REQ-* (with optional domain infix,
+# e.g. REQ-auth-3). Matches existing patterns used by verification_protocol.py
+# and traceability_generator.
+_SPEC_ID_RE = re.compile(
+    r"\b(?:AC|FR|REQ|NFR|US)-[A-Za-z]*-?\d+\b",
+)
+
+# Table-row AC extraction  (from verification_protocol._AC_TABLE_ROW_RE)
+_AC_TABLE_ROW_RE = re.compile(
+    r"\|\s*(?P<id>AC-\d+|[A-Z]{1,4}-\d+|\d+)\s*\|"
+    r"\s*(?P<desc>[^|]+)\s*\|"
+    r"\s*(?P<test>[^|]*)\s*\|",
+    re.IGNORECASE,
+)
+
+# List-style AC extraction
+_AC_LIST_RE = re.compile(
+    r"[-*]\s+(?:\*\*)?(?P<id>AC-\d+|[A-Z]{1,4}-\d+)(?:\*\*)?\s*[:\-]\s*(?P<desc>.+)",
+    re.IGNORECASE,
+)
+
+# Inline AC extraction (e.g. "AC1: Given ... When ... Then ...")
+_AC_INLINE_RE = re.compile(
+    r"(?P<id>AC\d+|[A-Z]{1,4}-\d+|AC-\d+)\s*[:\-]\s*(?P<desc>Given[^\n]+)",
+    re.IGNORECASE,
+)
+
+# Constraint signals — numeric quantifiers, scoping qualifiers, and modal
+# verbs that frequently appear in ACs and must be honored verbatim.
+_NUMERIC_CONSTRAINT_RE = re.compile(
+    r"\b(\d+)\s*(ms|s|seconds?|min(?:utes?)?|hours?|days?|%|requests?|"
+    r"attempts?|tries|sessions?|users?|bytes?|kb|mb|gb|tokens?|items?)\b",
+    re.IGNORECASE,
+)
+
+_SCOPE_PHRASE_RE = re.compile(
+    r"\bper\s+(session|request|user|tenant|account|minute|hour|day|page|call|token|device|ip)\b",
+    re.IGNORECASE,
+)
+
+_MODAL_DIRECTIVE_RE = re.compile(
+    r"\b(MUST NOT|MUST|SHALL NOT|SHALL|SHOULD NOT|SHOULD|REQUIRED|FORBIDDEN)\b",
+)
+
+# Word extraction for overlap scoring — alphanumeric tokens of length 3+,
+# lowercase normalised, minus stopwords.
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9]{2,}")
+
+_STOPWORDS = frozenset({
+    "the", "and", "for", "when", "then", "given", "that", "with", "this",
+    "has", "have", "will", "shall", "should", "must", "not", "are", "was",
+    "were", "from", "user", "users", "system", "code", "test", "case",
+    "example", "into", "than", "less", "more", "which", "while", "its",
+    "any", "all", "one", "two", "three", "four", "five", "also", "their",
+    "been", "being", "upon", "other", "some", "such", "each", "them",
+    "they", "these", "those", "there", "here", "above", "below",
+})
+
+# Context window around AC references (chars on either side) for overlap
+# scoring.
+_CONTEXT_WINDOW = 400
+
+# Alignment thresholds.
+_ALIGNED_OVERLAP_THRESHOLD = 0.35  # >= this ratio of AC keywords seen in context
+_DIVERGENT_MIN_OVERLAP = 0.10      # below this & referenced => divergent
+
+_DEFAULT_IMPL_EXTENSIONS = (
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".java", ".kt",
+    ".swift", ".rb", ".c", ".h", ".cpp", ".hpp", ".md", ".json", ".yaml",
+    ".yml", ".sh",
+)
+_DEFAULT_TEST_DIR_NAMES = ("tests", "test", "__tests__", "spec", "specs")
+
+# Complexity threshold at/above which semantic alignment is MANDATORY.
+SEMANTIC_ALIGNMENT_COMPLEXITY_THRESHOLD = 3
+
+# Gate-result verdicts
+_VERDICT_APPROVE = "APPROVE"
+_VERDICT_CONDITIONAL = "CONDITIONAL"
+_VERDICT_REJECT = "REJECT"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SpecItem:
+    """A single extracted acceptance criterion / functional requirement."""
+    id: str
+    description: str
+    source_file: str
+    priority: Optional[str] = None  # P0/P1/P2 when detected
+
+    def keywords(self) -> List[str]:
+        """Return deduped, lowercased, stopword-filtered keywords."""
+        return _keywords(self.description)
+
+    def constraints(self) -> List[str]:
+        """Return concrete constraint literals from the description."""
+        return _extract_constraint_literals(self.description)
+
+
+@dataclass
+class Finding:
+    """One Gap Report finding for a single spec item."""
+    id: str
+    description: str
+    source_file: str
+    status: str  # aligned | divergent | missing
+    confidence: float  # 0.0 - 1.0
+    evidence: List[str]  # file paths / snippets supporting the verdict
+    reason: str  # human-readable why
+    expected_constraints: List[str] = field(default_factory=list)
+    matched_constraints: List[str] = field(default_factory=list)
+    unmatched_constraints: List[str] = field(default_factory=list)
+    in_impl: bool = False
+    in_tests: bool = False
+
+
+@dataclass
+class GapReport:
+    """Full Gap Report payload."""
+    project: str
+    complexity: int
+    total: int
+    aligned: int
+    divergent: int
+    missing: int
+    verdict: str  # APPROVE | CONDITIONAL | REJECT
+    score: float  # aligned / total
+    findings: List[Finding]
+    summary: str
+    # Emit schema_version so downstream consumers can evolve safely.
+    schema_version: str = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_text(path: Path) -> str:
+    """Read file as UTF-8 text, replacing bad bytes. Returns "" on error."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return ""
+
+
+def _keywords(text: str) -> List[str]:
+    """Return deduped, lowercased, stopword-filtered tokens from text."""
+    seen: set = set()
+    out: List[str] = []
+    for tok in _WORD_RE.findall(text):
+        low = tok.lower()
+        if low in _STOPWORDS:
+            continue
+        if low not in seen:
+            seen.add(low)
+            out.append(low)
+    return out
+
+
+def _extract_constraint_literals(text: str) -> List[str]:
+    """Extract concrete numeric + scope constraints from a description.
+
+    Example: "3 failed attempts per session" -> ["3 attempts", "per session"].
+    Returned literals are normalised-lowercase and deduped preserving order.
+    """
+    found: List[str] = []
+    seen: set = set()
+
+    for match in _NUMERIC_CONSTRAINT_RE.finditer(text):
+        literal = f"{match.group(1)} {match.group(2).lower()}"
+        if literal not in seen:
+            seen.add(literal)
+            found.append(literal)
+
+    for match in _SCOPE_PHRASE_RE.finditer(text):
+        literal = f"per {match.group(1).lower()}"
+        if literal not in seen:
+            seen.add(literal)
+            found.append(literal)
+
+    return found
+
+
+def _iter_source_files(
+    root: Path,
+    extensions: Sequence[str] = _DEFAULT_IMPL_EXTENSIONS,
+    exclude_paths: Optional[Sequence[Path]] = None,
+) -> Iterable[Path]:
+    """Yield source files under root with matching extensions.
+
+    Skips common build / vcs / dep dirs so we don't index node_modules.
+    Also skips any path inside the explicit ``exclude_paths`` set (used to
+    prevent the spec files themselves from being scanned as implementation,
+    which otherwise self-matches every AC).
+    """
+    if not root.is_dir():
+        return
+    skip_dirs = {
+        ".git", "node_modules", "__pycache__", ".venv", "venv", "dist",
+        "build", ".pytest_cache", ".mypy_cache", "target", ".next",
+        "coverage", ".claude",
+    }
+    # The ``phases/`` tree of a crew project holds spec artefacts — never
+    # scan those as implementation. Using a ``parts`` check so we catch
+    # phases/ at any depth relative to ``root``.
+    skip_top_segments = {"phases"}
+    resolved_excludes = {Path(p).resolve() for p in (exclude_paths or [])}
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(root).parts[:-1]
+        if any(part in skip_dirs for part in rel_parts):
+            continue
+        if rel_parts and rel_parts[0] in skip_top_segments:
+            continue
+        if path.resolve() in resolved_excludes:
+            continue
+        if path.suffix.lower() in extensions:
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# Spec extraction
+# ---------------------------------------------------------------------------
+
+def extract_spec_items(
+    ac_file: Optional[Path] = None,
+    objective_file: Optional[Path] = None,
+    extra_sources: Optional[Sequence[Path]] = None,
+) -> List[SpecItem]:
+    """Extract numbered spec items (AC / FR / REQ) from given files.
+
+    Args:
+        ac_file: Path to ``acceptance-criteria.md`` (preferred primary source).
+        objective_file: Path to ``objective.md`` (secondary source; FR lines).
+        extra_sources: Additional markdown files to scan (e.g. ADRs).
+
+    Returns:
+        Deduped list of SpecItem ordered by first appearance.
+    """
+    sources: List[Path] = []
+    if ac_file and ac_file.exists():
+        sources.append(ac_file)
+    if objective_file and objective_file.exists():
+        sources.append(objective_file)
+    if extra_sources:
+        for src in extra_sources:
+            if src and src.exists():
+                sources.append(src)
+
+    items: List[SpecItem] = []
+    seen_ids: set = set()
+
+    for src in sources:
+        text = _read_text(src)
+        if not text:
+            continue
+        for item in _extract_from_text(text, str(src)):
+            # Normalise id casing — AC-1 and ac-1 should dedupe.
+            key = item.id.upper().replace(" ", "")
+            if key in seen_ids:
+                # Enrich: merge description if we had a shorter one before.
+                continue
+            seen_ids.add(key)
+            items.append(SpecItem(
+                id=item.id.upper().replace(" ", ""),
+                description=item.description,
+                source_file=item.source_file,
+                priority=item.priority,
+            ))
+
+    return items
+
+
+def _extract_from_text(text: str, source_file: str) -> List[SpecItem]:
+    """Pull AC/FR items out of a single markdown body."""
+    out: List[SpecItem] = []
+    seen: set = set()
+
+    # Strategy 1 — table rows
+    for match in _AC_TABLE_ROW_RE.finditer(text):
+        ac_id = match.group("id").strip()
+        desc = match.group("desc").strip()
+        if "criterion" in desc.lower() or "description" in desc.lower():
+            continue  # header row
+        if ac_id and ac_id not in seen:
+            seen.add(ac_id)
+            out.append(SpecItem(
+                id=ac_id,
+                description=desc,
+                source_file=source_file,
+                priority=_detect_priority(desc),
+            ))
+
+    # Strategy 2 — bulleted list "- AC-1: Given ..., When ..., Then ..."
+    for match in _AC_LIST_RE.finditer(text):
+        ac_id = match.group("id").strip()
+        desc = match.group("desc").strip()
+        if ac_id and ac_id not in seen:
+            seen.add(ac_id)
+            out.append(SpecItem(
+                id=ac_id,
+                description=desc,
+                source_file=source_file,
+                priority=_detect_priority(desc),
+            ))
+
+    # Strategy 3 — inline "AC1: Given ... When ... Then ..."
+    for match in _AC_INLINE_RE.finditer(text):
+        ac_id = match.group("id").strip()
+        desc = match.group("desc").strip()
+        if ac_id and ac_id not in seen:
+            seen.add(ac_id)
+            out.append(SpecItem(
+                id=ac_id,
+                description=desc,
+                source_file=source_file,
+                priority=_detect_priority(desc),
+            ))
+
+    # Strategy 4 — bare id mentions as last resort, pair with surrounding line
+    if not out:
+        for match in _SPEC_ID_RE.finditer(text):
+            ac_id = match.group(0)
+            if ac_id in seen:
+                continue
+            # Capture up to 240 chars of context after the id as description.
+            start = match.end()
+            tail = text[start:start + 240].strip()
+            if not tail:
+                continue
+            # Cut at next newline-newline (end of paragraph) if present.
+            end_idx = tail.find("\n\n")
+            if end_idx >= 0:
+                tail = tail[:end_idx].strip()
+            seen.add(ac_id)
+            out.append(SpecItem(
+                id=ac_id,
+                description=tail[:240],
+                source_file=source_file,
+                priority=_detect_priority(tail),
+            ))
+
+    return out
+
+
+_PRIORITY_RE = re.compile(r"\bP([012])\b")
+
+
+def _detect_priority(text: str) -> Optional[str]:
+    match = _PRIORITY_RE.search(text)
+    return f"P{match.group(1)}" if match else None
+
+
+# ---------------------------------------------------------------------------
+# Alignment scoring
+# ---------------------------------------------------------------------------
+
+def _find_references(corpus: Dict[str, str], spec_id: str) -> List[Tuple[str, str]]:
+    """Return list of (file_path, context_snippet) for occurrences of spec_id.
+
+    Uses case-insensitive literal search. Returns up to 20 hits per id to
+    keep reports bounded.
+    """
+    needle = spec_id.upper()
+    needle_lower = spec_id.lower()
+    results: List[Tuple[str, str]] = []
+    for file_path, text in corpus.items():
+        if not text:
+            continue
+        # Quick reject — case-insensitive substring check.
+        lower = text.lower()
+        if needle_lower not in lower:
+            continue
+        # Collect each occurrence's context window.
+        idx = 0
+        while True:
+            pos = lower.find(needle_lower, idx)
+            if pos < 0:
+                break
+            start = max(0, pos - _CONTEXT_WINDOW)
+            end = min(len(text), pos + len(needle) + _CONTEXT_WINDOW)
+            snippet = text[start:end]
+            results.append((file_path, snippet))
+            idx = pos + len(needle)
+            if len(results) >= 20:
+                return results
+    return results
+
+
+def _keyword_overlap(spec_keywords: Sequence[str], context: str) -> float:
+    """Ratio of spec keywords that appear in context text. Range 0.0-1.0."""
+    if not spec_keywords:
+        return 1.0
+    context_lower = context.lower()
+    hits = sum(1 for kw in spec_keywords if kw in context_lower)
+    return hits / len(spec_keywords)
+
+
+def _best_overlap(
+    spec_keywords: Sequence[str],
+    refs: Sequence[Tuple[str, str]],
+) -> float:
+    """Return highest keyword-overlap ratio across all references."""
+    if not refs:
+        return 0.0
+    return max(_keyword_overlap(spec_keywords, snippet) for _, snippet in refs)
+
+
+def _constraints_matched(
+    constraints: Sequence[str],
+    context: str,
+) -> Tuple[List[str], List[str]]:
+    """Return (matched, unmatched) constraint literals against context."""
+    matched: List[str] = []
+    unmatched: List[str] = []
+    lower = context.lower()
+    for literal in constraints:
+        if literal.lower() in lower:
+            matched.append(literal)
+        else:
+            unmatched.append(literal)
+    return matched, unmatched
+
+
+def _aggregate_constraints(
+    constraints: Sequence[str],
+    refs: Sequence[Tuple[str, str]],
+) -> Tuple[List[str], List[str]]:
+    """Aggregate constraint matching across ALL reference contexts.
+
+    A constraint is counted as matched if it appears in ANY reference snippet.
+    """
+    if not constraints:
+        return [], []
+    combined = "\n".join(snippet for _, snippet in refs)
+    return _constraints_matched(constraints, combined)
+
+
+def _classify(
+    item: SpecItem,
+    impl_refs: Sequence[Tuple[str, str]],
+    test_refs: Sequence[Tuple[str, str]],
+) -> Finding:
+    """Produce a Finding for a single spec item given impl + test references."""
+    in_impl = bool(impl_refs)
+    in_tests = bool(test_refs)
+
+    spec_keywords = item.keywords()
+    all_refs = list(impl_refs) + list(test_refs)
+
+    overlap = _best_overlap(spec_keywords, all_refs)
+    matched_c, unmatched_c = _aggregate_constraints(item.constraints(), all_refs)
+
+    evidence = [fp for fp, _ in all_refs[:8]]
+
+    # MISSING — literal id absent from both corpora.
+    if not in_impl and not in_tests:
+        return Finding(
+            id=item.id,
+            description=item.description,
+            source_file=item.source_file,
+            status="missing",
+            confidence=0.9,
+            evidence=[],
+            reason=(
+                f"Spec item {item.id} has no occurrence in implementation "
+                f"corpus or test corpus. Expected at least a comment or "
+                f"test-name reference."
+            ),
+            expected_constraints=item.constraints(),
+            matched_constraints=[],
+            unmatched_constraints=list(item.constraints()),
+            in_impl=False,
+            in_tests=False,
+        )
+
+    # DIVERGENT path 1 — referenced in one corpus only.
+    partial = (in_impl and not in_tests) or (in_tests and not in_impl)
+
+    # DIVERGENT path 2 — has numeric/scope constraints that aren't matched.
+    has_unmatched_constraints = bool(unmatched_c) and bool(item.constraints())
+
+    # DIVERGENT path 3 — keyword overlap below threshold
+    low_overlap = overlap < _ALIGNED_OVERLAP_THRESHOLD
+
+    if partial or has_unmatched_constraints or low_overlap:
+        # Build specific reason.
+        reasons: List[str] = []
+        if partial:
+            if in_impl and not in_tests:
+                reasons.append(
+                    f"{item.id} referenced in implementation but no matching "
+                    f"test asserts it"
+                )
+            else:
+                reasons.append(
+                    f"{item.id} referenced in tests but not in implementation"
+                )
+        if has_unmatched_constraints:
+            reasons.append(
+                f"constraint(s) {unmatched_c} from spec not found near "
+                f"{item.id} references"
+            )
+        if low_overlap and not (partial or has_unmatched_constraints):
+            reasons.append(
+                f"implementation context near {item.id} overlaps only "
+                f"{overlap:.0%} with spec keywords — likely divergent intent"
+            )
+        # Confidence: high when we have concrete constraint gaps, medium
+        # when only overlap is low.
+        confidence = 0.85 if has_unmatched_constraints else (
+            0.7 if partial else 0.6
+        )
+        return Finding(
+            id=item.id,
+            description=item.description,
+            source_file=item.source_file,
+            status="divergent",
+            confidence=confidence,
+            evidence=evidence,
+            reason="; ".join(reasons),
+            expected_constraints=item.constraints(),
+            matched_constraints=matched_c,
+            unmatched_constraints=unmatched_c,
+            in_impl=in_impl,
+            in_tests=in_tests,
+        )
+
+    # ALIGNED — in both corpora, overlap >= threshold, all constraints matched.
+    return Finding(
+        id=item.id,
+        description=item.description,
+        source_file=item.source_file,
+        status="aligned",
+        confidence=min(0.95, 0.5 + overlap * 0.5),
+        evidence=evidence,
+        reason=(
+            f"{item.id} referenced in implementation ({sum(1 for _ in impl_refs)} "
+            f"hit(s)) and tests ({sum(1 for _ in test_refs)} hit(s)); "
+            f"keyword overlap {overlap:.0%} >= "
+            f"{_ALIGNED_OVERLAP_THRESHOLD:.0%}"
+        ),
+        expected_constraints=item.constraints(),
+        matched_constraints=matched_c,
+        unmatched_constraints=[],
+        in_impl=True,
+        in_tests=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+def _build_corpus(
+    directory: Path,
+    extensions: Sequence[str] = _DEFAULT_IMPL_EXTENSIONS,
+    file_limit: int = 5000,
+    exclude_paths: Optional[Sequence[Path]] = None,
+) -> Dict[str, str]:
+    """Build a {path: text} corpus for a directory, bounded by file_limit.
+
+    ``exclude_paths`` lets callers keep the spec files (``acceptance-criteria.md``,
+    ``objective.md``) out of the implementation scan — otherwise every AC
+    self-matches and every project looks 100% aligned.
+    """
+    corpus: Dict[str, str] = {}
+    if not directory.is_dir():
+        return corpus
+    count = 0
+    for path in _iter_source_files(directory, extensions, exclude_paths=exclude_paths):
+        text = _read_text(path)
+        if not text:
+            continue
+        corpus[str(path)] = text
+        count += 1
+        if count >= file_limit:
+            break
+    return corpus
+
+
+def _build_corpus_from_files(files: Sequence[Path]) -> Dict[str, str]:
+    """Build a {path: text} corpus from an explicit file list."""
+    corpus: Dict[str, str] = {}
+    for path in files:
+        if not path.exists() or not path.is_file():
+            continue
+        text = _read_text(path)
+        if text:
+            corpus[str(path)] = text
+    return corpus
+
+
+def _split_impl_and_tests(corpus: Dict[str, str]) -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Partition an arbitrary corpus into (impl_corpus, test_corpus).
+
+    A file is considered a test file when any ancestor directory matches
+    a known test-dir name (``tests``, ``test``, ``spec``, etc.) or when
+    the filename starts with ``test_`` or ends with ``_test.py`` /
+    ``.test.ts`` / ``.spec.ts``.
+    """
+    impl: Dict[str, str] = {}
+    tests: Dict[str, str] = {}
+
+    for path_str, text in corpus.items():
+        p = Path(path_str)
+        is_test = False
+        for part in p.parts:
+            if part.lower() in _DEFAULT_TEST_DIR_NAMES:
+                is_test = True
+                break
+        if not is_test:
+            name = p.name.lower()
+            if (name.startswith("test_") or name.endswith("_test.py") or
+                    name.endswith(".test.ts") or name.endswith(".test.tsx") or
+                    name.endswith(".test.js") or name.endswith(".spec.ts") or
+                    name.endswith(".spec.js")):
+                is_test = True
+        if is_test:
+            tests[path_str] = text
+        else:
+            impl[path_str] = text
+
+    return impl, tests
+
+
+def generate_gap_report(
+    spec_items: Sequence[SpecItem],
+    impl_corpus: Dict[str, str],
+    test_corpus: Dict[str, str],
+    project: str = "unknown",
+    complexity: int = 0,
+) -> GapReport:
+    """Produce a complete Gap Report from spec items + impl/test corpora.
+
+    Args:
+        spec_items: Extracted AC/FR items from clarify-phase specs.
+        impl_corpus: {file_path: text} for non-test source files.
+        test_corpus: {file_path: text} for test files.
+        project: Project identifier (for the report header).
+        complexity: Project complexity score (0-7).
+
+    Returns:
+        GapReport dataclass — ``asdict`` it for JSON output.
+    """
+    findings: List[Finding] = []
+
+    for item in spec_items:
+        impl_refs = _find_references(impl_corpus, item.id)
+        test_refs = _find_references(test_corpus, item.id)
+        findings.append(_classify(item, impl_refs, test_refs))
+
+    total = len(findings)
+    aligned = sum(1 for f in findings if f.status == "aligned")
+    divergent = sum(1 for f in findings if f.status == "divergent")
+    missing = sum(1 for f in findings if f.status == "missing")
+
+    # Score = aligned ratio (1.0 when no specs — vacuously aligned).
+    score = (aligned / total) if total > 0 else 1.0
+
+    # Verdict: APPROVE only when all aligned; REJECT when anything missing;
+    # CONDITIONAL when only divergent findings.
+    if total == 0:
+        verdict = _VERDICT_APPROVE
+        summary = "No numbered spec items found — advisory skip."
+    elif missing > 0:
+        verdict = _VERDICT_REJECT
+        summary = (
+            f"{missing} spec item(s) missing from implementation. "
+            f"Hard reject — implement referenced AC before approval."
+        )
+    elif divergent > 0:
+        verdict = _VERDICT_CONDITIONAL
+        summary = (
+            f"{divergent} spec item(s) diverge from stated intent. "
+            f"Fix divergences or explicitly document the deviation."
+        )
+    else:
+        verdict = _VERDICT_APPROVE
+        summary = f"All {aligned} spec items aligned with implementation."
+
+    return GapReport(
+        project=project,
+        complexity=complexity,
+        total=total,
+        aligned=aligned,
+        divergent=divergent,
+        missing=missing,
+        verdict=verdict,
+        score=round(score, 3),
+        findings=findings,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ADR constraint extraction  (conservative MVP)
+# ---------------------------------------------------------------------------
+
+def extract_adr_constraints(adr_dir: Path) -> List[Dict[str, str]]:
+    """Extract MUST/SHALL directives from ADR markdown files.
+
+    Conservative regex-only approach: pulls every line containing a modal
+    directive (MUST / MUST NOT / SHALL / SHALL NOT / SHOULD NOT) and returns
+    ``{source, directive, statement}``. A follow-up iteration could run these
+    statements against the implementation corpus and flag violations.
+
+    Returns:
+        List of dicts; empty if dir missing or no directives.
+
+    Limitations:
+        - Line-granular only (no multi-line parsing).
+        - No negation / scope reasoning — downstream code must still decide
+          whether a match is a violation or a legitimate exception.
+        - Treats every modal-directive hit as equally important.
+    """
+    out: List[Dict[str, str]] = []
+    if not adr_dir.is_dir():
+        return out
+
+    for md in sorted(adr_dir.rglob("*.md")):
+        text = _read_text(md)
+        if not text:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            match = _MODAL_DIRECTIVE_RE.search(line)
+            if not match:
+                continue
+            # Skip section headers and front-matter noise.
+            stripped = line.strip()
+            if stripped.startswith("#") or stripped.startswith("---"):
+                continue
+            out.append({
+                "source": str(md),
+                "line": str(line_no),
+                "directive": match.group(1),
+                "statement": stripped[:240],
+            })
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — project-dir convention
+# ---------------------------------------------------------------------------
+
+def review_project(
+    project_dir: Path,
+    project_name: str = "",
+    complexity: int = 0,
+    ac_file: Optional[Path] = None,
+    objective_file: Optional[Path] = None,
+    impl_dir: Optional[Path] = None,
+    test_dir: Optional[Path] = None,
+) -> GapReport:
+    """Run a full semantic review over a project directory.
+
+    Expected layout (overrideable via args)::
+
+        <project_dir>/
+            phases/
+                clarify/
+                    acceptance-criteria.md   <-- ac_file default
+                    objective.md             <-- objective_file default
+            <impl sources>                   <-- impl_dir default = project_dir
+            tests/                           <-- test_dir default
+
+    Args:
+        project_dir: Root dir containing phases/ and source.
+        project_name: Name for the report header.
+        complexity: Project complexity 0-7.
+        ac_file: Override path to acceptance-criteria.md.
+        objective_file: Override path to objective.md.
+        impl_dir: Override implementation-scan root. Defaults to project_dir.
+        test_dir: Override test-scan root. When None, impl_dir is scanned and
+            files are partitioned by filename + dir heuristic.
+
+    Returns:
+        GapReport.
+    """
+    ac_path = ac_file or (project_dir / "phases" / "clarify" / "acceptance-criteria.md")
+    obj_path = objective_file or (project_dir / "phases" / "clarify" / "objective.md")
+
+    spec_items = extract_spec_items(ac_file=ac_path, objective_file=obj_path)
+
+    impl_root = impl_dir or project_dir
+
+    # Never scan the spec files themselves — otherwise every AC
+    # self-matches and overlap is trivially 100%.
+    spec_excludes: List[Path] = []
+    if ac_path and ac_path.exists():
+        spec_excludes.append(ac_path)
+    if obj_path and obj_path.exists():
+        spec_excludes.append(obj_path)
+
+    if test_dir:
+        impl_corpus = _build_corpus(impl_root, exclude_paths=spec_excludes)
+        test_corpus = _build_corpus(test_dir, exclude_paths=spec_excludes)
+        # Avoid double-counting: strip test files from impl_corpus.
+        test_paths = set(test_corpus.keys())
+        impl_corpus = {p: t for p, t in impl_corpus.items() if p not in test_paths}
+    else:
+        full_corpus = _build_corpus(impl_root, exclude_paths=spec_excludes)
+        impl_corpus, test_corpus = _split_impl_and_tests(full_corpus)
+
+    project = project_name or project_dir.name
+
+    return generate_gap_report(
+        spec_items=spec_items,
+        impl_corpus=impl_corpus,
+        test_corpus=test_corpus,
+        project=project,
+        complexity=complexity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation
+# ---------------------------------------------------------------------------
+
+def report_to_dict(report: GapReport) -> Dict[str, Any]:
+    """Convert a GapReport (incl. nested Findings) to a JSON-safe dict."""
+    return asdict(report)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="semantic_review.py",
+        description="Semantic reviewer — spec-to-code alignment (issue #444).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_review = sub.add_parser("review", help="Run full semantic review")
+    p_review.add_argument("--project-dir", required=True)
+    p_review.add_argument("--project-name", default="")
+    p_review.add_argument("--complexity", type=int, default=0)
+    p_review.add_argument("--ac-file", default=None)
+    p_review.add_argument("--objective-file", default=None)
+    p_review.add_argument("--impl-dir", default=None)
+    p_review.add_argument("--test-dir", default=None)
+    p_review.add_argument("--output", default=None, help="Write JSON report to this path")
+
+    p_constraints = sub.add_parser("constraints", help="Extract ADR constraints (MVP)")
+    p_constraints.add_argument("--adr-dir", required=True)
+    p_constraints.add_argument("--output", default=None)
+
+    return parser
+
+
+def _cli_review(args: argparse.Namespace) -> int:
+    project_dir = Path(args.project_dir).resolve()
+    if not project_dir.is_dir():
+        print(f"error: project-dir not found: {project_dir}", file=sys.stderr)
+        return 2
+
+    report = review_project(
+        project_dir=project_dir,
+        project_name=args.project_name,
+        complexity=args.complexity,
+        ac_file=Path(args.ac_file).resolve() if args.ac_file else None,
+        objective_file=Path(args.objective_file).resolve() if args.objective_file else None,
+        impl_dir=Path(args.impl_dir).resolve() if args.impl_dir else None,
+        test_dir=Path(args.test_dir).resolve() if args.test_dir else None,
+    )
+    payload = report_to_dict(report)
+    data = json.dumps(payload, indent=2)
+    if args.output:
+        out_path = Path(args.output).resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(data)
+    else:
+        sys.stdout.write(data + "\n")
+    # Non-zero exit only when verdict is REJECT — CONDITIONAL is advisory.
+    if report.verdict == _VERDICT_REJECT:
+        return 1
+    return 0
+
+
+def _cli_constraints(args: argparse.Namespace) -> int:
+    adr_dir = Path(args.adr_dir).resolve()
+    constraints = extract_adr_constraints(adr_dir)
+    data = json.dumps({"constraints": constraints, "count": len(constraints)}, indent=2)
+    if args.output:
+        out_path = Path(args.output).resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(data)
+    else:
+        sys.stdout.write(data + "\n")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "review":
+        return _cli_review(args)
+    if args.command == "constraints":
+        return _cli_constraints(args)
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/qe/test_semantic_review.py
+++ b/tests/qe/test_semantic_review.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Tests for the semantic reviewer (issue #444).
+
+Covers the P0 acceptance requirement explicitly (TestAc1DivergentAcceptance)
+plus aligned / missing detection, gate-result integration, complexity
+threshold honouring, and legacy bypass.
+
+Run with::
+
+    python3 -m pytest tests/qe/test_semantic_review.py -v
+    # or
+    python3 -m unittest tests.qe.test_semantic_review -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_QE = _SCRIPTS / "qe"
+_CREW = _SCRIPTS / "crew"
+
+sys.path.insert(0, str(_SCRIPTS))
+sys.path.insert(0, str(_QE))
+sys.path.insert(0, str(_CREW))
+
+
+import semantic_review  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic project factories
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _make_project(root: Path, ac_text: str, impl_map: dict, test_map: dict) -> Path:
+    """Create a synthetic project layout under root.
+
+    impl_map / test_map are {relative_path: body}.
+    """
+    project = root / "proj"
+    _write(project / "phases" / "clarify" / "acceptance-criteria.md", ac_text)
+    _write(project / "phases" / "clarify" / "objective.md",
+           "# Objective\nImplement the feature described by AC-1 and friends.\n")
+
+    for rel, body in impl_map.items():
+        _write(project / rel, body)
+    for rel, body in test_map.items():
+        _write(project / "tests" / rel, body)
+
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Acceptance test required by issue #444 — AC-1 Divergent finding
+# ---------------------------------------------------------------------------
+
+
+class TestAc1DivergentAcceptance(unittest.TestCase):
+    """Issue #444 acceptance: an AC-1 spec + implementation that partially
+    satisfies it produces a DIVERGENT finding naming AC-1.
+
+    Spec: "Given 3 failed login attempts per session, When user tries again,
+           Then account locked".
+    Impl: enforces rate limit PER REQUEST instead of PER SESSION — classic
+          scope drift.
+    """
+
+    def test_ac1_per_session_impl_per_request_is_divergent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            ac_text = (
+                "# Acceptance Criteria\n"
+                "\n"
+                "- AC-1: Given 3 failed login attempts per session, When user "
+                "tries again, Then account is locked for 15 minutes [P0]\n"
+            )
+            impl_map = {
+                "src/auth.py": (
+                    "# Handles login rate limiting.\n"
+                    "# See AC-1 — we enforce a 3-attempt cap per request.\n"
+                    "def login(user, password, request):\n"
+                    "    attempts = request.headers.get('X-Attempts', 0)\n"
+                    "    if attempts >= 3:\n"
+                    "        return 'locked'\n"
+                    "    return 'ok'\n"
+                ),
+            }
+            test_map = {
+                "test_auth.py": (
+                    "# AC-1 coverage\n"
+                    "def test_login_locks_after_three_attempts():\n"
+                    "    # asserts lock after 3 attempts\n"
+                    "    assert True\n"
+                ),
+            }
+            project = _make_project(Path(td), ac_text, impl_map, test_map)
+
+            report = semantic_review.review_project(
+                project_dir=project,
+                project_name="proj",
+                complexity=4,
+            )
+
+            self.assertEqual(report.total, 1, f"Expected 1 spec item, got {report.total}")
+
+            ac1_finding = next(
+                (f for f in report.findings if f.id.upper() == "AC-1"),
+                None,
+            )
+            self.assertIsNotNone(ac1_finding, "AC-1 finding missing")
+            self.assertEqual(
+                ac1_finding.status, "divergent",
+                f"Expected AC-1 divergent, got {ac1_finding.status}. Reason: {ac1_finding.reason}",
+            )
+            # Explicit check that the DIVERGENT finding names AC-1 (per #444 AC).
+            self.assertIn("AC-1", ac1_finding.id)
+            # The scope drift must surface as an unmatched 'per session'
+            # constraint.
+            self.assertIn("per session", [c.lower() for c in ac1_finding.unmatched_constraints],
+                          f"Expected 'per session' in unmatched; got {ac1_finding.unmatched_constraints}")
+            # Verdict at complexity 4 with 0 missing + 1 divergent -> CONDITIONAL.
+            self.assertEqual(report.verdict, "CONDITIONAL",
+                             f"Got verdict={report.verdict}; reason={report.summary}")
+            print(f"PASS AC-1 Divergent acceptance (confidence={ac1_finding.confidence:.2f})")
+
+
+# ---------------------------------------------------------------------------
+# Aligned detection
+# ---------------------------------------------------------------------------
+
+
+class TestAlignedDetection(unittest.TestCase):
+    def test_all_aligned_when_impl_and_tests_cover_ac(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            ac_text = (
+                "# Acceptance Criteria\n\n"
+                "- AC-1: User can greet the world and receive a response [P0]\n"
+            )
+            impl_map = {
+                "src/greet.py": (
+                    "# AC-1 — greet the world\n"
+                    "def greet(user):\n"
+                    "    # returns response when user greets the world\n"
+                    "    return f'hello {user}, welcome to the world'\n"
+                ),
+            }
+            test_map = {
+                "test_greet.py": (
+                    "# AC-1 coverage — user can greet the world, receive response\n"
+                    "def test_greet_returns_welcome():\n"
+                    "    from src.greet import greet\n"
+                    "    assert 'welcome' in greet('alice')\n"
+                ),
+            }
+            project = _make_project(Path(td), ac_text, impl_map, test_map)
+            report = semantic_review.review_project(project, "proj", complexity=4)
+
+            self.assertEqual(report.total, 1)
+            self.assertEqual(report.aligned, 1)
+            self.assertEqual(report.missing, 0)
+            self.assertEqual(report.divergent, 0)
+            self.assertEqual(report.verdict, "APPROVE")
+            print(f"PASS aligned detection (score={report.score})")
+
+
+# ---------------------------------------------------------------------------
+# Missing detection
+# ---------------------------------------------------------------------------
+
+
+class TestMissingDetection(unittest.TestCase):
+    def test_ac2_not_referenced_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            ac_text = (
+                "# Acceptance Criteria\n\n"
+                "- AC-1: User can greet [P0]\n"
+                "- AC-2: System logs the greeting for audit [P0]\n"
+            )
+            impl_map = {
+                "src/greet.py": (
+                    "# AC-1 — greet only\n"
+                    "def greet(user):\n"
+                    "    return f'hello {user}'\n"
+                ),
+            }
+            test_map = {
+                "test_greet.py": (
+                    "# AC-1 coverage\n"
+                    "def test_greet():\n"
+                    "    assert True\n"
+                ),
+            }
+            project = _make_project(Path(td), ac_text, impl_map, test_map)
+            report = semantic_review.review_project(project, "proj", complexity=4)
+
+            self.assertEqual(report.total, 2)
+            missing_ids = [f.id for f in report.findings if f.status == "missing"]
+            self.assertIn("AC-2", missing_ids, f"Expected AC-2 missing, got missing={missing_ids}")
+            self.assertEqual(report.verdict, "REJECT")
+            print(f"PASS missing detection (missing={missing_ids})")
+
+
+# ---------------------------------------------------------------------------
+# Gate-result integration via phase_manager._check_semantic_alignment_gate
+# ---------------------------------------------------------------------------
+
+
+class TestGateIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
+        # Fresh-import phase_manager to pick up env state.
+        if "phase_manager" in sys.modules:
+            del sys.modules["phase_manager"]
+        import phase_manager  # noqa: E402
+        self.pm = phase_manager
+
+    def _make_state(self, complexity: int) -> "self.pm.ProjectState":
+        return self.pm.ProjectState(
+            name="semtest",
+            current_phase="review",
+            created_at="2026-01-01T00:00:00Z",
+            complexity_score=complexity,
+        )
+
+    def test_missing_blocks_at_complexity_5(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "proj"
+            _write(project / "phases" / "clarify" / "acceptance-criteria.md",
+                   "- AC-9: Widget explodes on overload [P0]\n")
+            # Empty impl — AC-9 not referenced anywhere.
+            _write(project / "src" / "main.py", "# unrelated code\n")
+
+            state = self._make_state(complexity=5)
+            block, warnings = self.pm._check_semantic_alignment_gate(
+                state, project, "review",
+            )
+            self.assertIsNotNone(block, f"Expected block reason; warnings={warnings}")
+            self.assertIn("REJECT", block)
+            self.assertIn("AC-9", block)
+            print("PASS gate-integration: missing blocks at complexity 5")
+
+    def test_divergent_emits_warning_at_complexity_4(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "proj"
+            _write(project / "phases" / "clarify" / "acceptance-criteria.md",
+                   "- AC-1: Lock after 3 failed attempts per session [P0]\n")
+            _write(project / "src" / "auth.py",
+                   "# AC-1\n# attempts per request logic\n"
+                   "def check(r):\n    return r.attempts < 3\n")
+            _write(project / "tests" / "test_auth.py",
+                   "# AC-1 test\n"
+                   "def test_lock():\n    assert True\n")
+
+            state = self._make_state(complexity=4)
+            block, warnings = self.pm._check_semantic_alignment_gate(
+                state, project, "review",
+            )
+            self.assertIsNone(block, f"Expected no block; got {block}")
+            # Warnings must name AC-1 and divergent.
+            joined = "\n".join(warnings)
+            self.assertIn("AC-1", joined)
+            self.assertIn("DIVERGENT", joined)
+
+            # Verify conditions manifest was written.
+            manifest = project / "phases" / "review" / "conditions-manifest.json"
+            self.assertTrue(manifest.exists(),
+                            "Conditions manifest should be written for divergent findings")
+            body = json.loads(manifest.read_text())
+            descriptions = [c.get("description", "") for c in body.get("conditions", [])]
+            self.assertTrue(any("AC-1" in d for d in descriptions),
+                            f"Expected AC-1 in conditions manifest; got {descriptions}")
+
+            # Verify report artifact written.
+            report_path = project / "phases" / "review" / "semantic-gap-report.json"
+            self.assertTrue(report_path.exists())
+            report_data = json.loads(report_path.read_text())
+            self.assertEqual(report_data["verdict"], "CONDITIONAL")
+            print("PASS gate-integration: divergent yields conditions at complexity 4")
+
+
+# ---------------------------------------------------------------------------
+# Complexity threshold honouring (advisory vs blocking)
+# ---------------------------------------------------------------------------
+
+
+class TestComplexityThreshold(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
+        if "phase_manager" in sys.modules:
+            del sys.modules["phase_manager"]
+        import phase_manager  # noqa: E402
+        self.pm = phase_manager
+
+    def _setup_missing_project(self, td: Path) -> Path:
+        project = td / "proj"
+        _write(project / "phases" / "clarify" / "acceptance-criteria.md",
+               "- AC-99: missing feature [P0]\n")
+        _write(project / "src" / "foo.py", "# unrelated\n")
+        return project
+
+    def test_complexity_2_is_advisory_not_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = self._setup_missing_project(Path(td))
+            state = self.pm.ProjectState(
+                name="semtest", current_phase="review",
+                created_at="2026-01-01T00:00:00Z", complexity_score=2,
+            )
+            block, warnings = self.pm._check_semantic_alignment_gate(
+                state, project, "review",
+            )
+            self.assertIsNone(block,
+                              f"Complexity 2 must not block; got {block}")
+            self.assertTrue(
+                any("MISSING" in w for w in warnings),
+                f"Expected MISSING warning to still surface; got {warnings}",
+            )
+            print("PASS complexity threshold: complexity 2 is advisory")
+
+    def test_complexity_3_is_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = self._setup_missing_project(Path(td))
+            state = self.pm.ProjectState(
+                name="semtest", current_phase="review",
+                created_at="2026-01-01T00:00:00Z", complexity_score=3,
+            )
+            block, _ = self.pm._check_semantic_alignment_gate(
+                state, project, "review",
+            )
+            self.assertIsNotNone(block, "Complexity 3 must block on missing")
+            print("PASS complexity threshold: complexity 3 blocks on missing")
+
+
+# ---------------------------------------------------------------------------
+# Legacy bypass
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyBypass(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
+
+    def test_legacy_bypass_skips_gate_entirely(self) -> None:
+        os.environ["CREW_GATE_ENFORCEMENT"] = "legacy"
+        if "phase_manager" in sys.modules:
+            del sys.modules["phase_manager"]
+        import phase_manager  # noqa: E402
+
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "proj"
+            _write(project / "phases" / "clarify" / "acceptance-criteria.md",
+                   "- AC-9: missing everything [P0]\n")
+            state = phase_manager.ProjectState(
+                name="sem", current_phase="review",
+                created_at="2026-01-01T00:00:00Z", complexity_score=6,
+            )
+            block, warnings = phase_manager._check_semantic_alignment_gate(
+                state, project, "review",
+            )
+            self.assertIsNone(block,
+                              "CREW_GATE_ENFORCEMENT=legacy must bypass the gate")
+            self.assertEqual(warnings, [],
+                             "Legacy bypass should return no warnings")
+            print("PASS legacy bypass")
+
+
+# ---------------------------------------------------------------------------
+# ADR constraint extraction (MVP)
+# ---------------------------------------------------------------------------
+
+
+class TestAdrConstraints(unittest.TestCase):
+    def test_must_and_shall_directives_extracted(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            adr_dir = Path(td) / "adrs"
+            _write(adr_dir / "001-encryption.md",
+                   "# ADR-001: Encryption\n\n"
+                   "The system MUST encrypt all PII at rest.\n"
+                   "Passwords SHALL NOT be logged in plaintext.\n"
+                   "Developers SHOULD rotate keys quarterly.\n"
+                   "## Context\nbackground prose\n")
+            directives = semantic_review.extract_adr_constraints(adr_dir)
+            # At least 3 directives found (MUST, SHALL NOT, SHOULD).
+            self.assertGreaterEqual(len(directives), 3,
+                                    f"Expected >=3 directives; got {directives}")
+            kinds = {d["directive"] for d in directives}
+            self.assertIn("MUST", kinds)
+            self.assertIn("SHALL NOT", kinds)
+            print(f"PASS ADR constraint extraction ({len(directives)} directives)")
+
+    def test_missing_adr_dir_returns_empty_list(self) -> None:
+        result = semantic_review.extract_adr_constraints(Path("/nonexistent/adr/path"))
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# Extraction edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSpecExtraction(unittest.TestCase):
+    def test_table_row_extraction(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            ac = Path(td) / "ac.md"
+            ac.write_text(
+                "| ID | Criterion | Test |\n"
+                "|----|-----------|------|\n"
+                "| AC-1 | User logs in | test_login |\n"
+                "| AC-2 | User logs out | test_logout |\n",
+            )
+            items = semantic_review.extract_spec_items(ac_file=ac)
+            ids = [it.id for it in items]
+            self.assertIn("AC-1", ids)
+            self.assertIn("AC-2", ids)
+
+    def test_bullet_list_extraction(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            ac = Path(td) / "ac.md"
+            ac.write_text(
+                "- AC-1: Given X When Y Then Z\n"
+                "- **AC-2**: Given A When B Then C\n",
+            )
+            items = semantic_review.extract_spec_items(ac_file=ac)
+            ids = [it.id for it in items]
+            self.assertIn("AC-1", ids)
+            self.assertIn("AC-2", ids)
+
+    def test_no_ac_file_returns_empty(self) -> None:
+        items = semantic_review.extract_spec_items(
+            ac_file=Path("/nonexistent"), objective_file=Path("/also-nope"),
+        )
+        self.assertEqual(items, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #444 — P0 trust-critical.

## Summary
- Adds an autonomous post-implementation pass that extracts numbered AC / FR / REQ from clarify-phase specs (`acceptance-criteria.md`, `objective.md`) and classifies each against the implementation + test corpora as **aligned / divergent / missing**.
- Mandatory at complexity >= 3 (missing -> hard REJECT, divergent -> CONDITIONAL with auto-written conditions manifest); advisory below; `CREW_GATE_ENFORCEMENT=legacy` bypass.
- LLM-free heuristics: keyword overlap (threshold 35%), numeric + scope-phrase constraint matching, per-corpus reference counting.

## Surfaces added (all additive — safe for concurrent-PR merge)
- `agents/qe/semantic-reviewer.md` — specialist agent
- `scripts/qe/semantic_review.py` — stdlib-only analyzer + CLI (`review`, `constraints`)
- `scripts/crew/phase_manager.py` — new `_check_semantic_alignment_gate` helper invoked at the review-phase hook point alongside the planned `_check_convergence_gate` (PR #453). **Does not touch** `_apply_spec_rubric` (PR #450) or the existing gate-result machinery.
- `.claude-plugin/gate-policy.json` — new `semantic-alignment` entry appended after `final-audit`
- `tests/qe/test_semantic_review.py` — 13 tests

## Gap Report JSON schema
```json
{
  "schema_version": "1.0.0",
  "project": "<name>", "complexity": <int>,
  "total": <int>, "aligned": <int>, "divergent": <int>, "missing": <int>,
  "verdict": "APPROVE | CONDITIONAL | REJECT",
  "score": <0.0-1.0>, "summary": "<one-line>",
  "findings": [{
    "id": "AC-1", "description": "...", "source_file": "...",
    "status": "aligned | divergent | missing",
    "confidence": <0.0-1.0>,
    "evidence": ["path.py", ...],
    "reason": "<human>",
    "expected_constraints": ["3 attempts", "per session"],
    "matched_constraints": [...], "unmatched_constraints": [...],
    "in_impl": true, "in_tests": true
  }]
}
```

## Classification heuristics
- **Aligned**: id referenced in BOTH corpora, overlap >= 35%, all concrete constraints matched
- **Divergent**: id referenced but (one-corpus-only) OR (unmatched numeric/scope constraint) OR (overlap < 35%)
- **Missing**: id absent from both corpora

Confidence: 0.85 for constraint-mismatch divergence (strongest signal), 0.7 for partial-coverage divergence, 0.6 for overlap-only divergence, 0.9 for missing, up to 0.95 for aligned.

## Test plan
- [x] `tests/qe/test_semantic_review.py::TestAc1DivergentAcceptance::test_ac1_per_session_impl_per_request_is_divergent` — **P0 issue-acceptance test** passes (confidence 0.85)
- [x] Aligned detection (full overlap in impl + tests)
- [x] Missing detection (AC-2 absent -> REJECT verdict)
- [x] Gate integration: missing blocks at complexity 5
- [x] Gate integration: divergent at complexity 4 writes conditions-manifest.json + semantic-gap-report.json
- [x] Complexity threshold: 2 advisory (non-blocking), 3 blocking
- [x] `CREW_GATE_ENFORCEMENT=legacy` bypasses entirely
- [x] ADR constraint extraction (MUST / SHALL NOT / SHOULD regex)
- [x] All 142 repo tests still pass — no regressions

## Limitations
- Heuristics only — catches the 80% cheap divergences (scope drift, limit drift, unit drift, negation drift).
- ADR constraint extraction is MVP — identifies modal-directive lines but does not yet verify each against the implementation corpus. Documented in the agent spec as follow-up.
- Overlap scoring can miss rename-heavy refactors; scope-phrase regex (`per session|request|user|...`) catches literal scope drift.

## Concurrent-PR conflict check
- **#451 (#442)**, **#453 (#445)**: both add new entries to `gate-policy.json` — our new entry is appended after `final-audit` so any three can merge without overlap.
- **#450 (#446)**: added `_apply_spec_rubric` to `phase_manager.py` — we added `_check_semantic_alignment_gate`, distinct helper, different insertion point.
- **#453 (#445)**: planned `_check_convergence_gate` at the review-phase hook point — our helper is side-by-side; trivial merge.
- **#452 (#443)**, **#449 (#332)**: orthogonal.

## Follow-ups
- Pair each ADR `MUST`/`SHALL NOT` directive with an automatic verification query against the impl corpus (currently extraction-only).
- Optional: add AST-aware scope matching (for Python/TS) to detect scope drift beyond literal phrases.
- Optional: promote semantic-alignment to a `gate_required: true` phase-level entry in `phases.json` once the gate has shipped and baked.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)