### PR TITLE
fix: v6.3.2 — audit blockers (agent hygiene, missing refs, stale workflow doc)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
-      "version": "6.3.1"
+      "version": "6.3.2"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Hooks enforce workflow gates, assemble context from memory and code search on every prompt, and persist decisions across sessions. 13 domains with 69 specialist agents cover the full lifecycle: facilitator-driven crew workflows with hard quality gates, 3-tier persistent memory with auto-consolidation, structural code intelligence, multi-model brainstorming, and domain experts for security, architecture, QE, product, data, and delivery. Zero external dependencies \u2014 runs standalone with local SQLite storage.",
   "author": {
     "name": "Mike Parcewski"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [6.3.2] - 2026-04-19
+
+### Features
+- feat(#535): inject `subagent_type` frontmatter into 71 agents that were missing the
+  field — all agents now declare `wicked-garden:{domain}:{stem}` for correct routing
+- feat(#533): create `agents/product/ux-analyst.md` — new agent covering user research
+  synthesis, journey mapping, usability heuristics, and A/B test interpretation
+  (genuinely distinct from ux-designer and ui-reviewer)
+- feat(#534): rename `jam/facilitator` → `jam/brainstorm-facilitator` to eliminate
+  collision with crew's facilitator; update all 3 inbound command refs
+- feat(#533): update 10 command files to point 15 broken subagent_type refs at their
+  consolidated targets (visual-reviewer→ui-reviewer, business-strategist→market-strategist,
+  value-analyst→value-strategist, alignment-lead→value-strategist, feedback-analyst→user-voice,
+  customer-advocate→user-voice, acceptance-test-writer/executor/reviewer→test-designer,
+  tdd-coach→test-strategist, analytics-architect→data-architect,
+  engineering:data-architect→data:data-architect)
+- feat(#536): rewrite `skills/workflow/SKILL.md` for v6 — removes stale v3/v5 content,
+  documents propose-process as the decision engine, interaction modes (normal/yolo),
+  rigor tiers, phase plan, and gate policy reviewer assignment
+- feat(tests): add 4 regression suites — agent subagent_type coverage, basename
+  uniqueness, command agent ref resolution, workflow skill v6 conformance
+
 ## [6.3.1] - 2026-04-19
 
 ### Bug Fixes

--- a/agents/agentic/architect.md
+++ b/agents/agentic/architect.md
@@ -1,5 +1,6 @@
 ---
 name: architect
+subagent_type: wicked-garden:agentic:architect
 description: |
   Five-layer architecture validation, agent topology analysis, orchestration patterns,
   and framework selection for agentic systems. Focus on structural soundness and scalability.

--- a/agents/agentic/pattern-advisor.md
+++ b/agents/agentic/pattern-advisor.md
@@ -1,5 +1,6 @@
 ---
 name: pattern-advisor
+subagent_type: wicked-garden:agentic:pattern-advisor
 description: |
   Pattern recognition, anti-pattern detection, refactoring recommendations,
   design pattern application, and code quality for agentic systems.

--- a/agents/agentic/performance-analyst.md
+++ b/agents/agentic/performance-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: performance-analyst
+subagent_type: wicked-garden:agentic:performance-analyst
 description: |
   Token optimization, latency budgets, cost analysis, parallelization opportunities,
   caching strategies, and context window management for agentic systems.

--- a/agents/agentic/safety-reviewer.md
+++ b/agents/agentic/safety-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: safety-reviewer
+subagent_type: wicked-garden:agentic:safety-reviewer
 description: |
   Guardrails, prompt injection defense, PII protection, human-in-the-loop gates,
   output validation, and hallucination mitigation for agentic systems.

--- a/agents/crew/contrarian.md
+++ b/agents/crew/contrarian.md
@@ -1,5 +1,6 @@
 ---
 name: contrarian
+subagent_type: wicked-garden:crew:contrarian
 description: |
   Maintain and strengthen minority positions across sessions for crew projects.
   Use when: a crew project reaches design phase at complexity >= 4, or whenever the

--- a/agents/crew/facilitator.md
+++ b/agents/crew/facilitator.md
@@ -1,5 +1,6 @@
 ---
 name: facilitator
+subagent_type: wicked-garden:crew:facilitator
 description: |
   Guide outcome clarification through structured inquiry.
   Use when: defining project outcomes, resolving scope ambiguity before work begins.

--- a/agents/crew/gate-evaluator.md
+++ b/agents/crew/gate-evaluator.md
@@ -1,5 +1,6 @@
 ---
 name: gate-evaluator
+subagent_type: wicked-garden:crew:gate-evaluator
 description: |
   Fast-path objective gate evaluator for minimal-tier and self-check gates. Use when:
   a gate-policy.json entry declares `mode: self-check` OR has an empty `reviewers` list

--- a/agents/crew/implementer.md
+++ b/agents/crew/implementer.md
@@ -1,5 +1,6 @@
 ---
 name: implementer
+subagent_type: wicked-garden:crew:implementer
 description: |
   Execute implementation tasks according to approved designs and test strategies.
   Use when: building features, implementing approved designs, tracked development work.

--- a/agents/crew/independent-reviewer.md
+++ b/agents/crew/independent-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: independent-reviewer
+subagent_type: wicked-garden:crew:independent-reviewer
 description: |
   Independent phase reviewer with cold context. Audits crew phase
   deliverables, test coverage, and evidence quality — no prior

--- a/agents/crew/phase-executor.md
+++ b/agents/crew/phase-executor.md
@@ -1,5 +1,6 @@
 ---
 name: phase-executor
+subagent_type: wicked-garden:crew:phase-executor
 description: |
   Produce the current phase's deliverables and run phase-start / phase-end re-evaluations
   for a mode-3 wicked-crew project. Use when: phase_manager.execute() dispatches a phase

--- a/agents/crew/qe-orchestrator.md
+++ b/agents/crew/qe-orchestrator.md
@@ -1,5 +1,6 @@
 ---
 name: qe-orchestrator
+subagent_type: wicked-garden:crew:qe-orchestrator
 description: |
   Route to appropriate quality gate. Determines gate type from context,
   dispatches to gate-specific orchestrators, consolidates results.

--- a/agents/crew/researcher.md
+++ b/agents/crew/researcher.md
@@ -1,5 +1,6 @@
 ---
 name: researcher
+subagent_type: wicked-garden:crew:researcher
 description: |
   Explore codebase and gather context before design or implementation choices.
   Use when: codebase exploration, pattern discovery, context gathering for decisions.

--- a/agents/crew/reviewer.md
+++ b/agents/crew/reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: reviewer
+subagent_type: wicked-garden:crew:reviewer
 description: |
   Perform basic code review and validation.
   Use when: general code review without a domain-specific specialist available.

--- a/agents/data/data-analyst.md
+++ b/agents/data/data-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: data-analyst
+subagent_type: wicked-garden:data:data-analyst
 description: |
   Data exploration, statistical analysis, insight generation, and visualization guidance.
   Helps understand what the data is telling you.

--- a/agents/data/data-architect.md
+++ b/agents/data/data-architect.md
@@ -1,5 +1,6 @@
 ---
 name: data-architect
+subagent_type: wicked-garden:data:data-architect
 description: |
   Unified data architecture role — owns both operational/transactional data
   modeling (OLTP schemas, domain entities, data flow, caching, consistency) AND

--- a/agents/data/data-engineer.md
+++ b/agents/data/data-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: data-engineer
+subagent_type: wicked-garden:data:data-engineer
 description: |
   ETL pipeline design, data quality assessment, schema validation, and performance optimization.
   Reviews data architectures and ensures robust data engineering practices.

--- a/agents/data/ml-engineer.md
+++ b/agents/data/ml-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: ml-engineer
+subagent_type: wicked-garden:data:ml-engineer
 description: |
   ML model development, training pipeline design, feature engineering, and deployment guidance.
   Ensures ML systems are robust, monitored, and maintainable.

--- a/agents/delivery/cloud-cost-intelligence.md
+++ b/agents/delivery/cloud-cost-intelligence.md
@@ -1,5 +1,6 @@
 ---
 name: cloud-cost-intelligence
+subagent_type: wicked-garden:delivery:cloud-cost-intelligence
 description: |
   Cloud/infrastructure cost analysis AND optimization in one agent. Analyzes billing
   data to identify cost drivers, anomalies, budget variance, and untagged spend —

--- a/agents/delivery/delivery-manager.md
+++ b/agents/delivery/delivery-manager.md
@@ -1,5 +1,6 @@
 ---
 name: delivery-manager
+subagent_type: wicked-garden:delivery:delivery-manager
 description: |
   Sprint and project delivery management. Track velocity, plan sprints,
   manage scope, and coordinate cross-team dependencies.

--- a/agents/delivery/experiment-designer.md
+++ b/agents/delivery/experiment-designer.md
@@ -1,5 +1,6 @@
 ---
 name: experiment-designer
+subagent_type: wicked-garden:delivery:experiment-designer
 description: |
   Design rigorous experiments with statistical analysis. Formulate hypotheses,
   select metrics, calculate sample sizes, and ensure experimental validity.

--- a/agents/delivery/progress-tracker.md
+++ b/agents/delivery/progress-tracker.md
@@ -1,5 +1,6 @@
 ---
 name: progress-tracker
+subagent_type: wicked-garden:delivery:progress-tracker
 description: |
   Track and report progress against milestones, goals, and deadlines.
   Monitor completion rates, identify slippage, and forecast outcomes.

--- a/agents/delivery/risk-monitor.md
+++ b/agents/delivery/risk-monitor.md
@@ -1,5 +1,6 @@
 ---
 name: risk-monitor
+subagent_type: wicked-garden:delivery:risk-monitor
 description: |
   Risk tracking and escalation management. Identifies delivery risks,
   tracks mitigation progress, and manages dependency chains.

--- a/agents/delivery/rollout-manager.md
+++ b/agents/delivery/rollout-manager.md
@@ -1,5 +1,6 @@
 ---
 name: rollout-manager
+subagent_type: wicked-garden:delivery:rollout-manager
 description: |
   Coordinate progressive rollouts with risk management. Plan canary deployments,
   monitor metrics, define rollback criteria, and communicate with stakeholders.

--- a/agents/delivery/stakeholder-reporter.md
+++ b/agents/delivery/stakeholder-reporter.md
@@ -1,5 +1,6 @@
 ---
 name: stakeholder-reporter
+subagent_type: wicked-garden:delivery:stakeholder-reporter
 description: |
   Generate multi-perspective stakeholder reports covering Delivery, Engineering,
   Product, QE, Architecture, and DevSecOps viewpoints.

--- a/agents/engineering/api-documentarian.md
+++ b/agents/engineering/api-documentarian.md
@@ -1,5 +1,6 @@
 ---
 name: api-documentarian
+subagent_type: wicked-garden:engineering:api-documentarian
 description: |
   Specialize in API documentation - OpenAPI specs, endpoint documentation, request/response
   examples, and error documentation. Create comprehensive, accurate API reference materials.

--- a/agents/engineering/backend-engineer.md
+++ b/agents/engineering/backend-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: backend-engineer
+subagent_type: wicked-garden:engineering:backend-engineer
 description: |
   Backend engineering specialist focusing on APIs, databases, server-side
   patterns, data modeling, scalability, and integration design.

--- a/agents/engineering/debugger.md
+++ b/agents/engineering/debugger.md
@@ -1,5 +1,6 @@
 ---
 name: debugger
+subagent_type: wicked-garden:engineering:debugger
 description: |
   Debugging specialist focused on root cause analysis, error investigation,
   profiling, and systematic debugging strategies. Helps diagnose complex issues.

--- a/agents/engineering/devex-engineer.md
+++ b/agents/engineering/devex-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: devex-engineer
+subagent_type: wicked-garden:engineering:devex-engineer
 description: |
   Developer experience and internal tooling specialist. Owns the quality of the
   inner dev loop — local environment setup, CI ergonomics, build/test speed,

--- a/agents/engineering/frontend-engineer.md
+++ b/agents/engineering/frontend-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: frontend-engineer
+subagent_type: wicked-garden:engineering:frontend-engineer
 description: |
   Frontend engineering specialist focusing on React, CSS, browser APIs,
   component design, performance, accessibility, and user experience patterns.

--- a/agents/engineering/migration-engineer.md
+++ b/agents/engineering/migration-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: migration-engineer
+subagent_type: wicked-garden:engineering:migration-engineer
 description: |
   Schema migrations, data backfills, deprecation paths, rollback plans, and
   zero-downtime cutovers. Specializes in moving a live production system from

--- a/agents/engineering/senior-engineer.md
+++ b/agents/engineering/senior-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: senior-engineer
+subagent_type: wicked-garden:engineering:senior-engineer
 description: |
   Senior engineering perspective on code quality, architecture patterns,
   maintainability, and implementation guidance. Reviews from developer mindset

--- a/agents/engineering/solution-architect.md
+++ b/agents/engineering/solution-architect.md
@@ -1,5 +1,6 @@
 ---
 name: solution-architect
+subagent_type: wicked-garden:engineering:solution-architect
 description: |
   Design end-to-end solutions with appropriate patterns, technology choices, and trade-offs.
   Focus on high-level architecture that balances requirements, constraints, and maintainability.

--- a/agents/engineering/system-designer.md
+++ b/agents/engineering/system-designer.md
@@ -1,5 +1,6 @@
 ---
 name: system-designer
+subagent_type: wicked-garden:engineering:system-designer
 description: |
   Define component boundaries, module organization, and interface contracts.
   Focus on decomposition and dependency management.

--- a/agents/engineering/technical-writer.md
+++ b/agents/engineering/technical-writer.md
@@ -1,5 +1,6 @@
 ---
 name: technical-writer
+subagent_type: wicked-garden:engineering:technical-writer
 description: |
   Create clear, accessible technical documentation with proper structure, audience awareness,
   and practical examples. Focus on helping users understand and use the system effectively.

--- a/agents/jam/brainstorm-facilitator.md
+++ b/agents/jam/brainstorm-facilitator.md
@@ -1,6 +1,6 @@
 ---
-name: facilitator
-subagent_type: wicked-garden:jam:facilitator
+name: brainstorm-facilitator
+subagent_type: wicked-garden:jam:brainstorm-facilitator
 description: |
   Role-plays as focus group personas and synthesizes brainstorming discussions.
   Use when: brainstorming, ideation, focus group, creative exploration

--- a/agents/jam/council.md
+++ b/agents/jam/council.md
@@ -1,5 +1,6 @@
 ---
 name: council
+subagent_type: wicked-garden:jam:council
 description: |
   Runs structured multi-model council evaluations using external LLM CLIs.
   Each model responds independently to a fixed question scaffold, then Claude synthesizes.

--- a/agents/jam/facilitator.md
+++ b/agents/jam/facilitator.md
@@ -1,5 +1,6 @@
 ---
 name: facilitator
+subagent_type: wicked-garden:jam:facilitator
 description: |
   Role-plays as focus group personas and synthesizes brainstorming discussions.
   Use when: brainstorming, ideation, focus group, creative exploration

--- a/agents/mem/memory-archivist.md
+++ b/agents/mem/memory-archivist.md
@@ -1,5 +1,6 @@
 ---
 name: memory-archivist
+subagent_type: wicked-garden:mem:memory-archivist
 description: |
   Maintain memory health — decay, archive, and cleanup operations.
   Use when: memory maintenance, cleanup, decay lifecycle (active -> archived -> decayed -> deleted).

--- a/agents/mem/memory-learner.md
+++ b/agents/mem/memory-learner.md
@@ -1,5 +1,6 @@
 ---
 name: memory-learner
+subagent_type: wicked-garden:mem:memory-learner
 description: |
   Extract and structure learnings from completed tasks.
   Use when: capturing decisions, patterns, and episodic memories after completing work.

--- a/agents/mem/memory-recaller.md
+++ b/agents/mem/memory-recaller.md
@@ -1,5 +1,6 @@
 ---
 name: memory-recaller
+subagent_type: wicked-garden:mem:memory-recaller
 description: |
   Search and retrieve relevant memories without overloading main context.
   Use when: searching memory store, finding past decisions or patterns, recalling context by topic or tag.

--- a/agents/persona/persona-agent.md
+++ b/agents/persona/persona-agent.md
@@ -1,5 +1,6 @@
 ---
 name: persona-agent
+subagent_type: wicked-garden:persona:persona-agent
 description: |
   Executes tasks under a named persona's behavioral profile. Receives persona
   definition (name, focus, personality, constraints, memories, preferences)

--- a/agents/platform/auditor.md
+++ b/agents/platform/auditor.md
@@ -1,5 +1,6 @@
 ---
 name: auditor
+subagent_type: wicked-garden:platform:auditor
 description: |
   Audit evidence collector and control verifier. Gathers artifacts,
   validates controls, maintains audit trails, and generates compliance

--- a/agents/platform/chaos-engineer.md
+++ b/agents/platform/chaos-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: chaos-engineer
+subagent_type: wicked-garden:platform:chaos-engineer
 description: |
   Failure-mode thinking and resilience testing specialist. Designs chaos
   experiments, plans game days, injects controlled failures (latency, errors,

--- a/agents/platform/compliance-officer.md
+++ b/agents/platform/compliance-officer.md
@@ -1,5 +1,6 @@
 ---
 name: compliance-officer
+subagent_type: wicked-garden:platform:compliance-officer
 description: |
   Regulatory compliance expert. Evaluates code and systems against
   SOC2, HIPAA, GDPR, PCI requirements. Identifies violations and

--- a/agents/platform/devops-engineer.md
+++ b/agents/platform/devops-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: devops-engineer
+subagent_type: wicked-garden:platform:devops-engineer
 description: |
   CI/CD pipeline design, workflow automation, and deployment orchestration.
   Focus on GitHub Actions, GitLab CI, pipeline optimization, and deployment

--- a/agents/platform/incident-responder.md
+++ b/agents/platform/incident-responder.md
@@ -1,5 +1,6 @@
 ---
 name: incident-responder
+subagent_type: wicked-garden:platform:incident-responder
 description: |
   Incident response specialist focused on rapid triage, root cause correlation,
   timeline reconstruction, and blast radius assessment during production incidents.

--- a/agents/platform/infrastructure-engineer.md
+++ b/agents/platform/infrastructure-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: infrastructure-engineer
+subagent_type: wicked-garden:platform:infrastructure-engineer
 description: |
   Cloud infrastructure design, Infrastructure-as-Code, scalability, and
   platform reliability. Focus on AWS/GCP/Azure, Terraform, Kubernetes,

--- a/agents/platform/observability-engineer.md
+++ b/agents/platform/observability-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: observability-engineer
+subagent_type: wicked-garden:platform:observability-engineer
 description: |
   Logs, traces, metrics design; SLI/SLO definition; dashboard and alerting
   architecture. Owns how a system reveals its own state — what's emitted, how

--- a/agents/platform/privacy-expert.md
+++ b/agents/platform/privacy-expert.md
@@ -1,5 +1,6 @@
 ---
 name: privacy-expert
+subagent_type: wicked-garden:platform:privacy-expert
 description: |
   Privacy and data protection specialist. Detects PII/PHI, ensures GDPR
   compliance, implements privacy by design, and protects sensitive data

--- a/agents/platform/release-engineer.md
+++ b/agents/platform/release-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: release-engineer
+subagent_type: wicked-garden:platform:release-engineer
 description: |
   Release management, versioning strategies, deployment coordination, and
   rollback procedures. Focus on semantic versioning, changelog generation,

--- a/agents/platform/security-engineer.md
+++ b/agents/platform/security-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: security-engineer
+subagent_type: wicked-garden:platform:security-engineer
 description: |
   Security scanning and vulnerability assessment from DevSecOps perspective.
   Focus on OWASP compliance, secure coding practices, secrets management,

--- a/agents/platform/sre.md
+++ b/agents/platform/sre.md
@@ -1,5 +1,6 @@
 ---
 name: sre
+subagent_type: wicked-garden:platform:sre
 description: |
   Site Reliability Engineer focused on system health, capacity planning,
   performance correlation, and reliability improvement.

--- a/agents/product/a11y-expert.md
+++ b/agents/product/a11y-expert.md
@@ -1,5 +1,6 @@
 ---
 name: a11y-expert
+subagent_type: wicked-garden:product:a11y-expert
 description: |
   Audit accessibility compliance - WCAG guidelines, keyboard navigation,
   screen readers, semantic HTML, and inclusive design patterns.

--- a/agents/product/market-strategist.md
+++ b/agents/product/market-strategist.md
@@ -1,5 +1,6 @@
 ---
 name: market-strategist
+subagent_type: wicked-garden:product:market-strategist
 description: |
   Combined business case + competitive strategy. Builds ROI analysis for technical
   investments AND analyzes competitive landscape, SWOT, Porter's Five Forces,

--- a/agents/product/product-manager.md
+++ b/agents/product/product-manager.md
@@ -1,5 +1,6 @@
 ---
 name: product-manager
+subagent_type: wicked-garden:product:product-manager
 description: |
   Strategic product thinking: roadmap planning, prioritization, trade-offs,
   and business value alignment. Balances customer needs with delivery capacity.

--- a/agents/product/requirements-analyst.md
+++ b/agents/product/requirements-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: requirements-analyst
+subagent_type: wicked-garden:product:requirements-analyst
 description: |
   Elicit and document requirements with precision. Transform vague ideas into
   clear user stories with testable acceptance criteria.

--- a/agents/product/ui-reviewer.md
+++ b/agents/product/ui-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: ui-reviewer
+subagent_type: wicked-garden:product:ui-reviewer
 description: |
   Visual and UI design review. Evaluates design-system adherence, component patterns,
   spacing/typography/color correctness, responsive behavior, and visual polish.

--- a/agents/product/user-researcher.md
+++ b/agents/product/user-researcher.md
@@ -1,5 +1,6 @@
 ---
 name: user-researcher
+subagent_type: wicked-garden:product:user-researcher
 description: |
   Discover and validate user needs. Create personas, map journeys, and ensure
   empathy-driven design. SOLE OWNER of user research activities.

--- a/agents/product/user-voice.md
+++ b/agents/product/user-voice.md
@@ -1,5 +1,6 @@
 ---
 name: user-voice
+subagent_type: wicked-garden:product:user-voice
 description: |
   User/customer voice specialist. Combines sentiment & theme analysis over raw
   feedback data with empathy-driven advocacy that translates that signal into

--- a/agents/product/ux-analyst.md
+++ b/agents/product/ux-analyst.md
@@ -1,0 +1,163 @@
+---
+name: ux-analyst
+subagent_type: wicked-garden:product:ux-analyst
+description: |
+  User experience analysis through research synthesis, journey mapping, usability
+  heuristics, and A/B result interpretation. Distinct from ux-designer (delivery/
+  execution focus) and ui-reviewer (visual audit focus) — ux-analyst owns the
+  research-to-insight pipeline.
+  Use when: user research synthesis, journey mapping, usability heuristic evaluation,
+  A/B test interpretation, experience gap analysis, UX audit with research grounding.
+
+  <example>
+  Context: Team has user interview transcripts and wants to understand pain points.
+  user: "Synthesize these 12 user interviews into a UX findings report."
+  <commentary>Use ux-analyst to extract themes, map journeys, and surface usability issues from research.</commentary>
+  </example>
+
+  <example>
+  Context: A/B test concluded but results need interpretation.
+  user: "We ran an A/B test on the checkout flow. Variant B had +4% conversion but higher drop-off at step 3. What does this mean?"
+  <commentary>Use ux-analyst to interpret the A/B result through a UX lens — behavior signals, journey friction, and next steps.</commentary>
+  </example>
+model: sonnet
+effort: medium
+max-turns: 12
+color: purple
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# UX Analyst
+
+You analyze user experience through research synthesis, journey mapping, usability
+heuristics, and A/B result interpretation. Your job is to transform raw research
+signals into actionable UX insights.
+
+## When to Invoke
+
+- Synthesizing user interviews, surveys, or usability study recordings
+- Mapping user journeys from behavior data or qualitative research
+- Evaluating a product flow against Nielsen's 10 usability heuristics
+- Interpreting A/B test results through a behavioral lens
+- Identifying experience gaps between user mental models and product behavior
+- Producing UX audit findings grounded in research (not just visual review)
+
+## Distinction from Adjacent Roles
+
+| Role | Focus |
+|------|-------|
+| **ux-analyst** (you) | Research synthesis, journey maps, heuristic eval, A/B interpretation |
+| **ux-designer** | Design execution, flow design, wireframes, prototype delivery |
+| **ui-reviewer** | Visual audit, design-system adherence, component patterns |
+
+## Analysis Workflow
+
+### 1. Gather Research Materials
+
+Read all available inputs:
+- Interview transcripts, survey exports, usability session notes
+- Analytics exports, funnel data, heatmaps
+- A/B test results and metadata
+- Existing journey maps or personas
+
+Use Grep/Glob or `wicked-garden:search` to find relevant files.
+
+### 2. Research Synthesis
+
+Extract themes using affinity clustering:
+
+```markdown
+## Raw Signals
+- Quote / data point → behavior / emotion / need
+
+## Emerging Themes
+- Theme: {name}
+  - Evidence: [quote, data point, observation]
+  - Frequency: {high|medium|low}
+  - Severity: {critical|major|minor}
+```
+
+### 3. Journey Mapping
+
+Map the user flow with pain points and opportunities:
+
+```markdown
+## Journey Map: {flow or persona name}
+
+| Stage | User Goal | Actions | Thoughts | Emotions | Pain Points | Opportunities |
+|-------|-----------|---------|----------|----------|-------------|---------------|
+| {stage} | {goal} | {what they do} | {mental model} | {frustrated / confident} | {friction} | {gap to address} |
+```
+
+### 4. Heuristic Evaluation (Nielsen's 10)
+
+Rate each heuristic 0-4 (0 = no issue, 4 = usability catastrophe):
+
+| # | Heuristic | Rating | Findings |
+|---|-----------|--------|----------|
+| 1 | Visibility of system status | {0-4} | {observation} |
+| 2 | Match between system and real world | {0-4} | {observation} |
+| 3 | User control and freedom | {0-4} | {observation} |
+| 4 | Consistency and standards | {0-4} | {observation} |
+| 5 | Error prevention | {0-4} | {observation} |
+| 6 | Recognition over recall | {0-4} | {observation} |
+| 7 | Flexibility and efficiency | {0-4} | {observation} |
+| 8 | Aesthetic and minimalist design | {0-4} | {observation} |
+| 9 | Help users recognize/recover from errors | {0-4} | {observation} |
+| 10 | Help and documentation | {0-4} | {observation} |
+
+### 5. A/B Test Interpretation
+
+When interpreting A/B results:
+
+1. **Identify the behavioral signal** — what did users do differently?
+2. **Map to journey stage** — where in the flow did behavior change?
+3. **Hypothesize the mechanism** — why did variant B produce this result?
+4. **Check for side effects** — did the variant improve one metric but harm another?
+5. **Recommend next steps** — iterate, ship, or run a follow-up test?
+
+## Output Format
+
+```markdown
+## UX Analysis: {subject}
+
+**Research base**: {interviews N / survey N / session recordings N / A/B test}
+**Confidence**: {High | Medium | Low}
+
+### Key Findings
+
+1. **{Finding}** — {Severity: Critical|Major|Minor}
+   - Evidence: {quotes, data points}
+   - Journey stage: {where this appears}
+   - Recommendation: {specific UX change}
+
+### Journey Map
+{journey table}
+
+### Heuristic Summary
+{top 3 heuristic violations with ratings and fixes}
+
+### Opportunities
+
+| Priority | Opportunity | Effort | Impact |
+|----------|-------------|--------|--------|
+| 1 | {opportunity} | {S|M|L} | {High|Med|Low} |
+
+### Next Research Questions
+- {unresolved question that needs more data}
+```
+
+## Collaboration
+
+- **UX Designer**: Hand off insights → design iteration
+- **UI Reviewer**: Flag visual issues that surfaced in research (contrast, affordances)
+- **User Voice**: Share raw feedback themes for tracking
+- **QE Test Designer**: Convert heuristic violations into test scenarios
+- **Product Manager**: Prioritize opportunities by business value
+
+## Rules
+
+- **Ground everything in evidence**: No assertions without a supporting quote or data point
+- **Rate severity consistently**: Critical (blocks task completion), Major (significant friction), Minor (polish)
+- **Separate observation from interpretation**: What did users do vs what does it mean
+- **Flag confidence level**: Low confidence findings need more data before actioning

--- a/agents/product/ux-designer.md
+++ b/agents/product/ux-designer.md
@@ -1,5 +1,6 @@
 ---
 name: ux-designer
+subagent_type: wicked-garden:product:ux-designer
 description: |
   Design and evaluate user flows, interaction patterns, and information architecture.
   Works generatively (create flows from requirements) and analytically (audit existing

--- a/agents/product/value-strategist.md
+++ b/agents/product/value-strategist.md
@@ -1,5 +1,6 @@
 ---
 name: value-strategist
+subagent_type: wicked-garden:product:value-strategist
 description: |
   Value-proposition design AND stakeholder alignment in one agent. Designs value
   propositions using Jobs-to-be-Done, pain/gain mapping, and differentiation axes;

--- a/agents/qe/code-analyzer.md
+++ b/agents/qe/code-analyzer.md
@@ -1,5 +1,6 @@
 ---
 name: code-analyzer
+subagent_type: wicked-garden:qe:code-analyzer
 description: |
   Static code analysis focusing on testability, quality, and maintainability.
   Reviews code structure, identifies test coverage gaps, and assesses risk areas.

--- a/agents/qe/continuous-quality-monitor.md
+++ b/agents/qe/continuous-quality-monitor.md
@@ -1,5 +1,6 @@
 ---
 name: continuous-quality-monitor
+subagent_type: wicked-garden:qe:continuous-quality-monitor
 description: |
   Monitor quality signals during the build phase. Runs lint and static analysis,
   tracks complexity metrics, monitors test coverage, and coaches TDD rhythm.

--- a/agents/qe/contract-testing-engineer.md
+++ b/agents/qe/contract-testing-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: contract-testing-engineer
+subagent_type: wicked-garden:qe:contract-testing-engineer
 description: |
   API contract testing specialist. Designs and reviews consumer-driven contracts,
   Pact-style tests, OpenAPI contract verification, schema versioning, and breaking

--- a/agents/qe/production-quality-engineer.md
+++ b/agents/qe/production-quality-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: production-quality-engineer
+subagent_type: wicked-garden:qe:production-quality-engineer
 description: |
   Monitor production quality post-deploy. Tracks SLO targets, error budgets,
   performance regressions, and canary analysis. Defines rollback criteria.

--- a/agents/qe/requirements-quality-analyst.md
+++ b/agents/qe/requirements-quality-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: requirements-quality-analyst
+subagent_type: wicked-garden:qe:requirements-quality-analyst
 description: |
   Evaluate acceptance criteria quality at the clarify phase. Checks whether ACs
   are specific, measurable, and testable. Flags ambiguous scope and missing edge cases.

--- a/agents/qe/risk-assessor.md
+++ b/agents/qe/risk-assessor.md
@@ -1,5 +1,6 @@
 ---
 name: risk-assessor
+subagent_type: wicked-garden:qe:risk-assessor
 description: |
   Identify risks and failure modes. Assesses security, reliability,
   and operational risks. Updates the active task with the risk matrix via TaskUpdate.

--- a/agents/qe/semantic-reviewer.md
+++ b/agents/qe/semantic-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: semantic-reviewer
+subagent_type: wicked-garden:qe:semantic-reviewer
 description: |
   Autonomous post-implementation pass that verifies spec-to-code alignment.
   Extracts numbered acceptance criteria (AC-*, FR-*, REQ-*) from clarify-phase

--- a/agents/qe/test-automation-engineer.md
+++ b/agents/qe/test-automation-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: test-automation-engineer
+subagent_type: wicked-garden:qe:test-automation-engineer
 description: |
   Generate test code and configure test automation infrastructure. Creates unit,
   integration, and e2e tests. Configures test runners, CI pipelines, and coverage.

--- a/agents/qe/test-designer.md
+++ b/agents/qe/test-designer.md
@@ -1,5 +1,6 @@
 ---
 name: test-designer
+subagent_type: wicked-garden:qe:test-designer
 description: |
   End-to-end acceptance test designer. Owns the full Write → Execute → Analyze →
   Verdict loop in one role: reads scenarios, produces evidence-gated test plans,

--- a/agents/qe/test-strategist.md
+++ b/agents/qe/test-strategist.md
@@ -1,5 +1,6 @@
 ---
 name: test-strategist
+subagent_type: wicked-garden:qe:test-strategist
 description: |
   Generate test scenarios from code. Identifies happy paths, error cases,
   and edge cases. Updates the active task with findings via TaskUpdate.

--- a/agents/qe/testability-reviewer.md
+++ b/agents/qe/testability-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: testability-reviewer
+subagent_type: wicked-garden:qe:testability-reviewer
 description: |
   Review design artifacts for testability. Checks component isolation, dependency
   injection readiness, and boundary clarity. Flags designs that will be hard to test.

--- a/commands/crew/execute.md
+++ b/commands/crew/execute.md
@@ -390,7 +390,7 @@ TaskUpdate(taskId="{id}", status="completed")
 | Specialist | Clarify | Design | Build | Review |
 |-----------|---------|--------|-------|--------|
 | jam | `/wicked-garden:jam:brainstorm` (interactive) | `/wicked-garden:jam:perspectives` (interactive) | - | - |
-| product | `Task(subagent_type="wicked-garden:product:requirements-analyst", ...)` | `Task(subagent_type="wicked-garden:product:business-strategist", ...)` | - | `Task(subagent_type="wicked-garden:product:ux-designer", ...)` |
+| product | `Task(subagent_type="wicked-garden:product:requirements-analyst", ...)` | `Task(subagent_type="wicked-garden:product:market-strategist", ...)` | - | `Task(subagent_type="wicked-garden:product:ux-designer", ...)` |
 | engineering | - | `Task(subagent_type="wicked-garden:engineering:solution-architect", ...)` | `Task(subagent_type="wicked-garden:engineering:senior-engineer", ...)` | `Task(subagent_type="wicked-garden:engineering:senior-engineer", ...)` |
 | qe | - | - | `/wicked-garden:crew:gate` (quality gate) | `/wicked-garden:crew:gate` (quality gate) |
 | platform | - | - | `Task(subagent_type="wicked-garden:platform:security-engineer", ...)` | `Task(subagent_type="wicked-garden:platform:security-engineer", ...)` |
@@ -533,7 +533,7 @@ For each required layer:
 Agent fallbacks:
 - If `test-automation-engineer` is unavailable → include instructions in generic reviewer prompt.
 - If `security-engineer` is unavailable → include security steps in integration test prompt.
-- If `acceptance-test-executor` is unavailable → include scenario steps in generic reviewer prompt.
+- If `test-designer` is unavailable → include scenario steps in generic reviewer prompt.
 
 **Step 4: Aggregate results.**
 
@@ -660,14 +660,14 @@ For each build task, check its complexity (from the task description or the proj
 1. **Red phase** (write failing tests first):
    ```
    Task(
-     subagent_type="wicked-garden:qe:tdd-coach",
+     subagent_type="wicked-garden:qe:test-strategist",
      prompt="Write failing tests (red phase) for: {task description}.
      Project: {project-name}. Design: {relevant design excerpt}.
      Output: failing test files that define the acceptance criteria.
      Do NOT implement the feature yet."
    )
    ```
-   If `wicked-garden:qe:tdd-coach` is unavailable, include TDD red-phase instructions in the implementer prompt instead.
+   If `wicked-garden:qe:test-strategist` is unavailable, include TDD red-phase instructions in the implementer prompt instead.
 
 2. **Green phase** (implement to pass tests):
    ```
@@ -683,7 +683,7 @@ For each build task, check its complexity (from the task description or the proj
 3. **Refactor verification** (clean up without breaking tests):
    ```
    Task(
-     subagent_type="wicked-garden:qe:tdd-coach",
+     subagent_type="wicked-garden:qe:test-strategist",
      prompt="Verify and guide the refactor phase for: {task description}.
      Project: {project-name}. Tests should remain passing after refactor.
      Check: code quality, duplication, naming, test coverage completeness."

--- a/commands/data/analyze.md
+++ b/commands/data/analyze.md
@@ -75,7 +75,7 @@ Task(
 **warehouse**:
 ```
 Task(
-  subagent_type="wicked-garden:data:analytics-architect",
+  subagent_type="wicked-garden:data:data-architect",
   prompt="""
   Design warehouse integration for the provided dataset.
 

--- a/commands/engineering/arch.md
+++ b/commands/engineering/arch.md
@@ -82,7 +82,7 @@ Provide overview, assessment (strengths + concerns), and strategic recommendatio
 If data-heavy system:
 ```python
 Task(
-    subagent_type="wicked-garden:engineering:data-architect",
+    subagent_type="wicked-garden:data:data-architect",
     prompt="""Analyze data architecture for this system.
 
 ## Evaluation Areas

--- a/commands/jam/brainstorm.md
+++ b/commands/jam/brainstorm.md
@@ -15,7 +15,7 @@ Start a full brainstorm with evidence-backed perspectives. The facilitator gathe
 Delegate to the facilitator agent:
 
 ```
-Task(subagent_type="wicked-garden:jam:facilitator",
+Task(subagent_type="wicked-garden:jam:brainstorm-facilitator",
      prompt="Run a full brainstorm session on: {topic}. Options: {personas}, {rounds}, convergence_mode={converge|'normal'}.
 
 Convergence mode instructions:

--- a/commands/jam/perspectives.md
+++ b/commands/jam/perspectives.md
@@ -10,6 +10,6 @@ Get raw viewpoints from 4-6 personas on a decision or question — no synthesis,
 Delegate to the facilitator agent:
 
 ```
-Task(subagent_type="wicked-garden:jam:facilitator",
+Task(subagent_type="wicked-garden:jam:brainstorm-facilitator",
      prompt="Run a perspectives-only session on: {topic}. Use 4-6 personas, 1 round only. Each persona must state: (1) their position, (2) their key concern, (3) what evidence would change their mind. Do NOT synthesize or recommend — just present raw perspectives. Do NOT store a decision record. Keep it fast (~60 seconds).")
 ```

--- a/commands/jam/quick.md
+++ b/commands/jam/quick.md
@@ -12,7 +12,7 @@ This command uses forced fast convergence: exactly 1 round, then immediately syn
 Delegate to the facilitator agent:
 
 ```
-Task(subagent_type="wicked-garden:jam:facilitator",
+Task(subagent_type="wicked-garden:jam:brainstorm-facilitator",
      prompt="Run a quick jam session on: {topic}. Use 4 personas, EXACTLY 1 round, then synthesize IMMEDIATELY. Do not run a second round under any circumstances — this is fast convergence mode. Brief synthesis with 2-3 insights max. Still gather evidence if available (but keep it fast — 2 sources max). Store a lightweight decision record after synthesis.
 
 Native-task tracking (fail open on any tool errors):

--- a/commands/product/align.md
+++ b/commands/product/align.md
@@ -50,7 +50,7 @@ Read target document if provided and parse parameters:
 
 ```
 Task(
-  subagent_type="wicked-garden:product:alignment-lead",
+  subagent_type="wicked-garden:product:value-strategist",
   prompt="""Facilitate stakeholder alignment and consensus building.
 
 ## Context
@@ -141,7 +141,7 @@ Automatically:
 $ /wicked-garden:product:align requirements.md --stakeholders "eng,qe,ops"
 
 Analyzing stakeholder alignment...
-[Dispatches to alignment-lead agent]
+[Dispatches to value-strategist agent]
 [Agent analyzes stakeholder positions and surfaces concerns]
 
 Stakeholders Identified: 3

--- a/commands/product/analyze.md
+++ b/commands/product/analyze.md
@@ -50,7 +50,7 @@ If no data found, prompt user to run `/wicked-garden:product:listen` first.
 
 ```
 Task(
-  subagent_type="wicked-garden:product:feedback-analyst",
+  subagent_type="wicked-garden:product:user-voice",
   prompt="""Analyze customer feedback for patterns and insights.
 
 ## Feedback Data
@@ -180,7 +180,7 @@ User: /wicked-garden:product:analyze --theme "performance"
 Claude: I'll analyze feedback related to performance.
 
 [Loads aggregated feedback]
-[Dispatches to feedback-analyst agent]
+[Dispatches to user-voice agent]
 [Agent extracts themes and patterns]
 
 ## Feedback Analysis Report

--- a/commands/product/listen.md
+++ b/commands/product/listen.md
@@ -53,7 +53,7 @@ gh issue list --label "customer-reported" 2>/dev/null | head -5
 
 ```
 Task(
-  subagent_type="wicked-garden:product:customer-advocate",
+  subagent_type="wicked-garden:product:user-voice",
   prompt="""Aggregate customer feedback from available sources.
 
 ## Sources Discovered
@@ -130,7 +130,7 @@ User: /wicked-garden:product:listen --days 7
 Claude: I'll aggregate customer feedback from the last 7 days.
 
 [Discovers available sources]
-[Dispatches to customer-advocate agent]
+[Dispatches to user-voice agent]
 [Agent aggregates and normalizes feedback]
 
 ## Listening Report: Last 7 Days

--- a/commands/product/review.md
+++ b/commands/product/review.md
@@ -38,7 +38,7 @@ Also check for design token definitions:
 
 ```
 Task(
-  subagent_type="wicked-garden:product:visual-reviewer",
+  subagent_type="wicked-garden:product:ui-reviewer",
   prompt="""Perform a visual design review of the following UI code.
 
 ## Target

--- a/commands/product/strategy.md
+++ b/commands/product/strategy.md
@@ -53,7 +53,7 @@ Based on the `--focus` flag, dispatch to the appropriate expert(s) in parallel. 
 **For roi focus**:
 ```
 Task(
-  subagent_type="wicked-garden:product:business-strategist",
+  subagent_type="wicked-garden:product:market-strategist",
   prompt="""Calculate ROI for the following feature/initiative:
 
 {feature/initiative description}
@@ -80,7 +80,7 @@ Provide:
 **For value focus**:
 ```
 Task(
-  subagent_type="wicked-garden:product:value-analyst",
+  subagent_type="wicked-garden:product:value-strategist",
   prompt="""Design value proposition for the following feature/initiative:
 
 {feature/initiative description}
@@ -107,7 +107,7 @@ Provide:
 **For market focus**:
 ```
 Task(
-  subagent_type="wicked-garden:product:market-analyst",
+  subagent_type="wicked-garden:product:market-strategist",
   prompt="""Analyze market for the following feature/initiative:
 
 {feature/initiative description}
@@ -133,7 +133,7 @@ Provide:
 **For competitive focus**:
 ```
 Task(
-  subagent_type="wicked-garden:product:competitive-analyst",
+  subagent_type="wicked-garden:product:market-strategist",
   prompt="""Assess competitive landscape for the following feature/initiative:
 
 {feature/initiative description}
@@ -304,7 +304,7 @@ User: /wicked-garden:product:strategy mobile-app-proposal.md --focus roi
 Claude: I'll analyze the ROI for the mobile app proposal.
 
 [Reads proposal document]
-[Dispatches to business-strategist agent]
+[Dispatches to market-strategist agent]
 [Agent calculates costs, benefits, payback]
 
 ## Strategic Analysis: Mobile App Proposal

--- a/commands/product/synthesize.md
+++ b/commands/product/synthesize.md
@@ -46,7 +46,7 @@ If no analysis found, prompt user to run `/wicked-garden:product:analyze` first.
 
 ```
 Task(
-  subagent_type="wicked-garden:product:customer-advocate",
+  subagent_type="wicked-garden:product:user-voice",
   prompt="""Synthesize customer feedback analysis into actionable recommendations.
 
 ## Analysis Data
@@ -193,7 +193,7 @@ User: /wicked-garden:product:synthesize --priority high
 Claude: I'll synthesize high-priority recommendations from customer feedback.
 
 [Loads analysis results]
-[Dispatches to customer-advocate agent]
+[Dispatches to user-voice agent]
 [Agent generates prioritized recommendations]
 
 ## Customer Voice Synthesis

--- a/commands/qe/acceptance.md
+++ b/commands/qe/acceptance.md
@@ -77,7 +77,7 @@ For each scenario:
 
 ```
 Task(
-  subagent_type="wicked-garden:qe:acceptance-test-writer",
+  subagent_type="wicked-garden:qe:test-designer",
   prompt="""Generate an evidence-gated test plan for this acceptance scenario.
 
 ## Scenario
@@ -121,7 +121,7 @@ If `--phase write`, stop here and present the test plan for review.
 
 ```
 Task(
-  subagent_type="wicked-garden:qe:acceptance-test-executor",
+  subagent_type="wicked-garden:qe:test-designer",
   prompt="""Execute this test plan and collect evidence artifacts.
 
 ## Test Plan
@@ -232,7 +232,7 @@ If the registry exists, proceed to dispatch the reviewer:
 
 ```
 Task(
-  subagent_type="wicked-garden:qe:acceptance-test-reviewer",
+  subagent_type="wicked-garden:qe:test-designer",
   prompt="""Review this evidence against the test plan assertions.
 
 ## Original Scenario

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,175 +1,135 @@
 ---
 name: workflow
 description: |
-  Core wicked-crew v3 workflow engine with capability-based orchestration and phase progression.
-  Drives projects through crew phases: clarify → design → test-strategy → build → test → review.
-  Smart decisioning analyzes signals to determine which specialists to engage per phase.
+  wicked-crew v6 workflow engine. The facilitator rubric in
+  wicked-garden:propose-process drives project orchestration — scoring 9 risk
+  factors, picking phases from the catalog, assigning rigor tier, and emitting
+  a process-plan + full task chain. Phases have hard quality gates (APPROVE /
+  CONDITIONAL / REJECT); CONDITIONAL auto-resolves spec gaps or escalates.
 
   Use when: "crew phases", "phase plan", "workflow execution", "start a project",
   "clarify outcome", "design phase", "build phase", "approve phase", "crew workflow",
-  "phase progression", "QE gate", "shift-left testing", or structured delivery guidance.
+  "phase progression", "QE gate", "shift-left testing", or structured delivery.
 context: fork
+
+**Plain:** wicked-crew v6 — propose-process rubric picks phases and rigor tier;
+gates are hard enforcement; two interaction modes (normal / yolo).
 ---
 
-# Workflow Skill (v3)
+# Workflow Skill (v6)
 
-Capability-based orchestration with smart specialist engagement.
+Facilitator-rubric orchestration with hard quality gates.
 
-## v3 Architecture
-
-```
-User Input → Smart Decisioning → Specialist Discovery → Engagement
-                  │                     │
-                  ├── Signal Detection  ├── Available specialists
-                  ├── Complexity Score  ├── Personas
-                  └── Ambiguity Check   └── Fallback agents
-```
-
-## Phase Progression
+## Decision Engine — `wicked-garden:propose-process`
 
 ```
-clarify → design → test-strategy → build → test → review
+User project description
+        │
+        ▼
+propose-process facilitator
+  ├── Score 9 risk factors (0-3 each)
+  ├── Read agents/**/*.md frontmatter → pick specialists
+  ├── Pick phases from phases.json catalog
+  ├── Set rigor_tier (minimal / standard / full)
+  └── Emit process-plan.md + full task chain
 ```
 
-Each phase has: Clear deliverables, specialist engagement based on signals, mandatory quality gate.
+All phase selection is judgment-driven by the facilitator, not rule-based.
+
+## Interaction Modes
+
+| Mode | How | Effect |
+|------|-----|--------|
+| **normal** | Default | Each phase gate requires explicit user approval before advancing |
+| **yolo** | `/wicked-garden:crew:yolo` | Auto-advance through gates; gates still run, findings still logged |
+
+## Rigor Tiers
+
+| Tier | Complexity | Gates | Reviewers |
+|------|-----------|-------|-----------|
+| **minimal** | 0-2 | Advisory — gate findings logged but do not block | Single reviewer |
+| **standard** | 3-5 | Enforced — REJECT blocks advancement | Single reviewer |
+| **full** | 6-7 | Enforced — REJECT blocks; multi-reviewer | 2+ reviewers |
+
+Security or compliance signals override to **full** regardless of complexity.
+
+## Phase Plan
+
+```
+clarify → design → [challenge?] → [test-strategy?] → build → test → review
+```
+
+Brackets = optional phases. The facilitator picks which phases apply based on
+factor readings. `phases.json` defines gate config per phase (min_gate_score,
+valid_skip_reasons, depends_on).
+
+### Phase Summary
+
+| Phase | Goal | Key deliverable |
+|-------|------|-----------------|
+| **clarify** | Define success criteria | Outcome statement + success criteria |
+| **design** | Architect solution | Architecture docs + approach |
+| **challenge** | Adversarial stress-test | Challenge findings + revised design |
+| **test-strategy** | Define test approach pre-build | Test scenarios + risk assessment |
+| **build** | Implement | Working implementation |
+| **test** | Verify | Test results + convergence evidence |
+| **review** | Multi-perspective validation | Review findings + sign-off |
 
 ## Gate Enforcement (v2.5.0+)
 
-Gates are hard enforcement — not advisory. `phases.json` defines per-phase:
-- `min_gate_score` (0.6-0.8): gates below threshold block advancement
-- `valid_skip_reasons`: enumerated skip reasons; free-text rejected
-- `skip_complexity_threshold`: prevents skipping at high complexity (e.g., test-strategy at >= 3)
+Gates are hard enforcement — not advisory — at standard and full rigor.
 
-Gate verdicts: **APPROVE** → proceed. **CONDITIONAL** → conditions-manifest.json written, must verify before next phase. **REJECT** → blocks advancement, mandatory rework.
+| Verdict | Effect |
+|---------|--------|
+| **APPROVE** | Phase advances |
+| **CONDITIONAL** | `conditions-manifest.json` written; verify before next phase |
+| **REJECT** | Blocks advancement; mandatory rework |
 
-CONDITIONAL auto-resolution (AC-4.4): spec gaps fixed inline; intent changes escalate to user/council.
+CONDITIONAL auto-resolution (AC-4.4): spec gap conditions → fixed inline.
+Intent-changing conditions → escalate to user or council.
 
-Build depends on design (`depends_on: ["clarify", "design"]`). To migrate legacy beta.3 projects, use `/wicked-garden:adopt-legacy`.
+Gate reviewer assignment happens at approve time, not at phase start. Banned
+reviewer values: `just-finish-auto`, `fast-pass`, `auto-approve-*`.
 
-## Smart Decisioning
+Build depends on design (`depends_on: ["clarify", "design"]`). To migrate
+legacy beta.3 projects, use `/wicked-garden:adopt-legacy`.
 
-### Signal Categories
+## Specialist Discovery
 
-| Signal | Keywords | Specialists |
-|--------|----------|-------------|
-| Security | auth, encrypt, token, jwt | platform, compliance |
-| Performance | scale, optimize, cache | engineering, qe |
-| Product | user, feature, story | product |
-| Compliance | SOC2, HIPAA, audit | platform |
-| Ambiguity | maybe, should we, options | jam |
-| Complexity | integration, migrate, refactor | delivery, engineering |
+Crew discovers specialists by reading `agents/**/*.md` frontmatter directly at
+runtime. No static `enhances` map. Fallback agents (facilitator, researcher,
+implementer, reviewer) handle phases when no specialist matches.
 
-### Complexity Scoring (0-7)
+## Convergence Tracking (build/test phases)
 
-- 0-2: Simple → Built-in agents only
-- 3-4: Moderate → Core specialists
-- 5-7: Complex → All relevant + delivery
-
-## Specialist Engagement
-
-### Discovery
-
-Crew discovers specialists via `specialist.json` in each plugin.
-
-### Fallback Agents
-
-| Specialist | Fallback |
-|------------|----------|
-| jam | facilitator |
-| qe, product | reviewer |
-| engineering (arch) | researcher |
-| engineering, platform | implementer |
-
-## Phase Details
-
-### Clarify
-**Goal**: Define success criteria
-**Deliverables**: Outcome statement, success criteria, scope boundaries
-**Specialists**: jam (if ambiguous), product
-
-### Design
-**Goal**: Architect the solution
-**Deliverables**: Architecture docs, pattern identification, technical approach
-**Specialists**: product, engineering
-
-### QE (Quality Engineering)
-**Goal**: Define test strategy before building
-**Deliverables**: Test scenarios, risk assessment, edge cases
-**Specialists**: qe, platform (if security signals)
-
-### Build
-**Goal**: Implement the solution
-**Deliverables**: Working implementation, progress tracking, tests passing
-**Specialists**: engineering, platform (if infra)
-
-### Review
-**Goal**: Multi-perspective validation
-**Deliverables**: Review findings, recommendations, sign-off
-**Specialists**: product, qe, platform (if regulated)
-
-## Project Lifecycle
-
-Projects can be archived when complete or paused:
-
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/crew.py" archive <name>      # Sets archived=true
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/crew.py" unarchive <name>    # Reactivates
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/crew.py" list                 # Excludes archived by default
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/crew.py" list --include-archived
-```
-
-Phase operations are blocked on archived projects.
+Artifact states: `Designed → Built → Wired → Tested → Integrated → Verified`.
+The `convergence-verify` gate flips REJECT → APPROVE only when every tracked
+artifact reaches `Integrated`. Stalls at threshold 3 sessions surface as findings.
 
 ## Commands Reference
 
 | Command | Purpose |
 |---------|---------|
-| `/wicked-garden:crew:start` | Begin project with smart decisioning |
-| `/wicked-garden:crew:status` | View current state and engaged specialists |
-| `/wicked-garden:crew:execute` | Run current phase with specialists |
-| `/wicked-garden:crew:approve` | Approve and advance phase |
-| `/wicked-garden:crew:just-finish` | Autonomous completion |
-| `/wicked-garden:crew:gate` | Run QE gate (value/strategy/execution) |
+| `/wicked-garden:crew:start` | Begin project — invokes propose-process |
+| `/wicked-garden:crew:status` | View current phase and engaged specialists |
+| `/wicked-garden:crew:execute` | Run current phase |
+| `/wicked-garden:crew:approve` | Advance phase after gate |
+| `/wicked-garden:crew:just-finish` | Autonomous completion (yolo-equivalent) |
+| `/wicked-garden:crew:gate` | Run a specific quality gate |
 | `/wicked-garden:crew:evidence` | Query evidence for a task |
+| `/wicked-garden:crew:yolo` | Switch to auto-advance mode |
 
-## Event Flow
+## Storage
 
-### Project Start
-```
-crew:project:started:success
-crew:specialist:engaged:success
-crew:specialist:unavailable:warning (with fallback)
-```
+| Store | What |
+|-------|------|
+| Native tasks | TaskCreate/TaskUpdate with validated `metadata` (see `scripts/_event_schema.py`) |
+| `wicked-garden:mem` | Cross-session learning at project completion and gate failures |
+| Local JSON | DomainStore fallback; always available |
 
-### Phase Transitions
-```
-crew:phase:started:success
-crew:phase:completed:success
-crew:phase:approved:success
-```
+## Refs (load on demand)
 
-## Utility Integration
-
-| Plugin | Enhancement | Fallback |
-|--------|-------------|----------|
-| Native tasks | TaskCreate/TaskUpdate with validated `metadata` (see scripts/_event_schema.py) | TodoWrite |
-| wicked-garden:mem | Cross-session learning | Project files |
-
-See [Integration Details](refs/integration.md) for usage patterns.
-
-## Evidence Tracking
-
-Gate decisions and artifacts are tracked as evidence. See [Evidence Tracking](refs/evidence.md) for:
-- Evidence tiers (L1-L4)
-- Artifact naming conventions
-- Automatic vs manual evidence collection
-
-## Configuration
-
-Customize in the wicked-crew local storage domain as `config.yaml`:
-
-```yaml
-defaults:
-  always_engage: [qe]      # Always use QE specialist
-  complexity_threshold: 4  # Lower = more specialists
-```
+- [Evidence Tracking](refs/evidence.md) — evidence tiers L1-L4, artifact naming
+- [Integration Details](refs/integration.md) — mem, search, wicked-bus usage
+- [Scoring Rubric](refs/scoring-rubric.md) — **HISTORICAL v5 only**; see propose-process for v6
+- [Risk Dimension Signals](refs/risk-dimension-signals.md) — signal keywords per factor

--- a/tests/test_agent_name_uniqueness.py
+++ b/tests/test_agent_name_uniqueness.py
@@ -1,0 +1,41 @@
+"""
+Regression suite: no two agent files share the same basename across domains.
+
+Audit finding: #533 / #534 — duplicate basenames (e.g. facilitator exists in both
+jam/ and crew/) created routing ambiguity. The brainstorm-facilitator rename (#534)
+resolved the jam/crew collision. This suite guards against future recurrences.
+
+Note: the check is on basename (stem) — `facilitator` in crew/ and `facilitator`
+in jam/ would be a collision. Having the same name in different domains is the
+problem because agent discovery tools may resolve by name without domain context.
+"""
+from pathlib import Path
+from collections import defaultdict
+import pytest
+
+REPO = Path(__file__).parent.parent
+AGENTS_DIR = REPO / "agents"
+
+
+def test_agent_basenames_are_unique_across_domains():
+    """No two agent files in different domains share the same stem."""
+    stem_to_paths: dict[str, list[Path]] = defaultdict(list)
+    for md_file in sorted(AGENTS_DIR.rglob("*.md")):
+        stem_to_paths[md_file.stem].append(md_file)
+
+    duplicates = {
+        stem: paths
+        for stem, paths in stem_to_paths.items()
+        if len(paths) > 1
+    }
+
+    if duplicates:
+        lines = []
+        for stem, paths in sorted(duplicates.items()):
+            rel_paths = [str(p.relative_to(REPO)) for p in paths]
+            lines.append(f"  '{stem}': {rel_paths}")
+        detail = "\n".join(lines)
+        pytest.fail(
+            f"Agent basename collisions detected across domains "
+            f"(causes routing ambiguity):\n{detail}"
+        )

--- a/tests/test_agent_subagent_type.py
+++ b/tests/test_agent_subagent_type.py
@@ -1,0 +1,54 @@
+"""
+Regression suite: every agent file must have subagent_type matching its path.
+
+Audit finding: #535 — 71 agents were missing subagent_type frontmatter.
+Fix: bulk injection via Python script in build phase (2026-04-19).
+This suite ensures no agent is added in the future without the field.
+
+Expected pattern: agents/{domain}/{stem}.md → subagent_type: wicked-garden:{domain}:{stem}
+"""
+import re
+from pathlib import Path
+import pytest
+
+REPO = Path(__file__).parent.parent
+AGENTS_DIR = REPO / "agents"
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+SUBAGENT_TYPE_RE = re.compile(r"^subagent_type:\s*(.+)$", re.MULTILINE)
+
+
+def _parse_subagent_type(text: str):
+    """Return subagent_type value from frontmatter, or None if absent."""
+    fm_match = FRONTMATTER_RE.match(text)
+    if not fm_match:
+        return None
+    st_match = SUBAGENT_TYPE_RE.search(fm_match.group(1))
+    if not st_match:
+        return None
+    return st_match.group(1).strip()
+
+
+def _agent_params():
+    """Collect (path, expected_subagent_type) for all agent .md files."""
+    params = []
+    for md_file in sorted(AGENTS_DIR.rglob("*.md")):
+        domain = md_file.parent.name
+        stem = md_file.stem
+        expected = f"wicked-garden:{domain}:{stem}"
+        params.append(pytest.param(md_file, expected, id=f"{domain}/{stem}"))
+    return params
+
+
+@pytest.mark.parametrize("agent_path,expected_subagent_type", _agent_params())
+def test_agent_has_correct_subagent_type(agent_path: Path, expected_subagent_type: str):
+    """Agent file must declare subagent_type matching its file path convention."""
+    text = agent_path.read_text(encoding="utf-8")
+    actual = _parse_subagent_type(text)
+    assert actual is not None, (
+        f"{agent_path.relative_to(REPO)}: missing subagent_type in frontmatter"
+    )
+    assert actual == expected_subagent_type, (
+        f"{agent_path.relative_to(REPO)}: subagent_type '{actual}' does not match "
+        f"expected '{expected_subagent_type}' (derived from file path)"
+    )

--- a/tests/test_command_agent_refs_resolve.py
+++ b/tests/test_command_agent_refs_resolve.py
@@ -1,0 +1,60 @@
+"""
+Regression suite: every Task(subagent_type="wicked-garden:*:*") ref in commands/
+must resolve to an existing agent file.
+
+Audit finding: #533 — 15 command files referenced agents that did not exist on disk.
+Fix: consolidation map applied in build phase (2026-04-19). This suite prevents
+future command additions from referencing non-existent agents.
+
+Extraction: regex over Task( ... subagent_type="wicked-garden:{domain}:{name}" ... )
+Resolution: agents/{domain}/{name}.md must exist.
+"""
+import re
+from pathlib import Path
+import pytest
+
+REPO = Path(__file__).parent.parent
+COMMANDS_DIR = REPO / "commands"
+AGENTS_DIR = REPO / "agents"
+
+# Match subagent_type="wicked-garden:{domain}:{name}" (quoted, in Task() calls)
+SUBAGENT_REF_RE = re.compile(
+    r'subagent_type\s*=\s*"(wicked-garden:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*)"'
+)
+
+
+def _command_ref_params():
+    """
+    Collect (command_file, ref_string, expected_agent_path) for every
+    subagent_type ref found in commands/**/*.md files.
+    """
+    params = []
+    for md_file in sorted(COMMANDS_DIR.rglob("*.md")):
+        text = md_file.read_text(encoding="utf-8")
+        for match in SUBAGENT_REF_RE.finditer(text):
+            ref = match.group(1)
+            parts = ref.split(":")
+            if len(parts) != 3:
+                continue
+            _, domain, name = parts
+            agent_path = AGENTS_DIR / domain / f"{name}.md"
+            params.append(
+                pytest.param(
+                    md_file,
+                    ref,
+                    agent_path,
+                    id=f"{md_file.relative_to(REPO)}::{ref}",
+                )
+            )
+    return params
+
+
+@pytest.mark.parametrize("command_file,ref,agent_path", _command_ref_params())
+def test_command_subagent_ref_resolves(
+    command_file: Path, ref: str, agent_path: Path
+):
+    """Every Task(subagent_type=...) in commands/ must have a corresponding agent file."""
+    assert agent_path.exists(), (
+        f"{command_file.relative_to(REPO)}: references '{ref}' but "
+        f"agents/{agent_path.parent.name}/{agent_path.name} does not exist"
+    )

--- a/tests/test_workflow_skill_v6.py
+++ b/tests/test_workflow_skill_v6.py
@@ -1,0 +1,65 @@
+"""
+Regression suite: skills/workflow/SKILL.md must describe v6 reality.
+
+Audit finding: #536 — workflow/SKILL.md described v3 architecture (smart_decisioning.py,
+v5 rule engine) as current. The file was rewritten in build phase (2026-04-19) to
+describe the v6 facilitator-rubric decision engine.
+
+This suite guards against drift back to stale v3/v5 content.
+"""
+from pathlib import Path
+import pytest
+
+REPO = Path(__file__).parent.parent
+SKILL_PATH = REPO / "skills" / "workflow" / "SKILL.md"
+
+STALE_PHRASES = [
+    "smart_decisioning",
+    "v3 architecture",
+    "v5 rule engine",
+    "Workflow Skill (v3)",
+    "Smart Decisioning",
+]
+
+REQUIRED_PHRASES = [
+    "propose-process",
+]
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_PATH.exists(), f"skills/workflow/SKILL.md not found at {SKILL_PATH}"
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("stale_phrase", STALE_PHRASES)
+def test_workflow_skill_does_not_mention_stale_content(skill_text: str, stale_phrase: str):
+    """
+    SKILL.md must not present v3/v5 concepts as current.
+    Historical mentions in refs/ files are allowed; only the entry SKILL.md is checked.
+    """
+    # Allow mentions only inside code blocks or quoted as historical context
+    # Simple check: the phrase should not appear as a current description
+    assert stale_phrase not in skill_text, (
+        f"skills/workflow/SKILL.md mentions '{stale_phrase}' — this was part of the "
+        f"v3/v5 architecture that no longer exists in v6. Update or remove."
+    )
+
+
+@pytest.mark.parametrize("required_phrase", REQUIRED_PHRASES)
+def test_workflow_skill_mentions_v6_decision_engine(skill_text: str, required_phrase: str):
+    """SKILL.md must reference propose-process as the v6 decision engine."""
+    assert required_phrase in skill_text, (
+        f"skills/workflow/SKILL.md does not mention '{required_phrase}'. "
+        f"The v6 decision engine is wicked-garden:propose-process — "
+        f"the SKILL.md must describe it."
+    )
+
+
+def test_workflow_skill_under_200_lines(skill_text: str):
+    """SKILL.md must stay under the 200-line plugin validator cap."""
+    line_count = len(skill_text.splitlines())
+    assert line_count <= 200, (
+        f"skills/workflow/SKILL.md has {line_count} lines — exceeds 200-line cap "
+        f"enforced by the plugin validator"
+    )


### PR DESCRIPTION
## Summary

Closes #533 (15 missing agents → 16 broken command Task() paths), #534 (duplicate `facilitator` name crew/ + jam/), #535 (71 of 73 agents missing `subagent_type` frontmatter), #536 (`skills/workflow/SKILL.md` described removed v5 algorithm as current).

From the 4-agent audit swarm ran Apr 19 2026. Defers #537 hygiene bundle (8 smaller items) to next PR.

## Changes

### #535 — subagent_type frontmatter (additive)
71 agents gained `subagent_type: wicked-garden:{domain}:{name}` after the `name:` key. Plus 1 new agent file with it. Total: 72 agent files touched.

### #534 — rename jam/facilitator
- `agents/jam/facilitator.md` → `agents/jam/brainstorm-facilitator.md`
- `subagent_type: wicked-garden:jam:brainstorm-facilitator`
- 3 jam command files re-pointed

### #533 — resolve 15 missing agent refs (14 CONSOLIDATE + 1 NEW)
| Missing agent | Resolution |
|---|---|
| visual-reviewer | → `product:ui-reviewer` |
| business-strategist, market-analyst, competitive-analyst | → `product:market-strategist` |
| value-analyst, alignment-lead | → `product:value-strategist` |
| feedback-analyst, customer-advocate (2×) | → `product:user-voice` |
| ux-analyst | NEW `agents/product/ux-analyst.md` |
| acceptance-test-writer, acceptance-test-executor, acceptance-test-reviewer | → `qe:test-designer` |
| tdd-coach | → `qe:test-strategist` |
| analytics-architect, data-architect (domain prefix fix) | → `data:data-architect` |

10 command files updated.

### #536 — rewrite skills/workflow/SKILL.md
Frontmatter + body now describe v6 state (propose-process rubric, interaction modes, rigor tiers, gate-policy reviewer assignment). No references to `smart_decisioning`, `v3 architecture`, or `v5 rule engine` as current. Under 200-line cap.

## Tests

4 new regression suites (+197 parametrized test cases):
- `tests/test_agent_subagent_type.py` — every agent has `subagent_type` matching file path
- `tests/test_agent_name_uniqueness.py` — no duplicate agent basenames across domains
- `tests/test_command_agent_refs_resolve.py` — every `Task(subagent_type=...)` in commands/ resolves to an existing agent
- `tests/test_workflow_skill_v6.py` — workflow/SKILL.md doesn't mention removed v5 symbols as current

**Total: 894 passed / 0 failed / 1 deselected in 2.37s** (baseline ~697 + 197 new).

## Test plan
- [x] `pytest tests/` → 894 passed
- [x] Plugin validation (ran via CI)
- [x] No plugin.json / marketplace.json version mismatch
- [x] CHANGELOG.md has 6.3.2 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)