### PR TITLE
fix(crew): CLI parity bundle — closes #492, #493, #494, #498, #499

### DIFF
--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -295,6 +295,21 @@ _DEFAULT_MIN_TEST_COVERAGE: float = 0.80
 _DEFAULT_REQUIRED_SPECIALISTS: list = []
 _DEFAULT_REQUIRED_DELIVERABLES: list = []
 
+# Issue #493: per-phase hardcoded deliverable fallback used by
+# _check_phase_deliverables ONLY when phases.json has no required_deliverables
+# entry for the phase (e.g. older phases.json schema, missing config file).
+# phases.json is the source of truth; this dict is the backward-compat floor.
+# Keep additive and minimal — do not duplicate fields already in phases.json.
+_FALLBACK_REQUIRED_DELIVERABLES: Dict[str, List[Dict[str, Any]]] = {
+    "design": [{"file": "architecture.md", "min_bytes": 200}],
+    "test": [
+        {"file": "test-results.md", "min_bytes": 200},
+        {"file": "evidence/report.md", "min_bytes": 100},
+    ],
+    "review": [{"file": "review-findings.md", "min_bytes": 200}],
+    "clarify": [{"file": "objective.md", "min_bytes": 100}],
+}
+
 
 def get_min_test_coverage(phase_name: str) -> Optional[float]:
     """Return the minimum test coverage threshold for a phase.
@@ -1032,11 +1047,24 @@ def _check_phase_deliverables(state: ProjectState, phase: str) -> List[str]:
     and non-empty, they satisfy the phases.json required_deliverables check —
     the facilitator's factor readings + task metadata replace the legacy
     complexity.md / acceptance-criteria.md files. See issue #435.
+
+    Issue #493: the source of truth is phases.json's ``required_deliverables``
+    list. When phases.json is missing (or a particular phase has no entry) we
+    fall back to a small hardcoded map below so legacy phase names still get
+    a reasonable default check instead of silently approving a phase with no
+    deliverables at all. Edit phases.json first — the fallback map exists
+    purely for backward-compat with older phases.json files.
     """
     phase = resolve_phase(phase)
     issues = []
     phases_config = load_phases_config()
     deliverables = phases_config.get(phase, {}).get("required_deliverables", [])
+    if not deliverables:
+        # #493 backward-compat fallback: only applies when phases.json has no
+        # required_deliverables entry for this phase (missing config file, or
+        # older schema). Keep this list minimal and additive — phases.json is
+        # the preferred source.
+        deliverables = _FALLBACK_REQUIRED_DELIVERABLES.get(phase, [])
     if not deliverables:
         return issues
 
@@ -3298,6 +3326,17 @@ def create_project(
     if description:
         state.extras["description"] = description
 
+    # #498: Newly-created projects default to dispatch_mode="mode-3".
+    # Legacy detection (via _detect_dispatch_mode) only applies to projects
+    # loaded WITHOUT an explicit dispatch_mode in extras — those are the
+    # ones that predate mode-3 and should stay on v6-legacy. For fresh
+    # create_project() calls we stamp "mode-3" so the execute() / approve()
+    # paths opt in by default. Callers who need legacy behavior can pass
+    # initial_data={"dispatch_mode": "v6-legacy"} and it will be merged
+    # above and preserved here.
+    if "dispatch_mode" not in state.extras:
+        state.extras["dispatch_mode"] = "mode-3"
+
     # Start clarify phase
     state = start_phase(state, "clarify")
 
@@ -3671,6 +3710,22 @@ def execute(
             trigger="execute",
         )
         save_project_state(state)
+    else:
+        # #499: honest CLI stub. When execute() is invoked from the CLI
+        # (no dispatcher injection) and no phase-executor has written
+        # executor-status.json, we cannot dispatch reviewers ourselves.
+        # Return status="cli-stub" with a clear warning log so callers
+        # know the re-eval bookends were written but NO phase work was
+        # performed. Matches the pattern used for CLI approve (#492).
+        cli_stub_warning = (
+            "CLI execute does not dispatch phase-executor; invoke via "
+            "crew agent or provide a dispatcher. Re-eval bookends "
+            "written but no phase work performed."
+        )
+        logger.warning("[execute] %s", cli_stub_warning)
+        print(f"WARNING: {cli_stub_warning}", file=sys.stderr)
+        result["status"] = "cli-stub"
+        result["warning"] = cli_stub_warning
 
     return result
 
@@ -3949,13 +4004,29 @@ def main():
             return
 
         if args.json:
+            # #494: include rigor_tier, complexity_score, is_complete in the
+            # JSON payload so CLI consumers don't have to re-derive them.
+            # is_complete := every phase in phase_plan has status "approved".
+            phase_status_summary = get_phase_status_summary(state)
+            if state.phase_plan:
+                is_complete = all(
+                    phase_status_summary.get(resolve_phase(p)) == "approved"
+                    for p in state.phase_plan
+                )
+            else:
+                is_complete = False
             summary = {
                 "name": state.name,
                 "current_phase": state.current_phase,
                 "phase_plan": state.phase_plan,
-                "phases": get_phase_status_summary(state),
+                "phases": phase_status_summary,
                 "signals": state.signals_detected,
                 "complexity": state.complexity_score,
+                # New fields (#494): parity with the non-JSON output and
+                # propose-process rubric.
+                "complexity_score": state.complexity_score,
+                "rigor_tier": (state.extras or {}).get("rigor_tier"),
+                "is_complete": is_complete,
             }
             print(json.dumps(summary, indent=2))
         else:
@@ -3984,19 +4055,23 @@ def main():
 
     elif args.action == "approve":
         phase = args.phase or state.current_phase
-        # BLEND-RULE honesty note (review-gate condition a):
+        # BLEND-RULE honesty note (review-gate condition a / issue #492):
         # The CLI `approve` path cannot dispatch subagents — only an
         # Agent-driven caller can inject a real dispatcher. We log an
-        # explicit warning so users aren't silently surprised when
-        # `_dispatch_gate_reviewer` returns a "dispatcher-unavailable"
-        # stub instead of running reviewers. Agent-driven callers should
-        # pass `dispatcher=...` to approve_phase() directly.
-        logger.warning(
+        # explicit warning AND surface a structured
+        # `status: "cli-no-dispatcher"` marker in --json output so users
+        # aren't silently surprised when `_dispatch_gate_reviewer` returns
+        # a "dispatcher-unavailable" stub instead of running reviewers.
+        # Agent-driven callers should pass `dispatcher=...` to
+        # approve_phase() directly.
+        cli_dispatcher_warning = (
             "CLI approve path: no dispatcher available — gate reviewers "
             "will NOT be auto-dispatched. Use `crew:approve` via the "
             "wicked-garden agent path to invoke reviewers, or pre-stage "
             "a gate-result.json before approval. (BLEND-RULE)"
         )
+        logger.warning(cli_dispatcher_warning)
+        print(f"WARNING: {cli_dispatcher_warning}", file=sys.stderr)
         try:
             state, next_phase = approve_phase(
                 state,
@@ -4011,14 +4086,32 @@ def main():
                 dispatcher=None,
             )
         except ValueError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            if args.json:
+                print(json.dumps({
+                    "ok": False,
+                    "status": "cli-no-dispatcher",
+                    "approved_phase": resolve_phase(phase),
+                    "error": str(e),
+                    "warning": cli_dispatcher_warning,
+                }))
+            else:
+                print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
         save_project_state(state)
-        print(f"Approved phase: {resolve_phase(phase)}")
-        if next_phase:
-            print(f"Next phase: {next_phase}")
+        if args.json:
+            print(json.dumps({
+                "ok": True,
+                "status": "cli-no-dispatcher",
+                "approved_phase": resolve_phase(phase),
+                "next_phase": next_phase,
+                "warning": cli_dispatcher_warning,
+            }, indent=2))
         else:
-            print("Project complete!")
+            print(f"Approved phase: {resolve_phase(phase)}")
+            if next_phase:
+                print(f"Next phase: {next_phase}")
+            else:
+                print("Project complete!")
 
     elif args.action == "skip":
         phase = args.phase

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -580,5 +580,283 @@ class TestApprovePhaseHandlesGateResultSchemaError(unittest.TestCase):
             self.assertIsInstance(cm.exception, GateResultAuthorizationError)
 
 
+# ---------------------------------------------------------------------------
+# CLI parity bundle — issues #492, #493, #494, #498, #499
+# ---------------------------------------------------------------------------
+
+
+class TestCliApproveNoDispatcher(unittest.TestCase):
+    """Issue #492: CLI approve path is honest about not dispatching.
+
+    When ``main()`` runs the approve action without a dispatcher (the only
+    path a raw CLI caller can take), the JSON output must carry
+    ``status: "cli-no-dispatcher"`` so consumers can tell the gate was NOT
+    auto-dispatched. A warning must also hit stderr.
+    """
+
+    def test_cli_approve_json_contains_cli_no_dispatcher_status(self):
+        from io import StringIO
+        import contextlib
+
+        state = _make_state(name="cli-approve-proj", rigor_tier="standard")
+        state.current_phase = "clarify"
+        state.phases["clarify"] = pm.PhaseState(
+            status="in_progress", started_at="2026-04-19T00:00:00Z",
+        )
+
+        argv = [
+            "phase_manager.py", "cli-approve-proj", "approve",
+            "--phase", "clarify", "--json",
+        ]
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with patch.object(pm, "load_project_state", return_value=state), \
+             patch.object(pm, "save_project_state"), \
+             patch.object(
+                 pm, "approve_phase",
+                 return_value=(state, "design"),
+             ), \
+             patch.object(sys, "argv", argv), \
+             contextlib.redirect_stdout(stdout), \
+             contextlib.redirect_stderr(stderr):
+            pm.main()
+
+        out = stdout.getvalue()
+        err = stderr.getvalue()
+        payload = json.loads(out)
+        self.assertEqual(payload.get("status"), "cli-no-dispatcher")
+        self.assertTrue(payload.get("ok"))
+        self.assertIn("cli-no-dispatcher", payload.get("status", ""))
+        self.assertIn("WARNING", err)
+        self.assertIn("BLEND-RULE", err)
+
+
+class TestPhaseDeliverablesFallback(unittest.TestCase):
+    """Issue #493: _check_phase_deliverables reads phases.json first,
+    falls back to the hardcoded _FALLBACK_REQUIRED_DELIVERABLES map when
+    the config has no entry for the phase (backward-compat).
+    """
+
+    def test_fallback_used_when_phases_config_empty_for_phase(self):
+        state = _make_state(name="fallback-proj")
+
+        # Force phases_config to return NO deliverables for the 'design'
+        # phase so the fallback map is exercised. 'design' has
+        # architecture.md in _FALLBACK_REQUIRED_DELIVERABLES.
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "fallback-proj"
+            (project_dir / "phases" / "design").mkdir(parents=True)
+
+            with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                 patch.object(
+                     pm, "load_phases_config",
+                     return_value={"design": {"required_deliverables": []}},
+                 ):
+                issues = pm._check_phase_deliverables(state, "design")
+
+            # architecture.md is missing — fallback should surface it.
+            self.assertTrue(
+                any("architecture.md" in issue for issue in issues),
+                f"expected fallback architecture.md check, got: {issues}",
+            )
+
+    def test_phases_config_takes_precedence_over_fallback(self):
+        """When phases.json declares deliverables for a phase, those are
+        authoritative — the fallback map must NOT be consulted."""
+        state = _make_state(name="precedence-proj")
+
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "precedence-proj"
+            (project_dir / "phases" / "design").mkdir(parents=True)
+
+            # phases_config declares a DIFFERENT deliverable. Fallback
+            # map would flag architecture.md, but config says foo.md.
+            with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                 patch.object(
+                     pm, "load_phases_config",
+                     return_value={"design": {
+                         "required_deliverables": [
+                             {"file": "foo.md", "min_bytes": 10},
+                         ],
+                     }},
+                 ):
+                issues = pm._check_phase_deliverables(state, "design")
+
+            joined = " ".join(issues)
+            self.assertIn("foo.md", joined)
+            self.assertNotIn("architecture.md", joined)
+
+
+class TestStatusJsonFieldParity(unittest.TestCase):
+    """Issue #494: `phase_manager.py status --json` surfaces rigor_tier,
+    complexity_score, and is_complete alongside the existing fields."""
+
+    def test_status_json_includes_new_fields(self):
+        from io import StringIO
+        import contextlib
+
+        state = _make_state(name="status-proj", rigor_tier="full")
+        state.complexity_score = 5
+        # Mark all phases in phase_plan as approved so is_complete=True
+        for p in state.phase_plan:
+            state.phases[p] = pm.PhaseState(status="approved")
+
+        argv = ["phase_manager.py", "status-proj", "status", "--json"]
+
+        stdout = StringIO()
+        with patch.object(pm, "load_project_state", return_value=state), \
+             patch.object(sys, "argv", argv), \
+             contextlib.redirect_stdout(stdout):
+            pm.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertIn("rigor_tier", payload)
+        self.assertEqual(payload["rigor_tier"], "full")
+        self.assertIn("complexity_score", payload)
+        self.assertEqual(payload["complexity_score"], 5)
+        self.assertIn("is_complete", payload)
+        self.assertTrue(payload["is_complete"])
+
+    def test_status_json_is_complete_false_when_phases_pending(self):
+        from io import StringIO
+        import contextlib
+
+        state = _make_state(name="in-progress-proj")
+        state.complexity_score = 3
+        # Only first phase approved; rest pending -> not complete.
+        state.phases["clarify"] = pm.PhaseState(status="approved")
+
+        argv = ["phase_manager.py", "in-progress-proj", "status", "--json"]
+        stdout = StringIO()
+        with patch.object(pm, "load_project_state", return_value=state), \
+             patch.object(sys, "argv", argv), \
+             contextlib.redirect_stdout(stdout):
+            pm.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertFalse(payload["is_complete"])
+
+
+class TestCreateProjectDefaultsToMode3(unittest.TestCase):
+    """Issue #498: create_project() stamps dispatch_mode='mode-3' on new
+    projects so _detect_dispatch_mode() does NOT return 'v6-legacy' for
+    freshly created projects. Legacy projects (missing the field entirely)
+    still fall through to the existing legacy-detection code path.
+    """
+
+    def test_fresh_project_defaults_to_mode_3(self):
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "mode3-proj"
+
+            class _FakeStore:
+                def __init__(self):
+                    self._data = {}
+                def get(self, domain, key):
+                    return self._data.get(key)
+                def put(self, domain, key, value):
+                    self._data[key] = value
+                def create(self, domain, data):
+                    self._data[data.get("id") or data.get("name")] = data
+                def update(self, domain, key, data):
+                    self._data[key] = data
+                def list(self, domain):
+                    return list(self._data.values())
+                def delete(self, domain, key):
+                    self._data.pop(key, None)
+
+            fake_store = _FakeStore()
+            with patch.object(pm, "_sm", fake_store), \
+                 patch.object(pm, "get_project_dir", return_value=project_dir):
+                state, _ = pm.create_project(
+                    "mode3-proj", description="test mode3 default",
+                )
+
+            self.assertEqual(
+                state.extras.get("dispatch_mode"), "mode-3",
+                "newly created projects must default to dispatch_mode=mode-3",
+            )
+            # _detect_dispatch_mode must agree.
+            self.assertEqual(pm._detect_dispatch_mode(state), "mode-3")
+
+    def test_initial_data_dispatch_mode_preserved(self):
+        """A caller explicitly passing dispatch_mode='v6-legacy' in
+        initial_data must have that value preserved — create_project must
+        NOT overwrite an explicit caller choice."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "legacy-proj"
+
+            class _FakeStore:
+                def __init__(self):
+                    self._data = {}
+                def get(self, domain, key):
+                    return self._data.get(key)
+                def put(self, domain, key, value):
+                    self._data[key] = value
+                def create(self, domain, data):
+                    self._data[data.get("id") or data.get("name")] = data
+                def update(self, domain, key, data):
+                    self._data[key] = data
+                def list(self, domain):
+                    return list(self._data.values())
+                def delete(self, domain, key):
+                    self._data.pop(key, None)
+
+            fake_store = _FakeStore()
+            with patch.object(pm, "_sm", fake_store), \
+                 patch.object(pm, "get_project_dir", return_value=project_dir):
+                state, _ = pm.create_project(
+                    "legacy-proj",
+                    description="legacy test",
+                    initial_data={"dispatch_mode": "v6-legacy"},
+                )
+
+            self.assertEqual(
+                state.extras.get("dispatch_mode"), "v6-legacy",
+                "explicit initial_data.dispatch_mode must be preserved",
+            )
+
+
+class TestExecuteCliStub(unittest.TestCase):
+    """Issue #499: execute() with NO executor-status.json returns
+    ``status="cli-stub"`` and emits a clear warning — not a silent
+    ``status=ok, deliverables=[]`` stub."""
+
+    def test_execute_returns_cli_stub_when_no_executor_status(self):
+        from io import StringIO
+        import contextlib
+
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "stub-proj"
+            project_dir.mkdir()
+            state = pm.ProjectState(
+                name="stub-proj",
+                current_phase="build",
+                created_at="2026-04-19T00:00:00Z",
+                phase_plan=["clarify", "design", "build", "review"],
+                phases={
+                    "clarify": pm.PhaseState(status="approved"),
+                    "design": pm.PhaseState(status="approved"),
+                    "build": pm.PhaseState(status="in_progress"),
+                },
+                extras={"dispatch_mode": "mode-3", "rigor_tier": "standard"},
+            )
+
+            stderr = StringIO()
+            with patch.object(pm, "load_project_state", return_value=state), \
+                 patch.object(pm, "save_project_state"), \
+                 patch.object(pm, "get_project_dir", return_value=project_dir), \
+                 patch.object(pm, "_validate_gate_policy_full_rigor"), \
+                 contextlib.redirect_stderr(stderr):
+                result = pm.execute("stub-proj", "build")
+
+            self.assertEqual(result["status"], "cli-stub")
+            self.assertIn("warning", result)
+            self.assertIn("no phase work performed", result["warning"])
+            # stderr receives the explicit WARNING line.
+            self.assertIn("WARNING", stderr.getvalue())
+            self.assertIn("CLI execute", stderr.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Five additive CLI-parity fixes to `scripts/crew/phase_manager.py`, shipped together because they all touch the same module.

- **#492** CLI `approve`: stderr warning + `status: "cli-no-dispatcher"` in `--json` payload so callers see the gate was not auto-dispatched on the CLI path.
- **#493** `_check_phase_deliverables`: additive fallback to `_FALLBACK_REQUIRED_DELIVERABLES` when `phases.json` has no entry for a phase. `phases.json` remains the source of truth — the fallback is backward-compat only.
- **#494** `status --json`: payload now includes `rigor_tier`, `complexity_score`, and `is_complete` (derived from phase_plan approval state).
- **#498** `create_project`: new projects stamp `extras["dispatch_mode"] = "mode-3"`. Legacy projects (missing the field at load time) still resolve to `v6-legacy` via `_detect_dispatch_mode`. Explicit `initial_data.dispatch_mode` is preserved for overrides.
- **#499** `execute()`: when `executor-status.json` is absent (CLI path, no dispatcher injection), return `status="cli-stub"` with clear stderr warning instead of silent `status=ok, deliverables=[]`.

#492 and #499 share the "honest CLI stub" convention — callers can distinguish agent-driven results (`status: ok`) from CLI stubs (`status: cli-no-dispatcher` / `status: cli-stub`).

## Key design decisions

- **#493** — went additive (phases.json preferred, hardcoded dict as fallback). Did not add a new `deliverables` key to `phases.json`: the existing `required_deliverables` list already carries file + min_bytes, and every phase already has one.
- **#498** — caller-provided `initial_data.dispatch_mode` is preserved; default is applied only when the field is absent from `extras` post-merge.

## Test plan

Full suite: 505 → 513 (+8 new tests, 0 regressions).

- [x] `TestCliApproveNoDispatcher` — `--json` output carries `status=cli-no-dispatcher`, stderr has warning (#492)
- [x] `TestPhaseDeliverablesFallback` — fallback used when config empty; config takes precedence otherwise (#493)
- [x] `TestStatusJsonFieldParity` — `--json` includes `rigor_tier`, `complexity_score`, `is_complete`; `is_complete=False` when phases pending (#494)
- [x] `TestCreateProjectDefaultsToMode3` — new projects default to `mode-3`; explicit `v6-legacy` in `initial_data` preserved (#498)
- [x] `TestExecuteCliStub` — `execute()` with no executor-status.json returns `status=cli-stub` + stderr warning (#499)
- [x] `sh scripts/_python.sh -m pytest tests/ -q` → 513 passed

Closes #492
Closes #493
Closes #494
Closes #498
Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>