### PR TITLE
feat(#462): wire SessionState.last_phase_approved + build-phase guard hook + R3/R5 AST heuristics

### DIFF
--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -257,6 +257,13 @@ class SessionState:
     # senior-engineer review of this very project — meta bug fix.)
     phase_start_gate_due: bool = False
 
+    # Name of the last phase the user approved this session (#462).
+    # Written by scripts/crew/phase_manager.py::approve_phase() after a
+    # successful approval. Read by stop.py to decide whether to promote
+    # the guard pipeline profile (scalpel → standard) when build just closed.
+    # None when no approval has happened yet this session.
+    last_phase_approved: str | None = None
+
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -1611,6 +1611,88 @@ def _load_session_dispatches() -> List[Dict[str, Any]]:
         return []
 
 
+def _record_last_phase_approved(phase: str) -> None:
+    """Write the approved phase onto SessionState (#462).
+
+    Idempotent — re-approving the same phase just rewrites the same value.
+    Fail-open — if the session state module is unavailable (e.g. during a
+    script run outside the hook environment) we log and move on.  This
+    hook must never block or mutate the approve return path.
+    """
+    try:
+        # scripts/ is on sys.path via the module-level insert at the top of
+        # this file, so the import is direct (matches other call sites).
+        from _session import SessionState  # type: ignore
+        sess = SessionState.load()
+        if getattr(sess, "last_phase_approved", None) == phase:
+            return  # idempotent no-op
+        sess.update(last_phase_approved=phase)
+    except Exception as exc:
+        # Fail open — session wiring should never break approve_phase.
+        logger.debug("[approve] last_phase_approved wiring skipped: %s", exc)
+
+
+def _run_build_phase_guard(project_dir: Path) -> List[str]:
+    """Run the guard pipeline at build-phase approval (#462, Item 2).
+
+    Lazy-imports scripts/platform/guard_pipeline.run_pipeline and returns a
+    list of human-readable warning strings to surface in the approve output.
+    Fail-open on every axis — ImportError, missing module, exception during
+    scan, budget_exceeded — all return an empty list without raising.
+
+    Respects CREW_GATE_ENFORCEMENT=legacy as a rollback switch: when set
+    the guard hook is a complete no-op (matches the documented escape hatch
+    for additive gate enforcement layers).
+
+    Mirrors the fail-open pattern used by hooks/scripts/stop.py::_run_guard_pipeline.
+    """
+    # Rollback switch — keep the build-phase guard hook no-op when legacy
+    # enforcement is requested (matches the mode-flag escape pattern used
+    # by the telemetry step and the #448 stop-hook integration).
+    if os.environ.get("CREW_GATE_ENFORCEMENT", "").lower() == "legacy":
+        return []
+
+    try:
+        # scripts/platform/ is a sibling of scripts/crew/.  Add it to
+        # sys.path lazily so the import only pays the cost at build-phase
+        # approval, not at module import time.
+        _platform_path = str(Path(__file__).resolve().parents[1] / "platform")
+        if _platform_path not in sys.path:
+            sys.path.insert(0, _platform_path)
+        from guard_pipeline import run_pipeline, render_summary  # type: ignore
+    except ImportError as exc:
+        logger.debug("[approve] guard_pipeline unavailable: %s", exc)
+        return []
+    except Exception as exc:  # pragma: no cover — defense in depth
+        logger.debug("[approve] guard_pipeline import error: %s", exc)
+        return []
+
+    try:
+        report = run_pipeline(
+            profile_name="standard",
+            project_dir=project_dir if project_dir else None,
+        )
+    except Exception as exc:
+        # MUST NOT let a guard-pipeline error bubble up and block approval.
+        print(f"[approve] guard_pipeline error: {exc}", file=sys.stderr)
+        logger.warning("[approve] guard_pipeline exception during build approve: %s", exc)
+        return []
+
+    if not report or report.total_findings == 0:
+        return []
+
+    try:
+        summary = render_summary(report)
+    except Exception as exc:
+        logger.debug("[approve] guard render_summary error: %s", exc)
+        # Fall back to a minimal summary — we still want to surface the count.
+        summary = (
+            f"[Guard] standard pipeline surfaced {report.total_findings} "
+            f"finding(s) at build-phase approval."
+        )
+    return [summary]
+
+
 def approve_phase(
     state: ProjectState,
     phase: str,
@@ -1991,6 +2073,35 @@ def approve_phase(
         logger.warning(f"[checkpoint] {w}")
     if injected:
         logger.info(f"[checkpoint] Injected phases after '{phase}': {injected}")
+
+    # --- #462 wiring: SessionState + build-phase guard hook ---
+    # Record the approved phase on SessionState so stop.py can promote
+    # the guard pipeline profile (scalpel → standard) next cycle.
+    # Idempotent + fail-open: re-approving the same phase is safe.
+    _record_last_phase_approved(phase)
+
+    # Build-phase guard hook — additive, non-blocking.  Surfaces guard
+    # findings as warnings in the approve output without gating approval.
+    if phase == "build":
+        try:
+            project_dir = get_project_dir(state.name)
+        except Exception:
+            project_dir = None  # fail-open: still attempt the scan
+        guard_warnings = _run_build_phase_guard(project_dir)
+        if guard_warnings:
+            warnings.extend(guard_warnings)
+            # Mirror the existing pattern — push them to stderr via logger.
+            for gw in guard_warnings:
+                logger.warning("[approve] %s", gw)
+            # Persist the warnings on the project state so structured
+            # callers (CLI --json, tests, downstream consumers) can reach
+            # them without changing the approve_phase return signature.
+            try:
+                extras_warnings = list(state.extras.get("last_approve_warnings", []))
+                extras_warnings.extend(guard_warnings)
+                state.extras["last_approve_warnings"] = extras_warnings
+            except Exception:
+                pass  # fail open — extras is best-effort surface for CLI consumers
 
     # Determine next phase from dynamic order (may have changed via injection)
     phase_order = get_phase_order(state)

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -392,6 +392,205 @@ def _count_commented_blocks(path: str, lines: List[str]) -> List[Finding]:
     return findings
 
 
+# ---------------------------------------------------------------------------
+# R3 + R5 AST heuristics (Python only) — #462, Item 3
+# ---------------------------------------------------------------------------
+
+# R3 allow-list: numeric literals that are "boring idioms" we don't flag.
+# 0, 1, -1 cover the vast majority of loop guards, sentinels, empty-checks,
+# and index math where a named constant would be overkill.
+_R3_ALLOWED_NUMBERS = frozenset({0, 1, -1})
+
+
+def _detect_magic_values_r3(path: str, tree: "ast.AST") -> List[Finding]:
+    """R3 — flag magic numeric literals in Compare nodes (Python AST).
+
+    Heuristic: walk every ast.Compare and flag right-hand-side comparators
+    whose value is a numeric literal NOT in {0, 1, -1}.  Examples:
+
+        if x > 42:        # flagged: 42 is magic
+        if n == 0:        # NOT flagged: 0 is allow-listed
+        if x == -1:       # NOT flagged: -1 is allow-listed
+        if count > THRESHOLD:  # NOT flagged: Name, not Constant
+
+    Conservative on purpose — we expect false positives (e.g. HTTP status
+    codes 200/400/404 in test fixtures) and treat them as info/warn
+    surface, not a blocker.  Engineering review owns final calls.
+
+    Performance: AST walk is O(nodes); on typical Python files this runs
+    in sub-millisecond time.  Pre-parsed tree is passed in so the caller
+    can reuse it across R3/R5 without re-parsing.
+    """
+    import ast  # stdlib — local import keeps module-level cost unchanged
+    findings: List[Finding] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        # Each Compare can have multiple comparators (e.g. `a < b < c`);
+        # we scan each comparator, not just the first.
+        for comparator in node.comparators:
+            # ast.Constant covers int, float, bool.  We want numerics
+            # only (exclude bools — they are technically ints but are
+            # never "magic").
+            if isinstance(comparator, ast.Constant):
+                value = comparator.value
+                if isinstance(value, bool):
+                    continue
+                if isinstance(value, (int, float)) and value not in _R3_ALLOWED_NUMBERS:
+                    line_no = getattr(comparator, "lineno", getattr(node, "lineno", 0))
+                    findings.append(Finding(
+                        check="bulletproof_scan",
+                        rule_id="R3",
+                        severity=SEVERITY_WARN,
+                        message=f"R3: magic value {value} in conditional at {path}:{line_no}",
+                        file=path,
+                        line=line_no,
+                    ))
+            # Also handle ast.UnaryOp wrapping a Constant (e.g. `-42`).
+            # -1 is allow-listed above as a plain value; here we catch
+            # `-42`, `-100`, etc. that the parser emits as UnaryOp(USub).
+            elif isinstance(comparator, ast.UnaryOp) and isinstance(comparator.op, ast.USub):
+                operand = comparator.operand
+                if isinstance(operand, ast.Constant) and isinstance(operand.value, (int, float)) \
+                        and not isinstance(operand.value, bool):
+                    effective = -operand.value
+                    if effective in _R3_ALLOWED_NUMBERS:
+                        continue
+                    line_no = getattr(comparator, "lineno", getattr(node, "lineno", 0))
+                    findings.append(Finding(
+                        check="bulletproof_scan",
+                        rule_id="R3",
+                        severity=SEVERITY_WARN,
+                        message=f"R3: magic value {effective} in conditional at {path}:{line_no}",
+                        file=path,
+                        line=line_no,
+                    ))
+    return findings
+
+
+def _func_has_guard_before_call(func: "ast.AST", func_name: str) -> bool:
+    """Return True if the function body has an early-return / conditional-return
+    BEFORE any recursive self-call.  Heuristic used by R5.
+
+    Walks top-level statements in the function body in order.  A statement
+    counts as a "guard" if it is:
+        * a top-level `return` (bounded-exit early-out)
+        * an `If` whose body contains a `return` at any nested level
+        * a `raise` (exit path that prevents recursion from running)
+
+    Statements after the first recursive call do not count.
+    """
+    import ast
+
+    def _contains_recursive_call(node: "ast.AST") -> bool:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call):
+                callee = sub.func
+                if isinstance(callee, ast.Name) and callee.id == func_name:
+                    return True
+                # Also flag `self.func_name(...)` / `Class.func_name(...)`
+                if isinstance(callee, ast.Attribute) and callee.attr == func_name:
+                    return True
+        return False
+
+    def _contains_return(node: "ast.AST") -> bool:
+        for sub in ast.walk(node):
+            if isinstance(sub, (ast.Return, ast.Raise)):
+                return True
+        return False
+
+    for stmt in func.body:  # type: ignore[attr-defined]
+        # If the statement itself contains the recursive call, we've run
+        # out of guards — stop looking.
+        if _contains_recursive_call(stmt):
+            return False
+        # A bare `return` or `raise` at the top level is a guard.
+        if isinstance(stmt, (ast.Return, ast.Raise)):
+            return True
+        # An `if` whose body contains a return/raise is a guard.
+        if isinstance(stmt, ast.If) and _contains_return(stmt):
+            return True
+    return False
+
+
+def _detect_unbounded_recursion_r5(path: str, tree: "ast.AST") -> List[Finding]:
+    """R5 — flag functions that call themselves with no guard clause.
+
+    Heuristic: for each FunctionDef / AsyncFunctionDef, check whether the
+    function calls `<own_name>(...)` anywhere in its body AND the body
+    lacks any top-level return/raise/if-return guard BEFORE the first
+    recursive call.  Examples:
+
+        def f(n):                def f(n):
+            return f(n - 1)         if n <= 0:
+                                        return 0
+                                    return f(n - 1)
+        # flagged                # NOT flagged (guard clause)
+
+    Performance: O(nodes) AST walk; matches R3 cost.  Conservative — we
+    only look for same-name calls (not mutual recursion).  Documented
+    limitation: this is a structural hint, not a proof of unboundedness.
+    False positives possible when the guard is deep inside a try/except
+    or a for-else clause.  Engineering review owns final calls.
+    """
+    import ast
+    findings: List[Finding] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        name = node.name
+        # Does this function call itself anywhere?
+        calls_self = False
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call):
+                callee = sub.func
+                if isinstance(callee, ast.Name) and callee.id == name:
+                    calls_self = True
+                    break
+                if isinstance(callee, ast.Attribute) and callee.attr == name:
+                    calls_self = True
+                    break
+        if not calls_self:
+            continue
+        # Guard present? — early return / raise / conditional return BEFORE
+        # the recursive call.
+        if _func_has_guard_before_call(node, name):
+            continue
+        line_no = getattr(node, "lineno", 0)
+        findings.append(Finding(
+            check="bulletproof_scan",
+            rule_id="R5",
+            severity=SEVERITY_WARN,
+            message=f"R5: possibly unbounded recursion in {name} at {path}:{line_no}",
+            file=path,
+            line=line_no,
+        ))
+    return findings
+
+
+def _run_python_ast_heuristics(path: str, lines: List[str]) -> List[Finding]:
+    """Parse Python source once, then run R3 + R5 over the shared tree.
+
+    Returns an empty list on parse error — we do not attempt to salvage
+    partial findings from a syntactically-broken file.  This respects the
+    per-check budget: a single parse failure costs ms, not seconds.
+    """
+    import ast
+    try:
+        source = "\n".join(lines)
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    except Exception:
+        return []
+    findings: List[Finding] = []
+    findings.extend(_detect_magic_values_r3(path, tree))
+    findings.extend(_detect_unbounded_recursion_r5(path, tree))
+    return findings
+
+
 def check_bulletproof_scan(
     files: List[str],
     *,
@@ -433,6 +632,10 @@ def check_bulletproof_scan(
         if ext == ".py":
             result.findings.extend(_count_python_god_functions(filepath, lines))
             result.findings.extend(_detect_multiline_swallow(filepath, lines))
+            # R3 + R5 AST heuristics (#462, Item 3).  Single parse shared
+            # across both rules.  Fails open on SyntaxError — a broken file
+            # contributes zero R3/R5 findings rather than a scan failure.
+            result.findings.extend(_run_python_ast_heuristics(filepath, lines))
         result.findings.extend(_count_commented_blocks(filepath, lines))
 
     result.duration_ms = int((time.monotonic() - t0) * 1000)

--- a/tests/crew/test_approve_sessionstate.py
+++ b/tests/crew/test_approve_sessionstate.py
@@ -1,0 +1,261 @@
+"""Integration tests for the #462 approve-phase wiring.
+
+Covers:
+    AC-1: approve_phase(phase="build") writes SessionState.last_phase_approved
+    AC-2: guard_pipeline warnings surface in the approve output (state.extras)
+    AC-3: guard_pipeline raising during build-approve does NOT raise from approve
+
+All tests are deterministic and stdlib-only. Session state is isolated via
+TMPDIR + a per-test CLAUDE_SESSION_ID.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Path setup — keep in sync with tests/crew/test_phase_manager.py
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "platform"))
+
+import phase_manager as pm  # noqa: E402
+from phase_manager import ProjectState, PhaseState, approve_phase  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_build_ready_state(name: str = "issue-462-test") -> ProjectState:
+    state = ProjectState(
+        name=name,
+        current_phase="build",
+        created_at="2026-04-18T00:00:00Z",
+    )
+    state.phase_plan = ["clarify", "design", "build", "review"]
+    state.phases["clarify"] = PhaseState(status="approved")
+    state.phases["design"] = PhaseState(status="approved")
+    state.phases["build"] = PhaseState(
+        status="in_progress",
+        started_at="2026-04-18T01:00:00Z",
+    )
+    return state
+
+
+class _SessionTempTestCase(unittest.TestCase):
+    """Base class: isolate SessionState to a temp dir and patch phase_manager
+    helpers so approve_phase can reach the tail-end wiring without hitting
+    real deliverable / gate / addendum checks.
+    """
+
+    def setUp(self):
+        # Isolate SessionState by pointing TMPDIR at a per-test temp dir and
+        # setting a unique session id so no other test can see our state.
+        self._tempdir_obj = tempfile.TemporaryDirectory()
+        self._tempdir = Path(self._tempdir_obj.name)
+        self._env = patch.dict(os.environ, {
+            "TMPDIR": str(self._tempdir),
+            "CLAUDE_SESSION_ID": f"test-462-{id(self)}",
+        })
+        self._env.start()
+
+        self._proj_dir = Path(self._tempdir_obj.name) / "projects" / "issue-462-test"
+        self._proj_dir.mkdir(parents=True, exist_ok=True)
+        (self._proj_dir / "phases" / "build").mkdir(parents=True, exist_ok=True)
+
+        # Patch phase_manager to bypass real storage + deliverable checks.
+        self._patches = [
+            patch.object(pm, "get_project_dir", return_value=self._proj_dir),
+            patch.object(pm, "save_project_state"),
+            patch.object(pm, "_sm"),
+            patch.object(pm, "_check_addendum_freshness", return_value=None),
+            patch.object(pm, "_check_phase_deliverables", return_value=[]),
+            patch.object(pm, "load_phases_config", return_value={
+                "build": {"gate_required": False, "depends_on": []},
+            }),
+            patch.object(pm, "_load_session_dispatches", return_value=[]),
+            patch.object(pm, "_run_checkpoint_reanalysis", return_value=(
+                [], [])),
+            patch.object(pm, "get_phase_order", return_value=[
+                "clarify", "design", "build", "review"]),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._env.stop()
+        self._tempdir_obj.cleanup()
+
+    # ------------------------------------------------------------------
+    # SessionState helpers — must import freshly each call so asdict()
+    # serialization respects the current field schema.
+    # ------------------------------------------------------------------
+    def _load_session_state(self):
+        # The session module caches path resolution per-call, so env
+        # changes between tests are respected automatically.
+        if "_session" in sys.modules:
+            del sys.modules["_session"]
+        from _session import SessionState  # type: ignore
+        return SessionState.load()
+
+
+# ---------------------------------------------------------------------------
+# AC-1: last_phase_approved is set on successful build-phase approval
+# ---------------------------------------------------------------------------
+
+
+class TestLastPhaseApprovedWiring(_SessionTempTestCase):
+
+    def test_build_approve_sets_last_phase_approved(self):
+        """AC-1: after approving build, SessionState.last_phase_approved == 'build'."""
+        state = _make_build_ready_state()
+        # Guard pipeline is irrelevant to AC-1 — stub it to return nothing.
+        with patch.object(pm, "_run_build_phase_guard", return_value=[]):
+            result_state, next_phase = approve_phase(state, "build")
+
+        self.assertEqual(next_phase, "review")
+        sess = self._load_session_state()
+        self.assertEqual(sess.last_phase_approved, "build")
+
+    def test_re_approving_same_phase_is_idempotent(self):
+        """AC-1: re-running approve for the same phase is safe (no crash, value stable)."""
+        state = _make_build_ready_state()
+        with patch.object(pm, "_run_build_phase_guard", return_value=[]):
+            approve_phase(state, "build")
+        # Reset phase state to simulate a re-approval.
+        state.phases["build"] = PhaseState(
+            status="in_progress",
+            started_at="2026-04-18T01:00:00Z",
+        )
+        state.current_phase = "build"
+        with patch.object(pm, "_run_build_phase_guard", return_value=[]):
+            approve_phase(state, "build")
+
+        sess = self._load_session_state()
+        self.assertEqual(sess.last_phase_approved, "build")
+
+
+# ---------------------------------------------------------------------------
+# AC-2: guard-pipeline findings surface in approve output
+# ---------------------------------------------------------------------------
+
+
+class TestGuardWarningsSurface(_SessionTempTestCase):
+
+    def test_guard_findings_appended_to_state_extras(self):
+        """AC-2: when the guard emits findings at build-approve, they appear
+        in state.extras['last_approve_warnings']."""
+        state = _make_build_ready_state()
+
+        synthetic_warning = (
+            "[Guard] standard pipeline surfaced 3 finding(s) (120ms) — "
+            "block=0 warn=2 info=1. Review next-session briefing."
+        )
+        with patch.object(pm, "_run_build_phase_guard", return_value=[synthetic_warning]):
+            result_state, _ = approve_phase(state, "build")
+
+        warnings = result_state.extras.get("last_approve_warnings", [])
+        self.assertTrue(warnings, "expected approve warnings to be populated")
+        self.assertIn(synthetic_warning, warnings)
+
+    def test_no_findings_no_warnings(self):
+        """Empty guard result leaves state.extras untouched."""
+        state = _make_build_ready_state()
+        with patch.object(pm, "_run_build_phase_guard", return_value=[]):
+            result_state, _ = approve_phase(state, "build")
+
+        self.assertEqual(
+            result_state.extras.get("last_approve_warnings", []), [],
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: guard-pipeline exception does NOT block approve
+# ---------------------------------------------------------------------------
+
+
+class TestGuardFailOpen(_SessionTempTestCase):
+
+    def test_guard_exception_does_not_raise(self):
+        """AC-3: even if guard_pipeline raises, approve still succeeds."""
+        state = _make_build_ready_state()
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("synthetic guard crash")
+
+        # Patch the underlying run_pipeline so _run_build_phase_guard's
+        # try/except is exercised (not _run_build_phase_guard itself).
+        import guard_pipeline as gp  # noqa: WPS433 (local import by design)
+        with patch.object(gp, "run_pipeline", side_effect=_boom):
+            try:
+                result_state, next_phase = approve_phase(state, "build")
+            except Exception as exc:
+                self.fail(f"approve_phase must not raise on guard failure: {exc}")
+
+        # Sanity: approve still advanced to the next phase.
+        self.assertEqual(next_phase, "review")
+        # No warnings surface (guard errored silently).
+        self.assertEqual(result_state.extras.get("last_approve_warnings", []), [])
+
+    def test_guard_import_error_does_not_raise(self):
+        """Missing guard_pipeline module is a no-op (fail-open)."""
+        state = _make_build_ready_state()
+
+        # Poison the import so the lazy import path in _run_build_phase_guard
+        # hits ImportError.
+        with patch.dict(sys.modules, {"guard_pipeline": None}):
+            try:
+                result_state, _ = approve_phase(state, "build")
+            except Exception as exc:
+                self.fail(f"approve_phase must not raise on guard ImportError: {exc}")
+
+        self.assertEqual(result_state.extras.get("last_approve_warnings", []), [])
+
+
+# ---------------------------------------------------------------------------
+# CREW_GATE_ENFORCEMENT=legacy rollback — the build-phase guard is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyBypass(_SessionTempTestCase):
+
+    def test_legacy_enforcement_skips_guard(self):
+        """When CREW_GATE_ENFORCEMENT=legacy, the build-phase guard returns
+        an empty list without attempting to import guard_pipeline."""
+        state = _make_build_ready_state()
+
+        # If the guard ran, this patched run_pipeline would be called; we
+        # assert it's NOT called, proving the early-return in legacy mode.
+        import guard_pipeline as gp  # noqa: WPS433
+        called = {"count": 0}
+
+        def _counting(*_a, **_kw):
+            called["count"] += 1
+            return gp.PipelineReport(
+                pipeline_version="1.0", profile="standard",
+                budget_seconds=5.0, duration_ms=1, status="ok",
+            )
+
+        with patch.dict(os.environ, {"CREW_GATE_ENFORCEMENT": "legacy"}):
+            with patch.object(gp, "run_pipeline", side_effect=_counting):
+                approve_phase(state, "build")
+
+        self.assertEqual(called["count"], 0,
+                         "guard pipeline must not run under CREW_GATE_ENFORCEMENT=legacy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/platform/test_guard_pipeline.py
+++ b/tests/platform/test_guard_pipeline.py
@@ -188,6 +188,206 @@ class TestBulletproofScan(unittest.TestCase):
             self.assertTrue(r6, "expected R6 finding for >8 params")
 
 
+# ---------------------------------------------------------------------------
+# AC-4: R3 magic values in conditionals — AST heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestR3MagicValues(unittest.TestCase):
+    """#462, Item 3 — R3 detects magic numeric literals in Compare nodes
+    while allow-listing 0, 1, -1."""
+
+    def test_magic_value_flagged(self):
+        """`if x > 42:` triggers an R3 finding."""
+        src = "def f(x):\n    if x > 42:\n        return x\n    return 0\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/m.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertTrue(r3, "expected R3 finding for magic value 42")
+        self.assertTrue(any("42" in x.message for x in r3))
+
+    def test_allow_listed_zero_not_flagged(self):
+        """`if x > 0:` is NOT flagged — 0 is allow-listed."""
+        src = "def f(x):\n    if x > 0:\n        return x\n    return 0\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/z.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertEqual(r3, [], f"0 should not be flagged as magic: {r3}")
+
+    def test_allow_listed_negative_one_not_flagged(self):
+        """`if x == -1:` is NOT flagged — -1 is allow-listed."""
+        src = "def f(x):\n    if x == -1:\n        return x\n    return 0\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/neg.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertEqual(r3, [], f"-1 should not be flagged as magic: {r3}")
+
+    def test_allow_listed_one_not_flagged(self):
+        """`if n == 1:` is NOT flagged — 1 is allow-listed."""
+        src = "def f(n):\n    if n == 1:\n        return n\n    return 0\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/one.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertEqual(r3, [], f"1 should not be flagged as magic: {r3}")
+
+    def test_named_constant_not_flagged(self):
+        """`if x > THRESHOLD:` is NOT flagged — comparator is a Name, not Constant."""
+        src = (
+            "THRESHOLD = 42\n"
+            "def f(x):\n"
+            "    if x > THRESHOLD:\n"
+            "        return x\n"
+            "    return 0\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/named.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertEqual(r3, [], f"Named constant should not be flagged: {r3}")
+
+    def test_negative_magic_flagged_via_unary(self):
+        """`if x < -42:` is flagged — -42 not in allow-list, parsed as UnaryOp."""
+        src = "def f(x):\n    if x < -42:\n        return x\n    return 0\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/neg42.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r3 = [x for x in result.findings if x.rule_id == "R3"]
+        self.assertTrue(r3, "expected R3 finding for -42 via UnaryOp")
+
+
+# ---------------------------------------------------------------------------
+# AC-5: R5 unbounded recursion — AST heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestR5UnboundedRecursion(unittest.TestCase):
+    """#462, Item 3 — R5 detects functions that self-call with no guard."""
+
+    def test_unbounded_recursion_flagged(self):
+        """`def f(n): return f(n - 1)` — flagged."""
+        src = "def f(n):\n    return f(n - 1)\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/unbound.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r5 = [x for x in result.findings if x.rule_id == "R5"]
+        self.assertTrue(r5, "expected R5 finding for unguarded recursion")
+        self.assertTrue(any("f" in x.message for x in r5))
+
+    def test_guarded_recursion_not_flagged(self):
+        """Recursion with an early-return guard — NOT flagged."""
+        src = (
+            "def f(n):\n"
+            "    if n <= 0:\n"
+            "        return 0\n"
+            "    return f(n - 1)\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/guard.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r5 = [x for x in result.findings if x.rule_id == "R5"]
+        self.assertEqual(r5, [], f"Guarded recursion should not be flagged: {r5}")
+
+    def test_non_recursive_function_not_flagged(self):
+        """A plain function is not flagged."""
+        src = "def g(n):\n    return n + 1\n"
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/plain.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r5 = [x for x in result.findings if x.rule_id == "R5"]
+        self.assertEqual(r5, [], f"Non-recursive fn should not be R5: {r5}")
+
+    def test_method_self_call_flagged(self):
+        """`self.method(...)` also counts as self-call for R5 purposes."""
+        src = (
+            "class C:\n"
+            "    def walk(self, n):\n"
+            "        return self.walk(n - 1)\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            f = _make_py_file(tmpdir, "src/cls.py", src)
+            result = gp.check_bulletproof_scan([str(f)], budget_seconds=1.0)
+        r5 = [x for x in result.findings if x.rule_id == "R5"]
+        self.assertTrue(r5, "expected R5 finding for unguarded method recursion")
+
+
+# ---------------------------------------------------------------------------
+# AC-6: performance — scalpel + R3 + R5 stays under the 1s budget (2s CI slack)
+# ---------------------------------------------------------------------------
+
+
+class TestR3R5PerformanceBudget(unittest.TestCase):
+    """100-file synthetic diff with R3+R5 active on every Python file.
+    Must stay under the scalpel budget (1s target, 2s hard assert)."""
+
+    def test_scalpel_budget_with_r3_r5_active(self):
+        # Template includes both R3-eligible conditionals and a recursive
+        # guarded function — exercises the AST walkers on every file.
+        template = (
+            "import os\n"
+            "import sys\n"
+            "\n"
+            "def work(x):\n"
+            "    if x > 42:\n"                  # R3 candidate
+            "        return x\n"
+            "    if x == 0:\n"                  # allow-listed
+            "        return 0\n"
+            "    return work(x - 1)\n"          # R5 candidate (guarded)
+            "\n"
+            "class Worker:\n"
+            "    def run(self, value):\n"
+            "        if value < 100:\n"         # R3 candidate
+            "            return value\n"
+            "        return self.run(value - 1)\n"  # R5 (guarded via `if`)
+            "\n"
+            "def plain(y):\n"
+            "    return y + 1\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            tmpdir = Path(td)
+            files: List[str] = []
+            for i in range(100):
+                p = _make_py_file(tmpdir, f"src/mod_{i}.py", template)
+                files.append(str(p))
+
+            t0 = time.monotonic()
+            report = gp.run_pipeline(
+                profile_name="scalpel",
+                cwd=tmpdir,
+                files=files,
+            )
+            elapsed = time.monotonic() - t0
+
+            # Target budget 1s; 2s CI slack matches the baseline test at
+            # the top of this file.
+            self.assertLess(elapsed, 2.0,
+                            f"scalpel+R3+R5 took {elapsed:.3f}s on 100 files (target 1s)")
+            # Sanity: the scan should have surfaced at least the R3
+            # findings from `if x > 42:` and `if value < 100:`.
+            r3_count = sum(1 for c in report.checks for f in c.findings
+                           if f.rule_id == "R3")
+            self.assertGreater(r3_count, 0,
+                               "expected R3 findings from the synthetic diff")
+            # Print timing so CI always shows it.
+            sys.stderr.write(
+                f"\n[budget-test] scalpel+R3+R5 @ 100 files: {elapsed*1000:.1f}ms "
+                f"(internal={report.duration_ms}ms, r3={r3_count})\n"
+            )
+
+
 class TestDebugArtifacts(unittest.TestCase):
 
     def test_clean_file_no_findings(self):


### PR DESCRIPTION
Closes #462. Follow-up wiring from merged PR #456.

## Summary

- **Item 1 — SessionState wiring**: `approve_phase()` now writes
  `SessionState.last_phase_approved = phase` at the end of a successful
  approval. The field is a new `Optional[str]` on the `SessionState`
  dataclass. Write is idempotent and fail-open.
- **Item 2 — Build-phase guard hook**: when `phase == "build"` and
  approval succeeds, `approve_phase()` invokes
  `guard_pipeline.run_pipeline(profile="standard")`. Findings render to a
  human-readable summary and are appended to
  `state.extras["last_approve_warnings"]` plus `logger.warning` (mirrors
  the existing warnings pattern). Lazy-imported, try/except
  `ImportError` and `Exception` — never blocks approve. Respects
  `CREW_GATE_ENFORCEMENT=legacy` as a complete no-op rollback.
- **Item 3 — R3 + R5 AST heuristics** in `scripts/platform/guard_pipeline.py`:
    - R3 walks `ast.Compare` nodes and flags numeric literals not in
      `{0, 1, -1}`. Message: `"R3: magic value {n} in conditional at
      {file}:{line}"`. Named constants and bools are skipped.
    - R5 walks `FunctionDef`/`AsyncFunctionDef` for unguarded self-calls
      (same name). A top-level `return`/`raise` or `if`-containing-return
      before the recursive call counts as a guard. Message: `"R5:
      possibly unbounded recursion in {func} at {file}:{line}"`.
    - Shared `ast.parse()` per Python file. Measured 40.9ms for the
      100-file synthetic diff with scalpel profile (target 1s).

## Files touched

- `scripts/_session.py` (+7 lines) — new `last_phase_approved: str | None`
- `scripts/crew/phase_manager.py` (+111 lines) — wiring + helpers
- `scripts/platform/guard_pipeline.py` (+203 lines) — R3/R5 AST helpers
  + hook into `check_bulletproof_scan`
- `tests/crew/test_approve_sessionstate.py` (new, 7 tests) — AC-1/2/3
  + legacy bypass
- `tests/platform/test_guard_pipeline.py` (+200 lines) — AC-4/5/6

## Test plan

- [x] `sh scripts/_python.sh -m pytest tests/crew/test_approve_sessionstate.py -v` — 7/7 pass
- [x] `sh scripts/_python.sh -m pytest tests/platform/test_guard_pipeline.py -v` — 38/38 pass
- [x] Full sweep: `sh scripts/_python.sh -m pytest tests/ -q` — 345/345 pass
- [x] AC-1: `test_build_approve_sets_last_phase_approved` pass
- [x] AC-2: `test_guard_findings_appended_to_state_extras` pass
- [x] AC-3: `test_guard_exception_does_not_raise` +
      `test_guard_import_error_does_not_raise` pass
- [x] AC-4: `TestR3MagicValues` — 6 tests covering magic + 4 allow-list
      cases (0/1/-1/named-constant) pass
- [x] AC-5: `TestR5UnboundedRecursion` — 4 tests covering
      flagged/guarded/plain/method-self-call pass
- [x] AC-6: `TestR3R5PerformanceBudget` — 40.9ms for 100 files
      (budget 1s, CI slack 2s) pass