### PR TITLE
feat(crew): storage + DX bundle — reviewer-context, atomic conditions, amendments.jsonl, explain skill

### DIFF
--- a/agents/crew/phase-executor.md
+++ b/agents/crew/phase-executor.md
@@ -57,16 +57,23 @@ return a structured manifest to `phase_manager.execute()`. You are an **orchestr
    legacy `phases/{phase}/reeval-start.json` snapshot is accepted for
    backward compatibility only; the authoritative record is the addendum
    JSONL line.
-2. Produce the phase's required deliverables per `phases.json` `required_deliverables`.
+2. Produce `phases/{phase}/reviewer-context.md` (issue #474) capturing the
+   shared context reviewers will need: phase objective, deliverable index,
+   prior-phase gate findings to carry forward. Downstream reviewer briefs
+   link to this file by PATH instead of re-embedding the content — write
+   once, read many. Stub minimum: project name, phase, gate, deliverable
+   file list. Use `ensure_reviewer_context()` from
+   `scripts/crew/phase_manager.py` when producing this artifact.
+3. Produce the phase's required deliverables per `phases.json` `required_deliverables`.
    Each deliverable MUST be >= 100 bytes (content-validation rule).
-3. Run the **phase-end re-eval** by invoking the propose-process skill
+4. Run the **phase-end re-eval** by invoking the propose-process skill
    in `re-evaluate` mode a second time (after deliverables are written,
    before handoff). Append the returned mutations to BOTH
    `phases/{phase}/reeval-log.jsonl` AND `process-plan.addendum.jsonl`
    via `reeval_addendum.append()`. Use the schema pinned by
    `skills/propose-process/refs/re-eval-addendum-schema.md`.
-4. `TaskUpdate` your executor task: `in_progress` before work, `completed` when finished.
-5. **Convergence recording (build/test phases only).** After landing each code
+5. `TaskUpdate` your executor task: `in_progress` before work, `completed` when finished.
+6. **Convergence recording (build/test phases only).** After landing each code
    artifact produced by this phase, call
    `scripts/crew/convergence.py record --project <P> --artifact <id> --to <state> --verifier <agent> --phase <phase> --ref <path> --desc "<>= 10 chars>"`
    for the appropriate forward transition (`Built` when an implementation file
@@ -77,7 +84,7 @@ return a structured manifest to `phase_manager.execute()`. You are an **orchestr
    — those phases do not emit code artifacts. This is the expectation
    codified in `.claude/CLAUDE.md` "Convergence tracking"; today it is not
    hook-enforced, so the executor is the responsible caller.
-6. Return the structured JSON manifest (see "Return contract" below).
+7. Return the structured JSON manifest (see "Return contract" below).
 
 ## Dispatch Discipline (SC-6, AC-α10 — ENFORCED)
 
@@ -201,3 +208,25 @@ you write:
 - **Zero-byte deliverable** → rejected as `"deliverable-too-small"`.
 - **Addendum validator rejects record** → `"addendum-invalid: <reason>"`.
 - **`parallelization_check` missing with multi-sub-task run** → `"parallelization-check-missing"`.
+
+## Amendments Log (issue #478)
+
+Mid-phase design corrections are no longer written as per-file
+`design-addendum-N.md`. Instead, append a single JSONL record to
+`phases/{phase}/amendments.jsonl` using `scripts/crew/amendments.py append`:
+
+```python
+from crew.amendments import append as append_amendment
+append_amendment(
+    phase_dir,
+    trigger="gate-conditional",
+    summary="Clarify FR-3 acceptance threshold",
+    patches=[{"target": "phases/design/design.md#FR-3", "operation": "replace",
+              "rationale": "align threshold with SLO"}],
+    resolution_refs=["CONDITION-1"],
+)
+```
+
+Legacy `.md` addenda remain readable via `amendments show {phase}`; new
+amendments MUST use the JSONL log. The log is append-only — never rewrite
+earlier records.

--- a/commands/crew/explain.md
+++ b/commands/crew/explain.md
@@ -1,0 +1,83 @@
+---
+description: Translate jargon-heavy crew output into plain, grade-8 English
+argument-hint: "<text-or-path-to-explain> [--style paired|plain-only]"
+---
+
+# /wicked-garden:crew:explain
+
+Take any crew output — gate findings, reviewer briefs, phase summaries, process
+plans — and convert the specialist vocab into plain, grade-8 English. Output is
+2-4 sentences that tell the user what happened and what to do next.
+
+## Arguments
+
+- `<text-or-path>` — the jargon-heavy block to explain. May be inline text or a
+  path to a file containing the block (e.g.
+  `phases/design/gate-result.json`).
+- `--style paired` — keep the original block and append a `**Plain:**` line.
+- `--style plain-only` (default for direct invocation) — replace the jargon
+  block entirely.
+
+## Instructions
+
+### 1. Determine input
+
+If the argument starts with `./`, `/`, or `phases/`, treat it as a file path.
+Otherwise, treat it as inline text to explain.
+
+```bash
+if [ -f "$ARG" ]; then
+  INPUT="$(cat "$ARG")"
+else
+  INPUT="$ARG"
+fi
+```
+
+### 2. Invoke the explain skill
+
+Use the `wicked-garden:crew:explain` skill. Pass the input block plus the
+chosen style:
+
+```
+Skill: wicked-garden:crew:explain
+Args: {"text": INPUT, "style": STYLE}
+```
+
+The skill follows its SKILL.md rules: max 4 sentences, grade-8 reading level,
+no specialist vocab. See `skills/crew/explain/SKILL.md` for the full rulebook.
+
+### 3. Emit output
+
+Print the skill's result verbatim. Do not wrap in extra prose.
+
+## Configuration
+
+The orchestrator honors `crew.output_style` in project config:
+
+- `terse` — never invoke this skill (raw jargon only)
+- `paired` — invoke with `--style paired` (default)
+- `plain-only` — invoke with `--style plain-only`
+
+Set at project start via `/wicked-garden:crew:profile` or by editing the
+project config directly.
+
+## Examples
+
+```bash
+# Inline text
+/wicked-garden:crew:explain "Gate code-quality CONDITIONAL 0.62 < 0.70"
+
+# From a gate-result file
+/wicked-garden:crew:explain phases/design/gate-result.json
+
+# Keep the jargon, add a plain-English line after it
+/wicked-garden:crew:explain "BLEND: REJECT > CONDITIONAL > APPROVE" --style paired
+```
+
+## Notes
+
+- This command is safe to run on any text — it never mutates project state.
+- When invoked during a phase transition, the orchestrator uses `crew.output_style`
+  to decide whether to append a plain-language line to every gate finding.
+- The skill is also invoked automatically by reviewer briefs when
+  `crew.output_style != terse`.

--- a/scripts/crew/amendments.py
+++ b/scripts/crew/amendments.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+Amendments log — append-only JSONL replacement for design-addendum-N.md (#478).
+
+Historically, each mid-phase design correction was written as a new
+``phases/{phase}/design-addendum-{N}.md`` file. This scales poorly:
+per-file, human-authored markdown is hard to query, hard to diff
+mechanically, and race-prone when two subagents produce addenda at the
+same time. Issue #478 replaces the per-file pattern with a single
+append-only JSONL log at ``phases/{phase}/amendments.jsonl``.
+
+Record shape (one JSON object per line):
+
+    {
+        "amendment_id": "AMD-<slug>-<ts>",
+        "trigger": "gate-conditional" | "re-eval" | "manual" | ...,
+        "scope_version": int,       # monotonic per-phase version counter
+        "timestamp": ISO-8601 UTC,
+        "summary": str,             # one-line human summary
+        "patches": [                # structured description of what changed
+            {"target": "<rel-path-or-section>", "operation": "add|remove|replace",
+             "rationale": str}
+        ],
+        "resolution_refs": [str]    # back-links to condition IDs, PR numbers, etc.
+    }
+
+Back-compat: existing ``design-addendum-N.md`` files remain readable —
+:func:`list_amendments` will surface them as pseudo-records with
+``source="legacy-md"`` so downstream tooling can treat them uniformly.
+
+Public surface:
+    - :func:`append`   — append one amendment record, returning the
+      assigned ``amendment_id`` and ``scope_version``.
+    - :func:`list_amendments` — read all amendments (JSONL + legacy .md).
+    - :func:`render_markdown` — render amendments as human-readable markdown.
+    - CLI: ``amendments show {phase} [--project P]`` — renders markdown
+      to stdout for quick inspection.
+
+This module is stdlib-only (no external deps) per the hook rulebook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+AMENDMENTS_FILENAME = "amendments.jsonl"
+LEGACY_MD_PATTERN = re.compile(r"design-addendum-(\d+)\.md$", re.IGNORECASE)
+AMENDMENT_ID_PREFIX = "AMD"
+
+# Allowed trigger vocabulary. Free-text triggers are rejected to keep the
+# log queryable. Callers who need a new trigger extend this tuple and
+# send a PR.
+VALID_TRIGGERS: Tuple[str, ...] = (
+    "gate-conditional",
+    "gate-reject",
+    "re-eval",
+    "manual",
+    "council",
+    "challenge",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string with Z suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _slugify(value: str) -> str:
+    """Produce a short lowercase-kebab slug from free-text summary.
+
+    Keeps ASCII letters, digits, and hyphens; collapses runs of other
+    characters to a single ``-``; trims to 32 chars. Empty input yields
+    ``"amendment"`` as a fallback so the id shape is always stable.
+    """
+    value = (value or "").strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    if not value:
+        value = "amendment"
+    return value[:32]
+
+
+def _amendments_path(phase_dir: Path) -> Path:
+    """Return ``phase_dir / amendments.jsonl``."""
+    return Path(phase_dir) / AMENDMENTS_FILENAME
+
+
+def _validate_record(record: Dict[str, Any]) -> None:
+    """Raise ValueError if ``record`` is missing required fields."""
+    required = ("trigger", "summary")
+    missing = [k for k in required if not record.get(k)]
+    if missing:
+        raise ValueError(
+            f"amendment record missing required field(s): {missing}"
+        )
+    trigger = record.get("trigger")
+    if trigger not in VALID_TRIGGERS:
+        raise ValueError(
+            f"amendment trigger '{trigger}' not in allow-list "
+            f"{VALID_TRIGGERS}"
+        )
+    patches = record.get("patches")
+    if patches is not None and not isinstance(patches, list):
+        raise ValueError("amendment 'patches' must be a list when present")
+
+
+def _next_scope_version(phase_dir: Path) -> int:
+    """Compute the next monotonic scope_version for this phase.
+
+    Counts existing JSONL records + legacy ``design-addendum-N.md`` files
+    so the version number is globally monotonic across the two formats.
+    Returns ``1`` for a fresh phase.
+    """
+    highest = 0
+    for rec in _iter_jsonl(phase_dir):
+        try:
+            v = int(rec.get("scope_version") or 0)
+        except (TypeError, ValueError):
+            v = 0
+        if v > highest:
+            highest = v
+    for legacy_path in Path(phase_dir).glob("design-addendum-*.md"):
+        m = LEGACY_MD_PATTERN.search(legacy_path.name)
+        if m:
+            try:
+                v = int(m.group(1))
+            except ValueError:
+                continue
+            if v > highest:
+                highest = v
+    return highest + 1
+
+
+def _iter_jsonl(phase_dir: Path) -> Iterable[Dict[str, Any]]:
+    """Yield parsed JSONL records from ``amendments.jsonl`` if present."""
+    path = _amendments_path(phase_dir)
+    if not path.exists():
+        return
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                # Skip corrupt lines so one bad record doesn't blind the
+                # whole log. Upstream linter flags these separately.
+                continue
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def append(
+    phase_dir: Path,
+    *,
+    trigger: str,
+    summary: str,
+    patches: Optional[List[Dict[str, Any]]] = None,
+    resolution_refs: Optional[List[str]] = None,
+    amendment_id: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Append one amendment record to ``phase_dir/amendments.jsonl``.
+
+    Args:
+        phase_dir: ``phases/{phase}/`` directory. Created if missing.
+        trigger: One of :data:`VALID_TRIGGERS`.
+        summary: One-line human summary (trimmed, required).
+        patches: Optional list of structured patch descriptors.
+        resolution_refs: Optional list of back-links (condition IDs,
+            PR numbers, commit SHAs, etc.).
+        amendment_id: Optional explicit id. When omitted, one is
+            auto-generated as ``AMD-<slug(summary)>-<ts-compact>``.
+        extra: Optional dict merged into the record for forward-compat
+            fields. Reserved keys (``amendment_id``, ``trigger``, ...)
+            cannot be overridden.
+
+    Returns:
+        The full amendment record that was appended, including the
+        resolved ``amendment_id``, ``scope_version``, and ``timestamp``.
+
+    Raises:
+        ValueError: on missing/invalid fields.
+        OSError: on filesystem errors.
+    """
+    phase_dir = Path(phase_dir)
+    phase_dir.mkdir(parents=True, exist_ok=True)
+
+    # Reject non-list patches before any disk mutation so the caller sees
+    # a predictable ValueError rather than a TypeError from ``list(...)``.
+    if patches is not None and not isinstance(patches, list):
+        raise ValueError("amendment 'patches' must be a list when present")
+
+    timestamp = _utc_now_iso()
+    scope_version = _next_scope_version(phase_dir)
+
+    if not amendment_id:
+        # Compact timestamp suffix keeps the id shell-safe.
+        ts_compact = re.sub(r"[^0-9]", "", timestamp)[:14]
+        amendment_id = (
+            f"{AMENDMENT_ID_PREFIX}-{_slugify(summary)}-{ts_compact}"
+        )
+
+    record: Dict[str, Any] = {
+        "amendment_id": amendment_id,
+        "trigger": trigger,
+        "scope_version": scope_version,
+        "timestamp": timestamp,
+        "summary": summary.strip(),
+        "patches": list(patches or []),
+        "resolution_refs": list(resolution_refs or []),
+    }
+    if extra:
+        for k, v in extra.items():
+            record.setdefault(k, v)
+
+    _validate_record(record)
+
+    path = _amendments_path(phase_dir)
+    # Append with newline terminator. JSONL is append-only by contract;
+    # callers MUST NOT rewrite earlier lines.
+    line = json.dumps(record, sort_keys=False) + "\n"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except OSError:
+            # Fsync not supported (e.g. tmpfs, some FUSE backends).
+            # The append is still durable within the OS page cache for
+            # crash-safety in the typical case.
+            pass  # fail open: fsync unsupported on this FS
+
+    return record
+
+
+def list_amendments(
+    phase_dir: Path,
+    *,
+    include_legacy: bool = True,
+) -> List[Dict[str, Any]]:
+    """Return all amendments for a phase, JSONL first then legacy .md.
+
+    Args:
+        phase_dir: ``phases/{phase}/`` directory.
+        include_legacy: When True (default), legacy
+            ``design-addendum-N.md`` files are surfaced as pseudo-records
+            with ``source="legacy-md"`` and ``path`` pointing at the .md.
+
+    Returns:
+        List of amendment records sorted by ``scope_version``. Records
+        that cannot be parsed are skipped.
+    """
+    phase_dir = Path(phase_dir)
+    out: List[Dict[str, Any]] = []
+
+    for rec in _iter_jsonl(phase_dir):
+        rec.setdefault("source", "jsonl")
+        out.append(rec)
+
+    if include_legacy and phase_dir.exists():
+        for legacy_path in sorted(phase_dir.glob("design-addendum-*.md")):
+            m = LEGACY_MD_PATTERN.search(legacy_path.name)
+            if not m:
+                continue
+            try:
+                version = int(m.group(1))
+            except ValueError:
+                continue
+            try:
+                stat = legacy_path.stat()
+                mtime = datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).isoformat().replace("+00:00", "Z")
+            except OSError:
+                mtime = ""
+            out.append({
+                "amendment_id": f"LEGACY-{version}",
+                "trigger": "manual",
+                "scope_version": version,
+                "timestamp": mtime,
+                "summary": legacy_path.name,
+                "patches": [],
+                "resolution_refs": [],
+                "source": "legacy-md",
+                "path": str(legacy_path),
+            })
+
+    out.sort(key=lambda r: int(r.get("scope_version") or 0))
+    return out
+
+
+def render_markdown(amendments: List[Dict[str, Any]]) -> str:
+    """Render a list of amendments as human-readable markdown."""
+    if not amendments:
+        return "# Amendments\n\n_No amendments recorded._\n"
+
+    lines: List[str] = ["# Amendments", ""]
+    for rec in amendments:
+        header = (
+            f"## v{rec.get('scope_version', '?')} — "
+            f"{rec.get('amendment_id', 'UNKNOWN')}"
+        )
+        lines.append(header)
+        lines.append("")
+        lines.append(f"- **trigger:** {rec.get('trigger', 'manual')}")
+        lines.append(f"- **timestamp:** {rec.get('timestamp', '')}")
+        source = rec.get("source")
+        if source and source != "jsonl":
+            lines.append(f"- **source:** {source}")
+        if rec.get("path"):
+            lines.append(f"- **path:** `{rec['path']}`")
+        summary = rec.get("summary") or ""
+        if summary:
+            lines.append("")
+            lines.append(summary)
+        patches = rec.get("patches") or []
+        if patches:
+            lines.append("")
+            lines.append("### Patches")
+            for p in patches:
+                target = p.get("target", "?")
+                op = p.get("operation", "?")
+                rationale = p.get("rationale", "")
+                lines.append(f"- `{target}` ({op}) — {rationale}")
+        refs = rec.get("resolution_refs") or []
+        if refs:
+            lines.append("")
+            lines.append("### Resolution refs")
+            for r in refs:
+                lines.append(f"- {r}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _resolve_phase_dir(
+    project: Optional[str], phase: str
+) -> Path:
+    """Resolve ``phases/{phase}/`` for the given project.
+
+    When ``project`` is provided, uses ``crew.py find-project`` via
+    :mod:`_domain_store` through a lightweight path convention:
+    ``~/.something-wicked/wicked-crew/local/projects/{project}/phases/{phase}``
+    — but we don't hardcode that path. Instead we re-use the same
+    resolver ``phase_manager.py`` uses.
+
+    When ``project`` is None or the resolver is unavailable, treats
+    ``phase`` as a filesystem path (``./phases/{phase}``) relative to
+    the current working directory — useful for tests.
+    """
+    if project:
+        try:
+            here = Path(__file__).resolve().parent.parent
+            if str(here) not in sys.path:
+                sys.path.insert(0, str(here))
+            from _domain_store import get_local_path  # type: ignore
+            base = Path(get_local_path("wicked-crew")) / "projects" / project
+            candidate = base / "phases" / phase
+            if candidate.parent.exists():
+                return candidate
+        except Exception:
+            # Fall through to relative resolution.
+            pass  # intentional: CLI fallback to cwd-relative phase_dir
+    return Path.cwd() / "phases" / phase
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    phase_dir = _resolve_phase_dir(args.project, args.phase)
+    amendments = list_amendments(
+        phase_dir, include_legacy=not args.no_legacy
+    )
+    if args.json:
+        print(json.dumps(amendments, indent=2))
+    else:
+        print(render_markdown(amendments))
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="amendments",
+        description="Append-only amendments log CLI (#478).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    show = sub.add_parser(
+        "show", help="Render amendments for a phase as markdown."
+    )
+    show.add_argument("phase", help="Phase name (e.g. 'design').")
+    show.add_argument("--project", help="Project name.", default=None)
+    show.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of markdown.",
+    )
+    show.add_argument(
+        "--no-legacy",
+        action="store_true",
+        help="Skip legacy design-addendum-N.md files.",
+    )
+    show.set_defaults(func=_cmd_show)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "AMENDMENTS_FILENAME",
+    "VALID_TRIGGERS",
+    "append",
+    "list_amendments",
+    "render_markdown",
+    "main",
+]

--- a/scripts/crew/conditions_manifest.py
+++ b/scripts/crew/conditions_manifest.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Conditions manifest helpers — atomic, crash-safe mutations (issue #477).
+
+Writing `conditions-manifest.json` is a multi-step operation: the caller
+typically lands a resolution artifact on disk (e.g. a design addendum or
+a patched file), then flips the matching condition entry to
+``verified=True``. If the process dies between those two writes, the
+addendum is on disk but the manifest still reports the condition
+uncleared. This module centralizes the correct ordering — write the
+resolution reference first, fsync, update the manifest, fsync — so a
+crash between the two steps leaves the system in a state that a
+recovery pass can reconcile deterministically.
+
+Public helpers:
+    - ``mark_cleared(manifest_path, condition_id, resolution_ref)``:
+      clear one condition atomically. Returns the updated manifest dict.
+    - ``recover(manifest_path, resolutions_dir)``: scan the resolutions
+      directory on disk and fill in manifest entries where the resolution
+      artifact landed but the flip never completed.
+
+All writes go through :func:`atomic_write_json` which writes to a
+``<path>.tmp`` file, ``fsync``s it, and then ``os.replace``s the
+temporary file over the target. On POSIX ``os.replace`` is atomic; on
+Windows it is atomic as of Python 3.3.
+
+The helpers are fail-open in the sense that they raise
+``FileNotFoundError`` / ``ValueError`` on hard input problems (missing
+manifest, missing condition id) rather than swallow them — crash safety
+cannot rescue a caller who is pointing at the wrong file. But they do
+not raise on partial state on disk; partial state is exactly what
+:func:`recover` exists to fix.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# The resolution-reference file written by ``mark_cleared`` BEFORE the
+# manifest flip. Recovery keys off the presence of this sidecar.
+RESOLUTION_SIDECAR_SUFFIX = ".resolution.json"
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string with Z suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Write ``data`` as JSON to ``path`` atomically with fsync.
+
+    Sequence:
+        1. Serialize JSON to ``<path>.tmp``.
+        2. ``fsync`` the temp file descriptor (durability on POSIX).
+        3. ``os.replace`` the temp file over ``path`` (atomic rename).
+        4. ``fsync`` the parent directory if possible (POSIX only —
+           silently skipped on Windows, where directory fsync is not
+           supported).
+
+    Args:
+        path: Destination file path (will be created or overwritten).
+        data: JSON-serializable value.
+
+    Raises:
+        OSError: If the write, rename, or fsync fails.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    payload = json.dumps(data, indent=2, sort_keys=False)
+
+    # Write + fsync the temp file.
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except OSError:
+            # Fsync can fail on filesystems that don't support it (e.g.
+            # some FUSE mounts). The atomic rename below still provides
+            # ordering correctness for recovery — durability is the only
+            # thing we lose. Swallow and proceed.
+            pass  # fail open: durability best-effort on non-fsync FS
+
+    os.replace(tmp_path, path)
+
+    # Best-effort parent directory fsync. Not available on Windows
+    # (opening a directory for reading is not permitted); swallow any
+    # failure since durability is best-effort on non-POSIX platforms.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except (OSError, AttributeError):
+        pass  # fail open: directory fsync unsupported (Windows / FUSE)
+
+
+def _resolution_sidecar_path(manifest_path: Path, condition_id: str) -> Path:
+    """Return the sidecar path that records a resolution reference.
+
+    Sidecar lives next to the manifest so recovery is a single-directory
+    scan. Filename shape: ``<manifest-stem>.<condition-id>.resolution.json``.
+    """
+    stem = manifest_path.stem  # "conditions-manifest"
+    safe_id = condition_id.replace("/", "_").replace("\\", "_")
+    return manifest_path.parent / f"{stem}.{safe_id}{RESOLUTION_SIDECAR_SUFFIX}"
+
+
+def _load_manifest(manifest_path: Path) -> Dict[str, Any]:
+    """Load a manifest file, raising FileNotFoundError if missing."""
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"conditions-manifest.json not found at {manifest_path}"
+        )
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _find_condition_index(
+    manifest: Dict[str, Any], condition_id: str
+) -> int:
+    """Return the index of ``condition_id`` in ``manifest['conditions']``.
+
+    Raises:
+        ValueError: if no matching condition is found.
+    """
+    conditions: List[Dict[str, Any]] = manifest.get("conditions") or []
+    for idx, cond in enumerate(conditions):
+        if cond.get("id") == condition_id:
+            return idx
+    raise ValueError(
+        f"condition id '{condition_id}' not found in manifest "
+        f"(available: {[c.get('id') for c in conditions]})"
+    )
+
+
+def mark_cleared(
+    manifest_path: Path,
+    condition_id: str,
+    resolution_ref: str,
+    *,
+    note: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Clear one condition atomically.
+
+    Write ordering (crash-safe):
+
+        1. Write resolution sidecar to disk + fsync.
+        2. Load manifest, flip condition to ``verified=True``.
+        3. Atomically replace the manifest file + fsync.
+
+    If the process crashes between step 1 and step 3, the sidecar is on
+    disk but the manifest still reports the condition as unverified.
+    :func:`recover` finds such orphans on startup and finishes step 3.
+
+    Args:
+        manifest_path: Path to ``conditions-manifest.json``.
+        condition_id: ID of the condition to clear (e.g. ``"CONDITION-1"``).
+        resolution_ref: Path or URI to the artifact that resolves this
+            condition (e.g. a design addendum, a test result, a commit
+            SHA). Stored verbatim in the manifest and sidecar.
+        note: Optional free-text note explaining the resolution.
+
+    Returns:
+        The updated manifest dict.
+
+    Raises:
+        FileNotFoundError: if ``manifest_path`` does not exist.
+        ValueError: if ``condition_id`` is not present in the manifest.
+    """
+    manifest_path = Path(manifest_path)
+    manifest = _load_manifest(manifest_path)
+    idx = _find_condition_index(manifest, condition_id)
+
+    timestamp = _utc_now_iso()
+    sidecar = {
+        "condition_id": condition_id,
+        "resolution_ref": resolution_ref,
+        "note": note,
+        "written_at": timestamp,
+    }
+
+    # Step 1: resolution sidecar lands first. A crash after this point
+    # leaves a "claim" on disk that recovery can act on.
+    sidecar_path = _resolution_sidecar_path(manifest_path, condition_id)
+    atomic_write_json(sidecar_path, sidecar)
+
+    # Step 2: mutate the manifest in memory.
+    condition = manifest["conditions"][idx]
+    condition["verified"] = True
+    condition["resolution"] = resolution_ref
+    condition["verified_at"] = timestamp
+    if note is not None:
+        condition["resolution_note"] = note
+
+    # Step 3: atomic manifest replace.
+    atomic_write_json(manifest_path, manifest)
+
+    return manifest
+
+
+def recover(
+    manifest_path: Path,
+) -> List[str]:
+    """Reconcile orphan sidecars against the manifest.
+
+    Scans for ``<manifest-stem>.<id>.resolution.json`` sidecars in the
+    manifest's directory. For each sidecar whose condition is still
+    marked ``verified=False`` in the manifest, flips the condition using
+    the sidecar's ``resolution_ref`` and ``written_at`` values.
+
+    Idempotent — running recovery twice on the same on-disk state is a
+    no-op the second time.
+
+    Args:
+        manifest_path: Path to ``conditions-manifest.json``.
+
+    Returns:
+        List of condition IDs that were reconciled during this call.
+        Empty list when nothing needed reconciling.
+
+    Raises:
+        FileNotFoundError: if ``manifest_path`` does not exist.
+    """
+    manifest_path = Path(manifest_path)
+    manifest = _load_manifest(manifest_path)
+
+    stem = manifest_path.stem
+    directory = manifest_path.parent
+    prefix = f"{stem}."
+    suffix = RESOLUTION_SIDECAR_SUFFIX
+
+    reconciled: List[str] = []
+    mutated = False
+
+    for sidecar_path in sorted(directory.glob(f"{stem}.*{suffix}")):
+        name = sidecar_path.name
+        if not (name.startswith(prefix) and name.endswith(suffix)):
+            continue
+        condition_id = name[len(prefix): -len(suffix)]
+        try:
+            sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # Corrupt sidecar — skip. Don't let one bad file block the
+            # rest of recovery.
+            continue
+
+        try:
+            idx = _find_condition_index(manifest, condition_id)
+        except ValueError:
+            # Sidecar points at a condition that no longer exists in the
+            # manifest (e.g. manifest was regenerated). Leave sidecar
+            # alone so a human can investigate.
+            continue
+
+        condition = manifest["conditions"][idx]
+        if condition.get("verified"):
+            # Already cleared — nothing to do.
+            continue
+
+        condition["verified"] = True
+        condition["resolution"] = sidecar.get("resolution_ref")
+        condition["verified_at"] = sidecar.get("written_at") or _utc_now_iso()
+        if sidecar.get("note") is not None:
+            condition["resolution_note"] = sidecar.get("note")
+        reconciled.append(condition_id)
+        mutated = True
+
+    if mutated:
+        atomic_write_json(manifest_path, manifest)
+
+    return reconciled
+
+
+__all__ = [
+    "RESOLUTION_SIDECAR_SUFFIX",
+    "atomic_write_json",
+    "mark_cleared",
+    "recover",
+]

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -1353,6 +1353,103 @@ def _record_dispatch(
         )
 
 
+# ---------------------------------------------------------------------------
+# Shared reviewer context (issue #474)
+#
+# Writing the same "here is the phase, here are the deliverables, here are
+# the prior-phase gate findings" block into every reviewer brief is wasteful
+# — reviewers in a parallel dispatch all read the same upstream context.
+# The phase-executor produces a single ``phases/{phase}/reviewer-context.md``
+# up-front, and `_dispatch_gate_reviewer` + friends pass the file PATH into
+# the reviewer brief instead of re-embedding the content. Reviewers open the
+# file themselves with Read when they need it.
+#
+# Design constraints:
+#   - The helper is idempotent: if ``reviewer-context.md`` already exists,
+#     it is left alone. The phase-executor is the canonical writer; the
+#     dispatcher is only a fallback when the executor didn't produce one.
+#   - The helper is fail-open: when writing is not possible (no project_dir,
+#     no filesystem access), the dispatcher still injects whatever path it
+#     *would* have written so reviewer briefs remain consistent in shape.
+#   - Content is minimal — reviewer-specific context stays in the reviewer
+#     brief. The file is a pointer, not a replacement for reviewer prompts.
+# ---------------------------------------------------------------------------
+
+REVIEWER_CONTEXT_FILENAME = "reviewer-context.md"
+
+
+def _reviewer_context_path(project_dir: Path, phase: str) -> Path:
+    """Return the canonical reviewer-context.md path for ``(project, phase)``.
+
+    Does not read / write — just the location. Callers use
+    :func:`ensure_reviewer_context` to materialize content when absent.
+    """
+    return Path(project_dir) / "phases" / phase / REVIEWER_CONTEXT_FILENAME
+
+
+def ensure_reviewer_context(
+    state: Optional["ProjectState"],
+    phase: str,
+    gate_name: str,
+) -> Optional[Path]:
+    """Ensure ``phases/{phase}/reviewer-context.md`` exists; return its path.
+
+    The phase-executor is the canonical writer for this file (per #474), but
+    when the dispatcher is called outside a full phase-execution (e.g. a
+    manual ``/wicked-garden:crew:gate`` re-run), we still want reviewers to
+    be pointed at a file. This helper performs a cheap stub-write when
+    missing so reviewer briefs always carry a valid path.
+
+    Fails open: returns ``None`` when the path cannot be resolved (no
+    state, no project_dir, filesystem not writable). Callers handle
+    ``None`` by omitting the shared-context line from the reviewer brief.
+
+    Args:
+        state: Optional project state used to resolve ``project_dir``.
+        phase: Phase name under ``phases/``.
+        gate_name: Gate being dispatched — embedded in the stub so the
+            generated file is self-describing when recovered post-hoc.
+
+    Returns:
+        Absolute path to the reviewer-context.md file, or ``None`` if
+        not resolvable.
+    """
+    if state is None or not getattr(state, "name", None):
+        return None
+    try:
+        project_dir = get_project_dir(state.name)
+    except (ValueError, Exception):
+        return None
+
+    context_path = _reviewer_context_path(project_dir, phase)
+    if context_path.exists():
+        return context_path
+
+    try:
+        context_path.parent.mkdir(parents=True, exist_ok=True)
+        stub = (
+            f"# Reviewer Context — {state.name} / phase={phase}\n"
+            f"\n"
+            f"_Auto-generated stub. The phase-executor should produce a "
+            f"richer reviewer-context.md during phase execution._\n"
+            f"\n"
+            f"- **project:** {state.name}\n"
+            f"- **phase:** {phase}\n"
+            f"- **gate:** {gate_name}\n"
+            f"- **generated_at:** {get_utc_timestamp()}\n"
+            f"\n"
+            f"## Deliverables to review\n"
+            f"\n"
+            f"See `phases/{phase}/` for the full set of deliverables. "
+            f"Prior-phase gate findings live in "
+            f"`phases/*/gate-result.json`.\n"
+        )
+        context_path.write_text(stub, encoding="utf-8")
+    except OSError:
+        return None
+    return context_path
+
+
 def _banned_reviewer_error(reviewer: str) -> Optional[str]:
     """Return a reason string if `reviewer` is banned; None otherwise.
 
@@ -1606,6 +1703,7 @@ def _dispatch_fast_evaluator(
     *,
     dispatcher: Optional[Any] = None,
     fallback_reviewer: str = "gate-evaluator",
+    shared_context_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Fast-path dispatcher for self-check / advisory / empty-reviewers gates.
 
@@ -1617,16 +1715,27 @@ def _dispatch_fast_evaluator(
     # out-of-band gate-result written by a rogue agent fails the orphan
     # check. Fail-open — errors do not block dispatch.
     _record_dispatch(state, phase, gate_name, fallback_reviewer)
-    ctx = _strip_executor_self_score({
+    ctx: Dict[str, Any] = {
         "gate_name": gate_name,
         "phase": phase,
         "project": getattr(state, "name", None) if state is not None else None,
         "mode": "fast-evaluator",
-    })
+    }
+    # #474 — inject the shared reviewer-context.md path (not the content).
+    if shared_context_path is not None:
+        ctx["shared_context_path"] = str(shared_context_path)
+    # #473 — strip executor self-score keys before dispatching to reviewers.
+    ctx = _strip_executor_self_score(ctx)
     if dispatcher is None:
         return _empty_verdict_stub(
             gate_name, phase, "dispatcher-unavailable", reviewer=fallback_reviewer
         )
+    shared_line = (
+        f" Shared reviewer context: read `{shared_context_path}` for phase-wide "
+        f"deliverable and prior-finding context."
+        if shared_context_path is not None
+        else ""
+    )
     try:
         raw = dispatcher(
             "wicked-garden:crew:gate-evaluator",
@@ -1634,7 +1743,7 @@ def _dispatch_fast_evaluator(
                 f"Evaluate gate '{gate_name}' for phase '{phase}'. "
                 "Read gate-policy.json for objective thresholds and the "
                 f"deliverables under phases/{phase}/. Emit verdict + score + "
-                "reason + conditions."
+                "reason + conditions." + shared_line
             ),
             ctx,
         )
@@ -1658,6 +1767,7 @@ def _dispatch_sequential(
     reviewers: List[str],
     *,
     dispatcher: Optional[Any] = None,
+    shared_context_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Dispatch reviewers in order, stopping on the first REJECT.
 
@@ -1672,25 +1782,38 @@ def _dispatch_sequential(
         _record_dispatch(state, phase, gate_name, _reviewer)
     if not reviewers:
         return _dispatch_fast_evaluator(
-            state, phase, gate_name, dispatcher=dispatcher
+            state, phase, gate_name, dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
     if dispatcher is None:
         return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
 
+    shared_line = (
+        f" Shared reviewer context: read `{shared_context_path}` for phase-wide "
+        f"deliverable and prior-finding context."
+        if shared_context_path is not None
+        else ""
+    )
+
     collected: List[Dict[str, Any]] = []
     for reviewer in reviewers:
+        ctx: Dict[str, Any] = {
+            "gate_name": gate_name,
+            "phase": phase,
+            "reviewer": reviewer,
+        }
+        if shared_context_path is not None:
+            ctx["shared_context_path"] = str(shared_context_path)
+        # #473 — strip executor self-score keys before dispatching to reviewers.
+        ctx = _strip_executor_self_score(ctx)
         try:
             raw = dispatcher(
                 f"wicked-garden:crew:{reviewer}",
                 (
                     f"Review gate '{gate_name}' for phase '{phase}' as {reviewer}. "
-                    "Emit verdict + score + reason + conditions."
+                    "Emit verdict + score + reason + conditions." + shared_line
                 ),
-                _strip_executor_self_score({
-                    "gate_name": gate_name,
-                    "phase": phase,
-                    "reviewer": reviewer,
-                }),
+                ctx,
             )
         except Exception as exc:  # pragma: no cover — defensive
             raw = {"verdict": "CONDITIONAL", "score": 0.0,
@@ -1716,6 +1839,7 @@ def _dispatch_parallel_and_merge(
     reviewers: List[str],
     *,
     dispatcher: Optional[Any] = None,
+    shared_context_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Dispatch all reviewers in a single-message parallel Agent batch (SC-6).
 
@@ -1733,10 +1857,18 @@ def _dispatch_parallel_and_merge(
         _record_dispatch(state, phase, gate_name, _reviewer)
     if not reviewers:
         return _dispatch_fast_evaluator(
-            state, phase, gate_name, dispatcher=dispatcher
+            state, phase, gate_name, dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
     if dispatcher is None:
         return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
+
+    shared_line = (
+        f" Shared reviewer context: read `{shared_context_path}` for phase-wide "
+        f"deliverable and prior-finding context."
+        if shared_context_path is not None
+        else ""
+    )
 
     per_reviewer: List[Dict[str, Any]] = []
     # Attempt batched dispatch first via a sentinel subagent_type. If the
@@ -1744,19 +1876,24 @@ def _dispatch_parallel_and_merge(
     # we then fall back to per-reviewer dispatch. The caller supplies
     # whichever style they support.
     batched: Any = None
+    batch_ctx: Dict[str, Any] = {
+        "gate_name": gate_name,
+        "phase": phase,
+        "reviewers": reviewers,
+        "mode": "parallel",
+    }
+    if shared_context_path is not None:
+        batch_ctx["shared_context_path"] = str(shared_context_path)
+    # #473 — strip executor self-score keys before dispatching to reviewers.
+    batch_ctx = _strip_executor_self_score(batch_ctx)
     try:
         batched = dispatcher(
             "wicked-garden:crew:_parallel_batch",
             (
                 f"Dispatch reviewers in parallel for gate '{gate_name}' "
-                f"phase '{phase}'. reviewers={reviewers}"
+                f"phase '{phase}'. reviewers={reviewers}" + shared_line
             ),
-            _strip_executor_self_score({
-                "gate_name": gate_name,
-                "phase": phase,
-                "reviewers": reviewers,
-                "mode": "parallel",
-            }),
+            batch_ctx,
         )
     except Exception:
         batched = None
@@ -1786,19 +1923,25 @@ def _dispatch_parallel_and_merge(
         # loop itself.)
         count_before = _dispatcher_call_count(dispatcher)
         for reviewer in reviewers:
+            ctx: Dict[str, Any] = {
+                "gate_name": gate_name,
+                "phase": phase,
+                "reviewer": reviewer,
+                "mode": "parallel",
+            }
+            if shared_context_path is not None:
+                ctx["shared_context_path"] = str(shared_context_path)
+            # #473 — strip executor self-score keys before dispatching.
+            ctx = _strip_executor_self_score(ctx)
             try:
                 raw = dispatcher(
                     f"wicked-garden:crew:{reviewer}",
                     (
                         f"Review gate '{gate_name}' for phase '{phase}' as "
                         f"{reviewer}. Emit verdict + score + reason + conditions."
+                        + shared_line
                     ),
-                    _strip_executor_self_score({
-                        "gate_name": gate_name,
-                        "phase": phase,
-                        "reviewer": reviewer,
-                        "mode": "parallel",
-                    }),
+                    ctx,
                 )
             except Exception as exc:  # pragma: no cover
                 raw = {"verdict": "CONDITIONAL", "score": 0.0,
@@ -1832,6 +1975,7 @@ def _dispatch_council(
     *,
     min_concurrence: float = 0.6,
     dispatcher: Optional[Any] = None,
+    shared_context_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Council dispatch — parallel plurality vote with concurrence threshold.
 
@@ -1851,13 +1995,16 @@ def _dispatch_council(
         )
     if not reviewers:
         return _dispatch_fast_evaluator(
-            state, phase, gate_name, dispatcher=dispatcher
+            state, phase, gate_name, dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
     if dispatcher is None:
         return _empty_verdict_stub(gate_name, phase, "dispatcher-unavailable")
 
     merged = _dispatch_parallel_and_merge(
-        state, phase, gate_name, reviewers, dispatcher=dispatcher
+        state, phase, gate_name, reviewers,
+        dispatcher=dispatcher,
+        shared_context_path=shared_context_path,
     )
     merged["dispatch_mode"] = "council"
 
@@ -1955,6 +2102,12 @@ def _dispatch_gate_reviewer(
     reviewers = list(gate_policy_entry.get("reviewers") or [])
     fallback = gate_policy_entry.get("fallback") or "gate-evaluator"
 
+    # #474 — materialize a shared reviewer-context.md ONCE and pass the
+    # path into every reviewer brief instead of re-embedding context.
+    # Fail-open: when the file cannot be resolved, downstream helpers
+    # simply omit the ``shared_context_path`` key from their context dicts.
+    shared_context_path = ensure_reviewer_context(state, phase, gate_name)
+
     # BLEND RULE — fast path when no reviewers or advisory/self-check.
     if not reviewers or mode in ("self-check", "advisory"):
         return _dispatch_fast_evaluator(
@@ -1963,19 +2116,26 @@ def _dispatch_gate_reviewer(
             gate_name,
             dispatcher=dispatcher,
             fallback_reviewer=fallback,
+            shared_context_path=shared_context_path,
         )
 
     if mode == "sequential":
         return _dispatch_sequential(
-            state, phase, gate_name, reviewers, dispatcher=dispatcher
+            state, phase, gate_name, reviewers,
+            dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
     if mode == "parallel":
         return _dispatch_parallel_and_merge(
-            state, phase, gate_name, reviewers, dispatcher=dispatcher
+            state, phase, gate_name, reviewers,
+            dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
     if mode == "council":
         return _dispatch_council(
-            state, phase, gate_name, reviewers, dispatcher=dispatcher
+            state, phase, gate_name, reviewers,
+            dispatcher=dispatcher,
+            shared_context_path=shared_context_path,
         )
 
     # Unknown mode — conservative stub (do not raise: this path runs inside

--- a/skills/crew/explain/SKILL.md
+++ b/skills/crew/explain/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: explain
+description: |
+  Translate jargon-heavy crew output into plain language. Input is typically a
+  gate finding, reviewer brief, phase summary, or process plan containing
+  specialist vocab (RED, BLOCK, convergence, blast radius, parallelization_check,
+  CONDITIONAL, BLEND rule, etc.). Output is 2-4 sentences at a grade-8 reading
+  level with no specialist vocab left behind.
+
+  Use when: "explain this", "in plain English", "what does this mean",
+  "translate for me", "simplify", "dumb this down", or any request to render
+  crew jargon into language a non-practitioner can act on. Also used
+  automatically by the orchestrator when `crew.output_style = paired` or
+  `plain-only` — the skill produces the `**Plain:**` line.
+---
+
+# /wicked-garden:crew:explain
+
+Convert crew output to plain language. Grade-8 reading level. No jargon.
+
+## When to invoke
+
+- A gate finding with terms like REJECT, CONDITIONAL, BLOCK, convergence
+- A reviewer brief that references BLEND rule, parallelization_check,
+  dispatch_log, conditions-manifest, etc.
+- A process plan that uses rigor tiers, blast radius, reversibility scores
+- Anyone asking "in plain English" or "what does this actually mean"
+
+## Output rules
+
+- **Length**: 2-4 sentences. Never more.
+- **Reading level**: Grade 8. Short sentences. Plain verbs.
+- **No specialist vocab**. Do not use any of:
+  - REJECT, APPROVE, CONDITIONAL → say "blocked", "cleared", "needs fixes"
+  - BLEND rule, min_score, per_reviewer_verdicts → say "the reviewers agreed"
+  - convergence, Integrated, Wired → say "the code is hooked up" / "still missing"
+  - blast radius → say "what else this change could break"
+  - rigor tier, complexity score → say "how careful we're being"
+  - dispatch, council, parallel → say "we asked more than one reviewer"
+  - conditions-manifest, addendum, JSONL → say "the fix list" / "the log"
+- **Tell them what to DO next**, not what the system computed.
+
+## Output styles (orchestrator `crew.output_style`)
+
+The skill supports three modes set by `crew.output_style` in project config:
+
+| Mode | Behavior |
+|------|----------|
+| `paired` (default) | Keep the original jargon block, append `**Plain:**` line |
+| `terse` | Jargon only — skill is not invoked |
+| `plain-only` | Replace jargon entirely with the plain-language version |
+
+When invoked by the orchestrator, it passes the current mode in the prompt.
+When invoked directly by a user, default to `plain-only`.
+
+## Process
+
+1. Read the jargon-heavy input block.
+2. Identify the decision or state (did something pass, fail, or need work?).
+3. Identify the next action (what the user should do).
+4. Write 2-4 sentences:
+   - Sentence 1: what happened / what the state is
+   - Sentence 2 (optional): why it matters in one human concern
+   - Sentence 3-4: what to do next — concrete, actionable
+5. Scan the draft for specialist vocab (see list above). Replace anything that
+   survived with plain-English equivalents. Re-check grade level.
+6. Emit the final block in the format dictated by `crew.output_style`.
+
+## Example — paired mode
+
+**Input (jargon):**
+
+```
+Gate: code-quality — verdict: CONDITIONAL (score 0.62, min 0.70)
+  per_reviewer_verdicts:
+    - senior-engineer: CONDITIONAL — "god function in handler.py:process()"
+    - security-engineer: APPROVE
+  conditions-manifest.json written with 1 condition.
+```
+
+**Output:**
+
+```
+Gate: code-quality — verdict: CONDITIONAL (score 0.62, min 0.70)
+  per_reviewer_verdicts:
+    - senior-engineer: CONDITIONAL — "god function in handler.py:process()"
+    - security-engineer: APPROVE
+  conditions-manifest.json written with 1 condition.
+
+**Plain:** One reviewer flagged that `handler.py` has a giant function that
+does too much. Security was fine. Split the function into smaller pieces,
+then re-run the gate to clear the finding before moving to the next phase.
+```
+
+## Example — plain-only mode
+
+**Input (jargon):** same as above.
+
+**Output:**
+
+```
+One reviewer flagged that `handler.py` has a giant function that does too
+much. Security was fine. Split the function into smaller pieces, then re-run
+the gate to clear the finding before moving to the next phase.
+```
+
+## What NOT to do
+
+- Don't editorialize ("this is concerning", "surprisingly"). Stick to facts.
+- Don't add new recommendations the original output didn't contain.
+- Don't drop to sub-grade-8 (child-like) — aim for clear adult language.
+- Don't use more than 4 sentences. If the source has 10 findings, group them:
+  "Three reviewers found issues in X, Y, and Z."
+
+## Configuration
+
+Project-level configuration lives in the orchestrator config under
+`crew.output_style`:
+
+```json
+{
+  "crew": {
+    "output_style": "paired"
+  }
+}
+```
+
+Valid values: `terse` | `paired` | `plain-only`. Default: `paired`.

--- a/tests/crew/test_amendments.py
+++ b/tests/crew/test_amendments.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/crew/amendments.py (issue #478).
+
+Covers:
+    - append writes a JSONL record and assigns a monotonic scope_version.
+    - Validator rejects bad triggers and missing required fields.
+    - list_amendments merges JSONL + legacy design-addendum-N.md.
+    - render_markdown produces a non-empty report with section headers.
+    - scope_version continues counting past legacy .md addenda.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = _REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "crew"))
+
+import amendments  # noqa: E402  (path setup above)
+
+
+class AppendTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.phase_dir = Path(self.tmp.name) / "phases" / "design"
+
+    def test_append_assigns_monotonic_scope_version(self) -> None:
+        r1 = amendments.append(
+            self.phase_dir,
+            trigger="gate-conditional",
+            summary="first fix",
+        )
+        r2 = amendments.append(
+            self.phase_dir,
+            trigger="re-eval",
+            summary="second fix",
+        )
+        self.assertEqual(r1["scope_version"], 1)
+        self.assertEqual(r2["scope_version"], 2)
+
+        # JSONL file has exactly two lines.
+        path = self.phase_dir / "amendments.jsonl"
+        self.assertTrue(path.exists())
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 2)
+
+        # Each line is a valid JSON object with the expected keys.
+        parsed = [json.loads(ln) for ln in lines]
+        for rec in parsed:
+            for key in ("amendment_id", "trigger", "scope_version",
+                        "timestamp", "summary", "patches", "resolution_refs"):
+                self.assertIn(key, rec)
+
+    def test_append_rejects_invalid_trigger(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            amendments.append(
+                self.phase_dir,
+                trigger="not-a-real-trigger",
+                summary="x",
+            )
+        self.assertIn("trigger", str(ctx.exception).lower())
+
+    def test_append_rejects_missing_summary(self) -> None:
+        with self.assertRaises(ValueError):
+            amendments.append(
+                self.phase_dir,
+                trigger="manual",
+                summary="",
+            )
+
+    def test_append_rejects_non_list_patches(self) -> None:
+        with self.assertRaises(ValueError):
+            amendments.append(
+                self.phase_dir,
+                trigger="manual",
+                summary="ok",
+                patches={"not": "a list"},  # type: ignore[arg-type]
+            )
+
+    def test_append_accepts_and_preserves_resolution_refs(self) -> None:
+        record = amendments.append(
+            self.phase_dir,
+            trigger="gate-conditional",
+            summary="clarify acceptance criterion",
+            patches=[{"target": "design.md#FR-3", "operation": "replace",
+                      "rationale": "align with SLO"}],
+            resolution_refs=["CONDITION-1", "CONDITION-2"],
+        )
+        self.assertEqual(
+            record["resolution_refs"], ["CONDITION-1", "CONDITION-2"]
+        )
+        self.assertEqual(len(record["patches"]), 1)
+
+
+class LegacyCompatTests(unittest.TestCase):
+    """Legacy design-addendum-N.md files remain readable and count toward
+    the scope_version sequence."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.phase_dir = Path(self.tmp.name) / "phases" / "design"
+        self.phase_dir.mkdir(parents=True)
+
+        # Plant two legacy .md addenda (versions 1 and 2).
+        (self.phase_dir / "design-addendum-1.md").write_text(
+            "# Addendum 1\n\nearly fix.\n"
+        )
+        (self.phase_dir / "design-addendum-2.md").write_text(
+            "# Addendum 2\n\nsecond fix.\n"
+        )
+
+    def test_scope_version_continues_past_legacy(self) -> None:
+        record = amendments.append(
+            self.phase_dir,
+            trigger="manual",
+            summary="third fix (JSONL)",
+        )
+        # Legacy 1, legacy 2, new -> scope_version = 3.
+        self.assertEqual(record["scope_version"], 3)
+
+    def test_list_amendments_surfaces_legacy(self) -> None:
+        amendments.append(
+            self.phase_dir,
+            trigger="manual",
+            summary="jsonl fix",
+        )
+        records = amendments.list_amendments(self.phase_dir)
+        sources = [r.get("source") for r in records]
+        self.assertEqual(sources.count("legacy-md"), 2)
+        self.assertEqual(sources.count("jsonl"), 1)
+
+        # Ordered by scope_version.
+        versions = [r.get("scope_version") for r in records]
+        self.assertEqual(versions, sorted(versions))
+
+    def test_list_amendments_excludes_legacy_when_requested(self) -> None:
+        amendments.append(
+            self.phase_dir,
+            trigger="manual",
+            summary="jsonl fix",
+        )
+        records = amendments.list_amendments(
+            self.phase_dir, include_legacy=False
+        )
+        sources = [r.get("source") for r in records]
+        self.assertNotIn("legacy-md", sources)
+
+
+class RenderTests(unittest.TestCase):
+    def test_render_empty(self) -> None:
+        rendered = amendments.render_markdown([])
+        self.assertIn("Amendments", rendered)
+        self.assertIn("No amendments", rendered)
+
+    def test_render_includes_patches_and_refs(self) -> None:
+        record = {
+            "amendment_id": "AMD-test-20260101",
+            "trigger": "gate-conditional",
+            "scope_version": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "summary": "fix threshold",
+            "patches": [
+                {"target": "design.md#FR-3", "operation": "replace",
+                 "rationale": "align with SLO"}
+            ],
+            "resolution_refs": ["CONDITION-1"],
+        }
+        rendered = amendments.render_markdown([record])
+        self.assertIn("v1", rendered)
+        self.assertIn("AMD-test", rendered)
+        self.assertIn("design.md#FR-3", rendered)
+        self.assertIn("CONDITION-1", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/crew/test_conditions_manifest.py
+++ b/tests/crew/test_conditions_manifest.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/crew/conditions_manifest.py (issue #477).
+
+Covers:
+    - mark_cleared flips a condition atomically.
+    - Crash between sidecar-write and manifest-update leaves an orphan
+      that recover() reconciles.
+    - recover() is idempotent.
+    - Unknown condition_id raises ValueError.
+    - Missing manifest raises FileNotFoundError.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = _REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "crew"))
+
+import conditions_manifest  # noqa: E402  (path setup above)
+
+
+def _write_manifest(path: Path, conditions):
+    """Write a fresh conditions-manifest.json fixture."""
+    payload = {
+        "source_gate": "design",
+        "created_at": "2026-01-01T00:00:00Z",
+        "conditions": conditions,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+class MarkClearedTests(unittest.TestCase):
+    """Happy-path + error behavior of ``mark_cleared``."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.manifest_path = self.root / "phases" / "design" / "conditions-manifest.json"
+        _write_manifest(
+            self.manifest_path,
+            [
+                {"id": "CONDITION-1", "description": "foo", "verified": False,
+                 "resolution": None, "verified_at": None},
+                {"id": "CONDITION-2", "description": "bar", "verified": False,
+                 "resolution": None, "verified_at": None},
+            ],
+        )
+
+    def test_mark_cleared_flips_condition_and_writes_sidecar(self) -> None:
+        updated = conditions_manifest.mark_cleared(
+            self.manifest_path, "CONDITION-1",
+            resolution_ref="phases/design/amendments.jsonl#AMD-1",
+            note="resolved by design addendum",
+        )
+        self.assertTrue(updated["conditions"][0]["verified"])
+        self.assertEqual(
+            updated["conditions"][0]["resolution"],
+            "phases/design/amendments.jsonl#AMD-1",
+        )
+        self.assertFalse(updated["conditions"][1]["verified"],
+                         "sibling condition must not be touched")
+
+        # Sidecar present on disk.
+        sidecar = self.manifest_path.parent / "conditions-manifest.CONDITION-1.resolution.json"
+        self.assertTrue(sidecar.exists())
+        sidecar_payload = json.loads(sidecar.read_text())
+        self.assertEqual(sidecar_payload["condition_id"], "CONDITION-1")
+        self.assertEqual(
+            sidecar_payload["resolution_ref"],
+            "phases/design/amendments.jsonl#AMD-1",
+        )
+
+        # Persisted manifest matches the returned dict.
+        reloaded = json.loads(self.manifest_path.read_text())
+        self.assertTrue(reloaded["conditions"][0]["verified"])
+        self.assertEqual(reloaded["conditions"][0]["resolution_note"],
+                         "resolved by design addendum")
+
+    def test_mark_cleared_raises_on_missing_condition(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            conditions_manifest.mark_cleared(
+                self.manifest_path, "CONDITION-99", "ref"
+            )
+        self.assertIn("CONDITION-99", str(ctx.exception))
+
+    def test_mark_cleared_raises_on_missing_manifest(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            conditions_manifest.mark_cleared(
+                self.root / "does-not-exist.json", "CONDITION-1", "ref"
+            )
+
+
+class CrashRecoveryTests(unittest.TestCase):
+    """Simulate a crash between sidecar-write and manifest-flip.
+
+    The fix: recover() scans for orphan sidecars and finishes the flip.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.manifest_path = self.root / "phases" / "design" / "conditions-manifest.json"
+        _write_manifest(
+            self.manifest_path,
+            [
+                {"id": "CONDITION-1", "description": "foo", "verified": False,
+                 "resolution": None, "verified_at": None},
+            ],
+        )
+
+    def test_crash_between_sidecar_and_manifest_is_recovered(self) -> None:
+        # Simulate: mark_cleared raises AFTER the sidecar lands but
+        # BEFORE the manifest is replaced. We do this by patching
+        # atomic_write_json to raise on its SECOND call.
+        calls: list = []
+        real_write = conditions_manifest.atomic_write_json
+
+        def selective_write(path, data):
+            calls.append(path)
+            if len(calls) == 2:
+                # Second call is the manifest flip — simulate crash.
+                raise RuntimeError("simulated crash mid-flip")
+            return real_write(path, data)
+
+        with mock.patch.object(
+            conditions_manifest, "atomic_write_json",
+            side_effect=selective_write,
+        ):
+            with self.assertRaises(RuntimeError):
+                conditions_manifest.mark_cleared(
+                    self.manifest_path, "CONDITION-1",
+                    resolution_ref="phases/design/amendments.jsonl#AMD-1",
+                )
+
+        # Sidecar is on disk; manifest still shows unverified.
+        sidecar = self.manifest_path.parent / "conditions-manifest.CONDITION-1.resolution.json"
+        self.assertTrue(sidecar.exists(), "sidecar must have landed first")
+        manifest_before = json.loads(self.manifest_path.read_text())
+        self.assertFalse(
+            manifest_before["conditions"][0]["verified"],
+            "manifest must still be uncleared after crash",
+        )
+
+        # Recovery finds the orphan and finishes the flip.
+        reconciled = conditions_manifest.recover(self.manifest_path)
+        self.assertEqual(reconciled, ["CONDITION-1"])
+
+        manifest_after = json.loads(self.manifest_path.read_text())
+        self.assertTrue(manifest_after["conditions"][0]["verified"])
+        self.assertEqual(
+            manifest_after["conditions"][0]["resolution"],
+            "phases/design/amendments.jsonl#AMD-1",
+        )
+
+    def test_recover_is_idempotent(self) -> None:
+        # First clear normally.
+        conditions_manifest.mark_cleared(
+            self.manifest_path, "CONDITION-1", "ref-1"
+        )
+        # Running recover now should be a no-op (condition already verified).
+        reconciled = conditions_manifest.recover(self.manifest_path)
+        self.assertEqual(
+            reconciled, [],
+            "recovery must be a no-op when the manifest is already consistent",
+        )
+
+    def test_recover_ignores_sidecars_for_missing_conditions(self) -> None:
+        # Plant a sidecar for a condition that no longer exists in the
+        # manifest (e.g. manifest was regenerated since the crash).
+        sidecar = self.manifest_path.parent / "conditions-manifest.GHOST.resolution.json"
+        sidecar.write_text(json.dumps({
+            "condition_id": "GHOST",
+            "resolution_ref": "irrelevant",
+            "note": None,
+            "written_at": "2026-01-01T00:00:00Z",
+        }))
+        reconciled = conditions_manifest.recover(self.manifest_path)
+        self.assertEqual(reconciled, [])
+        # Manifest is untouched.
+        reloaded = json.loads(self.manifest_path.read_text())
+        self.assertFalse(reloaded["conditions"][0]["verified"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/crew/test_explain_skill.py
+++ b/tests/crew/test_explain_skill.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Structural tests for the wicked-garden:crew:explain skill (issue #480).
+
+The skill itself is prose — there is no code to unit-test — but we can
+assert on the shape and contract of SKILL.md and commands/crew/explain.md
+so future edits don't silently break the marketplace registration or the
+three-style contract (``terse``, ``paired``, ``plain-only``).
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SKILL = _REPO_ROOT / "skills" / "crew" / "explain" / "SKILL.md"
+_COMMAND = _REPO_ROOT / "commands" / "crew" / "explain.md"
+
+
+class SkillFilePresenceTests(unittest.TestCase):
+    def test_skill_md_exists(self) -> None:
+        self.assertTrue(
+            _SKILL.exists(),
+            "skills/crew/explain/SKILL.md must exist for #480.",
+        )
+
+    def test_command_md_exists(self) -> None:
+        self.assertTrue(
+            _COMMAND.exists(),
+            "commands/crew/explain.md must exist for #480.",
+        )
+
+
+class SkillContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = _SKILL.read_text(encoding="utf-8")
+
+    def test_has_yaml_frontmatter_with_name(self) -> None:
+        m = re.match(r"^---\n(.*?)\n---\n", self.content, re.DOTALL)
+        self.assertIsNotNone(m, "SKILL.md must open with YAML frontmatter")
+        frontmatter = m.group(1)
+        self.assertIn("name: explain", frontmatter)
+        self.assertIn("description:", frontmatter)
+
+    def test_names_three_output_styles(self) -> None:
+        for style in ("terse", "paired", "plain-only"):
+            self.assertIn(
+                style, self.content,
+                f"SKILL.md must document the '{style}' output style",
+            )
+
+    def test_enforces_grade_8_and_short_output(self) -> None:
+        lower = self.content.lower()
+        self.assertIn("grade", lower)
+        # The rule is "2-4 sentences" — accept either dash form.
+        self.assertTrue(
+            re.search(r"2[\s–-]4\s+sentences", lower),
+            "SKILL.md must cap output at 2-4 sentences",
+        )
+
+    def test_forbids_specialist_vocab(self) -> None:
+        # The "No specialist vocab" rulebook must appear.
+        self.assertIn("No specialist vocab", self.content)
+
+    def test_stays_under_200_lines(self) -> None:
+        line_count = len(self.content.splitlines())
+        self.assertLessEqual(
+            line_count, 200,
+            f"SKILL.md must stay <= 200 lines (progressive disclosure); "
+            f"current: {line_count}",
+        )
+
+
+class CommandContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = _COMMAND.read_text(encoding="utf-8")
+
+    def test_has_frontmatter_with_description(self) -> None:
+        m = re.match(r"^---\n(.*?)\n---\n", self.content, re.DOTALL)
+        self.assertIsNotNone(m, "explain.md must open with YAML frontmatter")
+        self.assertIn("description:", m.group(1))
+
+    def test_references_the_skill(self) -> None:
+        self.assertIn(
+            "wicked-garden:crew:explain", self.content,
+            "explain.md must reference the wicked-garden:crew:explain skill",
+        )
+
+    def test_has_h1_command_header(self) -> None:
+        self.assertTrue(
+            re.search(
+                r"^# /wicked-garden:crew:explain\s*$",
+                self.content,
+                re.MULTILINE,
+            ),
+            "explain.md h1 header must match the command name",
+        )
+
+    def test_documents_style_flag(self) -> None:
+        # --style flag with the three modes is part of the public contract.
+        self.assertIn("--style", self.content)
+        for style in ("paired", "plain-only"):
+            self.assertIn(style, self.content)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/crew/test_reviewer_context.py
+++ b/tests/crew/test_reviewer_context.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Unit tests for shared reviewer-context.md injection (issue #474).
+
+Covers:
+    - ensure_reviewer_context writes a stub when missing, leaves existing
+      content alone.
+    - _dispatch_fast_evaluator passes shared_context_path into the ctx
+      dict and embeds it in the reviewer prompt.
+    - _dispatch_sequential and _dispatch_parallel_and_merge propagate
+      shared_context_path to every reviewer dispatch.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = _REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "crew"))
+
+
+import phase_manager  # noqa: E402  (path setup above)
+
+
+class EnsureReviewerContextTests(unittest.TestCase):
+    """ensure_reviewer_context writes a stub + is idempotent."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.project_dir = Path(self.tmp.name) / "my-proj"
+        self.project_dir.mkdir(parents=True, exist_ok=True)
+
+    def _make_state(self, name: str = "proj"):
+        state = mock.Mock()
+        state.name = name
+        return state
+
+    def test_writes_stub_when_missing(self) -> None:
+        state = self._make_state("proj-1")
+        with mock.patch.object(
+            phase_manager, "get_project_dir", return_value=self.project_dir
+        ):
+            path = phase_manager.ensure_reviewer_context(
+                state, "design", "design-quality"
+            )
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())
+        content = path.read_text()
+        self.assertIn("proj-1", content)
+        self.assertIn("design", content)
+        self.assertIn("design-quality", content)
+
+    def test_idempotent_when_present(self) -> None:
+        state = self._make_state("proj-2")
+        # User-written context file — the helper must NOT overwrite.
+        ctx_path = self.project_dir / "phases" / "design" / "reviewer-context.md"
+        ctx_path.parent.mkdir(parents=True, exist_ok=True)
+        ctx_path.write_text("# Human-authored reviewer-context\n")
+
+        with mock.patch.object(
+            phase_manager, "get_project_dir", return_value=self.project_dir
+        ):
+            result = phase_manager.ensure_reviewer_context(
+                state, "design", "design-quality"
+            )
+        self.assertEqual(result, ctx_path)
+        self.assertIn("Human-authored", ctx_path.read_text())
+
+    def test_returns_none_when_state_is_none(self) -> None:
+        self.assertIsNone(
+            phase_manager.ensure_reviewer_context(None, "design", "design-quality")
+        )
+
+    def test_returns_none_when_state_has_no_name(self) -> None:
+        state = mock.Mock()
+        state.name = None
+        self.assertIsNone(
+            phase_manager.ensure_reviewer_context(state, "design", "design-quality")
+        )
+
+
+class DispatchInjectsContextTests(unittest.TestCase):
+    """Every dispatch helper must forward the shared_context_path."""
+
+    def setUp(self) -> None:
+        self.pm = phase_manager
+
+    def test_fast_evaluator_injects_path_into_ctx(self) -> None:
+        captured: dict = {}
+
+        def dispatcher(subagent_type, prompt, context):
+            captured["ctx"] = context
+            captured["prompt"] = prompt
+            return {"verdict": "APPROVE", "score": 0.9, "conditions": []}
+
+        shared = Path("/tmp/fake-phase/reviewer-context.md")
+        self.pm._dispatch_fast_evaluator(
+            None, "design", "design-quality",
+            dispatcher=dispatcher,
+            shared_context_path=shared,
+        )
+        self.assertEqual(
+            captured["ctx"].get("shared_context_path"), str(shared)
+        )
+        self.assertIn("reviewer-context.md", captured["prompt"])
+
+    def test_sequential_injects_path_into_every_reviewer(self) -> None:
+        captured_ctxs: list = []
+
+        def dispatcher(subagent_type, prompt, context):
+            captured_ctxs.append(context)
+            return {"verdict": "APPROVE", "score": 0.9, "conditions": []}
+
+        shared = Path("/tmp/fake-phase/reviewer-context.md")
+        self.pm._dispatch_sequential(
+            None, "design", "design-quality",
+            ["senior-engineer", "security-engineer"],
+            dispatcher=dispatcher,
+            shared_context_path=shared,
+        )
+        self.assertEqual(len(captured_ctxs), 2)
+        for ctx in captured_ctxs:
+            self.assertEqual(ctx.get("shared_context_path"), str(shared))
+
+    def test_parallel_injects_path_into_batch_and_per_reviewer(self) -> None:
+        captured: list = []
+
+        def dispatcher(subagent_type, prompt, context):
+            captured.append({"type": subagent_type, "ctx": context})
+            # Return None for the batch sentinel so we fall through to
+            # per-reviewer dispatch, exercising both code paths.
+            if subagent_type.endswith("_parallel_batch"):
+                return None
+            return {"verdict": "APPROVE", "score": 0.9, "conditions": []}
+
+        shared = Path("/tmp/fake-phase/reviewer-context.md")
+        self.pm._dispatch_parallel_and_merge(
+            None, "design", "design-quality",
+            ["senior-engineer", "qe-lead"],
+            dispatcher=dispatcher,
+            shared_context_path=shared,
+        )
+        # One batch call + two per-reviewer fallback calls.
+        self.assertGreaterEqual(len(captured), 3)
+        for entry in captured:
+            self.assertEqual(
+                entry["ctx"].get("shared_context_path"), str(shared)
+            )
+
+    def test_path_is_omitted_when_none(self) -> None:
+        """When no shared_context_path is supplied, ctx should not
+        carry the key at all (keeps the old behavior intact)."""
+        captured: dict = {}
+
+        def dispatcher(subagent_type, prompt, context):
+            captured["ctx"] = context
+            return {"verdict": "APPROVE", "score": 0.9, "conditions": []}
+
+        self.pm._dispatch_fast_evaluator(
+            None, "design", "design-quality",
+            dispatcher=dispatcher,
+        )
+        self.assertNotIn("shared_context_path", captured["ctx"])
+
+
+class DispatchGateReviewerIntegrationTests(unittest.TestCase):
+    """_dispatch_gate_reviewer materializes reviewer-context.md and passes
+    the path into the selected helper."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.project_dir = Path(self.tmp.name) / "integration-proj"
+        self.project_dir.mkdir(parents=True, exist_ok=True)
+
+    def test_materializes_context_and_forwards_to_fast_evaluator(self) -> None:
+        state = mock.Mock()
+        state.name = "integration-proj"
+
+        captured: dict = {}
+
+        def dispatcher(subagent_type, prompt, context):
+            captured["ctx"] = context
+            return {"verdict": "APPROVE", "score": 0.9, "conditions": []}
+
+        with mock.patch.object(
+            phase_manager, "get_project_dir", return_value=self.project_dir
+        ):
+            # Empty reviewers list -> fast-evaluator path.
+            phase_manager._dispatch_gate_reviewer(
+                state, "design", "design-quality",
+                {"reviewers": [], "mode": "self-check",
+                 "fallback": "gate-evaluator"},
+                dispatcher=dispatcher,
+            )
+        # File on disk after dispatch.
+        ctx_path = self.project_dir / "phases" / "design" / "reviewer-context.md"
+        self.assertTrue(ctx_path.exists())
+        # Path injected into reviewer context dict.
+        self.assertEqual(
+            captured["ctx"].get("shared_context_path"), str(ctx_path)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Bundled four storage + developer-experience issues into one PR (standard rigor).

- **#474 Shared reviewer-context.md** — one shared `phases/{phase}/reviewer-context.md`, written once by the phase-executor. `_dispatch_gate_reviewer` + all four helpers (`fast`, `sequential`, `parallel`, `council`) now thread the file **path** (not content) through reviewer briefs, cutting per-reviewer context duplication.
- **#477 Atomic conditions-manifest writes** — new `scripts/crew/conditions_manifest.py::mark_cleared()` writes a resolution sidecar first (fsync), then atomically replaces the manifest (fsync + parent-dir fsync on POSIX). `recover()` reconciles orphan sidecars on startup. Crash-simulation test included.
- **#478 amendments.jsonl refactor** — new `scripts/crew/amendments.py` append-only JSONL at `phases/{phase}/amendments.jsonl`. CLI: `amendments show {phase}` renders markdown. Legacy `design-addendum-N.md` files remain readable (`source="legacy-md"`) and continue the scope_version sequence.
- **#480 explain skill** — new `skills/crew/explain/SKILL.md` (128 lines, under the 200 cap) + `commands/crew/explain.md`. Grade-8, 2-4 sentence translator. Three output styles: `terse` | `paired` (default) | `plain-only`.

## Touches

- NEW: `scripts/crew/conditions_manifest.py`, `scripts/crew/amendments.py`, `skills/crew/explain/SKILL.md`, `commands/crew/explain.md`, 4 test files.
- MODIFIED additively: `agents/crew/phase-executor.md` (reviewer-context.md step 2 note + amendments.jsonl section), `scripts/crew/phase_manager.py` (new `ensure_reviewer_context()` + `shared_context_path=` kwarg threaded through dispatch helpers).

Concurrent Project 4 also edits `phase_manager.py` + `phase-executor.md`; edits here are additive (new kwarg with default `None`, new section at the bottom of the responsibility list) so rebase conflicts should be trivial to resolve.

## Test plan

- [x] Baseline 513/513 preserved.
- [x] +36 new tests (final: **549 passing**).
  - `test_conditions_manifest.py` — 6 tests: happy path, error cases, crash simulation, idempotent recovery, ghost-sidecar handling.
  - `test_amendments.py` — 10 tests: append validation, monotonic scope_version, legacy-md back-compat, markdown render.
  - `test_reviewer_context.py` — 9 tests: stub write + idempotency, path injection through fast/sequential/parallel helpers, end-to-end `_dispatch_gate_reviewer`.
  - `test_explain_skill.py` — 11 tests: file presence, frontmatter, three output styles, 200-line cap, command h1 header, `--style` flag docs.
- [x] No existing tests regressed (`test_phase_manager`, `test_gate_enforcement`, `test_blend_rule_helpers` all green).
- [x] `scripts/crew/amendments.py show design` CLI exercised locally (empty-log path).
- [x] Line-count / stub-audit checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)