### PR TITLE
fix(propose-process): auto-insert challenge phase at complexity >= 4

### DIFF
--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -84,10 +84,11 @@ Core archetypes: `requirements-analyst`, `product-manager`, `solution-architect`
 
 ### 5. Select phases
 
-Pick from: `ideate`, `clarify`, `design`, `test-strategy`, `build`, `test`, `review`.
-Dependencies are soft — skip `design` for a trivial typo, collapse `clarify`+`design`
-for a crisp bugfix, insert `migrate` between `design` and `build` when state_complexity
-is high. One sentence WHY per phase + primary specialist(s). See `refs/phase-catalog.md`.
+Pick from: `ideate`, `clarify`, `challenge`, `design`, `test-strategy`, `build`, `test`,
+`review`. Soft deps — skip `design` for a trivial typo, collapse `clarify`+`design` for a
+crisp bugfix, insert `migrate` between `design` and `build` when state_complexity is high.
+**MUST**: at complexity ≥ 4, `challenge` phase MUST be included between `design` and `build`;
+do not use facilitator judgment to skip it. One sentence WHY per phase. See `refs/phase-catalog.md`.
 
 ### 6. Assign evidence metadata per task
 
@@ -193,8 +194,7 @@ Before Step 3 (factor scoring), read per-project process memory — unresolved r
 - [`refs/phase-catalog.md`](refs/phase-catalog.md) — phase templates, soft deps
 - [`refs/evidence-framing.md`](refs/evidence-framing.md) — functional evidence rubric
 - [`refs/ambiguity.md`](refs/ambiguity.md) — when to stop and ask
-- [`refs/plan-template.md`](refs/plan-template.md) — `process-plan.md` template
-- [`refs/output-schema.md`](refs/output-schema.md) — JSON shape for measurement
+- [`refs/plan-template.md`](refs/plan-template.md) — `process-plan.md` template; [`refs/output-schema.md`](refs/output-schema.md) — JSON shape for measurement
 - [`refs/interaction-mode.md`](refs/interaction-mode.md) — normal vs. yolo, banned values
 - [`refs/gate-policy.md`](refs/gate-policy.md) — human-readable Gate × Rigor reviewer matrix
 - [`refs/re-eval-addendum-schema.md`](refs/re-eval-addendum-schema.md) — JSONL addendum schema; [`refs/spec-quality-rubric.md`](refs/spec-quality-rubric.md) — scored spec quality rubric (10 dims × 0-2 pts) + tier thresholds


### PR DESCRIPTION
## Summary

- Codifies the `challenge` phase as mandatory at complexity >= 4 in the facilitator rubric (`skills/propose-process/SKILL.md` Step 5), removing the facilitator-judgment loophole that allowed the phase to be skipped on complex work.
- Adds `challenge` to the phase-vocabulary list in Step 5 so the rubric references it inline alongside `ideate`...`review`.
- Consolidated two navigation entries onto one line (`plan-template` + `output-schema`) to keep the file at the 200-line structural-validation ceiling.

## Exact sentence added

> **MUST**: at complexity >= 4, \`challenge\` phase MUST be included between \`design\` and \`build\`; do not use facilitator judgment to skip it.

## Test plan

- [x] \`sh scripts/_python.sh scripts/ci/validate.py\` passes (0 errors, 0 warnings)
- [x] \`wc -l skills/propose-process/SKILL.md\` == 200
- [ ] Spot-check: on a complexity-5 project, facilitator now emits `challenge` phase between `design` and `build`

Closes #457

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)