### PR TITLE
feat(drift,session): WE runs rules + SessionState telemetry producers (#459)

### DIFF
--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -1104,6 +1104,21 @@ def main():
                 is_active = active_phase not in ("", "complete", "done", "archived")
                 state.update(active_project_id=project_name if is_active else None)
 
+                # #459 telemetry producer: anchor complexity_at_session_open
+                # from the active project's complexity_score so session-close
+                # drift capture has a delta baseline.  Only set when not
+                # already populated this session (first SessionStart wins).
+                try:
+                    raw_complexity = project_data.get("complexity_score", 0)
+                    complexity_val = int(raw_complexity) if raw_complexity is not None else 0
+                    updates = {"complexity_score": complexity_val}
+                    if getattr(state, "complexity_at_session_open", None) is None:
+                        updates["complexity_at_session_open"] = complexity_val
+                    state.update(**updates)
+                except (TypeError, ValueError):
+                    # Malformed complexity_score — fail-open, don't block bootstrap.
+                    pass
+
             # Enable memory compliance directives for crew sessions.
             # task_completed.py reads this flag to decide whether to emit
             # per-task memory prompts; stop.py reads it for session summary.

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -264,6 +264,21 @@ class SessionState:
     # None when no approval has happened yet this session.
     last_phase_approved: str | None = None
 
+    # Telemetry producers (#459). Read optimistically by
+    # scripts/delivery/telemetry.py::_extract_session_extras at session-close.
+    # - skip_reeval_count: count of --skip-reeval approvals in this session.
+    #   Incremented by scripts/crew/phase_manager.py::approve_phase when the
+    #   addendum-freshness bypass path is taken.
+    # - complexity_at_session_open: ProjectState.complexity_score as observed
+    #   at session-start (bootstrap) when an active crew project exists, or on
+    #   the first approve_phase of the session. Used by telemetry to compute
+    #   complexity_delta = complexity_close - complexity_open.
+    # - complexity_score: current ProjectState.complexity_score mirror, kept
+    #   on the session for telemetry close-out.
+    skip_reeval_count: int = 0
+    complexity_at_session_open: int | None = None
+    complexity_score: int = 0
+
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -2243,6 +2243,41 @@ def _record_last_phase_approved(phase: str) -> None:
         logger.debug("[approve] last_phase_approved wiring skipped: %s", exc)
 
 
+def _increment_skip_reeval_count() -> None:
+    """Bump SessionState.skip_reeval_count producer for telemetry (#459).
+
+    Fires from approve_phase() whenever the --skip-reeval bypass path is
+    actually exercised (addendum present AND bypass flag set AND reason given).
+    Read at session close by scripts/delivery/telemetry.py.
+    Fail-open — telemetry producers must never block approval.
+    """
+    try:
+        from _session import SessionState  # type: ignore
+        sess = SessionState.load()
+        current = int(getattr(sess, "skip_reeval_count", 0) or 0)
+        sess.update(skip_reeval_count=current + 1)
+    except Exception as exc:
+        logger.debug("[approve] skip_reeval_count producer skipped: %s", exc)
+
+
+def _record_complexity_snapshot(complexity: int) -> None:
+    """Mirror ProjectState.complexity_score onto SessionState (#459).
+
+    Sets complexity_at_session_open on FIRST observation this session (so the
+    telemetry delta is anchored to session start) and always updates
+    complexity_score so close-out sees the latest value.  Fail-open.
+    """
+    try:
+        from _session import SessionState  # type: ignore
+        sess = SessionState.load()
+        updates: Dict[str, Any] = {"complexity_score": int(complexity or 0)}
+        if getattr(sess, "complexity_at_session_open", None) is None:
+            updates["complexity_at_session_open"] = int(complexity or 0)
+        sess.update(**updates)
+    except Exception as exc:
+        logger.debug("[approve] complexity snapshot producer skipped: %s", exc)
+
+
 def _run_build_phase_guard(project_dir: Path) -> List[str]:
     """Run the guard pipeline at build-phase approval (#462, Item 2).
 
@@ -2375,6 +2410,8 @@ def approve_phase(
                 )
             # Write the bypass to the audit log (AC-14)
             _write_skip_reeval_log(project_dir_reeval, phase, skip_reeval_reason)
+            # Producer for telemetry drift (#459): count skip-reeval usage.
+            _increment_skip_reeval_count()
             print(
                 f"WARNING: [skip-reeval] Phase '{phase}' addendum check bypassed. "
                 f"Reason: {skip_reeval_reason}. "
@@ -2801,6 +2838,12 @@ def approve_phase(
     # the guard pipeline profile (scalpel → standard) next cycle.
     # Idempotent + fail-open: re-approving the same phase is safe.
     _record_last_phase_approved(phase)
+
+    # --- #459 wiring: telemetry producers on SessionState ---
+    # Mirror the project's complexity_score onto SessionState so the
+    # session-close telemetry capture can compute complexity_delta.  First
+    # approve of the session also anchors complexity_at_session_open.
+    _record_complexity_snapshot(getattr(state, "complexity_score", 0))
 
     # Build-phase guard hook — additive, non-blocking.  Surfaces guard
     # findings as warnings in the approve output without gating approval.

--- a/scripts/delivery/drift.py
+++ b/scripts/delivery/drift.py
@@ -16,6 +16,15 @@ Algorithms
 3. 3σ Western Electric zone-A rule (baseline mean ± 3 * baseline_stddev).
    Points outside 3σ are tagged ``special-cause``. Points outside 2σ are
    reported as ``warn`` (zone B). Everything else is ``common-cause`` noise.
+4. Western Electric runs rules (issue #459) beyond zone A:
+   - ``2_of_3_zone_b``: 2 of the last 3 points are beyond 2σ on the bad side
+     (below-baseline). Fires ``special-cause`` even when the latest point is
+     inside zone A.
+   - ``trending_down``: 6 consecutive points each lower than the one before
+     (monotonic degradation). Fires ``special-cause``.
+   - ``trending_up``: symmetric monotonic climb. Reported but never flips
+     ``drift`` — rising metrics on a "higher is better" axis are good news.
+   These runs rules are additive — they OR with the zone-A sigma check.
 
 Classification output
 ---------------------
@@ -68,6 +77,13 @@ DEFAULT_DROP_PCT_THRESHOLD = 0.15  # issue acceptance: 15% below 4-session basel
 DEFAULT_SPECIAL_CAUSE_SIGMA = 3.0  # Western Electric zone A
 DEFAULT_WARN_SIGMA = 2.0           # zone B
 MIN_SESSIONS_FOR_DRIFT = 5         # issue acceptance: >=5 sessions
+
+# Western Electric runs-rule thresholds (issue #459).
+# 2-of-3: "2 of the most recent 3 points beyond 2σ on the same side."
+WE_2OF3_WINDOW = 3
+WE_2OF3_COUNT = 2
+# Trending: 6 consecutive monotonically increasing / decreasing points.
+WE_TRENDING_WINDOW = 6
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +143,53 @@ def _pull_metric(records: List[Dict[str, Any]], metric: str) -> List[float]:
         if isinstance(v, (int, float)):
             out.append(float(v))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Western Electric runs rules (issue #459)
+# ---------------------------------------------------------------------------
+
+def _we_2_of_3_zone_b(
+    series: List[float],
+    mean: float,
+    stddev: float,
+    *,
+    warn_sigma: float = DEFAULT_WARN_SIGMA,
+) -> bool:
+    """WE rule: 2 of the last 3 points beyond 2σ below the baseline mean.
+
+    Requires at least 3 points and a non-zero baseline stddev. We only flag
+    the "bad" (below-baseline) side — metrics like gate_pass_rate are
+    higher-is-better. Callers with lower-is-better metrics should invert
+    the series before passing it in.
+    """
+    if stddev <= 0:
+        return False
+    if len(series) < WE_2OF3_WINDOW:
+        return False
+    recent = series[-WE_2OF3_WINDOW:]
+    # Point counts as "beyond 2σ on the bad side" when it sits at least
+    # warn_sigma standard deviations below the baseline mean.
+    threshold = mean - warn_sigma * stddev
+    breaches = sum(1 for x in recent if x < threshold)
+    return breaches >= WE_2OF3_COUNT
+
+
+def _we_trending(series: List[float], direction: str = "down") -> bool:
+    """WE rule: 6 consecutive points moving monotonically.
+
+    ``direction`` is "down" (each point strictly less than the previous) or
+    "up" (strictly greater). Flat runs (equal values) do NOT count — SPC
+    theory requires strict monotonicity for a trend signal.
+    """
+    if len(series) < WE_TRENDING_WINDOW:
+        return False
+    window = series[-WE_TRENDING_WINDOW:]
+    if direction == "down":
+        return all(window[i] < window[i - 1] for i in range(1, len(window)))
+    if direction == "up":
+        return all(window[i] > window[i - 1] for i in range(1, len(window)))
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +272,7 @@ def classify(
     slope = _slope(ewma_series)
     result["ewma_slope"] = round(slope, 6)
 
-    # Zone classification.
+    # Zone classification (zone-A sigma test).
     if z >= special_cause_sigma:
         zone = "special-cause"
         result["reasons"].append(f"outside {special_cause_sigma:.0f}σ (z={z:.2f})")
@@ -218,6 +281,33 @@ def classify(
         result["reasons"].append(f"outside {warn_sigma:.0f}σ (z={z:.2f})")
     else:
         zone = "common-cause"
+
+    # Western Electric runs rules (issue #459) — operate on the full observed
+    # series using the baseline mean/stddev as the reference frame. These fire
+    # independently of the single-point z-score.
+    we_rules: List[str] = []
+    if _we_2_of_3_zone_b(series, mu, sigma, warn_sigma=warn_sigma):
+        we_rules.append("2_of_3_zone_b")
+        result["reasons"].append(
+            f"WE 2-of-3: 2+ of last {WE_2OF3_WINDOW} points beyond "
+            f"{warn_sigma:.0f}σ below baseline"
+        )
+    if _we_trending(series, direction="down"):
+        we_rules.append("trending_down")
+        result["reasons"].append(
+            f"WE trending-down: {WE_TRENDING_WINDOW} consecutive decreasing points"
+        )
+    if _we_trending(series, direction="up"):
+        we_rules.append("trending_up")
+        result["reasons"].append(
+            f"WE trending-up: {WE_TRENDING_WINDOW} consecutive increasing points"
+        )
+    result["we_rules"] = we_rules
+
+    # Any "bad-side" WE runs rule escalates zone to special-cause.
+    # trending_up is informational only (higher-is-better metrics).
+    if "2_of_3_zone_b" in we_rules or "trending_down" in we_rules:
+        zone = "special-cause"
 
     # Drift alarm: >=15% drop below baseline OR special-cause zone.
     drift = False

--- a/tests/delivery/test_drift.py
+++ b/tests/delivery/test_drift.py
@@ -217,5 +217,194 @@ class FiveSessionScenarioTest(unittest.TestCase):
         self.assertIn("reasons", payload)
 
 
+class WesternElectricRulesTests(unittest.TestCase):
+    """WE runs rules beyond zone-A (issue #459)."""
+
+    def test_2_of_3_zone_b_direct_helper(self):
+        """Test the _we_2_of_3_zone_b helper directly with controlled inputs."""
+        # mean=0.90, stddev=0.01 → threshold at 2σ below = 0.88.
+        # 2 of last 3 below 0.88 → rule fires.
+        series = [0.90, 0.91, 0.89, 0.90, 0.85, 0.90, 0.85]
+        self.assertTrue(drift._we_2_of_3_zone_b(series, 0.90, 0.01))
+
+        # Only 1 of last 3 below threshold → rule does NOT fire.
+        series_one_breach = [0.90, 0.91, 0.89, 0.90, 0.90, 0.90, 0.85]
+        self.assertFalse(drift._we_2_of_3_zone_b(series_one_breach, 0.90, 0.01))
+
+        # Zero stddev → rule never fires (fail-safe).
+        self.assertFalse(drift._we_2_of_3_zone_b(series, 0.90, 0.0))
+
+        # Too few points → rule never fires.
+        self.assertFalse(drift._we_2_of_3_zone_b([0.85, 0.85], 0.90, 0.01))
+
+    def test_trending_down_6_consecutive(self):
+        """6 consecutive strictly decreasing points → trending_down fires."""
+        # Strictly monotonic decline — classic SPC trend signal.
+        series = [0.95, 0.90, 0.85, 0.80, 0.75, 0.70]
+        self.assertTrue(drift._we_trending(series, direction="down"))
+
+        # Break monotonicity with a flat point → does NOT fire.
+        series_flat = [0.95, 0.90, 0.90, 0.80, 0.75, 0.70]
+        self.assertFalse(drift._we_trending(series_flat, direction="down"))
+
+        # Break monotonicity with an uptick → does NOT fire.
+        series_blip = [0.95, 0.90, 0.85, 0.86, 0.75, 0.70]
+        self.assertFalse(drift._we_trending(series_blip, direction="down"))
+
+        # Only 5 points → below WE_TRENDING_WINDOW of 6 → does NOT fire.
+        self.assertFalse(drift._we_trending([0.95, 0.90, 0.85, 0.80, 0.75], "down"))
+
+    def test_trending_up_6_consecutive(self):
+        """6 consecutive strictly increasing points → trending_up fires."""
+        series = [0.70, 0.75, 0.80, 0.85, 0.90, 0.95]
+        self.assertTrue(drift._we_trending(series, direction="up"))
+
+        # Break with flat → no.
+        self.assertFalse(
+            drift._we_trending([0.70, 0.75, 0.75, 0.85, 0.90, 0.95], "up")
+        )
+
+    def test_classify_trending_down_flips_zone_to_special_cause(self):
+        """6-monotonic-decline series → zone=special-cause + drift=True."""
+        records = _mk_records([0.95, 0.90, 0.85, 0.80, 0.75, 0.70])
+        cls = drift.classify(records)
+        self.assertIn("trending_down", cls.get("we_rules", []))
+        self.assertEqual(cls["zone"], "special-cause")
+        self.assertTrue(cls["drift"])
+        self.assertTrue(drift.is_actionable(cls))
+
+    def test_classify_trending_up_is_informational(self):
+        """Rising metric on higher-is-better axis: trending_up reported, no drift."""
+        # 6 monotonic increase below special-cause z-score.
+        # Baseline_window default=4, so baseline = series[-5:-1].
+        records = _mk_records([0.50, 0.60, 0.70, 0.80, 0.85, 0.90])
+        cls = drift.classify(records)
+        self.assertIn("trending_up", cls.get("we_rules", []))
+        # trending_up MUST NOT flip drift (higher-is-better metric).
+        # Zone depends on z-score — latest is above baseline, so z<=0 → common-cause.
+        self.assertFalse(cls["drift"], f"trending_up should not flip drift; got {cls}")
+
+    def test_we_rules_field_present_on_every_classification(self):
+        """Every classify() return has the we_rules list (may be empty)."""
+        records = _mk_records([0.88, 0.86, 0.90, 0.87, 0.89])
+        cls = drift.classify(records)
+        self.assertIn("we_rules", cls)
+        self.assertIsInstance(cls["we_rules"], list)
+
+
+class SessionStateProducerTests(unittest.TestCase):
+    """SessionState producer wiring for #459 telemetry fields."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        # Isolate session state to a tmpdir so producer tests don't clobber
+        # the developer's real session state.
+        import os as _os
+        self._prev_tmpdir = _os.environ.get("TMPDIR")
+        self._prev_session = _os.environ.get("CLAUDE_SESSION_ID")
+        _os.environ["TMPDIR"] = self.tmp.name
+        _os.environ["CLAUDE_SESSION_ID"] = "test-producer-459"
+        # Fresh import — session path is captured at module-import time via
+        # _state_file_path() which reads TMPDIR each call, so no reload needed.
+        import importlib
+        scripts_root = _REPO_ROOT / "scripts"
+        if str(scripts_root) not in sys.path:
+            sys.path.insert(0, str(scripts_root))
+        if "_session" in sys.modules:
+            importlib.reload(sys.modules["_session"])
+        from _session import SessionState  # noqa: E402
+        self.SessionState = SessionState
+        # Start every test from a clean state.
+        SessionState().save()
+
+    def tearDown(self):
+        import os as _os
+        if self._prev_tmpdir is None:
+            _os.environ.pop("TMPDIR", None)
+        else:
+            _os.environ["TMPDIR"] = self._prev_tmpdir
+        if self._prev_session is None:
+            _os.environ.pop("CLAUDE_SESSION_ID", None)
+        else:
+            _os.environ["CLAUDE_SESSION_ID"] = self._prev_session
+        self.tmp.cleanup()
+
+    def test_session_state_has_telemetry_fields(self):
+        """SessionState exposes the fields telemetry.py reads."""
+        s = self.SessionState()
+        # Defaults documented in _session.py.
+        self.assertEqual(s.skip_reeval_count, 0)
+        self.assertIsNone(s.complexity_at_session_open)
+        self.assertEqual(s.complexity_score, 0)
+
+    def test_increment_skip_reeval_count_producer(self):
+        """phase_manager._increment_skip_reeval_count bumps the session field."""
+        crew_path = _REPO_ROOT / "scripts" / "crew"
+        if str(crew_path) not in sys.path:
+            sys.path.insert(0, str(crew_path))
+        import importlib
+        if "phase_manager" in sys.modules:
+            importlib.reload(sys.modules["phase_manager"])
+        from phase_manager import _increment_skip_reeval_count  # noqa: E402
+
+        _increment_skip_reeval_count()
+        s = self.SessionState.load()
+        self.assertEqual(s.skip_reeval_count, 1)
+
+        _increment_skip_reeval_count()
+        _increment_skip_reeval_count()
+        s = self.SessionState.load()
+        self.assertEqual(s.skip_reeval_count, 3)
+
+    def test_complexity_snapshot_first_write_anchors_open(self):
+        """First _record_complexity_snapshot sets complexity_at_session_open."""
+        crew_path = _REPO_ROOT / "scripts" / "crew"
+        if str(crew_path) not in sys.path:
+            sys.path.insert(0, str(crew_path))
+        import importlib
+        if "phase_manager" in sys.modules:
+            importlib.reload(sys.modules["phase_manager"])
+        from phase_manager import _record_complexity_snapshot  # noqa: E402
+
+        _record_complexity_snapshot(3)
+        s = self.SessionState.load()
+        self.assertEqual(s.complexity_at_session_open, 3)
+        self.assertEqual(s.complexity_score, 3)
+
+        # Subsequent writes update complexity_score but NOT the open anchor.
+        _record_complexity_snapshot(5)
+        s = self.SessionState.load()
+        self.assertEqual(
+            s.complexity_at_session_open, 3,
+            "first-observation anchor must be sticky",
+        )
+        self.assertEqual(s.complexity_score, 5)
+
+    def test_telemetry_reads_producer_fields(self):
+        """Telemetry._extract_session_extras picks up our producer writes."""
+        # Prime SessionState with producer values.
+        s = self.SessionState.load()
+        s.skip_reeval_count = 2
+        s.complexity_at_session_open = 4
+        s.complexity_score = 6
+        s.save()
+
+        # Fresh-import telemetry so its sys.path lookup resolves our isolated
+        # _session module.
+        delivery_path = _REPO_ROOT / "scripts" / "delivery"
+        if str(delivery_path) not in sys.path:
+            sys.path.insert(0, str(delivery_path))
+        import importlib
+        if "telemetry" in sys.modules:
+            importlib.reload(sys.modules["telemetry"])
+        import telemetry as tele  # noqa: E402
+
+        extras = tele._extract_session_extras()
+        self.assertEqual(extras["skip_reeval_count"], 2)
+        # complexity_delta = close(6) - open(4) = 2.
+        self.assertEqual(extras["complexity_delta"], 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #459. Two additive items:

1. **Western Electric runs rules beyond zone-A** in `scripts/delivery/drift.py`. The current classifier only checks the 3σ zone-A rule. This adds:
   - `2_of_3_zone_b` — 2 of the last 3 observed points beyond 2σ below the baseline mean.
   - `trending_down` — 6 consecutive strictly decreasing points (classic SPC trend signal).
   - `trending_up` — symmetric increase, reported but never flips `drift` (higher-is-better metrics like `gate_pass_rate`).

   Rules are OR'd into the zone-A verdict and surfaced in a new `we_rules` list on every classification. Reasons explain which rule fired.

2. **SessionState producers wired** for telemetry fields `scripts/delivery/telemetry.py` already reads optimistically:
   - `skip_reeval_count` — incremented by `phase_manager.approve_phase()` at the `--skip-reeval` bypass path.
   - `complexity_at_session_open` — captured by `bootstrap.py` at SessionStart from the active crew project's `complexity_score`; first-observation anchored.
   - `complexity_score` — mirrored onto SessionState on every approve.

   Fields added to `scripts/_session.py` dataclass with safe defaults. All producers fail-open.

### Scope boundary

Parallel PR #465 (augment-cap) also edits `phase_manager.py`. Per guidance, this PR does NOT touch `_run_checkpoint_reanalysis` — all edits are in a distinct region (new `_increment_skip_reeval_count` and `_record_complexity_snapshot` helpers + the approve-path tail next to the existing `#462` `_record_last_phase_approved` wiring, plus a one-line call in the skip-reeval branch).

## Test plan

- [x] `pytest tests/ -q` — 416 passed (was 406 on `main`; +10 WE + producer cases)
- [x] `pytest tests/delivery/test_drift.py -q` — 26 passed
- [x] Existing `DriftClassifyTests` unchanged — 2-of-3 does not fire on the `warn` case (tight baseline, only 1 breach in last 3)
- [x] `test_trending_down_populates_ewma_slope` still green — now also asserts on `we_rules` via new sibling test
- [x] Producer tests use isolated `TMPDIR` + `CLAUDE_SESSION_ID` so they don't clobber dev session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)