### PR TITLE
fix: match actual approve-blocked message in phase-boundary-reeval Case 2

### DIFF
--- a/scenarios/crew/phase-boundary-reeval.md
+++ b/scenarios/crew/phase-boundary-reeval.md
@@ -142,7 +142,9 @@ echo "Exit code: $?"
 ```
 
 **Pass criterion**: Exit code is non-zero AND stderr/stdout contains a message
-matching `re-evaluation required` (case-insensitive). Phase advance must be blocked.
+matching `re-evaluation` (case-insensitive) — the actual approve-blocked messages
+emitted by `phase_manager.py` are `Re-evaluation is required before approval.`
+and `Re-evaluation required before approval.`. Phase advance must be blocked.
 
 ### Assertion
 
@@ -152,7 +154,7 @@ output=$(sh "${PLUGIN_ROOT}/scripts/_python.sh" \
   scripts/crew/phase_manager.py "${TEST_PROJECT}" approve \
   --phase design 2>&1)
 exit_code=$?
-if [ "$exit_code" -ne 0 ] && echo "$output" | grep -qi "re-evaluation required"; then
+if [ "$exit_code" -ne 0 ] && echo "$output" | grep -qiE "re-evaluation (is )?required"; then
   echo "PASS blocked-approve-without-reeval"
 else
   echo "FAIL blocked-approve-without-reeval (exit=$exit_code, output=$output)"


### PR DESCRIPTION
## Summary
- Case 2 of `scenarios/crew/phase-boundary-reeval.md` asserted against the contiguous string `re-evaluation required`, but `scripts/crew/phase_manager.py` emits `Re-evaluation is required before approval.` (with an extra word "is") on one of the two approve-blocked paths.
- The existing `grep -qi` handled case but not the extra word, so the scenario could FAIL even when approve was correctly blocked.
- Switched to `grep -qiE "re-evaluation (is )?required"` so both emitted messages match; updated the Pass criterion prose to quote the actual strings.

Closes #468

## Test plan
- [ ] Run `/wg-test scenarios/crew/phase-boundary-reeval` Case 2 (`blocked-approve-without-reeval`)
- [ ] Verify exit code is non-zero and the assertion prints `PASS blocked-approve-without-reeval`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>