### PR TITLE
feat(#461): wire facilitator_context + retro auto-populate action items

### DIFF
--- a/commands/crew/retro.md
+++ b/commands/crew/retro.md
@@ -122,6 +122,22 @@ sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_ru
   --json
 ```
 
+### 6b. Auto-Populate Action Items (additive side-effect, issue #461)
+
+After the retro markdown artifact is written, scan it and seed each
+action item into `delivery.process_memory` so they receive stable `AI-NNN`
+identifiers and surface at future session starts via the facilitator
+context. This is a side-effect only — the retro markdown itself is not
+modified. Fails open if `process_memory` is unavailable.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/retro_action_items.py" \
+  --project "{project-name}" \
+  --retro-md "{retro_md_path}" \
+  --session-id "${CLAUDE_SESSION_ID:-}" \
+  --json
+```
+
 ### 7. Display Retrospective
 
 ```markdown

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -676,6 +676,64 @@ def _check_brain_dependency():
 # Discovery: contextual command suggestions based on project type (Issue #322)
 # ---------------------------------------------------------------------------
 
+def _check_facilitator_context(project_name: str | None) -> str | None:
+    """Return a briefing line for unresolved action items aged >= 2 sessions.
+
+    Lazily imports ``scripts.delivery.process_memory`` so environments that
+    do not ship that module (pre-#447 plugin installs) continue to boot.
+    Returns a short ``[ProcessMemory]`` line when the project has any
+    aging AIs, or ``None`` when:
+
+    - No active project was detected (nothing to surface for).
+    - ``delivery.process_memory`` is not importable (fail-open).
+    - The project has no unresolved action items at the aging threshold.
+    - Any exception is raised while reading the memory file.
+
+    Matches the fail-open pattern used by ``_run_quality_telemetry`` and
+    the guard pipeline in ``stop.py``.
+    """
+    if not project_name:
+        return None
+    try:
+        # Lazy import — absence must NOT break bootstrap on legacy installs.
+        sys.path.insert(0, str(_PLUGIN_ROOT / "scripts" / "delivery"))
+        try:
+            import process_memory as _pm  # type: ignore
+        except ImportError as exc:
+            print(
+                f"[wicked-garden] process_memory not importable ({exc!r}); "
+                "skipping facilitator context",
+                file=sys.stderr,
+            )
+            return None
+
+        ctx = _pm.facilitator_context(project_name)
+        aging = ctx.get("aging_action_items", []) if isinstance(ctx, dict) else []
+        if not aging:
+            return None
+
+        # Show up to 3 AIs inline so the line stays readable; rest are
+        # countable via the summary prefix and fully visible via
+        # process-memory.md on disk.
+        shown = aging[:3]
+        preview = ", ".join(
+            f"{ai.get('id', '?')} \"{(ai.get('title') or '')[:60]}\""
+            for ai in shown
+        )
+        more = f" (+{len(aging) - len(shown)} more)" if len(aging) > len(shown) else ""
+        return (
+            f"[ProcessMemory] {len(aging)} unresolved action item(s) "
+            f">=2 sessions old: {preview}{more}"
+        )
+    except Exception as exc:
+        # Fail-open: never block session start on process-memory errors.
+        print(
+            f"[wicked-garden] facilitator_context error: {exc!r}",
+            file=sys.stderr,
+        )
+        return None
+
+
 def _probe_onedrive_path() -> str | None:
     """Detect if cwd is under a OneDrive or CloudStorage path with spaces.
 
@@ -1077,6 +1135,13 @@ def main():
             discovery_lines = _suggest_commands_for_project()
             if discovery_lines:
                 briefing_parts.append(discovery_lines)
+
+        # Facilitator context: surface aging action items from process_memory.
+        # Additive briefing line (issue #461) — runs last of the informational
+        # notes and is independent of onboarding or setup state.
+        fc_note = _check_facilitator_context(project_name)
+        if fc_note:
+            briefing_parts.append(fc_note)
 
         # Onboarding directive goes LAST for highest priority
         if onboarding_directive:

--- a/scripts/crew/retro_action_items.py
+++ b/scripts/crew/retro_action_items.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""retro_action_items.py — scan retro markdown and auto-populate action items.
+
+Purpose
+-------
+The retro command (``/wicked-garden:crew:retro``) generates a markdown
+retrospective with a ``## Action Items`` section. Prior to this wiring
+(issue #461), action items surfaced in that section evaporated between
+sessions — they were only ever rendered to the retro artifact and not
+tracked anywhere durable.
+
+This helper is invoked by the retro command AFTER the markdown artifact
+is written. It scans the retro content for action-item patterns and calls
+``delivery.process_memory.add_action_item()`` so each item receives a
+stable ``AI-NNN`` identifier and becomes visible to the facilitator at
+future session starts (via ``aging_action_items``).
+
+**Additive side-effect only.** The retro markdown output is not modified.
+If ``delivery.process_memory`` is not importable (legacy environments or
+module removed), the helper fails open — no action items are added, no
+errors are raised, exit code is 0.
+
+Invocation
+----------
+::
+
+    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+        "${CLAUDE_PLUGIN_ROOT}/scripts/crew/retro_action_items.py" \
+        --project PROJECT --retro-md PATH
+
+Arguments
+---------
+--project:      Crew project slug (required).
+--retro-md:     Path to the retro markdown file (required).
+--session-id:   Session identifier to stamp on created action items.
+--json:         Emit JSON summary on stdout instead of human text.
+
+Stdlib-only. Safe to run in a hook or command context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterator
+
+# ---------------------------------------------------------------------------
+# Action-item parsing
+# ---------------------------------------------------------------------------
+#
+# Pattern: retros write action items as a bulleted checkbox list under a
+# heading that contains "Action Items" (case-insensitive). We extract each
+# bullet's text as the title, keeping the original line as description so
+# reviewers can always trace the source back to the retro.
+#
+# A bullet is any line matching one of:
+#   - [ ] <text>        (GitHub checkbox)
+#   - [x] <text>        (completed — still captured; owner may re-open)
+#   * <text>            (plain bullet)
+#   - <text>            (plain bullet)
+#
+# We stop collecting when we hit another top-level heading or the end of
+# the document. This keeps action-item parsing confined to the intended
+# section.
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_ACTION_HEADING_RE = re.compile(r"action\s+items?", re.IGNORECASE)
+_BULLET_RE = re.compile(
+    r"^\s*[-*]\s*(?:\[[ xX]\]\s*)?(?P<title>.+?)\s*$"
+)
+
+
+def _iter_action_items(md_text: str) -> Iterator[dict]:
+    """Yield {title, description} dicts for each action-item bullet found.
+
+    The scanner walks the markdown line-by-line, tracking whether we're
+    currently inside an Action Items section. A new top-level heading
+    closes the section.
+    """
+    in_section = False
+    section_level = 0
+    for raw_line in md_text.splitlines():
+        heading = _HEADING_RE.match(raw_line)
+        if heading:
+            level = len(heading.group(1))
+            title = heading.group(2).strip()
+            if _ACTION_HEADING_RE.search(title):
+                in_section = True
+                section_level = level
+                continue
+            # Another heading at the same or shallower level ends the section
+            if in_section and level <= section_level:
+                in_section = False
+            continue
+
+        if not in_section:
+            continue
+
+        bullet = _BULLET_RE.match(raw_line)
+        if not bullet:
+            continue
+        title = bullet.group("title").strip()
+        if not title:
+            continue
+        yield {"title": title, "description": raw_line.strip()}
+
+
+def scan_action_items(md_text: str) -> list[dict]:
+    """Return every action-item bullet discovered in ``md_text``."""
+    return list(_iter_action_items(md_text))
+
+
+# ---------------------------------------------------------------------------
+# process_memory integration (lazy + fail-open)
+# ---------------------------------------------------------------------------
+
+
+def _load_process_memory():
+    """Import delivery.process_memory lazily; return None if absent."""
+    _scripts_root = Path(__file__).resolve().parents[1]
+    if str(_scripts_root) not in sys.path:
+        sys.path.insert(0, str(_scripts_root))
+    try:
+        from delivery import process_memory  # type: ignore
+        return process_memory
+    except Exception as exc:  # pragma: no cover — only in broken envs
+        print(
+            f"[retro_action_items] delivery.process_memory not importable "
+            f"({exc!r}); skipping add_action_item calls",
+            file=sys.stderr,
+        )
+        return None
+
+
+def populate_action_items(
+    project: str,
+    retro_md_path: Path,
+    *,
+    session_id: str = "",
+) -> dict:
+    """Scan ``retro_md_path`` and append each action item via process_memory.
+
+    Returns a dict summarising what was done::
+
+        {
+          "project": "<slug>",
+          "retro_md": "<path>",
+          "items_found": <int>,
+          "items_added": [<AI-id>, ...],
+          "errors": [<str>, ...],
+          "process_memory_available": <bool>,
+        }
+
+    Fail-open: missing module, missing retro file, or per-item exceptions
+    are all captured in ``errors`` but never raise.
+    """
+    summary = {
+        "project": project,
+        "retro_md": str(retro_md_path),
+        "items_found": 0,
+        "items_added": [],
+        "errors": [],
+        "process_memory_available": False,
+    }
+
+    if not retro_md_path.exists():
+        summary["errors"].append(f"retro markdown not found: {retro_md_path}")
+        return summary
+
+    try:
+        md_text = retro_md_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        summary["errors"].append(f"cannot read retro markdown: {exc!r}")
+        return summary
+
+    items = scan_action_items(md_text)
+    summary["items_found"] = len(items)
+    if not items:
+        return summary
+
+    pm = _load_process_memory()
+    if pm is None:
+        return summary
+    summary["process_memory_available"] = True
+
+    for item in items:
+        try:
+            created = pm.add_action_item(
+                project,
+                title=item["title"],
+                description=item["description"],
+                source_session=session_id,
+            )
+            if isinstance(created, dict) and created.get("id"):
+                summary["items_added"].append(created["id"])
+        except Exception as exc:
+            summary["errors"].append(
+                f"add_action_item failed for {item['title']!r}: {exc!r}"
+            )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan a retro markdown file and auto-populate action items "
+            "via delivery.process_memory (issue #461)."
+        )
+    )
+    parser.add_argument("--project", required=True, help="Crew project slug.")
+    parser.add_argument(
+        "--retro-md",
+        required=True,
+        help="Path to the retro markdown artifact to scan.",
+    )
+    parser.add_argument(
+        "--session-id",
+        default=os.environ.get("CLAUDE_SESSION_ID", ""),
+        help="Session identifier to stamp on new action items.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON summary on stdout.",
+    )
+    args = parser.parse_args()
+
+    retro_path = Path(args.retro_md).expanduser()
+    summary = populate_action_items(
+        args.project, retro_path, session_id=args.session_id
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    added = summary["items_added"]
+    found = summary["items_found"]
+    if not summary["process_memory_available"]:
+        print(
+            "[retro_action_items] process_memory unavailable — "
+            f"{found} action item(s) parsed but not persisted."
+        )
+    else:
+        print(
+            f"[retro_action_items] {len(added)} of {found} action item(s) "
+            f"added to process memory for project '{args.project}'."
+        )
+        for ai_id in added:
+            print(f"  {ai_id}")
+    for err in summary["errors"]:
+        print(f"  warning: {err}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/tests/delivery/test_facilitator_context_integration.py
+++ b/tests/delivery/test_facilitator_context_integration.py
@@ -1,0 +1,326 @@
+"""Integration tests for the issue #461 facilitator-context wiring.
+
+Covers the two additive wiring edits that connect
+``scripts/delivery/process_memory.py`` to:
+
+1. The session bootstrap (``hooks/scripts/bootstrap.py``) — unresolved
+   action items aged >= 2 sessions should surface as a ``[ProcessMemory]``
+   briefing line.
+2. The retro command's action-item scanner
+   (``scripts/crew/retro_action_items.py``) — action-item bullets in the
+   retro markdown should be appended to ``process-memory.json`` via
+   ``add_action_item``.
+
+Acceptance criteria mapping:
+
+- **AC-1**: ``test_bootstrap_facilitator_context_surfaces_aged_ai``
+- **AC-2**: ``test_retro_action_items_populate_process_memory``
+- **AC-3**: ``test_bootstrap_facilitator_context_silent_when_no_aging_ai``
+- **AC-4**: ``test_retro_action_items_leaves_markdown_untouched``
+
+Each test redirects ``get_local_path`` into an isolated ``tmp_path`` so
+no global state leaks between tests.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "delivery"))
+sys.path.insert(0, str(_REPO_ROOT / "hooks" / "scripts"))
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect get_local_path so process-memory writes stay in tmp_path.
+
+    Mirrors the sandbox fixture in ``test_process_memory.py``. Both the
+    source ``_domain_store.get_local_path`` and the copy imported into
+    ``delivery.process_memory`` at module load are re-bound.
+    """
+    root = tmp_path / "local"
+
+    def _fake_get_local_path(domain: str, *subpath: str) -> Path:
+        p = root / domain
+        for part in subpath:
+            p = p / part
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import _domain_store
+
+    monkeypatch.setattr(_domain_store, "get_local_path", _fake_get_local_path)
+
+    from delivery import process_memory as pm
+
+    importlib.reload(pm)
+    monkeypatch.setattr(pm, "get_local_path", _fake_get_local_path)
+    return pm, tmp_path
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-3: bootstrap facilitator context
+# ---------------------------------------------------------------------------
+
+
+def _import_bootstrap(monkeypatch: pytest.MonkeyPatch):
+    """Import hooks/scripts/bootstrap.py as a module for direct function calls."""
+    import importlib.util
+
+    path = _REPO_ROOT / "hooks" / "scripts" / "bootstrap.py"
+    spec = importlib.util.spec_from_file_location("bootstrap_under_test", path)
+    assert spec and spec.loader, "bootstrap.py must be importable"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bootstrap_facilitator_context_surfaces_aged_ai(
+    sandbox, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-1: a project with unresolved AI-001 (age >= 2) produces a briefing
+    line that mentions AI-001."""
+    pm, _ = sandbox
+
+    # Seed process_memory with an AI that is >= 2 sessions old. The first
+    # add_action_item creates AI-001 with age_sessions=1. A subsequent
+    # touch_action_item with a different session_id increments the counter.
+    project = "demo-project"
+    pm.add_action_item(
+        project,
+        title="Wire PagerDuty alerts",
+        description="Follow-up from retro",
+        source_session="sess-initial",
+    )
+    pm.touch_action_item(project, "AI-001", "sess-later")
+
+    # AI should now qualify as aging.
+    aging = pm.aging_action_items(project)
+    assert aging, "precondition: AI-001 should be aging after touch"
+    assert aging[0]["id"] == "AI-001"
+
+    bootstrap = _import_bootstrap(monkeypatch)
+
+    # Ensure the bootstrap's lazy import picks up our sandboxed process_memory.
+    # The helper inserts scripts/delivery into sys.path and imports
+    # `process_memory`; we just need to make sure no stale copy is cached.
+    sys.modules.pop("process_memory", None)
+
+    note = bootstrap._check_facilitator_context(project)
+    assert note is not None, "AC-1: bootstrap should surface aging AIs"
+    assert "[ProcessMemory]" in note
+    assert "AI-001" in note
+    assert "Wire PagerDuty alerts" in note
+
+
+def test_bootstrap_facilitator_context_silent_when_no_aging_ai(
+    sandbox, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-3: with no aging AIs, the helper returns None (fail-open) so the
+    existing briefing format is unchanged."""
+    pm, _ = sandbox
+    project = "quiet-project"
+    # Fresh action item — age_sessions is 1, below the >=2 threshold.
+    pm.add_action_item(
+        project, title="Should not surface", source_session="sess-1"
+    )
+    bootstrap = _import_bootstrap(monkeypatch)
+    sys.modules.pop("process_memory", None)
+    assert bootstrap._check_facilitator_context(project) is None
+
+
+def test_bootstrap_facilitator_context_no_project(sandbox, monkeypatch: pytest.MonkeyPatch):
+    """Helper must no-op when no active project is passed."""
+    bootstrap = _import_bootstrap(monkeypatch)
+    assert bootstrap._check_facilitator_context(None) is None
+    assert bootstrap._check_facilitator_context("") is None
+
+
+def test_bootstrap_facilitator_context_missing_process_memory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """AC-3 fail-open: when process_memory cannot be imported, the helper
+    returns None rather than propagating the ImportError."""
+    bootstrap = _import_bootstrap(monkeypatch)
+
+    # Pretend the delivery module disappeared. Blocking the import at
+    # sys.modules AND raising from the underlying import hook exercises
+    # both branches of the lazy-import guard.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "process_memory":
+            raise ImportError("simulated missing module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    sys.modules.pop("process_memory", None)
+    assert bootstrap._check_facilitator_context("any-project") is None
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / AC-4: retro action-item auto-population
+# ---------------------------------------------------------------------------
+
+
+def _import_retro_scanner():
+    """Import the retro action-items backing script."""
+    import importlib.util
+
+    path = _REPO_ROOT / "scripts" / "crew" / "retro_action_items.py"
+    spec = importlib.util.spec_from_file_location("retro_action_items_under_test", path)
+    assert spec and spec.loader, "retro_action_items.py must be importable"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_retro_action_items_populate_process_memory(sandbox, tmp_path: Path):
+    """AC-2: running the retro backing script with markdown containing
+    ``## Action Items\\n- [ ] test AI`` causes process_memory.json to gain a
+    new AI-NNN entry."""
+    pm, _ = sandbox
+    scanner = _import_retro_scanner()
+
+    retro_md = tmp_path / "retro.md"
+    retro_md.write_text(
+        "# Retrospective: demo\n"
+        "\n"
+        "## Action Items\n"
+        "- [ ] test AI\n"
+        "- [ ] second item with more detail\n"
+        "\n"
+        "## Other Section\n"
+        "- [ ] not an action item\n",
+        encoding="utf-8",
+    )
+
+    project = "demo-project"
+    summary = scanner.populate_action_items(
+        project, retro_md, session_id="sess-retro"
+    )
+
+    assert summary["items_found"] == 2, (
+        "scanner should find exactly the two bullets under Action Items, "
+        "not the bullet under Other Section"
+    )
+    assert len(summary["items_added"]) == 2
+    assert summary["process_memory_available"] is True
+    assert summary["errors"] == []
+
+    items = pm.list_action_items(project)
+    titles = [i["title"] for i in items]
+    assert "test AI" in titles
+    assert "second item with more detail" in titles
+    # Every new AI starts at AI-001 and walks forward.
+    ids = sorted(i["id"] for i in items)
+    assert ids == ["AI-001", "AI-002"]
+    # source_session must be stamped.
+    assert all(i["source_session"] == "sess-retro" for i in items)
+
+
+def test_retro_action_items_leaves_markdown_untouched(sandbox, tmp_path: Path):
+    """AC-4: scanning a retro markdown file must not modify it."""
+    scanner = _import_retro_scanner()
+    retro_md = tmp_path / "retro.md"
+    original = (
+        "# Retrospective\n"
+        "\n"
+        "## Action Items\n"
+        "- [ ] audit the gate policy\n"
+    )
+    retro_md.write_text(original, encoding="utf-8")
+    mtime_before = retro_md.stat().st_mtime
+
+    scanner.populate_action_items("demo", retro_md, session_id="sess-1")
+
+    assert retro_md.read_text(encoding="utf-8") == original
+    assert retro_md.stat().st_mtime == mtime_before
+
+
+def test_retro_action_items_no_section_is_noop(sandbox, tmp_path: Path):
+    """A retro with no Action Items heading adds nothing (and does not error)."""
+    pm, _ = sandbox
+    scanner = _import_retro_scanner()
+    retro_md = tmp_path / "retro.md"
+    retro_md.write_text(
+        "# Retrospective\n\n## Summary\n\n- just a bullet\n", encoding="utf-8"
+    )
+    summary = scanner.populate_action_items("demo", retro_md, session_id="s")
+    assert summary["items_found"] == 0
+    assert summary["items_added"] == []
+    assert pm.list_action_items("demo") == []
+
+
+def test_retro_action_items_missing_file_fails_open(sandbox, tmp_path: Path):
+    """Missing retro markdown surfaces an error but does not raise."""
+    pm, _ = sandbox
+    scanner = _import_retro_scanner()
+    summary = scanner.populate_action_items(
+        "demo", tmp_path / "nope.md", session_id="s"
+    )
+    assert summary["items_found"] == 0
+    assert summary["items_added"] == []
+    assert any("not found" in err for err in summary["errors"])
+
+
+def test_retro_action_items_fails_open_without_process_memory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When delivery.process_memory cannot be imported, the scanner must
+    still report items_found but skip the add_action_item calls."""
+    scanner = _import_retro_scanner()
+    monkeypatch.setattr(scanner, "_load_process_memory", lambda: None)
+
+    retro_md = tmp_path / "retro.md"
+    retro_md.write_text(
+        "## Action Items\n- [ ] ensure fail-open works\n", encoding="utf-8"
+    )
+    summary = scanner.populate_action_items(
+        "demo", retro_md, session_id="s"
+    )
+    assert summary["items_found"] == 1
+    assert summary["items_added"] == []
+    assert summary["process_memory_available"] is False
+    assert summary["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Parser unit coverage — supports AC-2 via the extractor
+# ---------------------------------------------------------------------------
+
+
+def test_scan_action_items_handles_mixed_bullets():
+    scanner = _import_retro_scanner()
+    md = (
+        "## Action Items\n"
+        "- [ ] open checkbox\n"
+        "- [x] closed checkbox\n"
+        "* plain star bullet\n"
+        "- plain dash bullet\n"
+        "\n"
+        "Not a bullet, should be ignored.\n"
+        "## Follow-up Items\n"
+        "- [ ] not collected — different section\n"
+    )
+    items = scanner.scan_action_items(md)
+    titles = [i["title"] for i in items]
+    assert titles == [
+        "open checkbox",
+        "closed checkbox",
+        "plain star bullet",
+        "plain dash bullet",
+    ]
+
+
+def test_scan_action_items_handles_no_heading():
+    scanner = _import_retro_scanner()
+    assert scanner.scan_action_items("# Just a doc\n- nothing here\n") == []


### PR DESCRIPTION
## Summary

Two additive wiring edits connect `scripts/delivery/process_memory.py`
(shipped in #454) into the session bootstrap and the retro command. Both
edits are pure side-effects — existing briefing / markdown formats are
unchanged on projects that have nothing to surface.

- **Wiring 1** — `hooks/scripts/bootstrap.py` calls
  `process_memory.facilitator_context(project)` at session start and
  appends a `[ProcessMemory]` briefing line when any unresolved action
  items are aged `>= 2` sessions. Lazy-imported with fail-open so legacy
  installs without the `delivery` module continue to boot.
- **Wiring 2** — `commands/crew/retro.md` now invokes a new backing
  script `scripts/crew/retro_action_items.py` after the retro markdown
  is written. The scanner parses `## Action Items` bullets and calls
  `process_memory.add_action_item` for each one. Retro markdown itself
  is not mutated.

## Acceptance criteria

- **AC-1** — Aged `AI-001` produces a `[ProcessMemory]` briefing line
  that names the ID.
- **AC-2** — Retro markdown with `## Action Items\n- [ ] test AI` causes
  `process-memory.json` to gain a new `AI-NNN` entry.
- **AC-3** — Bootstrap briefing is unchanged when there are no aging
  AIs (fail-open).
- **AC-4** — Retro markdown file is byte-for-byte unchanged by the
  scanner.

## Test plan

- [x] `tests/delivery/test_facilitator_context_integration.py` — 11 new
      tests covering AC-1..AC-4 plus fail-open paths for both wirings.
- [x] `sh scripts/_python.sh -m pytest tests/ -q` — 327 passed, 0 failed.
- [x] End-to-end CLI smoke test of `retro_action_items.py --json` seeds
      `AI-001` into `process-memory.json` and the JSON summary matches.

Closes #461

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)