### PR TITLE
feat(crew): mode-3 phase-executor + gate dispatch + #466 legacy audit

### DIFF
--- a/.claude-plugin/gate-policy.json
+++ b/.claude-plugin/gate-policy.json
@@ -139,7 +139,7 @@
       }
     },
     "semantic-alignment": {
-      "description": "Spec-to-code alignment verification (issue #444). Runs at review-phase gate for complexity >= 3. Extracts numbered AC/FR from clarify-phase specs and classifies each as aligned / divergent / missing against the implementation + test corpora. Missing findings are hard REJECT; divergent findings become gate conditions. Advisory at complexity 0-2. Bypass with CREW_GATE_ENFORCEMENT=legacy.",
+      "description": "Spec-to-code alignment verification (issue #444). Runs at review-phase gate for complexity >= 3. Extracts numbered AC/FR from clarify-phase specs and classifies each as aligned / divergent / missing against the implementation + test corpora. Missing findings are hard REJECT; divergent findings become gate conditions. Advisory at complexity 0-2. Bypass not supported in v6.0; gate behavior is unconditional.",
       "minimal": {
         "reviewers": [],
         "mode": "advisory",

--- a/.claude-plugin/phases.json
+++ b/.claude-plugin/phases.json
@@ -22,6 +22,7 @@
       "min_gate_score": null,
       "min_test_coverage": null,
       "conditions_manifest_required": false,
+      "phase_executor_may_delegate": false,
       "valid_skip_reasons": [
         "complexity_below_threshold",
         "user_explicit_request",
@@ -50,7 +51,8 @@
       "gate_required": true,
       "min_gate_score": 0.6,
       "min_test_coverage": null,
-      "conditions_manifest_required": true
+      "conditions_manifest_required": true,
+      "phase_executor_may_delegate": false
     },
     "design": {
       "name": "design",
@@ -76,6 +78,7 @@
       "consensus_threshold": 5,
       "consensus_proposers": ["engineering", "devsecops", "product"],
       "strong_dissent_blocks": true,
+      "phase_executor_may_delegate": false,
       "valid_skip_reasons": [
         "complexity_below_threshold",
         "user_explicit_request",
@@ -105,6 +108,7 @@
       "min_test_coverage": null,
       "conditions_manifest_required": false,
       "skip_complexity_threshold": 3,
+      "phase_executor_may_delegate": false,
       "valid_skip_reasons": [
         "complexity_below_threshold",
         "user_explicit_request",
@@ -133,6 +137,7 @@
       "min_test_coverage": null,
       "conditions_manifest_required": true,
       "skip_complexity_threshold": 4,
+      "phase_executor_may_delegate": false,
       "valid_skip_reasons": [
         "complexity_below_threshold",
         "user_explicit_request",
@@ -160,7 +165,8 @@
       "conditions_manifest_required": false,
       "consensus_threshold": 5,
       "consensus_proposers": ["engineering", "quality-engineering", "devsecops"],
-      "strong_dissent_blocks": true
+      "strong_dissent_blocks": true,
+      "phase_executor_may_delegate": true
     },
     "test": {
       "name": "test",
@@ -184,6 +190,7 @@
       "min_gate_score": 0.8,
       "min_test_coverage": 0.80,
       "conditions_manifest_required": false,
+      "phase_executor_may_delegate": true,
       "valid_skip_reasons": [
         "user_explicit_request",
         "ci_equivalent_exists"
@@ -212,7 +219,8 @@
       "conditions_manifest_required": true,
       "consensus_threshold": 5,
       "consensus_proposers": ["quality-engineering", "product", "engineering"],
-      "strong_dissent_blocks": true
+      "strong_dissent_blocks": true,
+      "phase_executor_may_delegate": false
     },
     "operate": {
       "name": "operate",
@@ -236,6 +244,7 @@
       "min_test_coverage": null,
       "conditions_manifest_required": false,
       "skip_complexity_threshold": 3,
+      "phase_executor_may_delegate": false,
       "valid_skip_reasons": [
         "complexity_below_threshold",
         "user_explicit_request",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -161,7 +161,7 @@ Quality gates are hard enforcement mechanisms, not advisory:
 - **Build depends on design**: `phases.json` `build.depends_on: ["clarify", "design"]`
 - **Structured skip reasons**: `valid_skip_reasons` per phase; free-text rejected
 - **Non-skippable test-strategy**: `skip_complexity_threshold: 3` prevents skipping at complexity >= 3
-- **Rollback**: `CREW_GATE_ENFORCEMENT=legacy` env var bypasses all enforcement
+- **Rollback**: git revert on the PR; no runtime toggle.
 - **Cross-session learning**: crew agents store learnings in wicked-garden:mem at project completion and gate failures
 
 ### Bulletproof Standards
@@ -269,7 +269,7 @@ Tasks carry agent-coordination fields in the `metadata` dict passed to `TaskCrea
 
 `gate-finding` additionally requires `verdict` (APPROVE | CONDITIONAL | REJECT), `min_score`, `score`; CONDITIONAL requires `conditions_manifest_path`.
 
-**Enforcement mode**: `WG_TASK_METADATA=warn|strict|off` (default: `warn`). Warn emits a deprecation `systemMessage` on violations; strict denies via `permissionDecision: "deny"`. Mirrors the `CREW_GATE_ENFORCEMENT=legacy` rollback pattern.
+**Enforcement mode**: `WG_TASK_METADATA=warn|strict|off` (default: `warn`). Warn emits a deprecation `systemMessage` on violations; strict denies via `permissionDecision: "deny"`.
 
 **Procedure injection**: SubagentStart hook reads the most-recently-modified in-progress task at `${CLAUDE_CONFIG_DIR}/tasks/{session_id}/` and injects the procedure bundle keyed on `metadata.event_type` (e.g. `coding-task` → R1-R6 bulletproof standards, `gate-finding` → Gate Finding Protocol).
 

--- a/agents/crew/gate-evaluator.md
+++ b/agents/crew/gate-evaluator.md
@@ -1,0 +1,80 @@
+---
+name: gate-evaluator
+description: |
+  Fast-path objective gate evaluator for minimal-tier and self-check gates. Use when:
+  a gate-policy.json entry declares `mode: self-check` OR has an empty `reviewers` list
+  OR is `mode: advisory` (findings-only). DO NOT use for full-rigor specialist gates —
+  those dispatch via their declared reviewers (solution-architect, security-engineer,
+  senior-engineer, etc.).
+
+  <example>
+  Context: A minimal-rigor crew project approves its design phase; gate-policy.json
+  sets `design-quality.minimal` to `mode: self-check` with `reviewers: []`.
+  user: (invoked by phase_manager.approve_phase via _dispatch_gate_reviewer)
+  <commentary>
+  gate-evaluator reads phases/design/design.md, checks byte-count and required-deliverable
+  presence, and emits {verdict: APPROVE|CONDITIONAL, score, reason, conditions}. Never
+  dispatches specialists; never makes subjective calls.
+  </commentary>
+  </example>
+model: haiku
+effort: low
+max-turns: 3
+color: gray
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# Gate-Evaluator
+
+You are the **fast-path objective gate evaluator**. You run ONLY when:
+
+- `gate-policy.json` lists `mode: self-check` OR
+- the `reviewers[]` list is empty OR
+- `mode: advisory` (findings-only).
+
+You are explicitly **NOT** for full-rigor specialist gates. Specialists (senior-engineer,
+solution-architect, security-engineer, risk-assessor, etc.) run when the policy declares
+them with `mode: sequential | parallel | council`.
+
+## Responsibilities
+
+1. Read the gate's `gate-policy.json` entry for the current rigor tier (objective
+   thresholds only — `min_score`, required deliverables, evidence types).
+2. Read the deliverables under `phases/{phase}/`.
+3. Emit `{verdict, score, reason, conditions}` based **solely** on **objective** checks:
+   - file presence
+   - byte counts (>= 100 bytes per evidence-minimums rule)
+   - `phases.json` `required_deliverables` presence
+   - rubric thresholds when a rubric is present and measurable
+4. Never make subjective calls. Escalate to `CONDITIONAL` when in doubt.
+
+## Output Contract
+
+Your final message MUST end with a fenced JSON block:
+
+```json
+{
+  "verdict": "APPROVE",
+  "score": 0.85,
+  "reason": "All required deliverables present and >= min_bytes.",
+  "conditions": [],
+  "reviewer": "gate-evaluator"
+}
+```
+
+- `verdict` is one of APPROVE | CONDITIONAL | REJECT.
+- REJECT is reserved for clear objective failures (missing file, zero bytes, banned reviewer).
+- When in doubt, emit CONDITIONAL with concrete conditions, not a REJECT.
+
+## Speed Budget
+
+- Target <5s sync latency (NFR-α1).
+- max-turns: 3. If you cannot decide in 3 turns, return CONDITIONAL with a
+  "needs-specialist-review" condition.
+
+## Failure Modes
+
+- Missing required deliverable → `verdict: REJECT`, `reason: "missing-deliverable: <name>"`.
+- Zero-byte deliverable → `verdict: REJECT`, `reason: "deliverable-too-small: <name>"`.
+- Banned reviewer authored a prior gate-result → `verdict: REJECT`, `reason: "banned-reviewer"`.
+- Ambiguous or subjective call → `verdict: CONDITIONAL` with explicit conditions.

--- a/agents/crew/phase-executor.md
+++ b/agents/crew/phase-executor.md
@@ -1,0 +1,151 @@
+---
+name: phase-executor
+description: |
+  Produce the current phase's deliverables and run phase-start / phase-end re-evaluations
+  for a mode-3 wicked-crew project. Use when: phase_manager.execute() dispatches a phase
+  for a full-rigor crew project; the agent receives a phase brief and returns a
+  deliverables manifest plus a parallelization_check block. Re-eval records are written
+  to disk (phases/{phase}/reeval-start.json + reeval-log.jsonl + process-plan.addendum.jsonl).
+
+  <example>
+  Context: A crew project has just entered the design phase; the clarify gate APPROVED.
+  user: (invoked by phase_manager.execute(project, "design"))
+  <commentary>
+  phase-executor reads the clarify-phase outputs, runs phase-start re-eval (usually a no-op
+  at phase-start), produces phases/design/design.md per the phase template, runs phase-end
+  re-eval appending to reeval-log.jsonl + process-plan.addendum.jsonl, and returns a JSON
+  manifest with files_written, scope_changes, plan_mutations, parallelization_check.
+  </commentary>
+  </example>
+
+  <example>
+  Context: build phase with 3 independent code-edit sub-tasks.
+  user: (invoked by phase_manager.execute(project, "build"))
+  <commentary>
+  Because phases.json sets phase_executor_may_delegate=true for build, the executor
+  dispatches the 3 edits in a single parallel Task batch (SC-6), aggregates results,
+  writes executor-status.json with sub_agent_timing entries showing overlapping
+  [dispatched_at, completed_at] windows, and returns parallelization_check with
+  dispatched_in_parallel=true.
+  </commentary>
+  </example>
+model: sonnet
+effort: high
+max-turns: 12
+color: cyan
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
+tool-capabilities:
+  - version-control
+---
+
+# Phase-Executor
+
+You are the per-phase orchestrator-executor for a mode-3 wicked-crew project. You own
+**one phase** at a time: produce its deliverables, bookend it with re-eval records, and
+return a structured manifest to `phase_manager.execute()`. You are an **orchestrator-executor**
+— within your assigned phase you MAY delegate sub-tasks to focused sub-agents when
+`phase_executor_may_delegate=true` in `phases.json`; outside your phase you dispatch nothing.
+
+## Your Role
+
+1. Read inputs in canonical order (`process-plan.md`, prior phase deliverables,
+   prior-phase `gate-result.json`, `phases.json` entry for the target phase).
+2. Write `phases/{phase}/reeval-start.json` (phase-start snapshot — no-op on first phase).
+3. Produce the phase's required deliverables per `phases.json` `required_deliverables`.
+   Each deliverable MUST be >= 100 bytes (content-validation rule).
+4. Append the phase-end re-eval JSONL record to BOTH `phases/{phase}/reeval-log.jsonl`
+   AND `process-plan.addendum.jsonl` at project root. Use the schema pinned by
+   `skills/propose-process/refs/re-eval-addendum-schema.md`.
+5. `TaskUpdate` your executor task: `in_progress` before work, `completed` when finished.
+6. Return the structured JSON manifest (see "Return contract" below).
+
+## Dispatch Discipline (SC-6, AC-α10 — ENFORCED)
+
+**Default: parallelize when independent.** When you emit N >= 2 sub-tasks whose outputs
+do not depend on each other (no shared state writes, no consumer-of-producer ordering),
+you MUST dispatch them in a **single-message multi-Task(...) batch**, not serially.
+
+**Serial dispatch is allowed only when:**
+
+- Sub-tasks have real `blockedBy` dependencies on each other.
+- Sub-tasks mutate shared state where ordering matters (e.g. sequential edits to the
+  same file).
+- You declare a principled reason in `parallelization_check.serial_reason`.
+
+Your return output MUST always include a `parallelization_check` block:
+
+```json
+{
+  "parallelization_check": {
+    "sub_task_count": 4,
+    "dispatched_in_parallel": true,
+    "serial_reason": null
+  }
+}
+```
+
+When `sub_task_count >= 2` and `dispatched_in_parallel: false`, `serial_reason` MUST be a
+non-empty string. `phase_manager.execute()` treats the execution as `failed` with
+reason `"parallelization-check-missing"` otherwise.
+
+## Delegation Contract
+
+- `phases.json` `phase_executor_may_delegate` governs per-phase delegation:
+  - `build` / `test` → `true` (delegation encouraged for parallelizable artifacts).
+  - `clarify` / `design` / `challenge` / `review` → `false` (single-narrative deliverables).
+- When delegation is off, you produce deliverables directly (no sub-agent dispatch).
+- When delegation is on, you MAY dispatch focused sub-agents (implementer, test-designer,
+  etc.) via the Task tool, **in parallel when independent**. Aggregate their outputs into
+  the single `ExecuteResult` returned upstream.
+
+## Re-eval Bookends
+
+- **Phase-start (`reeval-start.json`, NOT jsonl).** Snapshot of prior state used to compute
+  factor_deltas at phase-end. On the first phase (clarify) write a no-op record:
+  `{prior_tasks_completed: 0, scope_changes: [], note: "fresh plan"}`.
+- **Phase-end (`reeval-log.jsonl` + project-root `process-plan.addendum.jsonl`).** Full
+  validated mutation record per `scripts/crew/validate_reeval_addendum.py`. Append only —
+  never rewrite. Use `scripts/crew/reeval_addendum.py append` to write atomically.
+
+## Return Contract
+
+Your final message MUST end with a fenced JSON block of this shape:
+
+```json
+{
+  "status": "ok",
+  "files_written": ["<abs path>", "<abs path>"],
+  "scope_changes": [{"what": "...", "why": "..."}],
+  "plan_mutations": [
+    {"op": "prune|augment|re_tier", "task_id": "...", "new_rigor_tier": "...", "why": "..."}
+  ],
+  "parallelization_check": {
+    "sub_task_count": 0,
+    "dispatched_in_parallel": true,
+    "serial_reason": null
+  },
+  "self_notes": "<free text for the approver>"
+}
+```
+
+## R1-R6 Bulletproof Standards
+
+This agent's procedure-injection bundle is `coding-task` (via `event_type` in task
+metadata). The SubagentStart hook reads it. You MUST apply R1-R6 to every deliverable
+you write:
+
+- **R1** no dead code
+- **R2** no bare panics
+- **R3** no magic values
+- **R4** no swallowed errors
+- **R5** no unbounded ops
+- **R6** no god functions
+
+## Failure Modes
+
+- **Empty deliverables** → `phase_manager.execute()` returns `status: "failed"` with
+  reason `"executor-empty-deliverables"`.
+- **Deliverable outside `phases/{phase}/`** → rejected as `"deliverable-out-of-scope"`.
+- **Zero-byte deliverable** → rejected as `"deliverable-too-small"`.
+- **Addendum validator rejects record** → `"addendum-invalid: <reason>"`.
+- **`parallelization_check` missing with multi-sub-task run** → `"parallelization-check-missing"`.

--- a/agents/qe/semantic-reviewer.md
+++ b/agents/qe/semantic-reviewer.md
@@ -160,8 +160,8 @@ minimal-rigor tier.
 
 ## Bypass
 
-Set `CREW_GATE_ENFORCEMENT=legacy` to skip the semantic gate entirely
-(emergency rollback only — log the bypass in status.md).
+(v6.0 removed the env-var bypass; strict enforcement is always active.
+Rollback is a `git revert` on the PR, not a runtime toggle.)
 
 ## Common Divergence Patterns
 

--- a/commands/crew/convergence.md
+++ b/commands/crew/convergence.md
@@ -112,4 +112,4 @@ been started for this project and how to record the first transition.
 - Gate verdict is informational here; enforcement happens inside
   `phase_manager.approve_phase` during review approval.
 - Fails open when the log is missing (graceful degradation).
-- `CREW_GATE_ENFORCEMENT=legacy` forces APPROVE verdict.
+- (v6.0 removed the env-var bypass; strict enforcement is always active.)

--- a/commands/crew/cutover.md
+++ b/commands/crew/cutover.md
@@ -1,0 +1,80 @@
+---
+description: Cut an in-flight crew project over to mode-3 dispatch
+argument-hint: "<project-name> --to=mode-3"
+---
+
+# /wicked-garden:crew:cutover
+
+**In-flight cutover** (CR-2 / AC-α11). Legacy crew projects (created before the mode-3
+merge) default to `state.dispatch_mode = "v6-legacy"` and run on the pre-existing
+dispatcher. This command opts a project into the new mode-3 phase-executor path.
+
+**No silent upgrade.** Existing projects run to completion on legacy dispatch unless
+the user explicitly invokes this command. Mode-3 semantics apply only from the next
+phase forward after cutover; prior-phase re-eval bookends are NOT synthesized retroactively.
+
+## Arguments
+
+- `project-name` (required): crew project slug.
+- `--to=mode-3` (required): target dispatch mode. Currently only `mode-3` is supported.
+
+## Safe Cutover Window
+
+The command validates the project is in a safe state before writing. Cutover is
+**refused** when any of these hold:
+
+- An in-flight phase dispatch exists (a phase-executor task is `in_progress`).
+- Unresolved conditions exist on the current or prior phase's `conditions-manifest.json`.
+- A mid-phase scope-increase is pending re-eval (phase-end re-eval has emitted an
+  augment / re-tier-up mutation that has not been applied yet).
+
+## Flow
+
+1. Resolve the project via `phase_manager.py` (reject if archived).
+2. Read `state.dispatch_mode` via `_detect_dispatch_mode()`. If already `mode-3`, print
+   "already on mode-3" and exit.
+3. Validate the safe cutover window. If any validation fails, surface the reason and
+   exit non-zero.
+4. Write:
+
+   ```bash
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+     scripts/crew/phase_manager.py "${PROJECT_NAME}" cutover --to mode-3
+   ```
+
+   This writes `state.dispatch_mode = "mode-3"` AND emits the one-time migration marker
+   at `{project_dir}/phases/.cutover-to-mode-3.json`:
+
+   ```json
+   {"timestamp": "<ISO>",
+    "prior_mode": "v6-legacy",
+    "new_mode": "mode-3",
+    "prior_phase_pointer": "<current_phase>",
+    "user_ack": "explicit-cutover-command",
+    "note": "Mode-3 semantics apply from the next phase forward."}
+   ```
+
+5. Print confirmation + next-steps:
+
+   ```
+   Project <name> cut over to mode-3. The next /wicked-garden:crew:execute will use
+   the phase-executor path. Prior phases retain their legacy bookends.
+   ```
+
+## Example
+
+```
+/wicked-garden:crew:cutover my-legacy-project --to=mode-3
+# → Project my-legacy-project cut over to mode-3.
+
+/wicked-garden:crew:cutover fresh-project --to=mode-3
+# → Already on mode-3 (new projects default to mode-3).
+```
+
+## Safety Notes
+
+- Cutover is irreversible in-session. To revert, manually edit ProjectState (not
+  recommended).
+- The `.cutover-to-mode-3.json` marker is an append-only audit artifact.
+- Prior phase re-eval bookends are NOT backfilled. Mode-3 starts clean from the
+  current phase.

--- a/commands/crew/yolo.md
+++ b/commands/crew/yolo.md
@@ -1,0 +1,79 @@
+---
+description: Grant or revoke yolo (auto-approve) for a crew project
+argument-hint: "<project-name> --approve | --revoke | --status"
+---
+
+# /wicked-garden:crew:yolo
+
+Grant, revoke, or inspect **yolo auto-approval** for a crew project. When granted,
+`phase_manager.approve_phase()` auto-advances on APPROVE verdicts without user
+confirmation. CONDITIONAL and REJECT always surface to the user regardless.
+
+**Full-rigor policy**: yolo is ALLOWED at full rigor with explicit `--approve`. A
+scope-increase (augment OR re-tier-up) mutation in phase-end re-eval AUTO-REVOKES
+yolo with an audit line — safety is one-way.
+
+## Arguments
+
+- `project-name` (required): crew project slug.
+- `--approve`: grant yolo (writes `yolo_approved_by_user=true` to ProjectState).
+- `--revoke`: user-initiated revoke (writes `yolo_approved_by_user=false`).
+- `--status`: show current flag + last yolo-audit entry.
+
+## Flow
+
+1. Resolve the project via `phase_manager.py` (reject if archived).
+2. Read `rigor_tier` from ProjectState extras.
+3. If `rigor_tier == "full"` and `--approve`: print the full-rigor warning:
+
+   ```
+   YOLO @ full rigor is an explicit safety waiver. Auto-approve applies to APPROVE
+   verdicts only; CONDITIONAL and REJECT still surface. A scope-increase mutation
+   auto-revokes yolo. Confirmed by your --approve flag.
+   ```
+
+4. Write the flag:
+
+   ```bash
+   # Grant
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+     scripts/crew/phase_manager.py "${PROJECT_NAME}" yolo --action approve
+
+   # Revoke
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+     scripts/crew/phase_manager.py "${PROJECT_NAME}" yolo --action revoke
+
+   # Status
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" \
+     scripts/crew/phase_manager.py "${PROJECT_NAME}" yolo --action status
+   ```
+
+5. The `phase_manager.py yolo` action appends an audit line to
+   `{project_dir}/yolo-audit.jsonl` of shape:
+
+   ```json
+   {"event": "granted|revoked|status",
+    "timestamp": "<ISO>",
+    "reason": "<text>",
+    "scope": "project:<slug>",
+    "prior_value": <bool>, "new_value": <bool>}
+   ```
+
+6. Print confirmation + the revoke command.
+
+## Example
+
+```
+/wicked-garden:crew:yolo my-project --approve
+# → "Yolo granted for my-project. To revoke: /wicked-garden:crew:yolo my-project --revoke"
+
+/wicked-garden:crew:yolo my-project --status
+# → "yolo_approved_by_user=true; granted_at=2026-04-19T..."
+```
+
+## Safety Notes
+
+- Yolo NEVER bypasses CONDITIONAL or REJECT — only APPROVE.
+- Yolo NEVER bypasses the banned-reviewer check.
+- Scope-increase mutations (`op: augment` or `op: re_tier` with `new_rigor_tier: full`)
+  auto-revoke yolo and emit a `yolo-audit.jsonl` entry.

--- a/docs/audits/466-inventory.md
+++ b/docs/audits/466-inventory.md
@@ -1,0 +1,36 @@
+# #466 — CREW_GATE_ENFORCEMENT=legacy Audit Inventory
+
+**Closed by**: PR #472 (batch α mode-3 infrastructure)
+**Branch**: feat/466-mode3-crew-execution
+**v6.0 posture**: strict enforcement unconditional; env-var bypass removed.
+
+## Files changed
+
+| File | Change | Kind |
+|---|---|---|
+| `hooks/scripts/pre_tool.py` | removed `CREW_GATE_ENFORCEMENT=legacy` branch in `_challenge_gate_bypassed` | code |
+| `scripts/crew/phase_manager.py` | removed 3 env-var branches + comments (lines 929, 965, 974-977, 1086, 1562, 1643, 1652) | code |
+| `scripts/crew/convergence.py` | removed `legacy_bypass` read + dict field | code |
+| `.claude/CLAUDE.md` | removed Rollback bullet + WG_TASK_METADATA mirror note | docs |
+| `.claude-plugin/gate-policy.json` | description text → "bypass not supported" | config |
+| `agents/qe/semantic-reviewer.md` | replaced Bypass section | docs |
+| `commands/crew/convergence.md` | replaced note line | docs |
+| `skills/propose-process/refs/challenge-gate.md` | kept `WG_CHALLENGE_GATE=off` (scoped), noted global switch removed | docs |
+| `scenarios/crew/gate-enforcement-adversarial.md` | removed Step 8 (legacy bypass test) | scenario |
+| `tests/crew/test_approve_sessionstate.py` | removed `TestLegacyBypass` class | test |
+| `tests/crew/test_convergence.py` | removed `test_legacy_bypass_forces_approve` | test |
+| `tests/crew/test_gate_enforcement.py` | removed 4 setUp env-pop lines | test |
+| `tests/qe/test_semantic_review.py` | removed `TestLegacyBypass` class | test |
+
+## Retained references (intentional)
+
+| File | Why |
+|---|---|
+| `CHANGELOG.md` | historical release-note entries |
+| `tests/crew/test_adopt_legacy.py` | migration-tool tests that detect/transform leftover legacy references in USER projects |
+| `hooks/scripts/pre_tool.py` (comments) | explicit "removed in #466" historical notes |
+| `skills/propose-process/refs/challenge-gate.md` (replacement text) | one-line historical marker |
+
+## Rollback posture
+
+Rollback = git revert on PR #472. No runtime toggle. Strict mode is hardcoded at `scripts/crew/phase_manager.py:67` (`GATE_ENFORCEMENT_MODE="strict"`).

--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -247,7 +247,9 @@ def _handle_write_guard(tool_input: dict) -> str:
 
     Issue #442: Also blocks Write/Edit during build phase when the
     challenge-artifacts gate has not cleared (complexity >= 4). Respects
-    ``CREW_GATE_ENFORCEMENT=legacy`` and ``WG_CHALLENGE_GATE=off`` bypasses.
+    ``WG_CHALLENGE_GATE=off`` as a scoped bypass. (The legacy global
+    ``CREW_GATE_ENFORCEMENT=legacy`` switch was removed in #466 — v6 gate
+    enforcement is unconditional; use ``git revert`` to roll back.)
 
     TODO (Issue #329): When Claude Code supports updatedInput for PreToolUse hooks
     to redirect tool calls, change the MEMORY.md deny into an updatedInput redirect
@@ -290,13 +292,13 @@ def _handle_write_guard(tool_input: dict) -> str:
 # ---------------------------------------------------------------------------
 
 def _challenge_gate_bypassed() -> bool:
-    """Respect ``CREW_GATE_ENFORCEMENT=legacy`` and ``WG_CHALLENGE_GATE=off``.
+    """Respect ``WG_CHALLENGE_GATE=off`` as a scoped bypass.
 
-    Either env var disables the challenge gate — matches the existing gate
-    rollback convention used elsewhere in the codebase.
+    Only the scoped flag disables the challenge gate. The global
+    ``CREW_GATE_ENFORCEMENT=legacy`` switch was removed in #466 — v6 gate
+    enforcement is unconditional. Rollback is a ``git revert``, not a
+    runtime toggle.
     """
-    if (os.environ.get("CREW_GATE_ENFORCEMENT") or "").strip().lower() == "legacy":
-        return True
     if (os.environ.get("WG_CHALLENGE_GATE") or "").strip().lower() == "off":
         return True
     return False
@@ -386,8 +388,7 @@ def _check_challenge_gate(file_path: str) -> str:
             f"phases/design/challenge-artifacts.md before continuing build. "
             f"Run `wicked-garden:crew:contrarian` or dispatch Task("
             f"subagent_type='wicked-garden:crew:contrarian'). "
-            f"To bypass temporarily, set WG_CHALLENGE_GATE=off or "
-            f"CREW_GATE_ENFORCEMENT=legacy."
+            f"To bypass temporarily, set WG_CHALLENGE_GATE=off."
         )
     except Exception:
         return ""

--- a/scenarios/crew/gate-enforcement-adversarial.md
+++ b/scenarios/crew/gate-enforcement-adversarial.md
@@ -1,7 +1,7 @@
 ---
 name: gate-enforcement-adversarial
 title: Adversarial Gate Enforcement — Bypass Attempts Blocked
-description: Verify that all Tier 1 gate enforcement checks in pre_tool.py block adversarial bypass attempts and that legacy mode cleanly overrides all checks
+description: Verify that all Tier 1 gate enforcement checks in pre_tool.py block adversarial bypass attempts under strict-mode enforcement
 type: testing
 difficulty: advanced
 estimated_minutes: 20
@@ -13,7 +13,7 @@ This scenario deliberately tries to bypass gate enforcement and verifies each at
 blocked with a specific error message. All checks are Tier 1 (hook layer, `pre_tool.py`)
 and run at <100ms via file stat + small reads before `phase_manager.py` ever executes.
 
-The scenario tests seven adversarial paths:
+The scenario tests six adversarial paths:
 
 1. Missing phase directory — phase has no output at all
 2. Missing required deliverables — phase directory exists but deliverables absent
@@ -21,7 +21,9 @@ The scenario tests seven adversarial paths:
 4. Test coverage below threshold — test-results.md has 25% coverage when 80% is required
 5. Missing specialist engagement — complexity 7 project missing required specialists
 6. Unresolved conditions — prior CONDITIONAL gate conditions not verified
-7. Legacy mode bypass — `CREW_GATE_ENFORCEMENT=legacy` disables all checks
+
+(v6.0 removed the env-var bypass; strict enforcement is always active. Rollback is a
+`git revert` on the PR, not a runtime toggle.)
 
 The hook functions are tested directly via Python import. This avoids requiring a running
 Claude session and makes the tests deterministic and infrastructure-free.
@@ -88,7 +90,6 @@ preflight() {
 import sys, os
 sys.path.insert(0, '${PLUGIN_ROOT}/hooks/scripts')
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
-os.environ['CREW_GATE_ENFORCEMENT'] = os.environ.get('CREW_GATE_ENFORCEMENT', 'strict')
 from pre_tool import _crew_gate_preflight
 cmd = '${PLUGIN_ROOT}/scripts/crew/phase_manager.py ${TEST_PROJECT} approve --phase $phase'
 result = _crew_gate_preflight(cmd)
@@ -368,53 +369,14 @@ print('reason:', reason)
 
 The reason must reference `design` and unresolved conditions.
 
-### Step 8: Legacy mode bypass — all checks skipped
-
-Set `CREW_GATE_ENFORCEMENT=legacy` and repeat the missing-deliverables scenario
-from Step 2. The hook must return `ok: true` immediately.
-
-```bash
-# Remove clarify deliverables to recreate a normally-blocked state
-rm -rf "${PROJECT_DIR}/phases/clarify"
-mkdir -p "${PROJECT_DIR}/phases/clarify"
-# No deliverables inside
-
-result=$(CREW_GATE_ENFORCEMENT=legacy preflight clarify)
-echo "${result}"
-echo "${result}" | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-assert d['ok'], f'Expected ok=True in legacy mode but got: {d}'
-print('PASS: legacy mode bypasses all checks')
-"
-```
-
-**Expected**: `PASS: legacy mode bypasses all checks`
-
-Verify the same scenario blocks in strict mode (confirming legacy bypass is the
-only reason it passed):
-
-```bash
-result=$(CREW_GATE_ENFORCEMENT=strict preflight clarify)
-echo "${result}"
-echo "${result}" | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-assert not d['ok'], 'Expected block in strict mode'
-print('PASS: strict mode blocks the same scenario')
-"
-```
-
-**Expected**: `PASS: strict mode blocks the same scenario`
-
 ## Expected Outcome
 
 Every adversarial bypass attempt produces a specific, actionable error message — not a
 generic "gate failed". The messages identify the exact file, phase, or condition that
 failed so engineers can fix the root cause rather than guess.
 
-Legacy mode is a clean escape hatch: `CREW_GATE_ENFORCEMENT=legacy` overrides all Tier 1
-checks with a single env var and is verified to restore blocking behavior when removed.
+(v6.0 removed the env-var bypass; strict enforcement is always active. Rollback is a
+`git revert` on the PR, not a runtime toggle.)
 
 ## Success Criteria
 
@@ -425,8 +387,6 @@ checks with a single env var and is verified to restore blocking behavior when r
 - [ ] Missing specialist engagement blocked with specialist domain name referenced
 - [ ] Successful path passes when all checks are satisfied
 - [ ] Unresolved conditions manifest blocked with prior phase name and "condition" referenced
-- [ ] Legacy mode (`CREW_GATE_ENFORCEMENT=legacy`) passes the same scenario that was blocked
-- [ ] Strict mode re-blocks the same scenario after legacy bypass confirms it was the bypass that passed
 
 ## Value Demonstrated
 

--- a/scenarios/crew/in-flight-cutover.md
+++ b/scenarios/crew/in-flight-cutover.md
@@ -1,0 +1,130 @@
+---
+name: in-flight-cutover
+title: In-Flight Crew Project Cutover to Mode-3 (CR-2 / AC-α11)
+description: |
+  Acceptance scenario for CR-2 / AC-α11: legacy projects auto-tag as
+  dispatch_mode="v6-legacy"; fresh projects default to "mode-3"; the
+  /wicked-garden:crew:cutover command opts a legacy project into mode-3
+  with an audit marker.
+type: testing
+difficulty: intermediate
+estimated_minutes: 5
+covers:
+  - AC-α11 (in-flight cutover)
+  - CR-2   (dispatch_mode field + _detect_dispatch_mode + /crew:cutover)
+---
+
+# In-Flight Crew Project Cutover
+
+Projects created BEFORE the mode-3 merge retain `state.dispatch_mode: "v6-legacy"`
+(auto-tagged on first approve call). Fresh projects default to `"mode-3"`. Users opt
+legacy projects into mode-3 via `/wicked-garden:crew:cutover`.
+
+---
+
+## Setup
+
+```bash
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export LEGACY_PROJECT="cutover-legacy-test"
+export FRESH_PROJECT="cutover-fresh-test"
+
+export LEGACY_DIR=$(sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys; sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from _paths import get_local_path
+print(get_local_path('wicked-crew', 'projects') / '${LEGACY_PROJECT}')
+")
+export FRESH_DIR=$(sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys; sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from _paths import get_local_path
+print(get_local_path('wicked-crew', 'projects') / '${FRESH_PROJECT}')
+")
+
+rm -rf "${LEGACY_DIR}" "${FRESH_DIR}"
+mkdir -p "${LEGACY_DIR}/phases" "${FRESH_DIR}/phases"
+
+# Legacy project — NO dispatch_mode field
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+d = {'id': '${LEGACY_PROJECT}', 'name': '${LEGACY_PROJECT}',
+     'complexity_score': 3, 'current_phase': 'design',
+     'phase_plan': ['clarify', 'design', 'build', 'review'],
+     'phases': {}}
+pathlib.Path('${LEGACY_DIR}/project.json').write_text(json.dumps(d, indent=2))
+"
+
+# Fresh project — dispatch_mode set to mode-3 from creation
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+d = {'id': '${FRESH_PROJECT}', 'name': '${FRESH_PROJECT}',
+     'complexity_score': 3, 'current_phase': 'clarify',
+     'phase_plan': ['clarify', 'design', 'build', 'review'],
+     'dispatch_mode': 'mode-3',
+     'phases': {}}
+pathlib.Path('${FRESH_DIR}/project.json').write_text(json.dumps(d, indent=2))
+"
+```
+
+---
+
+## Case 1: legacy auto-tag
+
+**Verifies**: AC-α11(i) — a project without `state.dispatch_mode` backfills to
+`"v6-legacy"` on first `_detect_dispatch_mode()` read.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" "${PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/crew/phase_manager.py "${LEGACY_PROJECT}" detect-mode
+```
+
+### Assertions
+
+- stdout contains `"dispatch_mode": "v6-legacy"`.
+- The project record now has the field written back.
+
+---
+
+## Case 2: fresh project mode-3
+
+**Verifies**: AC-α11(ii) — a fresh project defaults to `"mode-3"`.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" "${PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/crew/phase_manager.py "${FRESH_PROJECT}" detect-mode
+```
+
+### Assertions
+
+- stdout contains `"dispatch_mode": "mode-3"`.
+
+---
+
+## Case 3: /crew:cutover opts legacy into mode-3
+
+**Verifies**: AC-α11(iii) — `/wicked-garden:crew:cutover` flips the field and emits the
+audit marker.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" "${PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/crew/phase_manager.py "${LEGACY_PROJECT}" cutover --to mode-3
+```
+
+### Assertions
+
+- `state.dispatch_mode == "mode-3"` after cutover.
+- `{LEGACY_DIR}/phases/.cutover-to-mode-3.json` exists and parses as JSON.
+- The marker contains `prior_mode: "v6-legacy"` and `new_mode: "mode-3"`.
+
+---
+
+## Teardown
+
+```bash
+rm -rf "${LEGACY_DIR}" "${FRESH_DIR}"
+```

--- a/scenarios/crew/mode3-execution.md
+++ b/scenarios/crew/mode3-execution.md
@@ -1,0 +1,140 @@
+---
+name: mode3-execution
+title: Mode-3 Crew Execution — Full Pipeline Traversal
+description: |
+  Acceptance scenario for AC-α8: exercises the full mode-3 pipeline on a synthetic
+  crew project from clarify through review. Assertions are structural — script exit
+  codes, file presence, JSONL record counts, and gate-result contents. No
+  LLM-in-the-loop assertions.
+type: testing
+difficulty: advanced
+estimated_minutes: 10
+covers:
+  - AC-α1 (phase-executor agent exists and is discoverable)
+  - AC-α2 (phase_manager.execute records deliverables + executor-status.json)
+  - AC-α3 (phase_manager.approve dispatches gate + persists gate-result.json)
+  - AC-α4 (re-eval wiring; addendum JSONL written per phase)
+  - AC-α8 (full pipeline traversal)
+---
+
+# Mode-3 Crew Execution — Full Pipeline Traversal
+
+This scenario verifies that a mode-3 crew project traverses **clarify → design →
+challenge → build → test → review** with:
+
+- A `phase-executor` dispatch per phase.
+- A gate dispatch per phase producing `gate-result.json` with `result: APPROVE`.
+- Re-eval addendum records accumulating in `process-plan.addendum.jsonl`.
+
+---
+
+## Setup
+
+```bash
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export TEST_PROJECT="mode3-exec-test"
+
+export PROJECT_DIR=$(sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from _paths import get_local_path
+print(get_local_path('wicked-crew', 'projects') / '${TEST_PROJECT}')
+")
+
+rm -rf "${PROJECT_DIR}"
+mkdir -p "${PROJECT_DIR}/phases"
+
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+d = {
+    'id': '${TEST_PROJECT}',
+    'name': '${TEST_PROJECT}',
+    'complexity_score': 3,
+    'current_phase': 'clarify',
+    'phase_plan': ['clarify', 'design', 'build', 'review'],
+    'phase_plan_mode': 'facilitator',
+    'rigor_tier': 'standard',
+    'dispatch_mode': 'mode-3',
+    'phases': {k: {'status': 'pending'} for k in ['clarify', 'design', 'build', 'review']}
+}
+pathlib.Path('${PROJECT_DIR}/project.json').write_text(json.dumps(d, indent=2))
+print('project.json written')
+"
+```
+
+**Expected stdout**: `project.json written`
+
+---
+
+## Case 1: executor + approve per phase
+
+**Verifies**: AC-α2 (execute records deliverables) + AC-α3 (approve persists gate-result.json).
+
+### Test
+
+For each phase in the plan:
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" "${PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/crew/phase_manager.py "${TEST_PROJECT}" execute --phase "${PHASE}"
+
+sh "${PLUGIN_ROOT}/scripts/_python.sh" "${PLUGIN_ROOT}/scripts/_run.py" \
+  scripts/crew/phase_manager.py "${TEST_PROJECT}" approve --phase "${PHASE}"
+```
+
+### Assertions
+
+- Every `phases/{phase}/executor-status.json` exists and parses as JSON.
+- Every `phases/{phase}/gate-result.json` contains `"result": "APPROVE"`.
+- `process-plan.addendum.jsonl` contains at least one record per phase.
+
+### Pass criteria
+
+```
+count_executor_status == len(phase_plan)
+count_gate_result == len(phase_plan)
+all(gate_result["result"] == "APPROVE" for each phase)
+```
+
+---
+
+## Case 2: CONDITIONAL blocks next-phase execute
+
+**Verifies**: AC-α7(b) — a CONDITIONAL verdict blocks the next phase until conditions clear.
+
+### Test
+
+Seed a CONDITIONAL gate result at `phases/design/gate-result.json`:
+
+```json
+{"result": "CONDITIONAL", "score": 0.65, "min_score": 0.70,
+ "conditions": [{"description": "Clarify FR-1 ambiguity", "source": "reviewer"}]}
+```
+
+Attempt `phase_manager.py execute --phase build` → **expected non-zero exit** with
+`unresolved-conditions` in stderr.
+
+Resolve the manifest (write `resolved: true` on each condition) and retry →
+**expected exit 0**.
+
+---
+
+## Case 3: addendum integrity
+
+**Verifies**: AC-α4 — every phase emits a phase-end JSONL record.
+
+### Assertions
+
+- `process-plan.addendum.jsonl` line count >= `len(phase_plan)`.
+- Every record passes `scripts/crew/validate_reeval_addendum.py`.
+- Every record's `chain_id` starts with `${TEST_PROJECT}.`.
+
+---
+
+## Teardown
+
+```bash
+rm -rf "${PROJECT_DIR}"
+```
+
+The scenario is idempotent — re-running it from Setup produces the same evidence.

--- a/scenarios/crew/parallel-dispatch-verification.md
+++ b/scenarios/crew/parallel-dispatch-verification.md
@@ -1,0 +1,131 @@
+---
+name: parallel-dispatch-verification
+title: Parallel Subagent Dispatch Verification (SC-6 / AC-α10)
+description: |
+  Acceptance scenario for SC-6 / AC-α10: verifies that multi-reviewer parallel gates
+  actually dispatch reviewers in parallel (timestamp overlap in gate-result.json)
+  AND that build-phase executors emit the parallelization_check self-statement.
+type: testing
+difficulty: advanced
+estimated_minutes: 5
+covers:
+  - AC-α10 (parallel subagent dispatch enforcement)
+  - SC-6   (prefer parallel subagent dispatch — design principle)
+---
+
+# Parallel Subagent Dispatch Verification
+
+When `gate-policy.json` declares `mode: parallel` with `reviewers` of length >= 2, the
+gate-dispatch helper MUST issue all reviewer calls in a **single batched message**, not
+serially. When a phase-executor produces >= 2 independent sub-tasks in the `build` or
+`test` phase, its output MUST include `parallelization_check.dispatched_in_parallel: true`.
+
+---
+
+## Setup
+
+```bash
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export TEST_PROJECT="parallel-dispatch-test"
+
+export PROJECT_DIR=$(sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from _paths import get_local_path
+print(get_local_path('wicked-crew', 'projects') / '${TEST_PROJECT}')
+")
+
+rm -rf "${PROJECT_DIR}"
+mkdir -p "${PROJECT_DIR}/phases/build"
+```
+
+---
+
+## Case 1: multi-reviewer gate timestamp overlap
+
+**Verifies**: AC-α10 — reviewer dispatch windows overlap in time when `mode: parallel`.
+
+### Test
+
+Seed a synthetic `gate-result.json` that records a parallel dispatch:
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+gr = {
+    'result': 'APPROVE',
+    'score': 0.85,
+    'dispatch_mode': 'parallel',
+    'reviewers_dispatched': ['senior-engineer', 'security-engineer', 'risk-assessor'],
+    'per_reviewer_verdicts': [
+        {'reviewer': 'senior-engineer', 'verdict': 'APPROVE', 'score': 0.85,
+         'dispatched_at': '2026-04-19T14:00:00Z', 'completed_at': '2026-04-19T14:00:10Z'},
+        {'reviewer': 'security-engineer', 'verdict': 'APPROVE', 'score': 0.82,
+         'dispatched_at': '2026-04-19T14:00:00Z', 'completed_at': '2026-04-19T14:00:12Z'},
+        {'reviewer': 'risk-assessor', 'verdict': 'APPROVE', 'score': 0.80,
+         'dispatched_at': '2026-04-19T14:00:01Z', 'completed_at': '2026-04-19T14:00:11Z'},
+    ]
+}
+pathlib.Path('${PROJECT_DIR}/phases/build/gate-result.json').write_text(json.dumps(gr, indent=2))
+"
+```
+
+### Assertions
+
+- `gate-result.json`  `dispatch_mode == "parallel"`.
+- At least two `per_reviewer_verdicts` entries have overlapping `[dispatched_at, completed_at]` windows.
+
+---
+
+## Case 2: executor parallelization_check self-statement
+
+**Verifies**: SC-6 — every phase-executor return includes the `parallelization_check` block.
+
+### Test
+
+Seed a synthetic `executor-status.json` with three sub-agent timing entries showing overlap:
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+es = {
+    'executor_task_id': 'task-123',
+    'phase': 'build',
+    'started_at': '2026-04-19T14:01:00Z',
+    'finished_at': '2026-04-19T14:01:30Z',
+    'deliverables': ['phases/build/impl.md'],
+    'parallelization_check': {'sub_task_count': 3, 'dispatched_in_parallel': True, 'serial_reason': None},
+    'sub_agent_timing': [
+        {'task_id': 's1', 'dispatched_at': '2026-04-19T14:01:00Z', 'completed_at': '2026-04-19T14:01:15Z'},
+        {'task_id': 's2', 'dispatched_at': '2026-04-19T14:01:00Z', 'completed_at': '2026-04-19T14:01:20Z'},
+        {'task_id': 's3', 'dispatched_at': '2026-04-19T14:01:01Z', 'completed_at': '2026-04-19T14:01:18Z'},
+    ]
+}
+pathlib.Path('${PROJECT_DIR}/phases/build/executor-status.json').write_text(json.dumps(es, indent=2))
+"
+```
+
+### Assertions
+
+- `executor-status.json` `parallelization_check.dispatched_in_parallel == True`.
+- `sub_agent_timing` has at least 3 entries.
+- At least two `sub_agent_timing` entries have overlapping windows.
+
+---
+
+## Case 3: missing parallelization_check with >= 2 sub-tasks fails execution
+
+**Verifies**: AC-α10 failure-mode — `phase_manager.execute()` returns `status: "failed"`
+with reason `"parallelization-check-missing"` when `sub_task_count >= 2` and
+`dispatched_in_parallel: false` with null/empty `serial_reason`.
+
+Assert: the check is enforced by `scripts/crew/phase_manager.py::execute()` per design
+addendum-3 §SC-6.
+
+---
+
+## Teardown
+
+```bash
+rm -rf "${PROJECT_DIR}"
+```

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -145,6 +145,13 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.phase",
         "description": "Phase auto-advanced for low-complexity project (audit trail)",
     },
+    # Yolo scope-increase revoke — emitted by _apply_scope_increase_revoke when
+    # an augment/re-tier-up mutation flips yolo_approved_by_user to False.
+    "wicked.crew.yolo_revoked": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.yolo",
+        "description": "Yolo auto-approval revoked due to scope-increase mutation (audit + observability)",
+    },
     # Smaht domain — fact_extractor.py → brain auto-memorize subscriber
     "wicked.fact.extracted": {
         "domain": "smaht",

--- a/scripts/crew/convergence.py
+++ b/scripts/crew/convergence.py
@@ -533,7 +533,9 @@ def evaluate_review_gate(
         - Over-budget artifacts (sessions > aging budget for their state)
           are surfaced as CONDITIONAL findings when the verdict would
           otherwise be APPROVE.
-        - ``CREW_GATE_ENFORCEMENT=legacy`` forces APPROVE regardless of findings.
+
+    (v6.0 removed the env-var bypass; strict enforcement is always active.
+    Rollback is a ``git revert`` on the PR, not a runtime toggle.)
 
     Returns:
         Dict with keys:
@@ -541,10 +543,7 @@ def evaluate_review_gate(
             result:    APPROVE | CONDITIONAL | REJECT
             findings:  list of {kind, artifact_id, state, message}
             summary:   dict (counts + totals)
-            legacy_bypass: bool
     """
-    legacy_bypass = os.environ.get("CREW_GATE_ENFORCEMENT", "").lower() == "legacy"
-
     log_paths = _iter_all_log_paths(project_dir)
     if not log_paths:
         # No log — fail-open per graceful-degradation policy.
@@ -556,7 +555,6 @@ def evaluate_review_gate(
                 "note": "No convergence log found — skipping gate.",
                 "total_artifacts": 0,
             },
-            "legacy_bypass": legacy_bypass,
         }
 
     status = project_status(project_dir, current_session_id=current_session_id)
@@ -616,9 +614,6 @@ def evaluate_review_gate(
     else:
         result = _GATE_CONDITIONAL
 
-    if legacy_bypass:
-        result = _GATE_APPROVE
-
     return {
         "gate": "convergence-verify",
         "result": result,
@@ -628,7 +623,6 @@ def evaluate_review_gate(
             "counts": status["counts"],
             "threshold": threshold,
         },
-        "legacy_bypass": legacy_bypass,
     }
 
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -1032,10 +1032,8 @@ def _load_gate_result(project_dir: Path, phase: str) -> Optional[Dict]:
 # checks (see call site in ``approve_phase``). Complexity-aware: mandatory at
 # complexity >= 3, advisory otherwise.
 #
-# Emergency bypass honoured via CREW_GATE_ENFORCEMENT=legacy env var. The
-# wider v6 enforcement machinery removed the general legacy flag, but this
-# specific gate is new and its own rollback lever is additive — matches the
-# WG_TASK_METADATA escape-hatch pattern for newly-added validators.
+# (v6.0 removed the env-var bypass; strict enforcement is always active.
+# Rollback is a ``git revert`` on the PR, not a runtime toggle.)
 # ---------------------------------------------------------------------------
 
 # Complexity at/above which semantic alignment is MANDATORY (blocking).
@@ -1068,21 +1066,12 @@ def _check_semantic_alignment_gate(
         complexity <  3                 -> advisory warning only; never blocks
         no spec items found             -> advisory skip
 
-    Respects ``CREW_GATE_ENFORCEMENT=legacy`` — returns (None, []) when set.
     Fails safe — any exception during analysis becomes a warning, not a block.
+    (v6.0 removed the env-var bypass; strict enforcement is always active.)
     """
     # Only runs for the review phase. Caller should pre-check but we
     # defensively verify here too.
     if resolve_phase(phase) != "review":
-        return None, []
-
-    # Emergency rollback — honoured for this gate explicitly per issue #444
-    # acceptance ("Respect CREW_GATE_ENFORCEMENT=legacy bypass").
-    if os.environ.get("CREW_GATE_ENFORCEMENT", "").lower() == "legacy":
-        logger.info(
-            "[semantic-alignment] CREW_GATE_ENFORCEMENT=legacy set — "
-            "skipping spec-to-code alignment check."
-        )
         return None, []
 
     complexity = int(getattr(state, "complexity_score", 0) or 0)
@@ -1189,8 +1178,7 @@ def _check_semantic_alignment_gate(
                 f"missing from implementation ({', '.join(missing_ids)}). "
                 f"See {project_dir / 'phases' / 'review' / 'semantic-gap-report.json'}. "
                 f"Implement the referenced AC or remove them from the spec "
-                f"before approving, or set CREW_GATE_ENFORCEMENT=legacy to "
-                f"bypass (emergency rollback only)."
+                f"before approving."
             ),
             warnings,
         )
@@ -1665,13 +1653,12 @@ def _check_convergence_gate(state: "ProjectState") -> List[str]:
     Fails open on:
         - missing module (module not importable)
         - missing log file (no convergence data recorded yet)
-        - `CREW_GATE_ENFORCEMENT=legacy`
 
     Returns:
         List of human-readable CONDITIONAL finding strings.  Empty means the
-        gate passed (or was bypassed).  These are warnings, not hard REJECTs —
-        they are appended to the approve_phase warnings list so the reviewer
-        sees them without the approval itself being blocked by this gate.
+        gate passed.  These are warnings, not hard REJECTs — they are
+        appended to the approve_phase warnings list so the reviewer sees
+        them without the approval itself being blocked by this gate.
     """
     try:
         from convergence import evaluate_review_gate as _eval_cv_gate
@@ -1690,7 +1677,6 @@ def _check_convergence_gate(state: "ProjectState") -> List[str]:
         logger.warning("[convergence-verify] evaluate_review_gate failed: %s", exc)
         return []
 
-    # Legacy bypass already handled inside evaluate_review_gate.
     if result.get("result") == "APPROVE":
         return []
 
@@ -1746,18 +1732,11 @@ def _run_build_phase_guard(project_dir: Path) -> List[str]:
     Fail-open on every axis — ImportError, missing module, exception during
     scan, budget_exceeded — all return an empty list without raising.
 
-    Respects CREW_GATE_ENFORCEMENT=legacy as a rollback switch: when set
-    the guard hook is a complete no-op (matches the documented escape hatch
-    for additive gate enforcement layers).
+    (v6.0 removed the env-var bypass; strict enforcement is always active.
+    Rollback is a ``git revert`` on the PR, not a runtime toggle.)
 
     Mirrors the fail-open pattern used by hooks/scripts/stop.py::_run_guard_pipeline.
     """
-    # Rollback switch — keep the build-phase guard hook no-op when legacy
-    # enforcement is requested (matches the mode-flag escape pattern used
-    # by the telemetry step and the #448 stop-hook integration).
-    if os.environ.get("CREW_GATE_ENFORCEMENT", "").lower() == "legacy":
-        return []
-
     try:
         # scripts/platform/ is a sibling of scripts/crew/.  Add it to
         # sys.path lazily so the import only pays the cost at build-phase

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -1025,6 +1025,525 @@ def _load_gate_result(project_dir: Path, phase: str) -> Optional[Dict]:
 
 
 # ---------------------------------------------------------------------------
+# BLEND-RULE gate dispatch helpers (design §3, AC-α3 / FR-α3.1..FR-α3.5)
+#
+# `_dispatch_gate_reviewer()` is the main entry point. It reads the
+# `gate-policy.json` entry for `{gate_name, rigor_tier}` and routes to one
+# of four sub-helpers based on the policy's `mode`:
+#
+#   - `_dispatch_fast_evaluator`    (self-check | advisory | empty reviewers)
+#   - `_dispatch_sequential`        (mode: sequential — stops on first REJECT)
+#   - `_dispatch_parallel_and_merge` (mode: parallel — single-batch dispatch,
+#                                     merged via REJECT > CONDITIONAL > APPROVE)
+#   - `_dispatch_council`           (mode: council — parallel + plurality)
+#
+# Since Task/Agent dispatching from within a Python script is
+# environment-dependent (not always available in unit tests or CLI subshells),
+# every helper accepts an injectable `dispatcher` callable with shape
+# `(subagent_type, prompt, context) -> dict`. Callers supply the real
+# orchestrator in production; tests supply a mock. When `dispatcher` is None,
+# helpers return a conservative CONDITIONAL stub with
+# `reason: "dispatcher-unavailable"` so callers can fall back to the existing
+# disk-based `gate-result.json` contract without blowing up.
+#
+# Merge rule (per design §3):
+#   - Any banned reviewer identity  -> REJECT "banned-reviewer"
+#   - Any REJECT                    -> REJECT (safety bias)
+#   - No REJECT, any CONDITIONAL    -> CONDITIONAL (union conditions)
+#   - All APPROVE                   -> APPROVE
+#   - Score = min of per-reviewer scores (conservative)
+# ---------------------------------------------------------------------------
+
+
+def _banned_reviewer_error(reviewer: str) -> Optional[str]:
+    """Return a reason string if `reviewer` is banned; None otherwise.
+
+    Mirrors _validate_gate_reviewer() logic but returns a short tag suitable
+    for embedding in a synthesized gate_result.
+    """
+    if not reviewer:
+        return None
+    r = reviewer.lower().strip()
+    if r in (name.lower() for name in BANNED_REVIEWER_NAMES):
+        return f"banned-reviewer:{reviewer}"
+    for prefix in BANNED_REVIEWER_PREFIXES:
+        if r.startswith(prefix.lower()):
+            return f"banned-reviewer:{reviewer}"
+    return None
+
+
+def _empty_verdict_stub(
+    gate_name: str, phase: str, reason: str, *, reviewer: str = "phase-manager"
+) -> Dict[str, Any]:
+    """Return a conservative CONDITIONAL gate_result used when dispatch
+    is unavailable. Callers may treat this as "no decision made"."""
+    return {
+        "verdict": "CONDITIONAL",
+        "score": 0.0,
+        "min_score": 0.0,
+        "reviewer": reviewer,
+        "reason": reason,
+        "timestamp": get_utc_timestamp(),
+        "conditions": [],
+        "gate_name": gate_name,
+        "phase": phase,
+        "per_reviewer_verdicts": [],
+        "reviewers_dispatched": [],
+        "dispatch_mode": "stub",
+        "external_review": False,
+    }
+
+
+def _normalize_reviewer_result(
+    raw: Any, *, reviewer: str
+) -> Dict[str, Any]:
+    """Normalize a reviewer's output into the canonical verdict shape.
+
+    Accepts a dict from the dispatcher with keys like
+    `{verdict|result, score, reason, conditions}` and produces:
+        {reviewer, verdict, score, reason, conditions}
+    Unknown / missing values degrade to CONDITIONAL with score 0.
+    """
+    if not isinstance(raw, dict):
+        return {
+            "reviewer": reviewer,
+            "verdict": "CONDITIONAL",
+            "score": 0.0,
+            "reason": "malformed-reviewer-output",
+            "conditions": [],
+        }
+    verdict = str(raw.get("verdict") or raw.get("result") or "CONDITIONAL").upper()
+    if verdict not in ("APPROVE", "CONDITIONAL", "REJECT"):
+        verdict = "CONDITIONAL"
+    try:
+        score = float(raw.get("score") or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    conditions = raw.get("conditions") or []
+    if not isinstance(conditions, list):
+        conditions = []
+    return {
+        "reviewer": raw.get("reviewer") or reviewer,
+        "verdict": verdict,
+        "score": score,
+        "reason": raw.get("reason") or "",
+        "conditions": conditions,
+    }
+
+
+def _merge_reviewer_verdicts(
+    per_reviewer: List[Dict[str, Any]],
+    *,
+    gate_name: str,
+    phase: str,
+    dispatch_mode: str,
+) -> Dict[str, Any]:
+    """Apply the BLEND-RULE merge to a list of normalized reviewer results.
+
+    Rules (design §3):
+      - Any banned identity        -> REJECT "banned-reviewer"
+      - Any REJECT                 -> REJECT
+      - No REJECT, any CONDITIONAL -> CONDITIONAL (union conditions)
+      - All APPROVE                -> APPROVE
+      - Merged score               -> min of scores (conservative)
+    """
+    if not per_reviewer:
+        return _empty_verdict_stub(
+            gate_name, phase, "no-reviewer-results", reviewer="phase-manager"
+        )
+
+    # 1. Banned reviewer short-circuit (highest priority).
+    for pr in per_reviewer:
+        banned = _banned_reviewer_error(pr.get("reviewer", ""))
+        if banned:
+            return {
+                "verdict": "REJECT",
+                "score": 0.0,
+                "min_score": 0.0,
+                "reviewer": pr.get("reviewer", ""),
+                "reason": banned,
+                "timestamp": get_utc_timestamp(),
+                "conditions": [],
+                "gate_name": gate_name,
+                "phase": phase,
+                "per_reviewer_verdicts": per_reviewer,
+                "reviewers_dispatched": [p.get("reviewer", "") for p in per_reviewer],
+                "dispatch_mode": dispatch_mode,
+                "external_review": len(per_reviewer) > 1,
+            }
+
+    verdicts = [pr["verdict"] for pr in per_reviewer]
+    scores = [pr["score"] for pr in per_reviewer]
+    merged_score = min(scores) if scores else 0.0
+    reviewers = [pr.get("reviewer", "") for pr in per_reviewer]
+    union_conditions: List[Any] = []
+    reasons: List[str] = []
+    for pr in per_reviewer:
+        union_conditions.extend(pr.get("conditions", []))
+        if pr.get("reason"):
+            reasons.append(f"{pr.get('reviewer', '?')}: {pr['reason']}")
+
+    if "REJECT" in verdicts:
+        merged_verdict = "REJECT"
+    elif "CONDITIONAL" in verdicts:
+        merged_verdict = "CONDITIONAL"
+    else:
+        merged_verdict = "APPROVE"
+
+    return {
+        "verdict": merged_verdict,
+        "result": merged_verdict,  # legacy alias consumed by approve_phase
+        "score": merged_score,
+        "min_score": merged_score,
+        "reviewer": reviewers[0] if reviewers else "phase-manager",
+        "reason": "; ".join(reasons) if reasons else merged_verdict,
+        "timestamp": get_utc_timestamp(),
+        "conditions": union_conditions,
+        "gate_name": gate_name,
+        "phase": phase,
+        "per_reviewer_verdicts": per_reviewer,
+        "reviewers_dispatched": reviewers,
+        "dispatch_mode": dispatch_mode,
+        "external_review": len(per_reviewer) > 1,
+    }
+
+
+def _dispatch_fast_evaluator(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+    *,
+    dispatcher: Optional[Any] = None,
+    fallback_reviewer: str = "gate-evaluator",
+) -> Dict[str, Any]:
+    """Fast-path dispatcher for self-check / advisory / empty-reviewers gates.
+
+    Dispatches the `gate-evaluator` agent with a deliverable-summary context
+    and returns a normalized gate_result. When `dispatcher` is None (unit
+    tests / CLI shells without Task tool), returns a CONDITIONAL stub.
+    """
+    ctx = {
+        "gate_name": gate_name,
+        "phase": phase,
+        "project": getattr(state, "name", None) if state is not None else None,
+        "mode": "fast-evaluator",
+    }
+    if dispatcher is None:
+        return _empty_verdict_stub(
+            gate_name, phase, "dispatcher-unavailable", reviewer=fallback_reviewer
+        )
+    try:
+        raw = dispatcher(
+            "wicked-garden:crew:gate-evaluator",
+            (
+                f"Evaluate gate '{gate_name}' for phase '{phase}'. "
+                "Read gate-policy.json for objective thresholds and the "
+                f"deliverables under phases/{phase}/. Emit verdict + score + "
+                "reason + conditions."
+            ),
+            ctx,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        return _empty_verdict_stub(
+            gate_name, phase, f"dispatch-error:{exc}", reviewer=fallback_reviewer
+        )
+    norm = _normalize_reviewer_result(raw, reviewer=fallback_reviewer)
+    return _merge_reviewer_verdicts(
+        [norm],
+        gate_name=gate_name,
+        phase=phase,
+        dispatch_mode="fast-evaluator",
+    )
+
+
+def _dispatch_sequential(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+    reviewers: List[str],
+    *,
+    dispatcher: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Dispatch reviewers in order, stopping on the first REJECT.
+
+    Merged verdict uses BLEND-RULE over the results collected so far.
+    """
+    if not reviewers:
+        return _dispatch_fast_evaluator(
+            state, phase, gate_name, dispatcher=dispatcher
+        )
+    if dispatcher is None:
+        return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
+
+    collected: List[Dict[str, Any]] = []
+    for reviewer in reviewers:
+        try:
+            raw = dispatcher(
+                f"wicked-garden:crew:{reviewer}",
+                (
+                    f"Review gate '{gate_name}' for phase '{phase}' as {reviewer}. "
+                    "Emit verdict + score + reason + conditions."
+                ),
+                {"gate_name": gate_name, "phase": phase, "reviewer": reviewer},
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            raw = {"verdict": "CONDITIONAL", "score": 0.0,
+                   "reason": f"dispatch-error:{exc}", "conditions": []}
+        norm = _normalize_reviewer_result(raw, reviewer=reviewer)
+        collected.append(norm)
+        if norm["verdict"] == "REJECT":
+            # Short-circuit — do not dispatch remaining reviewers.
+            break
+
+    return _merge_reviewer_verdicts(
+        collected,
+        gate_name=gate_name,
+        phase=phase,
+        dispatch_mode="sequential",
+    )
+
+
+def _dispatch_parallel_and_merge(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+    reviewers: List[str],
+    *,
+    dispatcher: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Dispatch all reviewers in a single-message parallel Agent batch (SC-6).
+
+    The dispatcher is expected to support a batched call — we pass the
+    reviewer list and a per-reviewer context in one invocation. A single-
+    reviewer dispatcher is accepted too; we invoke it once per reviewer but
+    the intent is that the caller's wrapper preserves the parallel batch
+    (see `parallelization_check` in execute() for the SC-6 contract).
+
+    Merge rule: REJECT if any REJECT, CONDITIONAL if any CONDITIONAL, else
+    APPROVE. Conditions are unioned; score = min.
+    """
+    if not reviewers:
+        return _dispatch_fast_evaluator(
+            state, phase, gate_name, dispatcher=dispatcher
+        )
+    if dispatcher is None:
+        return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
+
+    per_reviewer: List[Dict[str, Any]] = []
+    # Attempt batched dispatch first via a sentinel subagent_type. If the
+    # dispatcher doesn't recognize the batch shape it returns None / raises;
+    # we then fall back to per-reviewer dispatch. The caller supplies
+    # whichever style they support.
+    batched: Any = None
+    try:
+        batched = dispatcher(
+            "wicked-garden:crew:_parallel_batch",
+            (
+                f"Dispatch reviewers in parallel for gate '{gate_name}' "
+                f"phase '{phase}'. reviewers={reviewers}"
+            ),
+            {
+                "gate_name": gate_name,
+                "phase": phase,
+                "reviewers": reviewers,
+                "mode": "parallel",
+            },
+        )
+    except Exception:
+        batched = None
+
+    if isinstance(batched, list) and batched:
+        for idx, raw in enumerate(batched):
+            name = reviewers[idx] if idx < len(reviewers) else f"reviewer-{idx}"
+            per_reviewer.append(
+                _normalize_reviewer_result(raw, reviewer=name)
+            )
+    else:
+        # Fallback: call the dispatcher once per reviewer. We still mark
+        # dispatch_mode=parallel — the contract is the merge rule.
+        for reviewer in reviewers:
+            try:
+                raw = dispatcher(
+                    f"wicked-garden:crew:{reviewer}",
+                    (
+                        f"Review gate '{gate_name}' for phase '{phase}' as "
+                        f"{reviewer}. Emit verdict + score + reason + conditions."
+                    ),
+                    {
+                        "gate_name": gate_name,
+                        "phase": phase,
+                        "reviewer": reviewer,
+                        "mode": "parallel",
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                raw = {"verdict": "CONDITIONAL", "score": 0.0,
+                       "reason": f"dispatch-error:{exc}", "conditions": []}
+            per_reviewer.append(
+                _normalize_reviewer_result(raw, reviewer=reviewer)
+            )
+
+    return _merge_reviewer_verdicts(
+        per_reviewer,
+        gate_name=gate_name,
+        phase=phase,
+        dispatch_mode="parallel",
+    )
+
+
+def _dispatch_council(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+    reviewers: List[str],
+    *,
+    min_concurrence: float = 0.6,
+    dispatcher: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Council dispatch — parallel plurality vote with concurrence threshold.
+
+    Verdict is the plurality of (APPROVE | CONDITIONAL | REJECT). When the
+    plurality share < `min_concurrence`, the verdict is downgraded to
+    CONDITIONAL with reason `insufficient-concurrence`. REJECT still
+    short-circuits any plurality analysis (one REJECT blocks).
+    """
+    if not reviewers:
+        return _dispatch_fast_evaluator(
+            state, phase, gate_name, dispatcher=dispatcher
+        )
+    if dispatcher is None:
+        return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
+
+    merged = _dispatch_parallel_and_merge(
+        state, phase, gate_name, reviewers, dispatcher=dispatcher
+    )
+    merged["dispatch_mode"] = "council"
+
+    per_reviewer = merged.get("per_reviewer_verdicts") or []
+    total = len(per_reviewer)
+    if not total:
+        return merged
+
+    # REJECT short-circuit already applied by the merge helper.
+    if merged.get("verdict") == "REJECT":
+        return merged
+
+    verdict_counts: Dict[str, int] = {"APPROVE": 0, "CONDITIONAL": 0, "REJECT": 0}
+    for pr in per_reviewer:
+        v = pr.get("verdict", "CONDITIONAL")
+        verdict_counts[v] = verdict_counts.get(v, 0) + 1
+
+    # Plurality (ties broken in the safer direction: CONDITIONAL > APPROVE).
+    plurality_verdict = "APPROVE"
+    plurality_count = verdict_counts["APPROVE"]
+    if verdict_counts["CONDITIONAL"] >= plurality_count:
+        plurality_verdict = "CONDITIONAL"
+        plurality_count = verdict_counts["CONDITIONAL"]
+
+    concurrence = plurality_count / total
+    merged["concurrence"] = concurrence
+    merged["min_concurrence"] = min_concurrence
+    merged["plurality_verdict"] = plurality_verdict
+    if concurrence < min_concurrence and plurality_verdict == "APPROVE":
+        # Downgrade — not enough agreement to approve.
+        merged["verdict"] = "CONDITIONAL"
+        merged["result"] = "CONDITIONAL"
+        prior_reason = merged.get("reason") or ""
+        merged["reason"] = (
+            "insufficient-concurrence"
+            + (f"; {prior_reason}" if prior_reason else "")
+        )
+    else:
+        merged["verdict"] = plurality_verdict
+        merged["result"] = plurality_verdict
+
+    return merged
+
+
+# Phase -> default gate_name mapping. Used by approve_phase() when it needs
+# to call _dispatch_gate_reviewer() but the caller didn't pass an explicit
+# gate_name. Mirrors skills/propose-process/refs/gate-policy.md. Phases not
+# listed fall back to the phase-name (e.g. 'review' -> 'review') which will
+# surface as "unknown gate" via _resolve_gate_reviewer.
+_PHASE_DEFAULT_GATE: Dict[str, str] = {
+    "clarify": "requirements-quality",
+    "design": "design-quality",
+    "build": "code-quality",
+    "review": "evidence-quality",
+    "test-strategy": "testability",
+    "challenge": "challenge-resolution",
+}
+
+
+def _gate_name_for_phase(phase: str) -> str:
+    """Return the default gate_name for a given phase (BLEND dispatch)."""
+    return _PHASE_DEFAULT_GATE.get(resolve_phase(phase), resolve_phase(phase))
+
+
+def _dispatch_gate_reviewer(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+    gate_policy_entry: Dict[str, Any],
+    *,
+    dispatcher: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Main BLEND-RULE entry point.
+
+    Reads the policy entry for `{tier}` and delegates to the right
+    sub-helper. Returns a merged gate_result dict with
+    `{verdict, score, reason, conditions, per_reviewer_verdicts[]}`.
+
+    Args:
+        state:              ProjectState for context (may be None in stubs).
+        phase:              Phase being approved.
+        gate_name:          One of the configured gates.
+        gate_policy_entry:  The rigor-tier block from gate-policy.json
+                            (dict with `reviewers`, `mode`, `fallback`).
+        dispatcher:         Optional injectable callable
+                            `(subagent_type, prompt, context) -> dict`.
+                            When None, returns a CONDITIONAL stub.
+    """
+    if not isinstance(gate_policy_entry, dict):
+        return _empty_verdict_stub(
+            gate_name, phase, "missing-gate-policy-entry"
+        )
+
+    mode = str(gate_policy_entry.get("mode") or "self-check").lower()
+    reviewers = list(gate_policy_entry.get("reviewers") or [])
+    fallback = gate_policy_entry.get("fallback") or "gate-evaluator"
+
+    # BLEND RULE — fast path when no reviewers or advisory/self-check.
+    if not reviewers or mode in ("self-check", "advisory"):
+        return _dispatch_fast_evaluator(
+            state,
+            phase,
+            gate_name,
+            dispatcher=dispatcher,
+            fallback_reviewer=fallback,
+        )
+
+    if mode == "sequential":
+        return _dispatch_sequential(
+            state, phase, gate_name, reviewers, dispatcher=dispatcher
+        )
+    if mode == "parallel":
+        return _dispatch_parallel_and_merge(
+            state, phase, gate_name, reviewers, dispatcher=dispatcher
+        )
+    if mode == "council":
+        return _dispatch_council(
+            state, phase, gate_name, reviewers, dispatcher=dispatcher
+        )
+
+    # Unknown mode — conservative stub (do not raise: this path runs inside
+    # approve_phase() where a raise would abort advancement for all callers).
+    return _empty_verdict_stub(
+        gate_name, phase, f"unknown-dispatch-mode:{mode}", reviewer=fallback
+    )
+
+
+# ---------------------------------------------------------------------------
 # Semantic alignment gate (issue #444)
 #
 # Post-implementation pass that verifies spec-to-code alignment per numbered
@@ -1788,6 +2307,8 @@ def approve_phase(
     override_deliverables_reason: str = "",
     skip_reeval: bool = False,
     skip_reeval_reason: str = "",
+    *,
+    dispatcher: Optional[Any] = None,
 ) -> Tuple[ProjectState, Optional[str]]:
     """Approve a phase and return next phase (or None if done).
 
@@ -1801,6 +2322,13 @@ def approve_phase(
                             This is a deliberate, logged, audited bypass — NOT a
                             silent escape (AC-14, AC-15).
         skip_reeval_reason: Mandatory justification string when skip_reeval=True.
+        dispatcher:         Optional injectable callable for BLEND-RULE gate
+                            dispatch (design §3). When provided, and the gate
+                            hasn't been run (no existing gate-result.json),
+                            approve_phase() dispatches reviewers per
+                            gate-policy.json instead of raising. When None
+                            (legacy callers), existing behavior is preserved —
+                            "Gate not run" raises as before.
     """
     phase = resolve_phase(phase)
     warnings: List[str] = []
@@ -1912,6 +2440,39 @@ def approve_phase(
         project_dir = get_project_dir(state.name)
         rigor_tier = state.extras.get("rigor_tier")
         gate_run = _check_gate_run(project_dir, phase, rigor_tier=rigor_tier)
+
+        # BLEND-RULE dispatch hook (design §3, FR-α3.x): when the gate
+        # hasn't been run yet and a dispatcher was supplied, synthesize
+        # a gate-result.json by invoking reviewers per gate-policy.json
+        # BEFORE the legacy "gate not run" branch fires. Writing the
+        # artifact lets the existing post-load check chain run unchanged.
+        if not gate_run and dispatcher is not None and not override_gate:
+            try:
+                gate_name = _gate_name_for_phase(phase)
+                gate_entry = _resolve_gate_reviewer(
+                    gate_name, rigor_tier or "standard"
+                )
+                synthesized = _dispatch_gate_reviewer(
+                    state, phase, gate_name, gate_entry,
+                    dispatcher=dispatcher,
+                )
+                phase_dir = project_dir / "phases" / phase
+                phase_dir.mkdir(parents=True, exist_ok=True)
+                (phase_dir / "gate-result.json").write_text(
+                    json.dumps(synthesized, indent=2, sort_keys=True)
+                )
+                # Re-run the run-detector now that we've written the file.
+                gate_run = _check_gate_run(
+                    project_dir, phase, rigor_tier=rigor_tier
+                )
+            except (ValueError, FileNotFoundError, OSError) as exc:
+                # Failed BLEND dispatch — fall through to legacy "gate not
+                # run" raise below so the user gets the familiar error.
+                logger.warning(
+                    "[approve] BLEND dispatch failed for phase '%s': %s; "
+                    "falling back to legacy gate-required error.",
+                    phase, exc,
+                )
 
         if not gate_run:
             if override_gate and not gate_override_allowed:
@@ -2058,6 +2619,61 @@ def approve_phase(
                         warnings.append(f"Score check overridden: {score_error}")
                     else:
                         raise ValueError(score_error)
+
+    # FR-α5.2: Approve-time yolo auto-accept.
+    #
+    # Policy (design §3 + task spec):
+    #   - yolo + APPROVE      -> advance normally, append yolo-audit line
+    #   - yolo + CONDITIONAL  -> DO NOT auto-advance; surface to user with
+    #                            conditions-manifest (raise ValueError)
+    #   - yolo + REJECT       -> existing REJECT raise already fired above
+    #   - no yolo             -> unchanged
+    #
+    # The REJECT path is already handled by the "Gate returned REJECT"
+    # raise earlier in this function, so only APPROVE + CONDITIONAL need
+    # new logic here. Audit lines go to yolo-audit.jsonl; advance logic
+    # is otherwise untouched (preserves legacy callers).
+    yolo_flag = bool((state.extras or {}).get("yolo_approved_by_user"))
+    if yolo_flag and gate_result:
+        _verdict_raw = (
+            gate_result.get("verdict") or gate_result.get("result") or ""
+        )
+        _verdict = str(_verdict_raw).upper()
+        if _verdict == "APPROVE":
+            try:
+                _project_dir_yolo = get_project_dir(state.name)
+            except Exception:
+                _project_dir_yolo = None
+            if _project_dir_yolo is not None:
+                _append_yolo_audit(
+                    _project_dir_yolo,
+                    event="auto-accepted",
+                    reason=f"phase:{phase} verdict:APPROVE",
+                    prior_value=True,
+                    new_value=True,
+                    extra={
+                        "phase": phase,
+                        "verdict": "APPROVE",
+                        "score": gate_result.get("score"),
+                        "reviewer": gate_result.get("reviewer"),
+                    },
+                )
+        elif _verdict == "CONDITIONAL":
+            # Surface CONDITIONAL to the user — do not silently advance
+            # under yolo. Conditions-manifest has already been written
+            # above (Check 2b). Raise so the CLI exits non-zero and the
+            # user sees the manifest path in the error text.
+            conditions_manifest = (
+                get_project_dir(state.name) / "phases" / phase
+                / "conditions-manifest.json"
+            )
+            raise ValueError(
+                f"Phase '{phase}' gate verdict is CONDITIONAL under yolo "
+                f"— auto-advance blocked. Review "
+                f"{conditions_manifest} and re-run approve after "
+                f"conditions are resolved, or pass --override-gate "
+                f"with a reason to bypass."
+            )
 
     # Emit gate decision to wicked-bus
     if gate_result:

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -2329,6 +2329,16 @@ def approve_phase(
                             gate-policy.json instead of raising. When None
                             (legacy callers), existing behavior is preserved —
                             "Gate not run" raises as before.
+
+                            IMPORTANT (review-gate condition a): the
+                            `handle_approve` CLI entry always passes
+                            dispatcher=None because raw CLI invocations
+                            cannot dispatch Claude Code subagents. Only
+                            Agent-driven callers (e.g. the `crew:approve`
+                            slash command running inside claude-code) can
+                            inject a real dispatcher. `handle_approve`
+                            logs an explicit warning in that case so the
+                            behaviour is honest rather than silent.
     """
     phase = resolve_phase(phase)
     warnings: List[str] = []
@@ -3650,6 +3660,19 @@ def main():
 
     elif args.action == "approve":
         phase = args.phase or state.current_phase
+        # BLEND-RULE honesty note (review-gate condition a):
+        # The CLI `approve` path cannot dispatch subagents — only an
+        # Agent-driven caller can inject a real dispatcher. We log an
+        # explicit warning so users aren't silently surprised when
+        # `_dispatch_gate_reviewer` returns a "dispatcher-unavailable"
+        # stub instead of running reviewers. Agent-driven callers should
+        # pass `dispatcher=...` to approve_phase() directly.
+        logger.warning(
+            "CLI approve path: no dispatcher available — gate reviewers "
+            "will NOT be auto-dispatched. Use `crew:approve` via the "
+            "wicked-garden agent path to invoke reviewers, or pre-stage "
+            "a gate-result.json before approval. (BLEND-RULE)"
+        )
         try:
             state, next_phase = approve_phase(
                 state,
@@ -3661,6 +3684,7 @@ def main():
                 override_deliverables_reason=args.reason or "",
                 skip_reeval=getattr(args, "skip_reeval", False),
                 skip_reeval_reason=args.reason or "",
+                dispatcher=None,
             )
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -167,6 +167,112 @@ def _resolve_gate_reviewer(gate_name: str, rigor_tier: str) -> dict:
     return tier_map[rigor_tier]
 
 
+# ---------------------------------------------------------------------------
+# Startup validation (SC-4) — full-rigor gates must declare non-empty reviewers
+# ---------------------------------------------------------------------------
+
+
+class ConfigError(ValueError):
+    """Raised on a mis-configured gate-policy.json (e.g. empty full-rigor reviewers).
+
+    Subclass of ValueError so existing callers that catch ValueError continue
+    to degrade gracefully, while new callers can discriminate config errors.
+    """
+
+
+_GATE_POLICY_FULL_VALIDATED: bool = False
+
+
+def _validate_gate_policy_full_rigor() -> None:
+    """Raise ConfigError if any gate at 'full' rigor has an empty reviewers list.
+
+    Runs once per process invocation; result cached in module-level flag
+    ``_GATE_POLICY_FULL_VALIDATED``. Called lazily from
+    ``phase_manager.execute()`` and ``approve_phase()`` entry points.
+
+    Rationale (SC-4 / CHL-04): silent fallback to the fast gate-evaluator at
+    full rigor is a correctness bug — the user asked for specialist council
+    scrutiny. Hard validation surfaces the misconfiguration immediately.
+
+    Behaviour:
+        - Each gate's ``full.reviewers`` list (when ``full`` tier is defined)
+          MUST be non-empty.
+        - Gates without a ``full`` tier are skipped (they do not advertise
+          full-rigor support).
+    """
+    global _GATE_POLICY_FULL_VALIDATED
+    if _GATE_POLICY_FULL_VALIDATED:
+        return
+    try:
+        policy = _load_gate_policy()
+    except FileNotFoundError:
+        # gate-policy.json missing is handled elsewhere; this validator only
+        # inspects a loadable policy.
+        return
+    for gate_name, tiers in (policy.get("gates") or {}).items():
+        if not isinstance(tiers, dict):
+            continue
+        full = tiers.get("full")
+        if not isinstance(full, dict):
+            continue
+        reviewers = full.get("reviewers")
+        if isinstance(reviewers, list) and len(reviewers) == 0:
+            raise ConfigError(
+                f"Gate policy for '{gate_name}' at full rigor has empty "
+                f"reviewers — full rigor requires at least one reviewer, "
+                f"found none. Configure reviewers or remove the full tier."
+            )
+    _GATE_POLICY_FULL_VALIDATED = True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-mode detection (CR-2 / AC-α11) — in-flight cutover rule
+# ---------------------------------------------------------------------------
+
+
+_DISPATCH_MODE_VALID = ("mode-3", "v6-legacy", "v5")
+_DISPATCH_MODE_DEFAULT_LEGACY = "v6-legacy"
+_DISPATCH_MODE_DEFAULT_FRESH = "mode-3"
+
+
+def _detect_dispatch_mode(state: "ProjectState") -> str:
+    """Return the dispatch mode for a project (reads + backfills).
+
+    Reads ``state.extras['dispatch_mode']`` if present. When absent, inspects
+    the project directory for mode-3 evidence (``phases/{phase}/reeval-log.jsonl``
+    or ``phases/{phase}/executor-status.json``) and returns ``"mode-3"`` when
+    any is found, else ``"v6-legacy"``. Writes the detected value back to
+    ``state.extras`` (caller persists via ``save_project_state``).
+
+    Safety: on any unexpected error, returns ``"v6-legacy"`` (preserves
+    existing behavior; mode-3 is opt-in).
+    """
+    try:
+        extras = getattr(state, "extras", None) or {}
+        stored = extras.get("dispatch_mode")
+        if isinstance(stored, str) and stored in _DISPATCH_MODE_VALID:
+            return stored
+
+        # Backfill path — inspect project dir for mode-3 evidence.
+        project_dir = get_project_dir(state.name)
+        phases_dir = project_dir / "phases"
+        detected = _DISPATCH_MODE_DEFAULT_LEGACY
+        if phases_dir.is_dir():
+            for phase_dir in phases_dir.iterdir():
+                if not phase_dir.is_dir():
+                    continue
+                if (phase_dir / "reeval-log.jsonl").exists() or (
+                    phase_dir / "executor-status.json"
+                ).exists():
+                    detected = _DISPATCH_MODE_DEFAULT_FRESH
+                    break
+        extras["dispatch_mode"] = detected
+        state.extras = extras
+        return detected
+    except Exception:  # noqa: BLE001 — safety: fail-safe default
+        return _DISPATCH_MODE_DEFAULT_LEGACY
+
+
 def load_phases_config() -> dict:
     """Load phase definitions from phases.json in .claude-plugin/."""
     config_path = _get_plugin_root() / ".claude-plugin" / "phases.json"
@@ -2380,13 +2486,406 @@ def _merge_data_into_state(state: ProjectState, data: Dict[str, Any]) -> Project
     return state
 
 
+# ---------------------------------------------------------------------------
+# Mode-3 execute() entry point (AC-α2 / FR-α2.1..FR-α2.5)
+# ---------------------------------------------------------------------------
+
+
+def _append_yolo_audit(
+    project_dir: Path,
+    *,
+    event: str,
+    reason: str,
+    prior_value: bool,
+    new_value: bool,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Append a single yolo-audit.jsonl record at the project root.
+
+    Append-only; never rewrites. Fails open — audit log failures log but
+    do not abort the caller (matches plugin's graceful-degradation pattern).
+    """
+    try:
+        audit_path = project_dir / "yolo-audit.jsonl"
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "event": event,
+            "timestamp": get_utc_timestamp(),
+            "reason": reason,
+            "scope": f"project:{project_dir.name}",
+            "prior_value": prior_value,
+            "new_value": new_value,
+        }
+        if extra:
+            record.update(extra)
+        with open(audit_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        logger.warning("[yolo-audit] append failed: %s", exc)
+
+
+def _apply_scope_increase_revoke(
+    state: "ProjectState",
+    *,
+    plan_mutations: List[Dict[str, Any]],
+    project_dir: Path,
+    trigger: str,
+) -> bool:
+    """Revoke yolo if any mutation is an augment or re-tier-up to 'full'.
+
+    Returns True when yolo was revoked by this call; False otherwise.
+    Idempotent — caller may invoke at both execute() and approve() points.
+    """
+    scope_increased = any(
+        (m.get("op") == "augment")
+        or (
+            m.get("op") == "re_tier"
+            and m.get("new_rigor_tier") == "full"
+        )
+        for m in (plan_mutations or [])
+    )
+    if not scope_increased:
+        return False
+    extras = getattr(state, "extras", None) or {}
+    if not extras.get("yolo_approved_by_user"):
+        return False
+    extras["yolo_approved_by_user"] = False
+    extras["yolo_revoked_count"] = int(extras.get("yolo_revoked_count") or 0) + 1
+    state.extras = extras
+    _append_yolo_audit(
+        project_dir,
+        event="revoked",
+        reason=f"scope-increase@{trigger}",
+        prior_value=True,
+        new_value=False,
+        extra={"triggering_mutations": plan_mutations},
+    )
+    return True
+
+
+class ExecuteResult(Dict[str, Any]):
+    """Result shape for ``execute()``.
+
+    Keys:
+        status:                 "ok" | "failed"
+        deliverables:           list[str] of absolute paths (>= 100 bytes each)
+        executor_task_id:       opaque task identifier
+        reeval_start_path:      phases/{phase}/reeval-start.json
+        reeval_end_path:        phases/{phase}/reeval-log.jsonl
+        parallelization_check:  {sub_task_count, dispatched_in_parallel, serial_reason}
+        reason:                 present when status == "failed"
+    """
+
+
+def _check_parallelization(check: Dict[str, Any]) -> Optional[str]:
+    """Return a failure reason string when the parallelization_check is invalid.
+
+    Enforces SC-6 / AC-α10: when ``sub_task_count >= 2`` and
+    ``dispatched_in_parallel is False``, ``serial_reason`` MUST be non-empty.
+    Returns None when the check is satisfied.
+    """
+    if not isinstance(check, dict):
+        return "parallelization-check-missing"
+    sub_count = int(check.get("sub_task_count") or 0)
+    if sub_count < 2:
+        return None
+    in_parallel = bool(check.get("dispatched_in_parallel"))
+    if in_parallel:
+        return None
+    serial_reason = (check.get("serial_reason") or "").strip()
+    if not serial_reason:
+        return "parallelization-check-missing"
+    return None
+
+
+def execute(
+    project: str,
+    phase: str,
+    *,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Dispatch the phase-executor, collect deliverables, persist addendum.
+
+    Signature (AC-α2 / FR-α2.1): ``execute(project, phase) -> ExecuteResult``.
+
+    Returns a dict with keys listed in :class:`ExecuteResult`.
+
+    The live dispatch (Task tool invocation) is owned by the orchestrator;
+    this function is the server-side persistence / validation / status
+    writer. When called by an agent via the CLI, it reads an
+    ``executor-status.json`` already produced by the phase-executor and
+    performs post-dispatch enforcement (parallelization-check + yolo
+    auto-revoke + addendum validation).
+
+    Raises:
+        ValueError:  project unknown, archived, wrong phase, unresolved
+                     conditions, or ConfigError from gate-policy validator.
+        RuntimeError: executor produced empty deliverables, or the
+                     parallelization-check failed (AC-α10 failure mode).
+    """
+    # SC-4 startup validation (first line of every mode-3 entry point).
+    _validate_gate_policy_full_rigor()
+
+    state = load_project_state(project)
+    if state is None:
+        raise ValueError(f"Project not found: {project}")
+
+    # Dispatch-mode routing (CR-2 / AC-α11).
+    dispatch_mode = _detect_dispatch_mode(state)
+    if dispatch_mode in ("v6-legacy", "v5"):
+        return {
+            "status": "skipped",
+            "reason": f"dispatch_mode={dispatch_mode}; mode-3 execute() is opt-in",
+            "dispatch_mode": dispatch_mode,
+            "deliverables": [],
+        }
+
+    phase = resolve_phase(phase)
+    project_dir = get_project_dir(project)
+    phase_dir = project_dir / "phases" / phase
+    phase_dir.mkdir(parents=True, exist_ok=True)
+
+    reeval_start_path = phase_dir / "reeval-start.json"
+    reeval_log_path = phase_dir / "reeval-log.jsonl"
+    executor_status_path = phase_dir / "executor-status.json"
+
+    # When executor-status.json was already written by the phase-executor
+    # agent, apply post-dispatch enforcement to it.
+    result: Dict[str, Any] = {
+        "status": "ok",
+        "deliverables": [],
+        "executor_task_id": "",
+        "reeval_start_path": str(reeval_start_path),
+        "reeval_end_path": str(reeval_log_path),
+        "parallelization_check": {
+            "sub_task_count": 0,
+            "dispatched_in_parallel": True,
+            "serial_reason": None,
+        },
+        "dispatch_mode": dispatch_mode,
+    }
+
+    if dry_run:
+        return result
+
+    if executor_status_path.exists():
+        try:
+            status_doc = json.loads(executor_status_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            raise RuntimeError(f"executor-status-unreadable: {exc}")
+        deliverables = status_doc.get("deliverables") or []
+        if not deliverables:
+            raise RuntimeError("executor-empty-deliverables")
+        # Validate deliverables are under phases/{phase}/.
+        for rel in deliverables:
+            rel_path = Path(rel)
+            if rel_path.is_absolute():
+                abs_path = rel_path
+            else:
+                abs_path = project_dir / rel
+            try:
+                abs_path.resolve().relative_to(project_dir.resolve())
+            except ValueError:
+                raise RuntimeError(f"deliverable-out-of-scope: {rel}")
+
+        p_check = status_doc.get("parallelization_check") or {}
+        fail = _check_parallelization(p_check)
+        if fail:
+            result["status"] = "failed"
+            result["reason"] = fail
+            return result
+
+        result["deliverables"] = [str(p) for p in deliverables]
+        result["executor_task_id"] = status_doc.get("executor_task_id", "")
+        result["parallelization_check"] = p_check
+
+        # Scope-increase revoke hook (Point A — execute-time).
+        _apply_scope_increase_revoke(
+            state,
+            plan_mutations=status_doc.get("plan_mutations") or [],
+            project_dir=project_dir,
+            trigger="execute",
+        )
+        save_project_state(state)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Yolo management (AC-α5)
+# ---------------------------------------------------------------------------
+
+
+def yolo_action(project: str, action: str, reason: str = "") -> Dict[str, Any]:
+    """Grant / revoke / inspect the yolo flag for a project.
+
+    Actions:
+        approve  — set yolo_approved_by_user=True (writes audit line).
+        revoke   — set yolo_approved_by_user=False (writes audit line).
+        status   — return current flag + last audit record (no write).
+    """
+    state = load_project_state(project)
+    if state is None:
+        raise ValueError(f"Project not found: {project}")
+    project_dir = get_project_dir(project)
+    extras = state.extras or {}
+    prior = bool(extras.get("yolo_approved_by_user"))
+
+    if action == "status":
+        return {
+            "project": project,
+            "yolo_approved_by_user": prior,
+            "yolo_approved_at": extras.get("yolo_approved_at"),
+            "yolo_revoked_count": int(extras.get("yolo_revoked_count") or 0),
+            "rigor_tier": extras.get("rigor_tier"),
+        }
+
+    if action == "approve":
+        new_value = True
+        extras["yolo_approved_by_user"] = True
+        extras["yolo_approved_at"] = get_utc_timestamp()
+        state.extras = extras
+        save_project_state(state)
+        _append_yolo_audit(
+            project_dir,
+            event="granted",
+            reason=reason or "user-granted",
+            prior_value=prior,
+            new_value=new_value,
+        )
+        return {
+            "project": project,
+            "yolo_approved_by_user": True,
+            "prior_value": prior,
+        }
+
+    if action == "revoke":
+        new_value = False
+        extras["yolo_approved_by_user"] = False
+        state.extras = extras
+        save_project_state(state)
+        _append_yolo_audit(
+            project_dir,
+            event="revoked",
+            reason=reason or "user-revoked",
+            prior_value=prior,
+            new_value=new_value,
+        )
+        return {
+            "project": project,
+            "yolo_approved_by_user": False,
+            "prior_value": prior,
+        }
+
+    raise ValueError(f"Unknown yolo action: {action} (expected approve|revoke|status)")
+
+
+# ---------------------------------------------------------------------------
+# Cutover command (CR-2 / AC-α11)
+# ---------------------------------------------------------------------------
+
+
+def _safe_cutover_window(state: "ProjectState", project_dir: Path) -> Optional[str]:
+    """Return an error string when the project is NOT in a safe cutover window.
+
+    Validates:
+      - no in-flight phase dispatch (phase-executor task in_progress)
+      - no unresolved conditions on the current/prior phase
+      - no pending scope-increase re-eval
+    """
+    # Unresolved conditions check — reuse _verify_conditions heuristics.
+    try:
+        current = resolve_phase(state.current_phase)
+        condition_issues = _verify_conditions(project_dir, current) or []
+        if condition_issues:
+            return f"unresolved-conditions: {condition_issues[0]}"
+    except Exception:  # noqa: BLE001
+        pass  # fail open: absence of evidence is not evidence of absence
+    # In-flight-dispatch check: phase status == in_progress AND executor-status
+    # not yet written indicates an active dispatch.
+    cur = state.phases.get(resolve_phase(state.current_phase))
+    if cur and cur.status == "in_progress":
+        status_path = project_dir / "phases" / state.current_phase / "executor-status.json"
+        if not status_path.exists():
+            return "in-flight-dispatch: current phase still executing"
+    return None
+
+
+def cutover_action(project: str, target_mode: str) -> Dict[str, Any]:
+    """Opt a legacy project into mode-3 dispatch (writes state + audit marker).
+
+    Validates the safe cutover window (no in-flight dispatch, no unresolved
+    conditions). Writes ``state.dispatch_mode = "mode-3"`` and emits
+    ``{project_dir}/phases/.cutover-to-mode-3.json``.
+    """
+    if target_mode != "mode-3":
+        raise ValueError(f"Unsupported --to value: {target_mode} (only 'mode-3' supported)")
+
+    state = load_project_state(project)
+    if state is None:
+        raise ValueError(f"Project not found: {project}")
+
+    project_dir = get_project_dir(project)
+    prior_mode = _detect_dispatch_mode(state)
+
+    if prior_mode == "mode-3":
+        return {
+            "project": project,
+            "dispatch_mode": "mode-3",
+            "already_on_target": True,
+            "note": "Project is already on mode-3 dispatch.",
+        }
+
+    err = _safe_cutover_window(state, project_dir)
+    if err:
+        raise ValueError(f"cutover-refused: {err}")
+
+    extras = state.extras or {}
+    extras["dispatch_mode"] = "mode-3"
+    state.extras = extras
+    save_project_state(state)
+
+    phases_dir = project_dir / "phases"
+    phases_dir.mkdir(parents=True, exist_ok=True)
+    marker_path = phases_dir / ".cutover-to-mode-3.json"
+    try:
+        marker_path.write_text(json.dumps({
+            "timestamp": get_utc_timestamp(),
+            "prior_mode": prior_mode,
+            "new_mode": "mode-3",
+            "prior_phase_pointer": state.current_phase,
+            "user_ack": "explicit-cutover-command",
+            "note": "Mode-3 semantics apply from the next phase forward.",
+        }, indent=2))
+    except OSError as exc:
+        logger.warning("[cutover] marker write failed: %s", exc)
+
+    return {
+        "project": project,
+        "dispatch_mode": "mode-3",
+        "prior_mode": prior_mode,
+        "marker_path": str(marker_path),
+    }
+
+
+def detect_mode_action(project: str) -> Dict[str, Any]:
+    """Return the detected dispatch mode (with backfill side-effect)."""
+    state = load_project_state(project)
+    if state is None:
+        raise ValueError(f"Project not found: {project}")
+    mode = _detect_dispatch_mode(state)
+    # Persist backfill (detect may have mutated extras).
+    save_project_state(state)
+    return {"project": project, "dispatch_mode": mode}
+
+
 def main():
     """CLI interface for phase management."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Phase manager for wicked-crew")
     parser.add_argument("project", help="Project name")
-    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance"])
+    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode"])
     parser.add_argument("--phase", help="Target phase")
     parser.add_argument("--reason", help="Reason for skip or gate override")
     parser.add_argument("--approved-by", default=None, help="Approver identity (default: 'auto' for skip, 'user' for approve)")
@@ -2405,6 +2904,16 @@ def main():
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--description", default="", help="Project description (for create)")
     parser.add_argument("--data", default=None, help="JSON string of fields to set/update")
+    parser.add_argument("--to", default=None, help="Target dispatch mode for cutover (e.g. mode-3)")
+    parser.add_argument(
+        "--yolo-action", dest="yolo_action",
+        default=None, choices=["approve", "revoke", "status"],
+        help="Sub-action for the 'yolo' action (approve|revoke|status). Also accepted via --action.",
+    )
+    parser.add_argument(
+        "--action", dest="sub_action", default=None,
+        help="Sub-action name (e.g. approve|revoke|status for yolo).",
+    )
     parser.add_argument(
         "--skip-reeval",
         action="store_true",
@@ -2702,6 +3211,69 @@ def main():
         else:
             print(f"Approved phase: {approved_phase}")
             print(f"Started phase: {next_phase}")
+
+    elif args.action == "execute":
+        phase = args.phase or state.current_phase
+        try:
+            result = execute(args.project, phase)
+        except (ValueError, RuntimeError, ConfigError) as exc:
+            if args.json:
+                print(json.dumps({"ok": False, "error": str(exc)}))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps({"ok": True, **result}, indent=2))
+        else:
+            status = result.get("status")
+            print(f"execute: status={status} phase={resolve_phase(phase)}")
+            if status == "failed":
+                print(f"Reason: {result.get('reason')}", file=sys.stderr)
+                sys.exit(1)
+
+    elif args.action == "yolo":
+        sub = args.yolo_action or args.sub_action or "status"
+        try:
+            yr = yolo_action(args.project, sub, reason=args.reason or "")
+        except ValueError as exc:
+            if args.json:
+                print(json.dumps({"ok": False, "error": str(exc)}))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps({"ok": True, **yr}, indent=2))
+        else:
+            print(json.dumps(yr, indent=2))
+
+    elif args.action == "cutover":
+        target = args.to or "mode-3"
+        try:
+            cr = cutover_action(args.project, target)
+        except ValueError as exc:
+            if args.json:
+                print(json.dumps({"ok": False, "error": str(exc)}))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps({"ok": True, **cr}, indent=2))
+        else:
+            print(json.dumps(cr, indent=2))
+
+    elif args.action == "detect-mode":
+        try:
+            dm = detect_mode_action(args.project)
+        except ValueError as exc:
+            if args.json:
+                print(json.dumps({"ok": False, "error": str(exc)}))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps({"ok": True, **dm}, indent=2))
+        else:
+            print(json.dumps(dm, indent=2))
 
 
 if __name__ == "__main__":

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -2333,6 +2333,17 @@ def approve_phase(
     phase = resolve_phase(phase)
     warnings: List[str] = []
 
+    # SC-4 startup validation (COND-TG-4): when the project is running at full
+    # rigor, assert gate-policy.json declares non-empty reviewers for every
+    # full-tier gate. Empty reviewers would silently degrade to the fast
+    # evaluator which is a correctness bug at full rigor. Non-full tiers skip
+    # this check because an empty reviewer list is legitimate at minimal
+    # rigor (advisory-only gates). Matches the docstring claim that the
+    # validator is called from both execute() and approve_phase() entry
+    # points (see _validate_gate_policy_full_rigor docstring).
+    if (state.extras or {}).get("rigor_tier") == "full":
+        _validate_gate_policy_full_rigor()
+
     # Check 0 (AC-8): phase-end re-eval addendum freshness — fail-closed.
     # Must happen before deliverable check so the user sees the most actionable
     # error first.  skip_reeval=True bypasses with a mandatory logged reason.
@@ -3155,6 +3166,22 @@ def _apply_scope_increase_revoke(
         new_value=False,
         extra={"triggering_mutations": plan_mutations},
     )
+    # Observability: emit bus event so subscribers see the scope-increase
+    # revoke without tailing yolo-audit.jsonl. Fail-open on bus absence —
+    # emit_event() is a no-op when the bus is unavailable (see _bus.py).
+    try:
+        from _bus import emit_event
+        emit_event(
+            "wicked.crew.yolo_revoked",
+            {
+                "project": project_dir.name,
+                "trigger": trigger,
+                "mutation_count": len(plan_mutations or []),
+                "revoked_count": int(extras.get("yolo_revoked_count") or 0),
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — observability fail-open
+        logger.debug("[yolo-revoke] bus emit failed (fail-open): %s", exc)
     return True
 
 
@@ -3271,7 +3298,15 @@ def execute(
         deliverables = status_doc.get("deliverables") or []
         if not deliverables:
             raise RuntimeError("executor-empty-deliverables")
-        # Validate deliverables are under phases/{phase}/.
+        # Validate deliverables are under phases/{phase}/ — hard path-traversal
+        # guard (COND-TG-2). Resolves the declared path and asserts the real
+        # on-disk location is scoped inside the phase directory. `..` segments
+        # that escape phase_dir or absolute paths outside it are rejected with
+        # a ValueError so callers can distinguish "bad input" from runtime
+        # failures. Using phase_dir (not project_dir) matches the original
+        # intent of the comment and prevents a phase-executor from declaring
+        # deliverables under a sibling phase or the project root.
+        phase_dir_resolved = phase_dir.resolve()
         for rel in deliverables:
             rel_path = Path(rel)
             if rel_path.is_absolute():
@@ -3279,9 +3314,9 @@ def execute(
             else:
                 abs_path = project_dir / rel
             try:
-                abs_path.resolve().relative_to(project_dir.resolve())
+                abs_path.resolve().relative_to(phase_dir_resolved)
             except ValueError:
-                raise RuntimeError(f"deliverable-out-of-scope: {rel}")
+                raise ValueError(f"deliverable-out-of-scope: {rel}")
 
         p_check = status_doc.get("parallelization_check") or {}
         fail = _check_parallelization(p_check)

--- a/scripts/crew/reeval_addendum.py
+++ b/scripts/crew/reeval_addendum.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""reeval_addendum.py — Read and append re-eval addendum records (AC-α4).
+
+Schema is pinned by ``skills/propose-process/refs/re-eval-addendum-schema.md``
+v1.0.0. Validation is delegated to ``scripts/crew/validate_reeval_addendum.py``.
+
+Two write targets per phase-end re-eval:
+    - per-phase log:    ``{project_dir}/phases/{phase}/reeval-log.jsonl``
+    - project-level:    ``{project_dir}/process-plan.addendum.jsonl``
+
+Usage (library):
+    from reeval_addendum import append, read, read_latest
+
+    append(project_dir, phase="design", record={...})
+    records = read(project_dir, phase_filter="design")
+    latest = read_latest(project_dir, phase="design")
+
+Usage (CLI):
+    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \\
+      "${CLAUDE_PLUGIN_ROOT}/scripts/crew/reeval_addendum.py" \\
+      read <project_dir> [--phase PHASE]
+
+    echo '<record>' | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \\
+      "${CLAUDE_PLUGIN_ROOT}/scripts/crew/reeval_addendum.py" \\
+      append <project_dir> --phase PHASE
+
+Stdlib-only. Fail-open at the hook level — a missing or unreadable addendum
+file returns an empty list rather than raising (the gate's
+``_check_addendum_freshness`` is the authoritative enforcement surface).
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Minimum chain_id prefix length to sanity-check addendum records against the
+# project_dir we are writing them for. A record whose chain_id does not start
+# with the project slug indicates a wiring bug.
+_MIN_CHAIN_ID_LEN = 1
+
+
+def _per_phase_log_path(project_dir: Path, phase: str) -> Path:
+    """Return the per-phase reeval-log.jsonl path."""
+    return project_dir / "phases" / phase / "reeval-log.jsonl"
+
+
+def _project_addendum_path(project_dir: Path) -> Path:
+    """Return the project-root process-plan.addendum.jsonl path."""
+    return project_dir / "process-plan.addendum.jsonl"
+
+
+def _validate_record(record: Dict[str, Any]) -> Optional[str]:
+    """Return None when the record is valid, else a short error string.
+
+    This is a lightweight structural check — the full schema validation
+    happens via ``scripts/crew/validate_reeval_addendum.py`` which we shell
+    out to when available. This function is the fast local gate.
+    """
+    if not isinstance(record, dict):
+        return f"record must be a dict, got {type(record).__name__}"
+
+    required = {
+        "chain_id", "triggered_at", "trigger",
+        "prior_rigor_tier", "new_rigor_tier",
+        "mutations", "mutations_applied", "mutations_deferred",
+        "validator_version",
+    }
+    missing = required - set(record.keys())
+    if missing:
+        return f"record missing required keys: {sorted(missing)}"
+
+    chain_id = record.get("chain_id")
+    if not isinstance(chain_id, str) or len(chain_id) < _MIN_CHAIN_ID_LEN:
+        return "chain_id must be a non-empty string"
+
+    for key in ("mutations", "mutations_applied", "mutations_deferred"):
+        if not isinstance(record.get(key), list):
+            return f"{key} must be a list"
+
+    return None
+
+
+def _atomic_append(path: Path, line: str) -> None:
+    """Append one line to ``path`` as atomically as the platform allows.
+
+    Uses exclusive-append + fsync on POSIX; falls back to best-effort on
+    Windows. Torn-write risk on cross-platform filesystems is documented
+    in design §4; the gate's addendum-freshness check re-validates on each
+    approve cycle.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Normalize line ending.
+    if not line.endswith("\n"):
+        line = line + "\n"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except (OSError, AttributeError):
+            pass  # fail open: Windows / non-fsync filesystems — best-effort only
+
+
+def append(
+    project_dir: Path,
+    *,
+    phase: str,
+    record: Dict[str, Any],
+) -> None:
+    """Validate then append ``record`` to BOTH per-phase and project logs.
+
+    Raises:
+        ValueError: Record failed structural validation.
+        OSError:    File I/O error after validation.
+    """
+    if not isinstance(project_dir, Path):
+        project_dir = Path(project_dir)
+    err = _validate_record(record)
+    if err:
+        raise ValueError(f"reeval_addendum.append: {err}")
+
+    line = json.dumps(record, sort_keys=True, ensure_ascii=False)
+    per_phase = _per_phase_log_path(project_dir, phase)
+    project_log = _project_addendum_path(project_dir)
+
+    _atomic_append(per_phase, line)
+    _atomic_append(project_log, line)
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    """Return all JSON records from a JSONL file.
+
+    Lines that fail to parse are skipped with a warning-style noop; the
+    gate's validator is authoritative for strict checks. Missing file ->
+    empty list (fail-open read).
+    """
+    out: List[Dict[str, Any]] = []
+    if not path.exists():
+        return out
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            rec = json.loads(stripped)
+            if isinstance(rec, dict):
+                out.append(rec)
+        except json.JSONDecodeError:
+            # Skip corrupt lines; validator will surface them on next approve.
+            continue
+    return out
+
+
+def read(
+    project_dir: Path,
+    *,
+    phase_filter: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return all addendum records from the project log.
+
+    When ``phase_filter`` is provided, only records whose ``chain_id``
+    suffix matches ``.{phase}`` (anywhere in the dotted chain) OR whose
+    ``trigger`` mentions the phase are returned. This matches the
+    chain_id format in ``scripts/_event_schema.py``.
+    """
+    if not isinstance(project_dir, Path):
+        project_dir = Path(project_dir)
+    records = _read_jsonl(_project_addendum_path(project_dir))
+    if not phase_filter:
+        return records
+    suffix_token = f".{phase_filter}"
+    filtered: List[Dict[str, Any]] = []
+    for rec in records:
+        chain_id = rec.get("chain_id", "") or ""
+        trigger = rec.get("trigger", "") or ""
+        if suffix_token in f".{chain_id}." or phase_filter in trigger:
+            filtered.append(rec)
+    return filtered
+
+
+def read_latest(
+    project_dir: Path,
+    *,
+    phase: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the most recent addendum record for ``phase``, or None."""
+    recs = read(project_dir, phase_filter=phase)
+    if not recs:
+        return None
+    # Records are append-only and time-ordered; last entry is latest.
+    return recs[-1]
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (AC-α4 / NFR-α5)
+# ---------------------------------------------------------------------------
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read / append re-eval addendum records."
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_read = sub.add_parser("read", help="Read addendum records")
+    p_read.add_argument("project_dir", type=Path)
+    p_read.add_argument("--phase", default=None)
+
+    p_append = sub.add_parser("append", help="Append a record from stdin")
+    p_append.add_argument("project_dir", type=Path)
+    p_append.add_argument("--phase", required=True)
+
+    p_latest = sub.add_parser("latest", help="Read latest record for a phase")
+    p_latest.add_argument("project_dir", type=Path)
+    p_latest.add_argument("--phase", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.action == "read":
+        recs = read(args.project_dir, phase_filter=args.phase)
+        print(json.dumps(recs, indent=2))
+        return 0
+
+    if args.action == "latest":
+        rec = read_latest(args.project_dir, phase=args.phase)
+        print(json.dumps(rec, indent=2) if rec else "null")
+        return 0
+
+    if args.action == "append":
+        raw = sys.stdin.read().strip()
+        if not raw:
+            print("error: no record on stdin", file=sys.stderr)
+            return 2
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(f"error: invalid JSON on stdin: {exc}", file=sys.stderr)
+            return 2
+        try:
+            append(args.project_dir, phase=args.phase, record=rec)
+        except ValueError as exc:
+            print(f"error: validation failed: {exc}", file=sys.stderr)
+            return 1
+        print("ok")
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -197,5 +197,4 @@ Before Step 3 (factor scoring), read per-project process memory — unresolved r
 - [`refs/output-schema.md`](refs/output-schema.md) — JSON shape for measurement
 - [`refs/interaction-mode.md`](refs/interaction-mode.md) — normal vs. yolo, banned values
 - [`refs/gate-policy.md`](refs/gate-policy.md) — human-readable Gate × Rigor reviewer matrix
-- [`refs/re-eval-addendum-schema.md`](refs/re-eval-addendum-schema.md) — JSONL addendum schema
-- [`refs/spec-quality-rubric.md`](refs/spec-quality-rubric.md) — scored spec quality rubric (10 dims × 0-2 pts) + tier thresholds
+- [`refs/re-eval-addendum-schema.md`](refs/re-eval-addendum-schema.md) — JSONL addendum schema; [`refs/spec-quality-rubric.md`](refs/spec-quality-rubric.md) — scored spec quality rubric (10 dims × 0-2 pts) + tier thresholds

--- a/skills/propose-process/refs/challenge-gate.md
+++ b/skills/propose-process/refs/challenge-gate.md
@@ -94,9 +94,10 @@ blocks `Write` / `Edit` during `build` phase when:
 
 ### Rollback
 
-Two env vars disable the gate:
+One env var disables the gate:
 
-- `CREW_GATE_ENFORCEMENT=legacy` — disables ALL gates (global)
 - `WG_CHALLENGE_GATE=off` — disables ONLY the challenge gate (targeted)
 
-Either takes effect immediately without re-starting the session.
+Takes effect immediately without re-starting the session. (v6.0 removed
+the global `CREW_GATE_ENFORCEMENT=legacy` switch; broader rollback is a
+`git revert` on the PR, not a runtime toggle.)

--- a/tests/crew/test_approve_sessionstate.py
+++ b/tests/crew/test_approve_sessionstate.py
@@ -225,37 +225,5 @@ class TestGuardFailOpen(_SessionTempTestCase):
         self.assertEqual(result_state.extras.get("last_approve_warnings", []), [])
 
 
-# ---------------------------------------------------------------------------
-# CREW_GATE_ENFORCEMENT=legacy rollback — the build-phase guard is a no-op
-# ---------------------------------------------------------------------------
-
-
-class TestLegacyBypass(_SessionTempTestCase):
-
-    def test_legacy_enforcement_skips_guard(self):
-        """When CREW_GATE_ENFORCEMENT=legacy, the build-phase guard returns
-        an empty list without attempting to import guard_pipeline."""
-        state = _make_build_ready_state()
-
-        # If the guard ran, this patched run_pipeline would be called; we
-        # assert it's NOT called, proving the early-return in legacy mode.
-        import guard_pipeline as gp  # noqa: WPS433
-        called = {"count": 0}
-
-        def _counting(*_a, **_kw):
-            called["count"] += 1
-            return gp.PipelineReport(
-                pipeline_version="1.0", profile="standard",
-                budget_seconds=5.0, duration_ms=1, status="ok",
-            )
-
-        with patch.dict(os.environ, {"CREW_GATE_ENFORCEMENT": "legacy"}):
-            with patch.object(gp, "run_pipeline", side_effect=_counting):
-                approve_phase(state, "build")
-
-        self.assertEqual(called["count"], 0,
-                         "guard pipeline must not run under CREW_GATE_ENFORCEMENT=legacy")
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_blend_rule_helpers.py
+++ b/tests/crew/test_blend_rule_helpers.py
@@ -425,5 +425,74 @@ class TestGateReviewerEntry(unittest.TestCase):
         self.assertEqual(result["verdict"], "CONDITIONAL")
 
 
+# ---------------------------------------------------------------------------
+# COND-TG-3 — BLEND dispatcher failures must surface, not silently APPROVE
+# ---------------------------------------------------------------------------
+
+
+def _raising_dispatcher(exc_factory=lambda: RuntimeError("simulated agent failure")):
+    """Return a dispatcher callable that unconditionally raises.
+
+    Used to verify that BLEND-RULE helpers never return a silent APPROVE
+    verdict when the underlying dispatch call fails.
+    """
+    calls = []
+
+    def dispatcher(subagent_type, prompt, context):
+        calls.append({"subagent_type": subagent_type, "context": context})
+        raise exc_factory()
+
+    dispatcher.calls = calls
+    return dispatcher
+
+
+class TestBlendHelpersPropagateOrSurfaceFailure(unittest.TestCase):
+    """COND-TG-3 — every BLEND helper must refuse to silently APPROVE on error.
+
+    The helpers either propagate the exception or return a clearly-marked
+    failure verdict (CONDITIONAL or REJECT with a `dispatch-error:` reason).
+    What they must NEVER do is swallow the error and return APPROVE, which
+    would let a broken agent quietly advance a phase.
+    """
+
+    def test_fast_evaluator_does_not_return_approve_on_raise(self):
+        """_dispatch_fast_evaluator surfaces dispatcher failure, not APPROVE."""
+        dispatcher = _raising_dispatcher()
+        result = phase_manager._dispatch_fast_evaluator(
+            None, "design", "design-quality", dispatcher=dispatcher,
+        )
+        self.assertNotEqual(result["verdict"], "APPROVE")
+
+    def test_sequential_does_not_return_approve_on_raise(self):
+        """_dispatch_sequential surfaces dispatcher failure, not APPROVE."""
+        dispatcher = _raising_dispatcher()
+        result = phase_manager._dispatch_sequential(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertNotEqual(result["verdict"], "APPROVE")
+
+    def test_parallel_does_not_return_approve_on_raise(self):
+        """_dispatch_parallel_and_merge surfaces dispatcher failure, not APPROVE."""
+        dispatcher = _raising_dispatcher()
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertNotEqual(result["verdict"], "APPROVE")
+
+    def test_council_does_not_return_approve_on_raise(self):
+        """_dispatch_council surfaces dispatcher failure, not APPROVE."""
+        dispatcher = _raising_dispatcher()
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality",
+            ["r1", "r2", "r3"],
+            dispatcher=dispatcher,
+        )
+        self.assertNotEqual(result["verdict"], "APPROVE")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_blend_rule_helpers.py
+++ b/tests/crew/test_blend_rule_helpers.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""tests/crew/test_blend_rule_helpers.py
+
+Unit tests for the BLEND-RULE gate-dispatch helpers added to phase_manager.py
+(design §3, FR-α3.1..FR-α3.5). Covers the five helpers:
+
+  - _dispatch_fast_evaluator        (self-check / advisory / empty reviewers)
+  - _dispatch_sequential            (stops on first REJECT)
+  - _dispatch_parallel_and_merge    (REJECT > CONDITIONAL > APPROVE merge)
+  - _dispatch_council               (plurality with min-concurrence threshold)
+  - _dispatch_gate_reviewer         (main entry — dispatch by mode)
+
+Stdlib-only; no sleep-based sync (T2); single-assertion focus where
+practical (T4); descriptive names (T5).
+"""
+
+import unittest
+from pathlib import Path
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+
+
+def _mock_dispatcher_factory(verdict_map):
+    """Return a dispatcher callable that looks up verdicts by reviewer name.
+
+    `verdict_map` is a dict
+       reviewer_name -> {verdict, score, reason, conditions}
+    When the subagent_type starts with `wicked-garden:crew:` we parse the
+    suffix as the reviewer name. `_parallel_batch` is treated as a batched
+    dispatch — we return the list of per-reviewer verdicts from context.
+    """
+    calls = []
+
+    def dispatcher(subagent_type, prompt, context):
+        calls.append({"subagent_type": subagent_type, "context": context})
+        # Parallel batch sentinel: return the list of reviewer verdicts.
+        if subagent_type.endswith("_parallel_batch"):
+            reviewers = context.get("reviewers") or []
+            return [
+                verdict_map.get(
+                    r, {"verdict": "CONDITIONAL", "score": 0.0, "reason": "unknown"}
+                )
+                for r in reviewers
+            ]
+        # Single reviewer dispatch.
+        name = subagent_type.split(":")[-1]
+        return verdict_map.get(
+            name, {"verdict": "CONDITIONAL", "score": 0.0, "reason": "unknown"}
+        )
+
+    dispatcher.calls = calls
+    return dispatcher
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_fast_evaluator
+# ---------------------------------------------------------------------------
+
+
+class TestFastEvaluator(unittest.TestCase):
+    """Fast path: empty reviewers / self-check / advisory."""
+
+    def test_returns_stub_when_dispatcher_none(self):
+        """Without a dispatcher, fast-evaluator returns a CONDITIONAL stub."""
+        result = phase_manager._dispatch_fast_evaluator(
+            None, "design", "design-quality", dispatcher=None,
+        )
+        self.assertEqual(result["verdict"], "CONDITIONAL")
+
+    def test_uses_dispatcher_when_provided(self):
+        """With a dispatcher, fast-evaluator returns its verdict."""
+        dispatcher = _mock_dispatcher_factory({
+            "gate-evaluator": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_fast_evaluator(
+            None, "design", "design-quality", dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "APPROVE")
+
+    def test_records_dispatch_mode_fast_evaluator(self):
+        """Fast evaluator sets dispatch_mode='fast-evaluator'."""
+        dispatcher = _mock_dispatcher_factory({
+            "gate-evaluator": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_fast_evaluator(
+            None, "design", "design-quality", dispatcher=dispatcher,
+        )
+        self.assertEqual(result["dispatch_mode"], "fast-evaluator")
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_sequential
+# ---------------------------------------------------------------------------
+
+
+class TestSequential(unittest.TestCase):
+    """Sequential dispatch — stops on first REJECT."""
+
+    def test_all_approve_returns_approve(self):
+        """Sequential over two APPROVEs merges to APPROVE."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.8, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_sequential(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "APPROVE")
+
+    def test_stops_on_first_reject(self):
+        """Sequential short-circuits on REJECT; later reviewers not called."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "REJECT", "score": 0.2, "reason": "fail"},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_sequential(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        # Only one dispatcher call — second reviewer not invoked.
+        self.assertEqual(len(dispatcher.calls), 1)
+
+    def test_reject_short_circuit_yields_reject_verdict(self):
+        """After short-circuit, merged verdict is REJECT."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "REJECT", "score": 0.2, "reason": "fail"},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_sequential(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "REJECT")
+
+    def test_conditional_does_not_short_circuit(self):
+        """CONDITIONAL does NOT short-circuit — later reviewers still run."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "CONDITIONAL", "score": 0.6,
+                                "reason": "warn", "conditions": [{"id": "c1"}]},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_sequential(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(len(dispatcher.calls), 2)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_parallel_and_merge
+# ---------------------------------------------------------------------------
+
+
+class TestParallelMerge(unittest.TestCase):
+    """Parallel dispatch + merge — REJECT > CONDITIONAL > APPROVE."""
+
+    def test_all_approve_merges_to_approve(self):
+        """All-APPROVE merge yields APPROVE."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.8, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "APPROVE")
+
+    def test_any_reject_merges_to_reject(self):
+        """Any-REJECT merge yields REJECT even with APPROVE peers."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+            "security-engineer": {"verdict": "REJECT", "score": 0.1,
+                                  "reason": "vuln"},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "REJECT")
+
+    def test_any_conditional_merges_to_conditional(self):
+        """CONDITIONAL + APPROVE (no REJECT) merges to CONDITIONAL."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+            "security-engineer": {"verdict": "CONDITIONAL", "score": 0.7,
+                                  "reason": "warn",
+                                  "conditions": [{"id": "c1", "desc": "fix"}]},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "CONDITIONAL")
+
+    def test_conditional_unions_all_conditions(self):
+        """All CONDITIONAL's `conditions` arrays union into the merged result."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "CONDITIONAL", "score": 0.7,
+                   "conditions": [{"id": "c1"}]},
+            "r2": {"verdict": "CONDITIONAL", "score": 0.6,
+                   "conditions": [{"id": "c2"}]},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality", ["r1", "r2"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(len(result["conditions"]), 2)
+
+    def test_merged_score_is_min_of_reviewer_scores(self):
+        """Merged score is the minimum across reviewer scores (conservative)."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9, "reason": "ok"},
+            "r2": {"verdict": "APPROVE", "score": 0.7, "reason": "ok"},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality", ["r1", "r2"],
+            dispatcher=dispatcher,
+        )
+        self.assertAlmostEqual(result["score"], 0.7)
+
+    def test_banned_reviewer_yields_reject(self):
+        """A banned reviewer identity short-circuits to REJECT."""
+        dispatcher = _mock_dispatcher_factory({
+            "just-finish-auto": {"verdict": "APPROVE", "score": 0.9,
+                                 "reason": "ok"},
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9,
+                                "reason": "ok"},
+        })
+        # The mock returns `reviewer` as the key; the merge helper inspects
+        # reviewer name. Ensure the mock echoes the reviewer identity.
+        dispatcher2 = _mock_dispatcher_factory({
+            "just-finish-auto": {"verdict": "APPROVE", "score": 0.9,
+                                 "reason": "ok", "reviewer": "just-finish-auto"},
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9,
+                                "reason": "ok", "reviewer": "senior-engineer"},
+        })
+        result = phase_manager._dispatch_parallel_and_merge(
+            None, "build", "code-quality",
+            ["just-finish-auto", "senior-engineer"],
+            dispatcher=dispatcher2,
+        )
+        self.assertEqual(result["verdict"], "REJECT")
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_council
+# ---------------------------------------------------------------------------
+
+
+class TestCouncil(unittest.TestCase):
+    """Council dispatch — plurality vote with min-concurrence threshold."""
+
+    def test_unanimous_approve_passes_threshold(self):
+        """Unanimous APPROVE yields APPROVE (concurrence = 1.0)."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.8},
+            "r3": {"verdict": "APPROVE", "score": 0.85},
+        })
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality", ["r1", "r2", "r3"],
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["verdict"], "APPROVE")
+
+    def test_split_verdicts_below_threshold_downgrade(self):
+        """2-APPROVE + 2-CONDITIONAL at threshold 0.6 downgrades to CONDITIONAL.
+
+        Plurality is a tie — 2/4 = 0.5 for either APPROVE or CONDITIONAL. Our
+        tie-break picks CONDITIONAL (safer). Concurrence 0.5 < 0.6 threshold
+        downgrades APPROVE paths, but CONDITIONAL plurality remains CONDITIONAL.
+        """
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.8},
+            "r3": {"verdict": "CONDITIONAL", "score": 0.6,
+                   "conditions": [{"id": "c1"}]},
+            "r4": {"verdict": "CONDITIONAL", "score": 0.5,
+                   "conditions": [{"id": "c2"}]},
+        })
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality", ["r1", "r2", "r3", "r4"],
+            dispatcher=dispatcher, min_concurrence=0.6,
+        )
+        self.assertEqual(result["verdict"], "CONDITIONAL")
+
+    def test_low_concurrence_approve_downgrades_to_conditional(self):
+        """2-APPROVE + 1-CONDITIONAL at threshold 0.8 downgrades APPROVE.
+
+        Concurrence 2/3 = 0.667 < 0.8 threshold → downgrade to CONDITIONAL.
+        """
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.8},
+            "r3": {"verdict": "CONDITIONAL", "score": 0.6,
+                   "conditions": [{"id": "c1"}]},
+        })
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality", ["r1", "r2", "r3"],
+            dispatcher=dispatcher, min_concurrence=0.8,
+        )
+        self.assertEqual(result["verdict"], "CONDITIONAL")
+
+    def test_reject_short_circuits_council(self):
+        """Any REJECT in council short-circuits to REJECT regardless of plurality."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.85},
+            "r3": {"verdict": "REJECT", "score": 0.1, "reason": "veto"},
+        })
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality", ["r1", "r2", "r3"],
+            dispatcher=dispatcher, min_concurrence=0.5,
+        )
+        self.assertEqual(result["verdict"], "REJECT")
+
+    def test_council_records_concurrence_score(self):
+        """Council result exposes the concurrence ratio for audit."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.85},
+            "r3": {"verdict": "APPROVE", "score": 0.8},
+        })
+        result = phase_manager._dispatch_council(
+            None, "design", "design-quality", ["r1", "r2", "r3"],
+            dispatcher=dispatcher, min_concurrence=0.6,
+        )
+        self.assertAlmostEqual(result["concurrence"], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_gate_reviewer (main entry)
+# ---------------------------------------------------------------------------
+
+
+class TestGateReviewerEntry(unittest.TestCase):
+    """Main BLEND-RULE entry point routing by policy mode."""
+
+    def test_empty_reviewers_routes_to_fast_evaluator(self):
+        """Empty reviewers → fast-evaluator path."""
+        dispatcher = _mock_dispatcher_factory({
+            "gate-evaluator": {"verdict": "APPROVE", "score": 0.8, "reason": "ok"},
+        })
+        policy_entry = {
+            "reviewers": [], "mode": "self-check", "fallback": "gate-evaluator",
+        }
+        result = phase_manager._dispatch_gate_reviewer(
+            None, "design", "design-quality", policy_entry,
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["dispatch_mode"], "fast-evaluator")
+
+    def test_sequential_mode_routes_to_sequential(self):
+        """mode=sequential → _dispatch_sequential path."""
+        dispatcher = _mock_dispatcher_factory({
+            "solution-architect": {"verdict": "APPROVE", "score": 0.9,
+                                   "reason": "ok"},
+        })
+        policy_entry = {
+            "reviewers": ["solution-architect"],
+            "mode": "sequential",
+            "fallback": "senior-engineer",
+        }
+        result = phase_manager._dispatch_gate_reviewer(
+            None, "design", "design-quality", policy_entry,
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["dispatch_mode"], "sequential")
+
+    def test_parallel_mode_routes_to_parallel(self):
+        """mode=parallel → _dispatch_parallel_and_merge path."""
+        dispatcher = _mock_dispatcher_factory({
+            "senior-engineer": {"verdict": "APPROVE", "score": 0.9},
+            "security-engineer": {"verdict": "APPROVE", "score": 0.9},
+        })
+        policy_entry = {
+            "reviewers": ["senior-engineer", "security-engineer"],
+            "mode": "parallel", "fallback": "senior-engineer",
+        }
+        result = phase_manager._dispatch_gate_reviewer(
+            None, "build", "code-quality", policy_entry,
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["dispatch_mode"], "parallel")
+
+    def test_council_mode_routes_to_council(self):
+        """mode=council → _dispatch_council path."""
+        dispatcher = _mock_dispatcher_factory({
+            "r1": {"verdict": "APPROVE", "score": 0.9},
+            "r2": {"verdict": "APPROVE", "score": 0.85},
+            "r3": {"verdict": "APPROVE", "score": 0.8},
+        })
+        policy_entry = {
+            "reviewers": ["r1", "r2", "r3"],
+            "mode": "council", "fallback": "senior-engineer",
+        }
+        result = phase_manager._dispatch_gate_reviewer(
+            None, "design", "design-quality", policy_entry,
+            dispatcher=dispatcher,
+        )
+        self.assertEqual(result["dispatch_mode"], "council")
+
+    def test_missing_policy_entry_returns_stub(self):
+        """A None or non-dict policy entry returns a conservative stub."""
+        result = phase_manager._dispatch_gate_reviewer(
+            None, "design", "design-quality", None,  # type: ignore[arg-type]
+            dispatcher=None,
+        )
+        self.assertEqual(result["verdict"], "CONDITIONAL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_convergence.py
+++ b/tests/crew/test_convergence.py
@@ -7,7 +7,6 @@ Coverage:
     - Stall detection: pre-Integrated, >= threshold sessions
     - Aging budget: over-budget flags
     - Review gate: APPROVE/CONDITIONAL/REJECT verdicts
-    - Legacy bypass via CREW_GATE_ENFORCEMENT=legacy
     - Fail-open when log missing
 
 All deterministic. Stdlib-only. No sleep. Cross-platform tempdirs.
@@ -15,12 +14,10 @@ All deterministic. Stdlib-only. No sleep. Cross-platform tempdirs.
 from __future__ import annotations
 
 import json
-import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_REPO_ROOT / "scripts"))
@@ -448,18 +445,6 @@ class TestReviewGate(unittest.TestCase):
             self.assertEqual(result["result"], "REJECT")  # art-2/3/4 block
             kinds = {f["kind"] for f in result["findings"]}
             self.assertIn("pre-integrated", kinds)
-
-    def test_legacy_bypass_forces_approve(self):
-        with _TmpProject() as pd:
-            _record(pd, "art-1", "Designed", phase="design", session_id="s1")
-            _record(pd, "art-1", "Built", phase="build", session_id="s1")
-            with patch.dict(os.environ, {"CREW_GATE_ENFORCEMENT": "legacy"}):
-                result = cv.evaluate_review_gate(pd)
-            self.assertEqual(result["result"], "APPROVE")
-            self.assertTrue(result["legacy_bypass"])
-            # Findings still attached for audit trail.
-            self.assertTrue(len(result["findings"]) >= 1)
-
 
 # ---------------------------------------------------------------------------
 # Project status aggregation

--- a/tests/crew/test_cutover.py
+++ b/tests/crew/test_cutover.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""tests/crew/test_cutover.py — CR-2 / AC-α11 in-flight cutover.
+
+Covers:
+    - Legacy auto-tag: project missing dispatch_mode → "v6-legacy" on detect.
+    - Fresh default: project with dispatch_mode="mode-3" reads "mode-3".
+    - /crew:cutover command flips the field + emits audit marker.
+    - Safe cutover window rejects when prior conditions are unresolved.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+
+
+def _synth_state(name: str, *, dispatch_mode=None, evidence_files=None):
+    """Construct a minimal ProjectState; caller patches load/save and get_project_dir."""
+    extras = {}
+    if dispatch_mode is not None:
+        extras["dispatch_mode"] = dispatch_mode
+    return phase_manager.ProjectState(
+        name=name,
+        current_phase="clarify",
+        created_at="2026-04-19T10:00:00Z",
+        phase_plan=["clarify", "design", "build", "review"],
+        phases={"clarify": phase_manager.PhaseState(status="in_progress")},
+        extras=extras,
+    )
+
+
+class TestDetectDispatchMode(unittest.TestCase):
+    """CR-2 — _detect_dispatch_mode auto-tags legacy projects."""
+
+    def test_missing_field_returns_v6_legacy(self):
+        """A project missing dispatch_mode + no mode-3 evidence backfills to v6-legacy."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "proj"
+            project_dir.mkdir()
+            state = _synth_state("proj")
+            with patch.object(phase_manager, "get_project_dir", return_value=project_dir):
+                mode = phase_manager._detect_dispatch_mode(state)
+            self.assertEqual(mode, "v6-legacy")
+            # Backfill was written to extras.
+            self.assertEqual(state.extras.get("dispatch_mode"), "v6-legacy")
+
+    def test_existing_mode_3_field_is_respected(self):
+        """A project with dispatch_mode='mode-3' reads mode-3 without backfill."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "proj"
+            project_dir.mkdir()
+            state = _synth_state("proj", dispatch_mode="mode-3")
+            with patch.object(phase_manager, "get_project_dir", return_value=project_dir):
+                mode = phase_manager._detect_dispatch_mode(state)
+            self.assertEqual(mode, "mode-3")
+
+    def test_mode_3_evidence_promotes_legacy_project(self):
+        """A project with reeval-log.jsonl evidence is detected as mode-3."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "proj"
+            phases_dir = project_dir / "phases" / "design"
+            phases_dir.mkdir(parents=True)
+            (phases_dir / "reeval-log.jsonl").write_text("{}\n")
+            state = _synth_state("proj")
+            with patch.object(phase_manager, "get_project_dir", return_value=project_dir):
+                mode = phase_manager._detect_dispatch_mode(state)
+            self.assertEqual(mode, "mode-3")
+
+
+class TestCutoverAction(unittest.TestCase):
+    """AC-α11(iii) — cutover flips field and emits marker."""
+
+    def test_cutover_writes_marker_and_field(self):
+        """cutover_action on a legacy project sets mode-3 and writes the marker."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "proj-legacy"
+            project_dir.mkdir()
+            state = _synth_state("proj-legacy")
+            state.phases["clarify"].status = "approved"
+            state.current_phase = "design"
+            state.phases["design"] = phase_manager.PhaseState(status="pending")
+
+            saved = []
+
+            def fake_save(s):
+                saved.append(s.extras.get("dispatch_mode"))
+
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state", side_effect=fake_save), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir):
+                result = phase_manager.cutover_action("proj-legacy", "mode-3")
+
+            self.assertEqual(result["dispatch_mode"], "mode-3")
+            marker = project_dir / "phases" / ".cutover-to-mode-3.json"
+            self.assertTrue(marker.exists())
+            marker_data = json.loads(marker.read_text())
+            self.assertEqual(marker_data["new_mode"], "mode-3")
+            self.assertIn("mode-3", saved)
+
+    def test_cutover_rejects_unsupported_target(self):
+        """cutover_action with --to != mode-3 raises ValueError."""
+        with self.assertRaises(ValueError):
+            phase_manager.cutover_action("anything", "v5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_gate_enforcement.py
+++ b/tests/crew/test_gate_enforcement.py
@@ -7,7 +7,6 @@ Run with: python3 scripts/crew/test_gate_enforcement.py
 """
 
 import json
-import os
 import sys
 import tempfile
 import unittest
@@ -32,10 +31,6 @@ def _make_project_dir(tmp_root: Path, project_name: str) -> Path:
 
 class TestBannedReviewer(unittest.TestCase):
     """T-1.4: Banned reviewer names are rejected."""
-
-    def setUp(self):
-        # Ensure strict mode
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
 
     def _import_fresh(self):
         """Re-import phase_manager to pick up env changes."""
@@ -93,9 +88,6 @@ class TestBannedReviewer(unittest.TestCase):
 
 class TestMinGateScore(unittest.TestCase):
     """T-1.3: Minimum gate score threshold blocks advancement."""
-
-    def setUp(self):
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
 
     def _import_fresh(self):
         if "phase_manager" in sys.modules:
@@ -184,9 +176,6 @@ class TestLegacyModeDeleted(unittest.TestCase):
 class TestEmptyDeliverable(unittest.TestCase):
     """T-1.5: Zero-byte deliverables are reported as empty."""
 
-    def setUp(self):
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
-
     def _import_fresh(self):
         if "phase_manager" in sys.modules:
             del sys.modules["phase_manager"]
@@ -204,10 +193,10 @@ class TestEmptyDeliverable(unittest.TestCase):
             empty_file.write_text("")  # 0 bytes
             self.assertEqual(empty_file.stat().st_size, 0)
 
-            # Verify the condition: GATE_ENFORCEMENT_MODE != "legacy" and size == 0 => issue
-            self.assertNotEqual(pm.GATE_ENFORCEMENT_MODE, "legacy")
+            # v6.0 strict mode is unconditional — empty file must always produce an issue.
+            self.assertEqual(pm.GATE_ENFORCEMENT_MODE, "strict")
             size = empty_file.stat().st_size
-            if pm.GATE_ENFORCEMENT_MODE != "legacy" and size == 0:
+            if size == 0:
                 issue = f"Empty deliverable for clarify: objective.md (0 bytes)"
             else:
                 issue = None
@@ -284,9 +273,6 @@ class TestPhasesJsonStructure(unittest.TestCase):
 class TestSkipPhaseStructuredReason(unittest.TestCase):
     """T-4.2 functional: skip_phase raises on unrecognized reason."""
 
-    def setUp(self):
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
-
     def _import_fresh(self):
         if "phase_manager" in sys.modules:
             del sys.modules["phase_manager"]
@@ -342,7 +328,7 @@ if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(TestBannedReviewer))
     suite.addTests(loader.loadTestsFromTestCase(TestMinGateScore))
-    suite.addTests(loader.loadTestsFromTestCase(TestLegacyMode))
+    suite.addTests(loader.loadTestsFromTestCase(TestLegacyModeDeleted))
     suite.addTests(loader.loadTestsFromTestCase(TestEmptyDeliverable))
     suite.addTests(loader.loadTestsFromTestCase(TestPhasesJsonStructure))
     suite.addTests(loader.loadTestsFromTestCase(TestSkipPhaseStructuredReason))

--- a/tests/crew/test_mode3_pipeline.py
+++ b/tests/crew/test_mode3_pipeline.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""tests/crew/test_mode3_pipeline.py — AC-α7 integration tests.
+
+Four sub-cases (a)..(d) per AC-α7 + happy-path / scope-revoke exercise.
+Stdlib-only, no sleep-based sync (T2), single-assertion focus (T4).
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+
+
+def _synth_state(name: str, *, dispatch_mode="mode-3", yolo=False):
+    extras = {
+        "dispatch_mode": dispatch_mode,
+        "rigor_tier": "full",
+    }
+    if yolo:
+        extras["yolo_approved_by_user"] = True
+    return phase_manager.ProjectState(
+        name=name,
+        current_phase="build",
+        created_at="2026-04-19T10:00:00Z",
+        phase_plan=["clarify", "design", "build", "review"],
+        phases={
+            "clarify": phase_manager.PhaseState(status="approved"),
+            "design": phase_manager.PhaseState(status="approved"),
+            "build": phase_manager.PhaseState(status="in_progress"),
+            "review": phase_manager.PhaseState(status="pending"),
+        },
+        extras=extras,
+    )
+
+
+def _write_executor_status(project_dir: Path, phase: str, *, deliverables, plan_mutations=None, parallelization_check=None):
+    phase_dir = project_dir / "phases" / phase
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    for d in deliverables:
+        rel = phase_dir / Path(d).name
+        rel.write_text("x" * 200)  # >= 100 bytes
+    status = {
+        "executor_task_id": "task-test-1",
+        "phase": phase,
+        "deliverables": [str(phase_dir / Path(d).name) for d in deliverables],
+        "plan_mutations": plan_mutations or [],
+        "parallelization_check": parallelization_check or {
+            "sub_task_count": 0, "dispatched_in_parallel": True, "serial_reason": None,
+        },
+    }
+    (phase_dir / "executor-status.json").write_text(json.dumps(status))
+    return status
+
+
+class TestExecuteHappyPath(unittest.TestCase):
+    """AC-α7(a) — happy-path execute returns ok."""
+
+    def test_execute_ok_when_status_present(self):
+        """execute() returns status=ok when executor-status.json is valid."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "happy"
+            project_dir.mkdir()
+            state = _synth_state("happy")
+            _write_executor_status(project_dir, "build", deliverables=["impl.md"])
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                result = phase_manager.execute("happy", "build")
+            self.assertEqual(result["status"], "ok")
+
+
+class TestExecuteLegacySkip(unittest.TestCase):
+    """AC-α11 — v6-legacy dispatch_mode short-circuits mode-3 execute()."""
+
+    def test_execute_returns_skipped_for_legacy_project(self):
+        """A v6-legacy project's execute() returns status=skipped."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "legacy"
+            project_dir.mkdir()
+            state = _synth_state("legacy", dispatch_mode="v6-legacy")
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                result = phase_manager.execute("legacy", "build")
+            self.assertEqual(result["status"], "skipped")
+
+
+class TestYoloAutoRevoke(unittest.TestCase):
+    """AC-α7(d) — yolo auto-revoke on scope-increase augment."""
+
+    def test_augment_mutation_revokes_yolo(self):
+        """Plan mutation op=augment flips yolo_approved_by_user to False."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-revoke"
+            project_dir.mkdir()
+            state = _synth_state("yolo-revoke", yolo=True)
+
+            _write_executor_status(
+                project_dir, "build",
+                deliverables=["impl.md"],
+                plan_mutations=[{"op": "augment", "task_id": "t-new", "why": "scope creep"}],
+            )
+
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                phase_manager.execute("yolo-revoke", "build")
+
+            self.assertFalse(state.extras.get("yolo_approved_by_user"))
+
+    def test_retier_down_does_not_revoke_yolo(self):
+        """Plan mutation op=re_tier to 'standard' does NOT revoke yolo."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-keep"
+            project_dir.mkdir()
+            state = _synth_state("yolo-keep", yolo=True)
+            _write_executor_status(
+                project_dir, "build",
+                deliverables=["impl.md"],
+                plan_mutations=[{"op": "re_tier", "task_id": "t1",
+                                 "new_rigor_tier": "standard", "why": "simplify"}],
+            )
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                phase_manager.execute("yolo-keep", "build")
+            self.assertTrue(state.extras.get("yolo_approved_by_user"))
+
+
+class TestParallelizationFailure(unittest.TestCase):
+    """AC-α7(c) relates — failure mode when parallelization_check is missing."""
+
+    def test_execute_fails_when_serial_without_reason(self):
+        """execute() returns status=failed with parallelization-check-missing."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "par-fail"
+            project_dir.mkdir()
+            state = _synth_state("par-fail")
+            _write_executor_status(
+                project_dir, "build",
+                deliverables=["impl.md"],
+                parallelization_check={
+                    "sub_task_count": 3,
+                    "dispatched_in_parallel": False,
+                    "serial_reason": "",
+                },
+            )
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                result = phase_manager.execute("par-fail", "build")
+            self.assertEqual(result["status"], "failed")
+
+
+class TestYoloActionAudit(unittest.TestCase):
+    """AC-α5 — yolo_action writes audit line."""
+
+    def test_yolo_approve_writes_audit(self):
+        """yolo_action('approve') sets flag and writes yolo-audit.jsonl."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-grant"
+            project_dir.mkdir()
+            state = _synth_state("yolo-grant", yolo=False)
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir):
+                phase_manager.yolo_action("yolo-grant", "approve", reason="unit-test")
+            audit = project_dir / "yolo-audit.jsonl"
+            self.assertTrue(audit.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_mode3_pipeline.py
+++ b/tests/crew/test_mode3_pipeline.py
@@ -185,5 +185,146 @@ class TestYoloActionAudit(unittest.TestCase):
             self.assertTrue(audit.exists())
 
 
+# ---------------------------------------------------------------------------
+# FR-α5.2 — approve-time yolo auto-accept
+# ---------------------------------------------------------------------------
+
+
+def _minimal_approve_patches(project_dir: Path):
+    """Common phase_manager patches so approve_phase() reaches the yolo block
+    without needing real gate/deliverable fixtures on disk."""
+    return [
+        patch.object(phase_manager, "get_project_dir", return_value=project_dir),
+        patch.object(phase_manager, "save_project_state"),
+        patch.object(phase_manager, "_sm"),
+        patch.object(phase_manager, "_check_addendum_freshness", return_value=None),
+        patch.object(phase_manager, "_check_phase_deliverables", return_value=[]),
+        patch.object(phase_manager, "load_phases_config", return_value={
+            "build": {"gate_required": False, "depends_on": []},
+        }),
+        patch.object(phase_manager, "_load_session_dispatches", return_value=[]),
+        patch.object(phase_manager, "_run_checkpoint_reanalysis",
+                     return_value=([], [])),
+        patch.object(phase_manager, "get_phase_order", return_value=[
+            "clarify", "design", "build", "review"]),
+        patch.object(phase_manager, "_run_build_phase_guard", return_value=[]),
+    ]
+
+
+class TestYoloApproveTimeAutoAccept(unittest.TestCase):
+    """FR-α5.2 — approve-time auto-accept on APPROVE / surface on CONDITIONAL."""
+
+    def _stub_gate_result(self, project_dir: Path, phase: str, verdict: str,
+                          score: float = 0.9, conditions=None):
+        phase_dir = project_dir / "phases" / phase
+        phase_dir.mkdir(parents=True, exist_ok=True)
+        (phase_dir / "gate-result.json").write_text(json.dumps({
+            "verdict": verdict,
+            "result": verdict,
+            "score": score,
+            "min_score": score,
+            "reviewer": "test-reviewer",
+            "reason": f"synthetic {verdict}",
+            "conditions": conditions or [],
+        }))
+
+    def test_yolo_auto_accept_on_approve(self):
+        """yolo + APPROVE → advance to next phase + write auto-accept audit."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-auto-approve"
+            project_dir.mkdir()
+            state = _synth_state("yolo-auto-approve", yolo=True)
+            self._stub_gate_result(project_dir, "build", "APPROVE")
+
+            patches = _minimal_approve_patches(project_dir)
+            for p in patches:
+                p.start()
+            # Gate must be "required" for the verdict check chain to load the
+            # synthetic gate-result.json we wrote above.
+            phases_patch = patch.object(phase_manager, "load_phases_config",
+                                        return_value={"build": {
+                                            "gate_required": True,
+                                            "gate_override_allowed": True,
+                                            "depends_on": [],
+                                            "min_gate_score": 0.5,
+                                        }})
+            phases_patch.start()
+            try:
+                _, next_phase = phase_manager.approve_phase(state, "build")
+            finally:
+                phases_patch.stop()
+                for p in patches:
+                    p.stop()
+
+            audit = project_dir / "yolo-audit.jsonl"
+            # Both advance AND audit fired.
+            self.assertEqual(next_phase, "review")
+            self.assertTrue(audit.exists())
+
+    def test_yolo_no_advance_on_conditional(self):
+        """yolo + CONDITIONAL → raise (surface to user); no advance."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-no-advance-cond"
+            project_dir.mkdir()
+            state = _synth_state("yolo-no-advance-cond", yolo=True)
+            self._stub_gate_result(
+                project_dir, "build", "CONDITIONAL",
+                conditions=[{"id": "c1", "desc": "fix this"}],
+            )
+
+            patches = _minimal_approve_patches(project_dir)
+            # CONDITIONAL requires gate_required=True to trigger the verdict
+            # check chain — override the phases config for this test.
+            for p in patches:
+                if getattr(p, "attribute", None) == "load_phases_config":
+                    p.start()
+                    # Replace the return_value with gate_required=True.
+                    continue
+                p.start()
+            # Swap the default phases config patch to one with gate_required.
+            phases_patch = patch.object(phase_manager, "load_phases_config",
+                                        return_value={"build": {
+                                            "gate_required": True,
+                                            "gate_override_allowed": True,
+                                            "depends_on": [],
+                                            "min_gate_score": 0.5,
+                                        }})
+            phases_patch.start()
+            try:
+                with self.assertRaises(ValueError):
+                    phase_manager.approve_phase(state, "build")
+            finally:
+                phases_patch.stop()
+                for p in patches:
+                    p.stop()
+
+    def test_yolo_no_advance_on_reject(self):
+        """yolo + REJECT → raise (surface to user); no advance."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "yolo-no-advance-reject"
+            project_dir.mkdir()
+            state = _synth_state("yolo-no-advance-reject", yolo=True)
+            self._stub_gate_result(project_dir, "build", "REJECT", score=0.1)
+
+            patches = _minimal_approve_patches(project_dir)
+            for p in patches:
+                p.start()
+            phases_patch = patch.object(phase_manager, "load_phases_config",
+                                        return_value={"build": {
+                                            "gate_required": True,
+                                            "gate_override_allowed": True,
+                                            "depends_on": [],
+                                            "min_gate_score": 0.5,
+                                        }})
+            phases_patch.start()
+            try:
+                with self.assertRaises(ValueError):
+                    phase_manager.approve_phase(state, "build")
+            finally:
+                phases_patch.stop()
+                for p in patches:
+                    p.stop()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_mode3_pipeline.py
+++ b/tests/crew/test_mode3_pipeline.py
@@ -326,5 +326,129 @@ class TestYoloApproveTimeAutoAccept(unittest.TestCase):
                     p.stop()
 
 
+# ---------------------------------------------------------------------------
+# COND-TG-1 — corrupt executor-status.json surfaces, is not silently swallowed
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteCorruptStatusRaises(unittest.TestCase):
+    """COND-TG-1 — corrupt executor-status.json must raise, not silently pass.
+
+    The phase-executor writes executor-status.json; execute() reads it. If the
+    file contains malformed JSON we MUST surface the error — silently falling
+    back to a default status would hide executor failures from the gate chain.
+    Current code wraps json.JSONDecodeError in RuntimeError with a descriptive
+    prefix; this test asserts that propagation path.
+    """
+
+    def test_corrupt_executor_status_raises_runtime_error(self):
+        """Malformed JSON in executor-status.json propagates as RuntimeError."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "corrupt-status"
+            project_dir.mkdir()
+            state = _synth_state("corrupt-status")
+            phase_dir = project_dir / "phases" / "build"
+            phase_dir.mkdir(parents=True, exist_ok=True)
+            # Write a deliberately malformed JSON payload (unclosed brace).
+            (phase_dir / "executor-status.json").write_text("{not-valid-json,,,")
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                with self.assertRaises(RuntimeError) as ctx:
+                    phase_manager.execute("corrupt-status", "build")
+            self.assertIn("executor-status-unreadable", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# COND-TG-2 — deliverable path-traversal guard
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDeliverablePathTraversal(unittest.TestCase):
+    """COND-TG-2 — deliverables declared outside phases/{phase}/ are rejected.
+
+    A malicious or buggy phase-executor could declare a deliverable at a path
+    like `../outside/dir.md` or an absolute path to a sibling phase. execute()
+    MUST reject any deliverable that does not resolve under the phase
+    directory (SC-2 scope containment).
+    """
+
+    def test_relative_parent_escape_raises_value_error(self):
+        """`../outside/doc.md` path-traversal is rejected with ValueError."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "pt-rel"
+            project_dir.mkdir()
+            state = _synth_state("pt-rel")
+            phase_dir = project_dir / "phases" / "build"
+            phase_dir.mkdir(parents=True, exist_ok=True)
+            # The escape target actually exists outside the phase dir so the
+            # resolve() call won't fail for a different reason.
+            outside_dir = project_dir / "outside"
+            outside_dir.mkdir(parents=True, exist_ok=True)
+            evil = outside_dir / "leak.md"
+            evil.write_text("x" * 200)
+            status = {
+                "executor_task_id": "task-pt-1",
+                "phase": "build",
+                "deliverables": [str(evil.resolve())],
+                "plan_mutations": [],
+                "parallelization_check": {
+                    "sub_task_count": 0,
+                    "dispatched_in_parallel": True,
+                    "serial_reason": None,
+                },
+            }
+            (phase_dir / "executor-status.json").write_text(json.dumps(status))
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"):
+                with self.assertRaises(ValueError) as ctx:
+                    phase_manager.execute("pt-rel", "build")
+            self.assertIn("deliverable-out-of-scope", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# COND-TG-5 — scope-increase revoke emits wicked.crew.yolo_revoked bus event
+# ---------------------------------------------------------------------------
+
+
+class TestScopeIncreaseRevokeEmitsBusEvent(unittest.TestCase):
+    """COND-TG-5 — _apply_scope_increase_revoke emits observability event.
+
+    After writing yolo-audit.jsonl the function must also emit
+    wicked.crew.yolo_revoked so downstream subscribers (delivery telemetry,
+    platform observability) see the auto-revoke without tailing the audit
+    file. Fail-open on bus absence is verified elsewhere; this test checks
+    the emit is wired up when the bus is available.
+    """
+
+    def test_augment_mutation_emits_yolo_revoked_bus_event(self):
+        """Scope-increase augment triggers emit of wicked.crew.yolo_revoked."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "bus-revoke"
+            project_dir.mkdir()
+            state = _synth_state("bus-revoke", yolo=True)
+            _write_executor_status(
+                project_dir, "build",
+                deliverables=["impl.md"],
+                plan_mutations=[{"op": "augment", "task_id": "t-new", "why": "creep"}],
+            )
+            # Patch the emit_event import target. phase_manager does a lazy
+            # `from _bus import emit_event` inside the function — patching the
+            # attribute on the _bus module covers both import styles.
+            import _bus as _bus_mod  # noqa: WPS433 — local test import
+            with patch.object(phase_manager, "load_project_state", return_value=state), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "get_project_dir", return_value=project_dir), \
+                 patch.object(phase_manager, "_validate_gate_policy_full_rigor"), \
+                 patch.object(_bus_mod, "emit_event") as mock_emit:
+                phase_manager.execute("bus-revoke", "build")
+            # Assert the yolo_revoked event was emitted exactly once.
+            event_types = [call.args[0] for call in mock_emit.call_args_list]
+            self.assertIn("wicked.crew.yolo_revoked", event_types)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_parallelization_enforcement.py
+++ b/tests/crew/test_parallelization_enforcement.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""tests/crew/test_parallelization_enforcement.py — SC-6 / AC-α10.
+
+Verifies that ``phase_manager._check_parallelization`` enforces:
+    - sub_task_count < 2 → vacuously OK.
+    - sub_task_count >= 2 AND dispatched_in_parallel=True → OK.
+    - sub_task_count >= 2 AND dispatched_in_parallel=False AND serial_reason empty
+        → fails with reason 'parallelization-check-missing'.
+"""
+
+import unittest
+from pathlib import Path
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+
+
+class TestParallelizationCheck(unittest.TestCase):
+    """AC-α10 — parallelization check enforcement."""
+
+    def test_single_subtask_is_vacuous(self):
+        """sub_task_count < 2 skips the check."""
+        check = {"sub_task_count": 1, "dispatched_in_parallel": False, "serial_reason": None}
+        self.assertIsNone(phase_manager._check_parallelization(check))
+
+    def test_parallel_dispatch_passes(self):
+        """dispatched_in_parallel=True with N>=2 passes."""
+        check = {"sub_task_count": 3, "dispatched_in_parallel": True, "serial_reason": None}
+        self.assertIsNone(phase_manager._check_parallelization(check))
+
+    def test_serial_without_reason_fails(self):
+        """dispatched_in_parallel=False with empty serial_reason fails."""
+        check = {"sub_task_count": 3, "dispatched_in_parallel": False, "serial_reason": ""}
+        fail = phase_manager._check_parallelization(check)
+        self.assertEqual(fail, "parallelization-check-missing")
+
+    def test_serial_with_reason_passes(self):
+        """dispatched_in_parallel=False with non-empty serial_reason passes."""
+        check = {
+            "sub_task_count": 3,
+            "dispatched_in_parallel": False,
+            "serial_reason": "Sub-tasks share a file — sequential writes required.",
+        }
+        self.assertIsNone(phase_manager._check_parallelization(check))
+
+    def test_missing_check_dict_fails(self):
+        """A non-dict parallelization_check fails."""
+        self.assertEqual(phase_manager._check_parallelization(None), "parallelization-check-missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -385,5 +385,84 @@ class TestMissingFileRaises(unittest.TestCase):
             self.assertIsNone(error)
 
 
+# ---------------------------------------------------------------------------
+# Review-gate condition (a): handle_approve without dispatcher logs a warning
+# ---------------------------------------------------------------------------
+
+class TestHandleApproveNoDispatcherWarning(unittest.TestCase):
+    """Review-gate condition (a): CLI approve path is honest about not
+    dispatching gate reviewers. `handle_approve` must emit a warning log
+    containing "no dispatcher" when invoked, so users are not silently
+    surprised by dispatcher-unavailable stubs."""
+
+    def test_handle_approve_logs_no_dispatcher_warning(self):
+        """Reading the source of the CLI approve branch must contain the
+        explicit warning log with "no dispatcher" text."""
+        src = Path(pm.__file__).read_text(encoding="utf-8")
+        # Find the approve branch. Match the CLI elif body.
+        idx = src.find('elif args.action == "approve":')
+        self.assertNotEqual(idx, -1, "handle_approve approve branch missing")
+        # Grab the next ~40 lines of source.
+        branch_src = src[idx:idx + 2500]
+        self.assertIn(
+            "logger.warning(",
+            branch_src,
+            "approve branch must call logger.warning() when no dispatcher "
+            "is injected",
+        )
+        self.assertIn(
+            "no dispatcher",
+            branch_src,
+            'approve branch warning text must contain "no dispatcher" so '
+            "the message is greppable and matches the review-gate "
+            "condition (a) acceptance test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Review-gate condition (b): phases.json has phase_executor_may_delegate
+# ---------------------------------------------------------------------------
+
+class TestPhasesJsonExecutorMayDelegate(unittest.TestCase):
+    """Review-gate condition (b) / design-addendum-2 §SC-2: every phase
+    entry in phases.json must declare `phase_executor_may_delegate`.
+    Only `build` and `test` are allowed to delegate; everything else
+    must explicitly opt out."""
+
+    @classmethod
+    def setUpClass(cls):
+        phases_path = (
+            _REPO_ROOT / ".claude-plugin" / "phases.json"
+        )
+        cls.phases = json.loads(phases_path.read_text(encoding="utf-8"))["phases"]
+
+    def test_every_phase_has_field(self):
+        for name, cfg in self.phases.items():
+            self.assertIn(
+                "phase_executor_may_delegate",
+                cfg,
+                f"phase '{name}' is missing phase_executor_may_delegate",
+            )
+
+    def test_build_and_test_may_delegate(self):
+        self.assertTrue(self.phases["build"]["phase_executor_may_delegate"])
+        self.assertTrue(self.phases["test"]["phase_executor_may_delegate"])
+
+    def test_other_phases_may_not_delegate(self):
+        for name in (
+            "ideate",
+            "clarify",
+            "design",
+            "test-strategy",
+            "challenge",
+            "review",
+            "operate",
+        ):
+            self.assertFalse(
+                self.phases[name]["phase_executor_may_delegate"],
+                f"phase '{name}' must not delegate (design-addendum-2 §SC-2)",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_reeval_addendum.py
+++ b/tests/crew/test_reeval_addendum.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""tests/crew/test_reeval_addendum.py — unit tests for reeval_addendum.py (AC-α4).
+
+Covers:
+    - append round-trip (single + multiple records)
+    - phase filter slicing via chain_id
+    - read_latest returns the last-appended record for a phase
+    - validation rejects structurally-invalid records
+
+Stdlib-only. No external fixtures.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import reeval_addendum  # noqa: E402
+
+
+def _valid_record(*, chain_suffix: str = "design") -> dict:
+    """Return a structurally-valid addendum record."""
+    return {
+        "chain_id": f"test-project.{chain_suffix}",
+        "triggered_at": "2026-04-19T14:00:00Z",
+        "trigger": "phase-end",
+        "prior_rigor_tier": "full",
+        "new_rigor_tier": "full",
+        "mutations": [],
+        "mutations_applied": [],
+        "mutations_deferred": [],
+        "validator_version": "1.0.0",
+    }
+
+
+class TestAppendRoundTrip(unittest.TestCase):
+    """AC-α4 + NFR-α5 — append validates, writes both targets, round-trips."""
+
+    def test_append_writes_to_both_targets(self):
+        """After append, both per-phase and project-root logs contain the record."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            rec = _valid_record(chain_suffix="design")
+            reeval_addendum.append(project_dir, phase="design", record=rec)
+
+            per_phase = project_dir / "phases" / "design" / "reeval-log.jsonl"
+            project_log = project_dir / "process-plan.addendum.jsonl"
+            self.assertTrue(per_phase.exists(), "per-phase JSONL missing")
+            self.assertTrue(project_log.exists(), "project-root JSONL missing")
+
+    def test_append_rejects_invalid_record(self):
+        """Records missing required keys raise ValueError without writing."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            bad_record = {"chain_id": "x.design"}  # missing all other required keys
+            with self.assertRaises(ValueError):
+                reeval_addendum.append(project_dir, phase="design", record=bad_record)
+            # Nothing written.
+            self.assertFalse((project_dir / "process-plan.addendum.jsonl").exists())
+
+
+class TestReadPhaseFilter(unittest.TestCase):
+    """AC-α4 — phase_filter slices by chain_id suffix."""
+
+    def test_read_returns_all_records_when_no_filter(self):
+        """read() with no filter returns every appended record."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            for phase in ("clarify", "design", "build"):
+                reeval_addendum.append(
+                    project_dir, phase=phase, record=_valid_record(chain_suffix=phase),
+                )
+            recs = reeval_addendum.read(project_dir)
+            self.assertEqual(len(recs), 3)
+
+    def test_read_phase_slice_filters_correctly(self):
+        """read(..., phase_filter='design') returns only design-chain records."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            for phase in ("clarify", "design", "build"):
+                reeval_addendum.append(
+                    project_dir, phase=phase, record=_valid_record(chain_suffix=phase),
+                )
+            design_recs = reeval_addendum.read(project_dir, phase_filter="design")
+            self.assertEqual(len(design_recs), 1)
+            self.assertIn("design", design_recs[0]["chain_id"])
+
+
+class TestReadLatest(unittest.TestCase):
+    """AC-α4 — read_latest returns the last-appended record for a phase."""
+
+    def test_read_latest_returns_last_record(self):
+        """When multiple design records exist, read_latest returns the last one."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            first = _valid_record(chain_suffix="design")
+            first["triggered_at"] = "2026-04-19T10:00:00Z"
+            second = _valid_record(chain_suffix="design")
+            second["triggered_at"] = "2026-04-19T11:00:00Z"
+            reeval_addendum.append(project_dir, phase="design", record=first)
+            reeval_addendum.append(project_dir, phase="design", record=second)
+            latest = reeval_addendum.read_latest(project_dir, phase="design")
+            self.assertIsNotNone(latest)
+            self.assertEqual(latest["triggered_at"], "2026-04-19T11:00:00Z")
+
+    def test_read_latest_missing_returns_none(self):
+        """read_latest on empty project returns None."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            self.assertIsNone(reeval_addendum.read_latest(project_dir, phase="design"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_validate_gate_policy.py
+++ b/tests/crew/test_validate_gate_policy.py
@@ -80,5 +80,121 @@ class TestValidateGatePolicyFullRigor(unittest.TestCase):
                 self.fail(f"Validator raised on policy without full tier: {exc}")
 
 
+# ---------------------------------------------------------------------------
+# COND-TG-4 — approve_phase() must call _validate_gate_policy_full_rigor()
+# ---------------------------------------------------------------------------
+
+
+class TestApprovePhaseInvokesFullRigorValidator(unittest.TestCase):
+    """COND-TG-4 — approve_phase surfaces a malformed full-rigor gate-policy.
+
+    The validator's docstring claims it is called from both ``execute()`` and
+    ``approve_phase()`` entry points. A bug previously dropped the call from
+    ``approve_phase()``; this regression test asserts the validator runs (and
+    raises on a malformed policy) when the project is at full rigor.
+    """
+
+    def setUp(self):
+        phase_manager._GATE_POLICY_FULL_VALIDATED = False
+        phase_manager._GATE_POLICY_CACHE = None
+
+    def tearDown(self):
+        phase_manager._GATE_POLICY_FULL_VALIDATED = False
+        phase_manager._GATE_POLICY_CACHE = None
+
+    def _make_full_rigor_state(self, name: str = "full-rigor-approve"):
+        return phase_manager.ProjectState(
+            name=name,
+            current_phase="build",
+            created_at="2026-04-18T00:00:00Z",
+            phase_plan=["clarify", "design", "build", "review"],
+            phases={
+                "clarify": phase_manager.PhaseState(status="approved"),
+                "design": phase_manager.PhaseState(status="approved"),
+                "build": phase_manager.PhaseState(
+                    status="in_progress",
+                    started_at="2026-04-18T01:00:00Z",
+                ),
+                "review": phase_manager.PhaseState(status="pending"),
+            },
+            extras={"rigor_tier": "full"},
+        )
+
+    def test_approve_phase_raises_config_error_on_malformed_policy(self):
+        """approve_phase at full rigor raises ConfigError when policy is malformed."""
+        bad_policy = {
+            "gates": {
+                "code-quality": {
+                    "full": {"reviewers": [], "mode": "parallel",
+                             "fallback": "senior-engineer"},
+                },
+            },
+        }
+        state = self._make_full_rigor_state()
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            (project_dir / "phases" / "build").mkdir(parents=True, exist_ok=True)
+            with patch.object(phase_manager, "_load_gate_policy",
+                              return_value=bad_policy), \
+                 patch.object(phase_manager, "get_project_dir",
+                              return_value=project_dir), \
+                 patch.object(phase_manager, "save_project_state"):
+                with self.assertRaises(phase_manager.ConfigError):
+                    phase_manager.approve_phase(state, "build")
+
+    def test_approve_phase_skips_validator_at_standard_rigor(self):
+        """approve_phase at non-full rigor does NOT run the full-rigor validator.
+
+        Empty reviewers are legitimate at minimal/standard rigor (advisory
+        gates); the validator MUST only fire at full rigor so low-rigor
+        projects aren't blocked by a policy gap that doesn't apply to them.
+        """
+        bad_policy = {
+            "gates": {
+                "code-quality": {
+                    "full": {"reviewers": [], "mode": "parallel",
+                             "fallback": "senior-engineer"},
+                },
+            },
+        }
+        state = self._make_full_rigor_state("standard-rigor-approve")
+        state.extras["rigor_tier"] = "standard"
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            (project_dir / "phases" / "build").mkdir(parents=True, exist_ok=True)
+            with patch.object(phase_manager, "_load_gate_policy",
+                              return_value=bad_policy), \
+                 patch.object(phase_manager, "get_project_dir",
+                              return_value=project_dir), \
+                 patch.object(phase_manager, "save_project_state"), \
+                 patch.object(phase_manager, "_check_addendum_freshness",
+                              return_value=None), \
+                 patch.object(phase_manager, "_check_phase_deliverables",
+                              return_value=[]), \
+                 patch.object(phase_manager, "load_phases_config", return_value={
+                     "build": {"gate_required": False, "depends_on": []},
+                 }), \
+                 patch.object(phase_manager, "_load_session_dispatches",
+                              return_value=[]), \
+                 patch.object(phase_manager, "_run_checkpoint_reanalysis",
+                              return_value=([], [])), \
+                 patch.object(phase_manager, "get_phase_order", return_value=[
+                     "clarify", "design", "build", "review"]), \
+                 patch.object(phase_manager, "_run_build_phase_guard",
+                              return_value=[]), \
+                 patch.object(phase_manager, "_sm"):
+                # Must NOT raise ConfigError — validator is gated on full rigor.
+                try:
+                    phase_manager.approve_phase(state, "build")
+                except phase_manager.ConfigError as exc:
+                    self.fail(
+                        f"Validator fired at non-full rigor (regression): {exc}"
+                    )
+                except ValueError:
+                    # Downstream checks may raise for unrelated reasons — we
+                    # only care that ConfigError from the validator does not.
+                    pass
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/crew/test_validate_gate_policy.py
+++ b/tests/crew/test_validate_gate_policy.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""tests/crew/test_validate_gate_policy.py — SC-4 startup validation.
+
+Verifies that ``_validate_gate_policy_full_rigor()`` raises ConfigError when
+any gate at full rigor has an empty reviewers list.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+
+
+class TestValidateGatePolicyFullRigor(unittest.TestCase):
+    """SC-4 / AC-α9 — empty full-rigor reviewers MUST raise ConfigError."""
+
+    def setUp(self):
+        # Reset the module-level cache flag so each test runs the validator.
+        phase_manager._GATE_POLICY_FULL_VALIDATED = False
+        phase_manager._GATE_POLICY_CACHE = None
+
+    def tearDown(self):
+        phase_manager._GATE_POLICY_FULL_VALIDATED = False
+        phase_manager._GATE_POLICY_CACHE = None
+
+    def test_raises_on_empty_full_reviewers(self):
+        """Synthesized gate-policy with empty full-rigor reviewers raises ConfigError."""
+        bad_policy = {
+            "gates": {
+                "design-quality": {
+                    "full": {"reviewers": [], "mode": "council", "fallback": "senior-engineer"},
+                    "standard": {"reviewers": ["senior-engineer"], "mode": "sequential"},
+                },
+            },
+        }
+        with patch.object(phase_manager, "_load_gate_policy", return_value=bad_policy):
+            with self.assertRaises(phase_manager.ConfigError):
+                phase_manager._validate_gate_policy_full_rigor()
+
+    def test_accepts_populated_full_reviewers(self):
+        """Policy with non-empty full-rigor reviewers passes validation."""
+        good_policy = {
+            "gates": {
+                "design-quality": {
+                    "full": {"reviewers": ["senior-engineer", "security-engineer"], "mode": "parallel"},
+                },
+            },
+        }
+        with patch.object(phase_manager, "_load_gate_policy", return_value=good_policy):
+            try:
+                phase_manager._validate_gate_policy_full_rigor()
+            except phase_manager.ConfigError as exc:
+                self.fail(f"Validator raised unexpectedly: {exc}")
+
+    def test_skips_gate_without_full_tier(self):
+        """Gates that do not advertise a full tier are skipped (not misconfigured)."""
+        mixed_policy = {
+            "gates": {
+                "requirements-quality": {
+                    "standard": {"reviewers": ["requirements-quality-analyst"]},
+                    # no 'full' tier
+                },
+            },
+        }
+        with patch.object(phase_manager, "_load_gate_policy", return_value=mixed_policy):
+            try:
+                phase_manager._validate_gate_policy_full_rigor()
+            except phase_manager.ConfigError as exc:
+                self.fail(f"Validator raised on policy without full tier: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/qe/test_semantic_review.py
+++ b/tests/qe/test_semantic_review.py
@@ -14,7 +14,6 @@ Run with::
 from __future__ import annotations
 
 import json
-import os
 import sys
 import tempfile
 import unittest
@@ -216,8 +215,7 @@ class TestMissingDetection(unittest.TestCase):
 
 class TestGateIntegration(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
-        # Fresh-import phase_manager to pick up env state.
+        # Fresh-import phase_manager to pick up any test-specific state.
         if "phase_manager" in sys.modules:
             del sys.modules["phase_manager"]
         import phase_manager  # noqa: E402
@@ -294,7 +292,6 @@ class TestGateIntegration(unittest.TestCase):
 
 class TestComplexityThreshold(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
         if "phase_manager" in sys.modules:
             del sys.modules["phase_manager"]
         import phase_manager  # noqa: E402
@@ -337,42 +334,6 @@ class TestComplexityThreshold(unittest.TestCase):
             )
             self.assertIsNotNone(block, "Complexity 3 must block on missing")
             print("PASS complexity threshold: complexity 3 blocks on missing")
-
-
-# ---------------------------------------------------------------------------
-# Legacy bypass
-# ---------------------------------------------------------------------------
-
-
-class TestLegacyBypass(unittest.TestCase):
-    def setUp(self) -> None:
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
-
-    def tearDown(self) -> None:
-        os.environ.pop("CREW_GATE_ENFORCEMENT", None)
-
-    def test_legacy_bypass_skips_gate_entirely(self) -> None:
-        os.environ["CREW_GATE_ENFORCEMENT"] = "legacy"
-        if "phase_manager" in sys.modules:
-            del sys.modules["phase_manager"]
-        import phase_manager  # noqa: E402
-
-        with tempfile.TemporaryDirectory() as td:
-            project = Path(td) / "proj"
-            _write(project / "phases" / "clarify" / "acceptance-criteria.md",
-                   "- AC-9: missing everything [P0]\n")
-            state = phase_manager.ProjectState(
-                name="sem", current_phase="review",
-                created_at="2026-01-01T00:00:00Z", complexity_score=6,
-            )
-            block, warnings = phase_manager._check_semantic_alignment_gate(
-                state, project, "review",
-            )
-            self.assertIsNone(block,
-                              "CREW_GATE_ENFORCEMENT=legacy must bypass the gate")
-            self.assertEqual(warnings, [],
-                             "Legacy bypass should return no warnings")
-            print("PASS legacy bypass")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# feat(crew): mode-3 formal crew execution — closes #466

## Summary
- New `crew:phase-executor` + `crew:gate-evaluator` agents for per-phase dispatch
- `phase_manager.execute()` + BLEND-dispatch helpers in `approve_phase()`
- Re-eval addendum JSONL + per-phase conditions-manifest
- Yolo-at-full-rigor support (user-approved, auto-revoke on scope increase)
- Startup validation for gate-policy (full-rigor reviewers list non-empty)
- CREW_GATE_ENFORCEMENT=legacy dead-code scrub (closes #466 audit)
- 2 new commands: `/wicked-garden:crew:yolo`, `/wicked-garden:crew:cutover`
- In-flight project cutover rule via `dispatch_mode` field
- 3 new acceptance scenarios (mode3-execution, parallel-dispatch-verification, in-flight-cutover)

## Self-demonstration
This project built mode-3 AND ran through mode-3 to build itself. 6 phases × 6 gates, 3 scope-version bumps, 11 scope items processed (7 applied + 4 deferred to GH). See `process-plan.md` in project dir.

## Test plan
- [x] 402/402 pytest green (baseline 345 + 57 net new)
- [x] 6 new test files for mode-3 (blend-rule, cutover, parallel-enforcement, mode3-pipeline, validate-gate-policy, reeval-addendum)
- [x] 3 acceptance scenarios authored
- [x] Zero regressions on baseline

## Follow-ups tracked
- #471 (security): prompt-injection validator for gate-result.json
- #473: multi-reviewer invariant enforcement
- #474: shared reviewer-context artifact
- #475: re-eval skill-call mandatory (JSON snapshots are placeholders)
- #476: blind reviewer — strip executor self-score from reviewer brief
- #477: atomic conditions-manifest write
- #478: addendums → amendments.jsonl refactor
- #479: schema validator on gate-result ingest (interim #471 hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
