### PR TITLE
fix: agent-feedback batch — close #562, #563, #564, #565, #566

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "6.3.6"
+      "version": "7.1.1"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "wicked-garden",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. 13 domains across the full lifecycle: crew workflows, context assembly, memory, code intelligence, brainstorming, and domain experts for security, architecture, QE, product, data, delivery, agentic, and personas. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
-  "wicked_testing_version": "^0.2.0",
+  "wicked_testing_version": "*",
   "author": {
     "name": "Mike Parcewski"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [7.1.1] - UNRELEASED
+
+### Bug Fixes
+
+- **fix(wicked-testing-probe)**: Relax `wicked_testing_version` pin to `"*"` so the probe no longer blocks crew commands when `npx wicked-testing --version` emits installer output rather than a plain semver string. `is_version_in_range` now short-circuits on the `"*"` wildcard before the caret parser. Marketplace version re-synced from 6.3.6 to 7.1.1 (was stale on the v6 line).
+
 ## [7.1.0] - UNRELEASED
 
 v7.1 completes the QE extraction by removing all deprecated surfaces (agents, skills, commands) and landing the deferred v7.0.1 backward-compat reader removal. wicked-testing remains a required peer plugin, unchanged from v7.0.

--- a/scripts/_wicked_testing_probe.py
+++ b/scripts/_wicked_testing_probe.py
@@ -60,15 +60,20 @@ _PROBE_TIMEOUT_S = 3
 def is_version_in_range(installed: str, pin: str) -> bool:
     """Evaluate a caret semver range.
 
-    Supports caret range only: "^X.Y.Z" means:
-      - X > 0:  >=X.Y.Z and <(X+1).0.0
-      - X == 0: >=0.Y.Z and <0.(Y+1).0
+    Supports:
+      - "*" wildcard: accepts any non-empty installed version string.
+      - Caret range "^X.Y.Z":
+        - X > 0:  >=X.Y.Z and <(X+1).0.0
+        - X == 0: >=0.Y.Z and <0.(Y+1).0
 
-    Prerelease tags (e.g. "0.1.1-beta.1") are rejected — strip the prerelease
-    suffix from installed before the numeric comparison.
+    Prerelease tags (e.g. "0.1.1-beta.1") are rejected for caret ranges —
+    strip the prerelease suffix from installed before the numeric comparison.
 
     Returns False for any malformed input.
     """
+    if pin == "*":
+        return bool(installed)
+
     if not pin.startswith("^"):
         return False
 

--- a/scripts/crew/gate_result_schema.py
+++ b/scripts/crew/gate_result_schema.py
@@ -82,6 +82,13 @@ BANNED_SOURCE_AGENT_PREFIXES = tuple(set(_EVENT_BANNED_PREFIXES) | {
 # ---------------------------------------------------------------------------
 
 
+# Issue #563: authoritative pointer to the schema source of truth. The code
+# IS the schema — there is no separate JSON-Schema doc — so point callers at
+# the module. Exposed via GateResultSchemaError.schema_doc and str(exc) so
+# users don't have to grep to learn where the rules live.
+SCHEMA_DOC = "scripts/crew/gate_result_schema.py § validate_gate_result (schema source of truth)"
+
+
 class GateResultSchemaError(Exception):
     """Raised by ``validate_gate_result`` on any schema or content violation.
 
@@ -92,6 +99,7 @@ class GateResultSchemaError(Exception):
       offending_value_excerpt: first 256 bytes of the raw violating value
                                (UTF-8 lossy decoded)
       violation_class:         one of ``{"schema", "content", "authorization"}``
+      schema_doc:              pointer to the schema reference (default SCHEMA_DOC)
     """
 
     def __init__(
@@ -101,12 +109,22 @@ class GateResultSchemaError(Exception):
         offending_field: Optional[str] = None,
         offending_value_excerpt: Optional[str] = None,
         violation_class: str = "schema",
+        schema_doc: Optional[str] = None,
     ) -> None:
         super().__init__(reason)
         self.reason = reason
         self.offending_field = offending_field
         self.offending_value_excerpt = offending_value_excerpt
         self.violation_class = violation_class
+        self.schema_doc = schema_doc or SCHEMA_DOC
+
+    def __str__(self) -> str:
+        # Issue #563: str(exc) surfaces the schema pointer so callers that log
+        # or re-raise don't need extra wiring to cite the source of truth.
+        base = self.reason
+        if self.offending_field:
+            base = f"{base} (field: {self.offending_field})"
+        return f"{base} — See: {self.schema_doc}"
 
 
 class GateResultAuthorizationError(GateResultSchemaError):

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3697,6 +3697,25 @@ def get_phase_status_summary(state: ProjectState) -> Dict[str, str]:
     return summary
 
 
+def compute_project_completion(state: ProjectState) -> Tuple[bool, List[str]]:
+    """Return (is_complete, remaining_phases).
+
+    is_complete is True only when every phase in phase_plan is 'approved'.
+    remaining_phases lists phases that are not yet approved, in plan order.
+    Used by the CLI approve/advance paths so we don't print "Project complete!"
+    while phases are still pending (issue #562).
+    """
+    if not state.phase_plan:
+        return False, []
+    status_map = get_phase_status_summary(state)
+    remaining = [
+        resolve_phase(p)
+        for p in state.phase_plan
+        if status_map.get(resolve_phase(p)) != "approved"
+    ]
+    return (not remaining), remaining
+
+
 def create_project(
     name: str,
     description: str = "",
@@ -4764,20 +4783,28 @@ def main():
                 print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
         save_project_state(state)
+        is_complete, remaining = compute_project_completion(state)
         if args.json:
             print(json.dumps({
                 "ok": True,
                 "status": "cli-no-dispatcher",
                 "approved_phase": resolve_phase(phase),
                 "next_phase": next_phase,
+                "is_complete": is_complete,
+                "remaining_phases": remaining,
                 "warning": cli_dispatcher_warning,
             }, indent=2))
         else:
             print(f"Approved phase: {resolve_phase(phase)}")
-            if next_phase:
-                print(f"Next phase: {next_phase}")
-            else:
+            if is_complete:
                 print("Project complete!")
+            elif next_phase:
+                print(f"Next phase in plan: {next_phase}")
+            elif remaining:
+                print(f"Next phase in plan: {remaining[0]} (remaining: {', '.join(remaining)})")
+            else:
+                # Phase plan empty or unresolvable — honest fallback.
+                print("No next phase resolved — run 'status' to verify state.")
 
     elif args.action == "skip":
         phase = args.phase
@@ -4923,16 +4950,28 @@ def main():
 
         if next_phase is None:
             save_project_state(state)
+            is_complete, remaining = compute_project_completion(state)
             if args.json:
                 print(json.dumps({
                     "ok": True,
                     "approved_phase": approved_phase,
                     "next_phase": None,
-                    "message": "Project complete — no next phase",
+                    "is_complete": is_complete,
+                    "remaining_phases": remaining,
+                    "message": (
+                        "Project complete — no next phase"
+                        if is_complete
+                        else f"Approved {approved_phase}; no successor resolved but phases still pending: {', '.join(remaining)}"
+                    ),
                 }))
             else:
                 print(f"Approved phase: {approved_phase}")
-                print("Project complete!")
+                if is_complete:
+                    print("Project complete!")
+                elif remaining:
+                    print(f"Next phase in plan: {remaining[0]} (remaining: {', '.join(remaining)})")
+                else:
+                    print("No next phase resolved — run 'status' to verify state.")
             return
 
         state = start_phase(state, next_phase)

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3697,6 +3697,59 @@ def get_phase_status_summary(state: ProjectState) -> Dict[str, str]:
     return summary
 
 
+def get_phase_spec(phase_name: str) -> Dict[str, Any]:
+    """Return a structured phase specification suitable for --json inspection.
+
+    Aggregates phases.json + gate-policy.json into a single read-only view so
+    callers can decide what to attempt before attempting it (issue #566).
+    Never mutates state; purely derives from config files.
+    """
+    resolved = resolve_phase(phase_name)
+    phases_cfg = load_phases_config()
+    phase_cfg = phases_cfg.get(resolved, {})
+
+    gate_name = _gate_name_for_phase(resolved)
+    gate_policy = _load_gate_policy() if phase_cfg.get("gate_required") else {}
+    gate_tiers = (gate_policy.get("gates", {}) or {}).get(gate_name, {}) if gate_policy else {}
+
+    # Surface reviewers per rigor tier when a gate is declared.
+    gate_by_tier: Dict[str, Dict[str, Any]] = {}
+    for tier, entry in gate_tiers.items():
+        if not isinstance(entry, dict):
+            continue
+        gate_by_tier[tier] = {
+            "reviewers": list(entry.get("reviewers", [])),
+            "mode": entry.get("mode"),
+            "fallback": entry.get("fallback"),
+            "min_score": entry.get("min_score"),
+        }
+
+    return {
+        "phase": resolved,
+        "known": bool(phase_cfg),
+        "description": phase_cfg.get("description"),
+        "is_skippable": phase_cfg.get("is_skippable", True),
+        "skip_complexity_threshold": phase_cfg.get("skip_complexity_threshold"),
+        "valid_skip_reasons": list(phase_cfg.get("valid_skip_reasons", [])),
+        "gate_required": phase_cfg.get("gate_required", False),
+        "gate_name": gate_name if phase_cfg.get("gate_required") else None,
+        "gate_type": phase_cfg.get("gate_type"),
+        "min_gate_score": phase_cfg.get("min_gate_score"),
+        "min_test_coverage": phase_cfg.get("min_test_coverage"),
+        "required_deliverables": get_required_deliverables(resolved),
+        "optional_deliverables": list(phase_cfg.get("optional_deliverables", [])),
+        "depends_on": list(phase_cfg.get("depends_on", [])),
+        "triggers": list(phase_cfg.get("triggers", [])),
+        "specialists": list(phase_cfg.get("specialists", [])),
+        "required_specialists": list(phase_cfg.get("required_specialists", [])),
+        "fallback_agent": phase_cfg.get("fallback_agent"),
+        "checkpoint": phase_cfg.get("checkpoint", False),
+        "conditions_manifest_required": phase_cfg.get("conditions_manifest_required", False),
+        "phase_executor_may_delegate": phase_cfg.get("phase_executor_may_delegate", False),
+        "gate_policy": gate_by_tier,
+    }
+
+
 def compute_project_completion(state: ProjectState) -> Tuple[bool, List[str]]:
     """Return (is_complete, remaining_phases).
 
@@ -4580,7 +4633,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Phase manager for wicked-crew")
     parser.add_argument("project", help="Project name")
-    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode"])
+    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode", "phase-spec"])
     parser.add_argument("--phase", help="Target phase")
     parser.add_argument("--reason", help="Reason for skip or gate override")
     parser.add_argument("--approved-by", default=None, help="Approver identity (default: 'auto' for skip, 'user' for approve)")
@@ -4665,7 +4718,7 @@ def main():
             sys.exit(1)
 
     state = load_project_state(args.project)
-    if not state and args.action not in ("status", "create"):
+    if not state and args.action not in ("status", "create", "phase-spec"):
         print(json.dumps({"ok": False, "error": f"Project not found: {args.project}"}) if args.json else f"Project not found: {args.project}")
         return
 
@@ -4682,6 +4735,40 @@ def main():
                 return
         except (json.JSONDecodeError, OSError):
             pass  # fail open: invalid project state skipped
+
+    if args.action == "phase-spec":
+        # Read-only config inspector — derives entirely from
+        # phases.json + gate-policy.json. Does not require project state.
+        phase = args.phase or state.current_phase if state else args.phase
+        if not phase:
+            msg = "Error: --phase is required for phase-spec (no current project to infer from)"
+            print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr if not args.json else sys.stdout)
+            sys.exit(1)
+        spec = get_phase_spec(phase)
+        if args.json:
+            print(json.dumps(spec, indent=2))
+        else:
+            print(f"Phase: {spec['phase']}")
+            if not spec["known"]:
+                print("  (unknown phase — not defined in phases.json)")
+            print(f"  description: {spec.get('description') or '(none)'}")
+            print(f"  is_skippable: {spec['is_skippable']}")
+            if spec["skip_complexity_threshold"] is not None:
+                print(f"  skip_complexity_threshold: {spec['skip_complexity_threshold']}")
+            if spec["valid_skip_reasons"]:
+                print(f"  valid_skip_reasons: {', '.join(spec['valid_skip_reasons'])}")
+            print(f"  gate_required: {spec['gate_required']}")
+            if spec["gate_required"]:
+                print(f"  gate_name: {spec['gate_name']}")
+                print(f"  min_gate_score: {spec['min_gate_score']}")
+            if spec["min_test_coverage"] is not None:
+                print(f"  min_test_coverage: {spec['min_test_coverage']}")
+            if spec["required_deliverables"]:
+                files = ", ".join(d["file"] for d in spec["required_deliverables"])
+                print(f"  required_deliverables: {files}")
+            if spec["depends_on"]:
+                print(f"  depends_on: {', '.join(spec['depends_on'])}")
+        return
 
     if args.action == "status":
         if not state:

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3835,6 +3835,155 @@ def get_phase_spec(phase_name: str) -> Dict[str, Any]:
     }
 
 
+def adopt_clarify_from_memo(
+    state: ProjectState,
+    memo_path: Path,
+    *,
+    memo_as: str = "deliberation",
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Clone a design memo into clarify's required deliverables (issue #565).
+
+    When the substantive clarify+design work already happened in a document,
+    this action writes phase-local stub deliverables that cite the memo as
+    the source of truth. The user-confirm pause is preserved — this does NOT
+    approve the phase; the caller still runs `approve --phase clarify`.
+
+    Args:
+        state:     Project state (must be at clarify phase).
+        memo_path: Path to the memo file (absolute or relative to CWD).
+        memo_as:   Provenance label written into addendum and deliverable frontmatter.
+                   Caller-visible hint about why the memo satisfies clarify.
+        force:     If True, overwrite existing deliverable files. Default False
+                   means a prior deliverable file causes an error so the user
+                   doesn't accidentally clobber their own work.
+
+    Returns:
+        Dict with keys: adopted_deliverables, memo, addendum_written.
+
+    Raises:
+        ValueError: Memo unreadable/empty, project not at clarify phase, or
+                    existing deliverables would be clobbered without --force.
+    """
+    clarify_phase = state.phases.get("clarify")
+    if clarify_phase is None or clarify_phase.status == "approved":
+        raise ValueError(
+            "adopt-clarify requires clarify to be pending or in_progress; "
+            f"current status is {clarify_phase.status if clarify_phase else 'missing'}."
+        )
+
+    if not memo_path.exists() or not memo_path.is_file():
+        raise ValueError(f"Memo not found: {memo_path}")
+    try:
+        memo_text = memo_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Memo unreadable: {memo_path} — {exc}")
+    if not memo_text.strip():
+        raise ValueError(f"Memo is empty: {memo_path}")
+
+    project_dir = get_project_dir(state.name)
+    phase_dir = project_dir / "phases" / "clarify"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+
+    deliverables = get_required_deliverables("clarify")
+    adopted_at = get_utc_timestamp()
+    written: List[str] = []
+
+    # Check for clobbering before writing anything.
+    if not force:
+        existing = [
+            d["file"] for d in deliverables
+            if (phase_dir / d["file"]).exists() and (phase_dir / d["file"]).stat().st_size > 0
+        ]
+        if existing:
+            raise ValueError(
+                f"clarify deliverables already exist: {existing}. "
+                "Pass --force to overwrite (will preserve the memo as source of truth "
+                "but clobber your current files)."
+            )
+
+    # Compose each deliverable. Content must clear min_bytes; include an excerpt
+    # of the memo so the artifact is substantive, not a placeholder.
+    excerpt = memo_text[:2000]
+    excerpt_suffix = "\n\n… (truncated — see source memo)" if len(memo_text) > 2000 else ""
+    memo_ref = str(memo_path)
+
+    for deliverable in deliverables:
+        fname = deliverable["file"]
+        label_from_file = fname.removesuffix(".md").replace("-", " ").title()
+        frontmatter_lines = [
+            "---",
+            f"adopted_from: {memo_ref}",
+            f"adopted_at: {adopted_at}",
+            f"adopted_as: {fname.removesuffix('.md')}",
+            f"memo_as: {memo_as}",
+        ]
+        # acceptance-criteria.md declares case_count in its frontmatter contract.
+        if fname == "acceptance-criteria.md":
+            frontmatter_lines.append("case_count: TBD")
+        frontmatter_lines.append("---")
+
+        body = [
+            "",
+            f"# {label_from_file} (adopted from design memo)",
+            "",
+            f"**Source memo**: `{memo_ref}`  ",
+            f"**Adopted at**: {adopted_at}  ",
+            f"**Role**: {memo_as} — the memo captured the clarify deliberation; this file",
+            "is the phase-local pointer that satisfies the clarify deliverable contract",
+            "while preserving the memo as the authoritative source.",
+            "",
+            "## Excerpt",
+            "",
+            "> " + excerpt.replace("\n", "\n> ") + excerpt_suffix,
+            "",
+        ]
+        (phase_dir / fname).write_text("\n".join(frontmatter_lines) + "\n".join(body))
+        written.append(fname)
+
+    # Record the adoption as a re-eval addendum entry — the memo IS the
+    # deliberation evidence, and the addendum preserves that provenance.
+    try:
+        import reeval_addendum
+        rigor_tier = (state.extras or {}).get("rigor_tier", "standard")
+        record = {
+            "chain_id": f"{state.name}.clarify",
+            "triggered_at": adopted_at,
+            "trigger": "adopt-clarify:memo-adoption",
+            "prior_rigor_tier": rigor_tier,
+            "new_rigor_tier": rigor_tier,
+            "mutations": [],
+            "mutations_applied": [],
+            "mutations_deferred": [],
+            "validator_version": "1.1.0",
+            "adoption_evidence": {
+                "memo": memo_ref,
+                "memo_as": memo_as,
+                "deliverables_written": written,
+            },
+        }
+        reeval_addendum.append(project_dir, phase="clarify", record=record)
+        addendum_written = True
+    except (ImportError, ValueError, OSError) as exc:
+        logger.warning(
+            "[adopt-clarify] addendum write failed (non-fatal): %s", exc
+        )
+        addendum_written = False
+
+    logger.info(
+        "[adopt-clarify] project '%s' adopted clarify deliverables from %s "
+        "(wrote %d files; user-confirm still required via `approve`).",
+        state.name, memo_ref, len(written),
+    )
+
+    return {
+        "adopted_deliverables": written,
+        "memo": memo_ref,
+        "memo_as": memo_as,
+        "addendum_written": addendum_written,
+    }
+
+
 def compute_project_completion(state: ProjectState) -> Tuple[bool, List[str]]:
     """Return (is_complete, remaining_phases).
 
@@ -4718,7 +4867,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Phase manager for wicked-crew")
     parser.add_argument("project", help="Project name")
-    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode", "phase-spec"])
+    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode", "phase-spec", "adopt-clarify"])
     parser.add_argument("--phase", help="Target phase")
     parser.add_argument("--reason", help="Reason for skip or gate override")
     parser.add_argument("--approved-by", default=None, help="Approver identity (default: 'auto' for skip, 'user' for approve)")
@@ -4738,6 +4887,24 @@ def main():
     parser.add_argument("--description", default="", help="Project description (for create)")
     parser.add_argument("--data", default=None, help="JSON string of fields to set/update")
     parser.add_argument("--to", default=None, help="Target dispatch mode for cutover (e.g. mode-3)")
+    parser.add_argument(
+        "--from",
+        dest="adopt_from",
+        default=None,
+        help="Memo path for adopt-clarify (design memo that captured the deliberation).",
+    )
+    parser.add_argument(
+        "--memo-as",
+        dest="memo_as",
+        default="deliberation",
+        help="Provenance label for adopt-clarify (default: 'deliberation').",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite existing deliverables during adopt-clarify.",
+    )
     parser.add_argument(
         "--yolo-action", dest="yolo_action",
         default=None, choices=["approve", "revoke", "status"],
@@ -4820,6 +4987,36 @@ def main():
                 return
         except (json.JSONDecodeError, OSError):
             pass  # fail open: invalid project state skipped
+
+    if args.action == "adopt-clarify":
+        if not args.adopt_from:
+            msg = "Error: adopt-clarify requires --from <memo-path>"
+            print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr if not args.json else sys.stdout)
+            sys.exit(1)
+        try:
+            result = adopt_clarify_from_memo(
+                state,
+                Path(args.adopt_from),
+                memo_as=args.memo_as or "deliberation",
+                force=args.force,
+            )
+        except ValueError as exc:
+            if args.json:
+                print(json.dumps({"ok": False, "error": str(exc)}))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        save_project_state(state)
+        if args.json:
+            print(json.dumps({"ok": True, **result, "next_step": "approve --phase clarify"}, indent=2))
+        else:
+            print(f"Adopted clarify deliverables from: {result['memo']}")
+            print(f"  Wrote: {', '.join(result['adopted_deliverables'])}")
+            print(f"  Addendum written: {result['addendum_written']}")
+            print("")
+            print("Next: review the adopted files and run:")
+            print(f"  phase_manager.py {args.project} approve --phase clarify")
+        return
 
     if args.action == "phase-spec":
         # Read-only config inspector — derives entirely from

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -162,17 +162,20 @@ def _apply_project_gate_overrides(
         return result
     extras = state.extras or {}
 
+    # Layer overrides bottom-up so partial specifics can extend wildcard
+    # defaults (gemini #568 review): apply legacy shorthand → wildcard →
+    # specific. Each layer adds its declared fields; later layers win on
+    # the keys they touch but never erase keys they don't.
     override: Dict[str, Any] = {}
+    legacy_method = extras.get("gate_method")
+    if isinstance(legacy_method, str) and legacy_method.strip():
+        override["mode"] = legacy_method.strip()
     overrides_map = extras.get("gate_overrides")
     if isinstance(overrides_map, dict):
+        if isinstance(overrides_map.get("*"), dict):
+            override.update(overrides_map["*"])
         if isinstance(overrides_map.get(gate_name), dict):
             override.update(overrides_map[gate_name])
-        elif isinstance(overrides_map.get("*"), dict):
-            override.update(overrides_map["*"])
-    # Legacy shorthand — exactly the shape the reporter used in #564.
-    legacy_method = extras.get("gate_method")
-    if "mode" not in override and isinstance(legacy_method, str) and legacy_method.strip():
-        override["mode"] = legacy_method.strip()
 
     if not override:
         return result
@@ -211,6 +214,36 @@ def _apply_project_gate_overrides(
                 getattr(state, "name", "<unknown>"),
                 gate_name,
             )
+
+    # Copilot #568 review: enforce the same semantic invariants the CI
+    # gate-policy coverage check enforces against gate-policy.json:
+    #   - empty reviewers list is only valid for self-check / advisory modes
+    #   - council mode requires >=2 reviewers
+    # If the merged result violates these, revert to the unmodified policy
+    # entry so a typo in project metadata can never silently corrupt dispatch.
+    final_mode = result.get("mode")
+    final_reviewers = result.get("reviewers") or []
+    invariant_violation: Optional[str] = None
+    if final_mode == "council" and len(final_reviewers) < 2:
+        invariant_violation = (
+            f"mode='council' requires >=2 reviewers (got {len(final_reviewers)})"
+        )
+    elif (
+        final_mode in {"sequential", "parallel"}
+        and len(final_reviewers) == 0
+    ):
+        invariant_violation = (
+            f"mode={final_mode!r} requires at least 1 reviewer (got 0)"
+        )
+    if invariant_violation:
+        logger.warning(
+            "[gate-override] project '%s' gate '%s' override violates "
+            "dispatch invariants (%s) — reverting to policy default.",
+            getattr(state, "name", "<unknown>"),
+            gate_name, invariant_violation,
+        )
+        return dict(entry)
+
     return result
 
 
@@ -3798,12 +3831,14 @@ def get_phase_spec(phase_name: str) -> Dict[str, Any]:
     gate_tiers = (gate_policy.get("gates", {}) or {}).get(gate_name, {}) if gate_policy else {}
 
     # Surface reviewers per rigor tier when a gate is declared.
+    # `or []` guards against an explicit JSON null on the reviewers field
+    # (gemini #568 review — list(None) would crash).
     gate_by_tier: Dict[str, Dict[str, Any]] = {}
     for tier, entry in gate_tiers.items():
         if not isinstance(entry, dict):
             continue
         gate_by_tier[tier] = {
-            "reviewers": list(entry.get("reviewers", [])),
+            "reviewers": list(entry.get("reviewers") or []),
             "mode": entry.get("mode"),
             "fallback": entry.get("fallback"),
             "min_score": entry.get("min_score"),
@@ -3865,11 +3900,23 @@ def adopt_clarify_from_memo(
         ValueError: Memo unreadable/empty, project not at clarify phase, or
                     existing deliverables would be clobbered without --force.
     """
+    # Copilot #568 review: a missing PhaseState is implicitly 'pending'
+    # (matches get_phase_status_summary), so materialize it on demand
+    # rather than rejecting projects that never instantiated it.
     clarify_phase = state.phases.get("clarify")
-    if clarify_phase is None or clarify_phase.status == "approved":
+    if clarify_phase is None:
+        clarify_phase = PhaseState(status="pending")
+        state.phases["clarify"] = clarify_phase
+    if clarify_phase.status in _TERMINAL_PHASE_STATUSES:
         raise ValueError(
-            "adopt-clarify requires clarify to be pending or in_progress; "
-            f"current status is {clarify_phase.status if clarify_phase else 'missing'}."
+            f"adopt-clarify requires clarify to be pending or in_progress; "
+            f"current status is {clarify_phase.status!r}."
+        )
+    if state.current_phase != "clarify":
+        raise ValueError(
+            f"adopt-clarify requires the project to be on the clarify phase; "
+            f"current_phase={state.current_phase!r}. Adopting deliverables for a "
+            f"phase the project has already moved past would corrupt provenance."
         )
 
     if not memo_path.exists() or not memo_path.is_file():
@@ -3938,7 +3985,10 @@ def adopt_clarify_from_memo(
             "> " + excerpt.replace("\n", "\n> ") + excerpt_suffix,
             "",
         ]
-        (phase_dir / fname).write_text("\n".join(frontmatter_lines) + "\n".join(body))
+        (phase_dir / fname).write_text(
+            "\n".join(frontmatter_lines) + "\n".join(body),
+            encoding="utf-8",
+        )
         written.append(fname)
 
     # Record the adoption as a re-eval addendum entry — the memo IS the
@@ -3984,13 +4034,19 @@ def adopt_clarify_from_memo(
     }
 
 
+_TERMINAL_PHASE_STATUSES = frozenset({"approved", "skipped"})
+
+
 def compute_project_completion(state: ProjectState) -> Tuple[bool, List[str]]:
     """Return (is_complete, remaining_phases).
 
-    is_complete is True only when every phase in phase_plan is 'approved'.
-    remaining_phases lists phases that are not yet approved, in plan order.
-    Used by the CLI approve/advance paths so we don't print "Project complete!"
-    while phases are still pending (issue #562).
+    is_complete is True only when every phase in phase_plan reached a terminal
+    status — 'approved' or 'skipped'. Skipped phases satisfy the plan the same
+    way can_transition treats them (Copilot #568 review).
+
+    remaining_phases lists phases that have not reached a terminal status,
+    in plan order. Used by the CLI approve/advance paths so we don't print
+    "Project complete!" while phases are still pending (issue #562).
     """
     if not state.phase_plan:
         return False, []
@@ -3998,7 +4054,7 @@ def compute_project_completion(state: ProjectState) -> Tuple[bool, List[str]]:
     remaining = [
         resolve_phase(p)
         for p in state.phase_plan
-        if status_map.get(resolve_phase(p)) != "approved"
+        if status_map.get(resolve_phase(p)) not in _TERMINAL_PHASE_STATUSES
     ]
     return (not remaining), remaining
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -137,12 +137,97 @@ def _load_gate_policy() -> dict:
     return _GATE_POLICY_CACHE
 
 
-def _resolve_gate_reviewer(gate_name: str, rigor_tier: str) -> dict:
+# Issue #564: valid gate dispatch modes. Used to reject bogus per-project
+# overrides so misconfiguration fails loud instead of silently falling through.
+_VALID_GATE_MODES: frozenset = frozenset(
+    {"self-check", "advisory", "sequential", "parallel", "council", "fast-evaluator"}
+)
+
+
+def _apply_project_gate_overrides(
+    entry: dict, state: Optional["ProjectState"], gate_name: str
+) -> dict:
+    """Merge per-project gate overrides from state.extras over the policy entry.
+
+    Supports three shapes in state.extras (precedence: specific → wildcard → legacy):
+      1. gate_overrides[gate_name]: {"mode": "...", "reviewers": [...]}
+      2. gate_overrides["*"]:       same shape, applies to every gate
+      3. gate_method: "council"     legacy shorthand = gate_overrides["*"]["mode"]
+
+    Unknown modes trigger a WARN and the override is ignored — issue #564's
+    "fail-loud" invariant. Returns a NEW dict; never mutates the input.
+    """
+    result = dict(entry)
+    if state is None:
+        return result
+    extras = state.extras or {}
+
+    override: Dict[str, Any] = {}
+    overrides_map = extras.get("gate_overrides")
+    if isinstance(overrides_map, dict):
+        if isinstance(overrides_map.get(gate_name), dict):
+            override.update(overrides_map[gate_name])
+        elif isinstance(overrides_map.get("*"), dict):
+            override.update(overrides_map["*"])
+    # Legacy shorthand — exactly the shape the reporter used in #564.
+    legacy_method = extras.get("gate_method")
+    if "mode" not in override and isinstance(legacy_method, str) and legacy_method.strip():
+        override["mode"] = legacy_method.strip()
+
+    if not override:
+        return result
+
+    # Validate mode; unknown values never silently apply.
+    mode = override.get("mode")
+    if mode is not None:
+        if not isinstance(mode, str) or mode not in _VALID_GATE_MODES:
+            logger.warning(
+                "[gate-override] project '%s' requested mode=%r for gate '%s' "
+                "but that mode is not one of %s — ignoring override.",
+                getattr(state, "name", "<unknown>"),
+                mode, gate_name, sorted(_VALID_GATE_MODES),
+            )
+        else:
+            logger.info(
+                "[gate-override] project '%s' overriding gate '%s' mode: %s -> %s",
+                getattr(state, "name", "<unknown>"),
+                gate_name, result.get("mode"), mode,
+            )
+            result["mode"] = mode
+
+    reviewers = override.get("reviewers")
+    if reviewers is not None:
+        if isinstance(reviewers, list) and all(isinstance(r, str) for r in reviewers):
+            logger.info(
+                "[gate-override] project '%s' overriding gate '%s' reviewers",
+                getattr(state, "name", "<unknown>"),
+                gate_name,
+            )
+            result["reviewers"] = list(reviewers)
+        else:
+            logger.warning(
+                "[gate-override] project '%s' gate '%s' reviewers override must be "
+                "a list of strings — ignoring.",
+                getattr(state, "name", "<unknown>"),
+                gate_name,
+            )
+    return result
+
+
+def _resolve_gate_reviewer(
+    gate_name: str,
+    rigor_tier: str,
+    state: Optional["ProjectState"] = None,
+) -> dict:
     """Return the dispatch block for a (gate_name, rigor_tier) pair (D1, D4).
 
     Args:
         gate_name:  One of the 6 defined gates (e.g. 'requirements-quality').
         rigor_tier: One of 'minimal', 'standard', 'full'.
+        state:      Optional project state — per-project overrides from
+                    ``state.extras['gate_overrides']`` or legacy
+                    ``state.extras['gate_method']`` are layered on top of the
+                    gate-policy.json default (issue #564).
 
     Returns:
         dict with keys: reviewers (list), mode (str), fallback (str).
@@ -164,7 +249,7 @@ def _resolve_gate_reviewer(gate_name: str, rigor_tier: str) -> dict:
             f"Unknown rigor_tier '{rigor_tier}' for gate '{gate_name}'. "
             f"Valid tiers: {sorted(tier_map.keys())}"
         )
-    return tier_map[rigor_tier]
+    return _apply_project_gate_overrides(tier_map[rigor_tier], state, gate_name)
 
 
 # ---------------------------------------------------------------------------
@@ -3196,7 +3281,7 @@ def approve_phase(
             try:
                 gate_name = _gate_name_for_phase(phase)
                 gate_entry = _resolve_gate_reviewer(
-                    gate_name, rigor_tier or "standard"
+                    gate_name, rigor_tier or "standard", state=state
                 )
                 synthesized = _dispatch_gate_reviewer(
                     state, phase, gate_name, gate_entry,

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -32,6 +32,31 @@ REQUIRED_TASK_METADATA_KEYS = {
     "chain_id", "event_type", "source_agent", "phase", "rigor_tier",
 }
 
+# Issue #563: every violation cites this doc so callers don't have to grep
+# to find the authoritative schema.
+SCHEMA_DOC = "skills/propose-process/refs/output-schema.md"
+
+# Per-section anchors within SCHEMA_DOC. Key is the violation-message prefix
+# (the text before ' — ', with [] / . suffixes stripped).
+_SECTION_ANCHORS = {
+    "top-level": "§ Required vs. optional fields",
+    "factors": "§ Schema — factors block",
+    "specialists": "§ Schema — specialists",
+    "phases": "§ Schema — phases",
+    "tasks": "§ Schema — tasks",
+    "rigor_tier": "§ rigor_tier enum (minimal|standard|full)",
+    "complexity": "§ complexity bounds (0..7)",
+}
+
+
+def _schema_pointer_for(violation: str) -> str:
+    """Return a 'See: <doc> § <anchor>' hint for a given violation message."""
+    head = violation.split(" — ", 1)[0]
+    # Strip index / dotted suffix so "tasks[0].metadata" → "tasks".
+    section = head.split(".", 1)[0].split("[", 1)[0]
+    anchor = _SECTION_ANCHORS.get(section, "")
+    return f"See: {SCHEMA_DOC}" + (f" {anchor}" if anchor else "")
+
 
 def _check_top_level(plan: dict, violations: list) -> None:
     missing = REQUIRED_TOP_LEVEL_KEYS - plan.keys()
@@ -280,6 +305,7 @@ def main() -> None:
     if violations:
         for v in violations:
             sys.stderr.write(f"ERROR: {path} — {v}\n")
+            sys.stderr.write(f"  {_schema_pointer_for(v)}\n")
         sys.exit(1)
 
     sys.exit(0)

--- a/tests/crew/test_adopt_clarify.py
+++ b/tests/crew/test_adopt_clarify.py
@@ -179,3 +179,33 @@ def test_adopt_refuses_when_clarify_already_approved(isolated_project, memo):
     state.phases["clarify"].status = "approved"
     with pytest.raises(ValueError, match="clarify"):
         adopt_clarify_from_memo(state, memo)
+
+
+def test_adopt_refuses_when_clarify_skipped(isolated_project, memo):
+    """A skipped clarify is also terminal — adoption would conflict with the skip."""
+    state = _state_at_clarify()
+    state.phases["clarify"].status = "skipped"
+    with pytest.raises(ValueError, match="clarify"):
+        adopt_clarify_from_memo(state, memo)
+
+
+def test_adopt_materializes_missing_clarify_phase_state(isolated_project, memo):
+    """Copilot #568 review: a project without an explicit clarify PhaseState
+    (legacy/minimal projects) is implicitly pending — adopt-clarify should
+    create the entry on demand instead of erroring."""
+    state = _state_at_clarify()
+    del state.phases["clarify"]
+    result = adopt_clarify_from_memo(state, memo)
+    assert "clarify" in state.phases
+    assert state.phases["clarify"].status == "pending"
+    assert "objective.md" in result["adopted_deliverables"]
+
+
+def test_adopt_refuses_when_current_phase_moved_past_clarify(isolated_project, memo):
+    """Copilot #568 review: enforce current_phase=='clarify' so projects that
+    already moved to design/build can't have clarify deliverables backfilled,
+    which would corrupt phase provenance."""
+    state = _state_at_clarify()
+    state.current_phase = "design"
+    with pytest.raises(ValueError, match="clarify"):
+        adopt_clarify_from_memo(state, memo)

--- a/tests/crew/test_adopt_clarify.py
+++ b/tests/crew/test_adopt_clarify.py
@@ -1,0 +1,181 @@
+"""tests/crew/test_adopt_clarify.py — issue #565 adopt-clarify fast-path.
+
+Verifies that adopt_clarify_from_memo writes the clarify required
+deliverables from a source memo, records an addendum citing the memo,
+and does NOT auto-approve the phase (safety property).
+
+Rules:
+  T1: deterministic — uses tmp_path for isolation
+  T3: isolated — no network / no shared state
+  T4: single behavior per test
+  T5: descriptive names
+  T6: docstrings cite the tracking issue
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+from phase_manager import (  # noqa: E402
+    PhaseState,
+    ProjectState,
+    adopt_clarify_from_memo,
+)
+
+
+_MEMO_BODY = (
+    "# Wiki-Driven Contracts\n\n"
+    "## Objective\n"
+    "Ship a schema-first contract layer that removes duplicate schema definitions.\n\n"
+    "## Complexity\n"
+    "Medium — 3 services affected, no external API changes.\n\n"
+    "## Acceptance Criteria\n"
+    "- All 3 services load schema from a single source.\n"
+    "- Unit tests cover the load path.\n"
+    "- Migration is reversible within 1 day.\n"
+)
+
+
+def _state_at_clarify():
+    return ProjectState(
+        name="adopt-test",
+        current_phase="clarify",
+        created_at="2026-04-22T00:00:00Z",
+        phase_plan=["clarify", "build", "test"],
+        phases={"clarify": PhaseState(status="in_progress")},
+        extras={"rigor_tier": "standard"},
+    )
+
+
+@pytest.fixture
+def isolated_project(tmp_path, monkeypatch):
+    """Pin get_project_dir to tmp so tests don't touch the real project store."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    monkeypatch.setattr(phase_manager, "get_project_dir", lambda name: project_dir)
+    return project_dir
+
+
+@pytest.fixture
+def memo(tmp_path):
+    """Create a memo file for adoption."""
+    path = tmp_path / "docs" / "wiki-driven-contracts.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(_MEMO_BODY)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Happy path — deliverables written, addendum recorded, no auto-approve
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_writes_all_required_deliverables(isolated_project, memo):
+    """Issue #565: adopt-clarify writes objective/complexity/acceptance-criteria files."""
+    state = _state_at_clarify()
+    result = adopt_clarify_from_memo(state, memo)
+    adopted = set(result["adopted_deliverables"])
+    assert {"objective.md", "complexity.md", "acceptance-criteria.md"} <= adopted
+
+    for fname in adopted:
+        path = isolated_project / "phases" / "clarify" / fname
+        assert path.exists(), f"missing {fname}"
+        assert path.stat().st_size >= 100, f"{fname} too small"
+
+
+def test_adopt_embeds_memo_path_in_deliverable_frontmatter(isolated_project, memo):
+    """Each written file cites the memo via 'adopted_from' frontmatter for provenance."""
+    state = _state_at_clarify()
+    adopt_clarify_from_memo(state, memo)
+    objective = (isolated_project / "phases" / "clarify" / "objective.md").read_text()
+    assert "adopted_from:" in objective
+    assert str(memo) in objective
+
+
+def test_adopt_includes_case_count_for_acceptance_criteria(isolated_project, memo):
+    """acceptance-criteria.md carries the required case_count frontmatter key."""
+    state = _state_at_clarify()
+    adopt_clarify_from_memo(state, memo)
+    ac = (isolated_project / "phases" / "clarify" / "acceptance-criteria.md").read_text()
+    assert "case_count:" in ac
+
+
+def test_adopt_does_not_approve_phase(isolated_project, memo):
+    """Safety property: adoption does NOT flip clarify to approved."""
+    state = _state_at_clarify()
+    adopt_clarify_from_memo(state, memo)
+    assert state.phases["clarify"].status == "in_progress"
+
+
+def test_adopt_writes_addendum_citing_memo(isolated_project, memo):
+    """Addendum record preserves memo provenance for the gate audit trail."""
+    state = _state_at_clarify()
+    result = adopt_clarify_from_memo(state, memo, memo_as="design-memo-adoption")
+    assert result["addendum_written"] is True
+    addendum_path = isolated_project / "process-plan.addendum.jsonl"
+    assert addendum_path.exists()
+    content = addendum_path.read_text()
+    assert "adopt-clarify:memo-adoption" in content
+    assert str(memo) in content
+
+
+# ---------------------------------------------------------------------------
+# Validation and safety checks
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_rejects_missing_memo(isolated_project, tmp_path):
+    """Non-existent memo path raises ValueError rather than writing stub files."""
+    state = _state_at_clarify()
+    missing = tmp_path / "does-not-exist.md"
+    with pytest.raises(ValueError, match="Memo not found"):
+        adopt_clarify_from_memo(state, missing)
+
+
+def test_adopt_rejects_empty_memo(isolated_project, tmp_path):
+    """Empty memo raises ValueError — garbage in, garbage out guard."""
+    state = _state_at_clarify()
+    empty = tmp_path / "empty.md"
+    empty.write_text("   \n\n  ")
+    with pytest.raises(ValueError, match="empty"):
+        adopt_clarify_from_memo(state, empty)
+
+
+def test_adopt_refuses_to_clobber_without_force(isolated_project, memo):
+    """Existing non-empty deliverables block adoption unless --force is passed."""
+    state = _state_at_clarify()
+    phase_dir = isolated_project / "phases" / "clarify"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "objective.md").write_text("# Existing work — please don't clobber\n" * 10)
+
+    with pytest.raises(ValueError, match="already exist"):
+        adopt_clarify_from_memo(state, memo)
+
+
+def test_adopt_force_overwrites_existing_deliverables(isolated_project, memo):
+    """--force overwrites existing files; caller accepts the risk."""
+    state = _state_at_clarify()
+    phase_dir = isolated_project / "phases" / "clarify"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "objective.md").write_text("# Existing\n" * 10)
+
+    adopt_clarify_from_memo(state, memo, force=True)
+    after = (phase_dir / "objective.md").read_text()
+    assert "adopted_from:" in after
+
+
+def test_adopt_refuses_when_clarify_already_approved(isolated_project, memo):
+    """Can't adopt into an approved phase — the adoption would be misleading."""
+    state = _state_at_clarify()
+    state.phases["clarify"].status = "approved"
+    with pytest.raises(ValueError, match="clarify"):
+        adopt_clarify_from_memo(state, memo)

--- a/tests/crew/test_gate_overrides_per_project.py
+++ b/tests/crew/test_gate_overrides_per_project.py
@@ -38,7 +38,10 @@ _DEFAULT_POLICY = {
     "gates": {
         "requirements-quality": {
             "standard": {
-                "reviewers": ["requirements-analyst"],
+                # 2 reviewers in the default lets council mode overrides
+                # satisfy the >=2 invariant without forcing every test to
+                # ship its own reviewers list.
+                "reviewers": ["requirements-analyst", "senior-engineer"],
                 "mode": "sequential",
                 "fallback": "senior-engineer",
             }
@@ -116,11 +119,26 @@ def test_specific_override_beats_wildcard():
     state = _state({
         "gate_overrides": {
             "*": {"mode": "parallel"},
-            "requirements-quality": {"mode": "council"},
+            "requirements-quality": {"mode": "council", "reviewers": ["a", "b"]},
         }
     })
     entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
     assert entry["mode"] == "council"
+
+
+def test_partial_specific_override_layers_on_wildcard(caplog):
+    """gemini #568 review: a specific override that only sets 'reviewers' must
+    still inherit 'mode' from the wildcard, not silently bypass it."""
+    state = _state({
+        "gate_overrides": {
+            "*": {"mode": "council"},
+            "requirements-quality": {"reviewers": ["product-manager", "senior-engineer"]},
+        }
+    })
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    # Specific layer set reviewers, wildcard layer set mode — both apply.
+    assert entry["mode"] == "council"
+    assert entry["reviewers"] == ["product-manager", "senior-engineer"]
 
 
 def test_reviewers_override_applies():
@@ -155,14 +173,61 @@ def test_non_list_reviewers_override_is_rejected(caplog):
     })
     with caplog.at_level("WARNING"):
         entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
-    assert entry["reviewers"] == ["requirements-analyst"]
+    assert entry["reviewers"] == ["requirements-analyst", "senior-engineer"]
 
 
 def test_override_does_not_mutate_policy_entry():
     """The returned entry is a new dict — the in-memory policy cache is untouched."""
-    state = _state({"gate_method": "council"})
+    state = _state({"gate_method": "council", "gate_overrides": {
+        "requirements-quality": {"reviewers": ["a", "b"]}
+    }})
     _resolve_gate_reviewer("requirements-quality", "standard", state=state)
     # Fetch default again — should still be 'sequential', proving no mutation.
     state2 = _state({})
     entry2 = _resolve_gate_reviewer("requirements-quality", "standard", state=state2)
     assert entry2["mode"] == "sequential"
+
+
+# ---------------------------------------------------------------------------
+# Semantic invariants — Copilot #568 review
+# ---------------------------------------------------------------------------
+
+
+def test_council_with_lt_2_reviewers_reverts_to_policy_default(caplog):
+    """council mode requires >=2 reviewers; an invalid override is rejected."""
+    state = _state({
+        "gate_overrides": {
+            "requirements-quality": {"mode": "council", "reviewers": ["only-one"]}
+        }
+    })
+    with caplog.at_level("WARNING"):
+        entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    # Reverted to policy default (sequential / [requirements-analyst]).
+    assert entry["mode"] == "sequential"
+    assert entry["reviewers"] == ["requirements-analyst", "senior-engineer"]
+    assert any("invariants" in rec.message for rec in caplog.records)
+
+
+def test_sequential_with_empty_reviewers_reverts_to_policy_default(caplog):
+    """sequential mode requires >=1 reviewer; empty reviewers list is invalid."""
+    state = _state({
+        "gate_overrides": {
+            "requirements-quality": {"mode": "sequential", "reviewers": []}
+        }
+    })
+    with caplog.at_level("WARNING"):
+        entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "sequential"
+    assert entry["reviewers"] == ["requirements-analyst", "senior-engineer"]
+
+
+def test_self_check_with_empty_reviewers_is_allowed():
+    """self-check mode legitimately runs without reviewers — must NOT be rejected."""
+    state = _state({
+        "gate_overrides": {
+            "requirements-quality": {"mode": "self-check", "reviewers": []}
+        }
+    })
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "self-check"
+    assert entry["reviewers"] == []

--- a/tests/crew/test_gate_overrides_per_project.py
+++ b/tests/crew/test_gate_overrides_per_project.py
@@ -1,0 +1,168 @@
+"""tests/crew/test_gate_overrides_per_project.py — issue #564.
+
+Verifies that per-project gate overrides in state.extras are honored when
+resolving the dispatch entry, with precedence:
+  1. gate_overrides[gate_name]   (specific)
+  2. gate_overrides["*"]          (wildcard)
+  3. gate_method                  (legacy shorthand)
+  4. gate-policy.json default     (fallback)
+
+Unknown modes are ignored (fail-loud via WARN), preserving the invariant
+that misconfiguration cannot silently change dispatch behavior.
+
+Rules:
+  T1: deterministic — patches _load_gate_policy to pin the default
+  T3: isolated — no filesystem side effects
+  T4: single behavior per test
+  T5: descriptive names
+  T6: docstrings cite the tracking issue
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+from phase_manager import PhaseState, ProjectState, _resolve_gate_reviewer  # noqa: E402
+
+
+_DEFAULT_POLICY = {
+    "gates": {
+        "requirements-quality": {
+            "standard": {
+                "reviewers": ["requirements-analyst"],
+                "mode": "sequential",
+                "fallback": "senior-engineer",
+            }
+        }
+    }
+}
+
+
+def _state(extras):
+    return ProjectState(
+        name="t",
+        current_phase="clarify",
+        created_at="2026-04-22T00:00:00Z",
+        phase_plan=["clarify"],
+        phases={"clarify": PhaseState(status="pending")},
+        extras=dict(extras),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _pin_policy():
+    """Pin gate-policy.json content so tests are deterministic."""
+    with patch.object(phase_manager, "_load_gate_policy", return_value=_DEFAULT_POLICY):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Legacy shorthand — the exact shape the reporter used in #564
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_gate_method_is_honored():
+    """Issue #564: state.extras['gate_method']='council' overrides the policy default."""
+    state = _state({"gate_method": "council"})
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "council"
+
+
+def test_no_overrides_preserves_policy_default():
+    """When no overrides are set, gate-policy.json wins."""
+    state = _state({})
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "sequential"
+
+
+def test_state_none_preserves_policy_default():
+    """Passing state=None (library-level callers) uses the policy default."""
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=None)
+    assert entry["mode"] == "sequential"
+
+
+# ---------------------------------------------------------------------------
+# gate_overrides — structured per-gate and wildcard shapes
+# ---------------------------------------------------------------------------
+
+
+def test_gate_overrides_specific_gate_wins():
+    """gate_overrides['requirements-quality'] applies to exactly that gate."""
+    state = _state({
+        "gate_overrides": {"requirements-quality": {"mode": "council"}}
+    })
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "council"
+
+
+def test_gate_overrides_wildcard_applies_to_all():
+    """gate_overrides['*'] applies to any gate without a specific override."""
+    state = _state({"gate_overrides": {"*": {"mode": "parallel"}}})
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "parallel"
+
+
+def test_specific_override_beats_wildcard():
+    """Precedence: specific gate override outranks wildcard."""
+    state = _state({
+        "gate_overrides": {
+            "*": {"mode": "parallel"},
+            "requirements-quality": {"mode": "council"},
+        }
+    })
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "council"
+
+
+def test_reviewers_override_applies():
+    """gate_overrides can replace the reviewer list too, not just the mode."""
+    state = _state({
+        "gate_overrides": {
+            "requirements-quality": {"reviewers": ["product-manager", "senior-engineer"]}
+        }
+    })
+    entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["reviewers"] == ["product-manager", "senior-engineer"]
+
+
+# ---------------------------------------------------------------------------
+# Validation — fail loud on bad values
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_mode_is_rejected(caplog):
+    """Unknown modes log a WARN and are ignored — never silently applied."""
+    state = _state({"gate_method": "turbo-council-9000"})
+    with caplog.at_level("WARNING"):
+        entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["mode"] == "sequential"  # fell back to policy default
+    assert any("turbo-council-9000" in rec.message for rec in caplog.records)
+
+
+def test_non_list_reviewers_override_is_rejected(caplog):
+    """Non-list reviewers override logs a WARN and is ignored."""
+    state = _state({
+        "gate_overrides": {"requirements-quality": {"reviewers": "not-a-list"}}
+    })
+    with caplog.at_level("WARNING"):
+        entry = _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    assert entry["reviewers"] == ["requirements-analyst"]
+
+
+def test_override_does_not_mutate_policy_entry():
+    """The returned entry is a new dict — the in-memory policy cache is untouched."""
+    state = _state({"gate_method": "council"})
+    _resolve_gate_reviewer("requirements-quality", "standard", state=state)
+    # Fetch default again — should still be 'sequential', proving no mutation.
+    state2 = _state({})
+    entry2 = _resolve_gate_reviewer("requirements-quality", "standard", state=state2)
+    assert entry2["mode"] == "sequential"

--- a/tests/crew/test_phase_spec.py
+++ b/tests/crew/test_phase_spec.py
@@ -1,0 +1,83 @@
+"""tests/crew/test_phase_spec.py — issue #566 phase-spec inspector.
+
+Covers the read-only phase-spec action: derives purely from phases.json +
+gate-policy.json, returns all the fields a caller needs to decide what to
+attempt (skip, approve, dispatch) before attempting it.
+
+Rules:
+  T1: deterministic — reads static config
+  T3: isolated — no live project state
+  T4: single behavior per test
+  T5: descriptive names
+  T6: docstrings cite the tracking issue
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+from phase_manager import get_phase_spec  # noqa: E402
+
+
+def test_phase_spec_clarify_has_required_fields():
+    """Issue #566: phase-spec must expose the fields a caller needs before acting."""
+    spec = get_phase_spec("clarify")
+    # Shape contract
+    assert spec["phase"] == "clarify"
+    assert spec["known"] is True
+    for key in (
+        "is_skippable",
+        "gate_required",
+        "min_gate_score",
+        "required_deliverables",
+        "depends_on",
+        "valid_skip_reasons",
+        "gate_policy",
+    ):
+        assert key in spec, f"phase-spec must expose '{key}'"
+
+
+def test_phase_spec_clarify_values():
+    """Known clarify phase config values surface verbatim from phases.json."""
+    spec = get_phase_spec("clarify")
+    assert spec["is_skippable"] is False
+    assert spec["gate_required"] is True
+    assert spec["gate_name"] == "requirements-quality"
+
+
+def test_phase_spec_required_deliverables_normalized():
+    """required_deliverables are dicts with file/min_bytes — the caller shouldn't need to re-parse."""
+    spec = get_phase_spec("clarify")
+    deliverables = spec["required_deliverables"]
+    assert len(deliverables) > 0
+    for entry in deliverables:
+        assert isinstance(entry, dict)
+        assert "file" in entry
+        assert "min_bytes" in entry
+
+
+def test_phase_spec_unknown_phase_reports_not_known():
+    """An unknown phase name returns known=False without crashing."""
+    spec = get_phase_spec("does-not-exist-phase-xyz")
+    assert spec["known"] is False
+    assert spec["phase"] == "does-not-exist-phase-xyz"
+    # Fields still present with safe defaults — caller can rely on the shape.
+    assert spec["required_deliverables"] == []
+    assert spec["depends_on"] == []
+
+
+def test_phase_spec_gate_policy_keyed_by_tier():
+    """When gate_required, gate_policy exposes reviewers per rigor tier (minimal/standard/full)."""
+    spec = get_phase_spec("clarify")
+    policy = spec["gate_policy"]
+    assert isinstance(policy, dict)
+    # At least one tier present with a reviewers field
+    assert any("reviewers" in tier_entry for tier_entry in policy.values())

--- a/tests/crew/test_project_completion.py
+++ b/tests/crew/test_project_completion.py
@@ -1,0 +1,91 @@
+"""tests/crew/test_project_completion.py — issue #562 regression.
+
+Verifies compute_project_completion() only reports is_complete=True when
+every phase in phase_plan is 'approved'. The approve and advance CLI paths
+depend on this helper to avoid the misleading "Project complete!" message
+when phases are still pending.
+
+Rules:
+  T1: deterministic — pure state inspection
+  T3: isolated — no filesystem or subprocess
+  T4: single behavior per test
+  T5: descriptive names
+  T6: docstrings cite the tracking issue
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import phase_manager  # noqa: E402
+from phase_manager import PhaseState, ProjectState, compute_project_completion  # noqa: E402
+
+
+def _state(phase_plan, statuses):
+    """Build a ProjectState with the given phase_plan and {phase: status} map."""
+    return ProjectState(
+        name="t",
+        current_phase=phase_plan[0] if phase_plan else "clarify",
+        created_at="2026-04-22T00:00:00Z",
+        phase_plan=list(phase_plan),
+        phases={p: PhaseState(status=s) for p, s in statuses.items()},
+    )
+
+
+def test_completion_false_when_later_phases_pending():
+    """Issue #562: approving clarify while build+test pending is NOT complete."""
+    state = _state(
+        ["clarify", "build", "test"],
+        {"clarify": "approved", "build": "pending", "test": "pending"},
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is False
+    assert remaining == ["build", "test"]
+
+
+def test_completion_true_only_when_all_approved():
+    """is_complete is True only when every phase in phase_plan is approved."""
+    state = _state(
+        ["clarify", "build"],
+        {"clarify": "approved", "build": "approved"},
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is True
+    assert remaining == []
+
+
+def test_completion_false_on_empty_plan():
+    """Empty phase_plan is not 'complete' — there's nothing planned yet."""
+    state = _state([], {})
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is False
+    assert remaining == []
+
+
+def test_completion_flags_in_progress_as_remaining():
+    """A phase in any non-approved status counts as remaining."""
+    state = _state(
+        ["clarify", "build"],
+        {"clarify": "approved", "build": "in_progress"},
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is False
+    assert remaining == ["build"]
+
+
+def test_completion_handles_missing_phase_state():
+    """Phases in the plan but absent from state.phases default to 'pending'."""
+    state = _state(
+        ["clarify", "build"],
+        {"clarify": "approved"},  # build is missing — should be treated as pending
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is False
+    assert remaining == ["build"]

--- a/tests/crew/test_project_completion.py
+++ b/tests/crew/test_project_completion.py
@@ -89,3 +89,25 @@ def test_completion_handles_missing_phase_state():
     is_complete, remaining = compute_project_completion(state)
     assert is_complete is False
     assert remaining == ["build"]
+
+
+def test_completion_treats_skipped_as_terminal():
+    """Copilot #568 review: 'skipped' phases satisfy completion alongside 'approved'."""
+    state = _state(
+        ["clarify", "design", "build"],
+        {"clarify": "approved", "design": "skipped", "build": "approved"},
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is True
+    assert remaining == []
+
+
+def test_completion_skipped_first_then_remaining():
+    """A skipped phase doesn't appear as remaining; pending later phases still do."""
+    state = _state(
+        ["clarify", "design", "build"],
+        {"clarify": "skipped", "design": "approved", "build": "pending"},
+    )
+    is_complete, remaining = compute_project_completion(state)
+    assert is_complete is False
+    assert remaining == ["build"]

--- a/tests/crew/test_validator_schema_pointers.py
+++ b/tests/crew/test_validator_schema_pointers.py
@@ -1,0 +1,91 @@
+"""tests/crew/test_validator_schema_pointers.py — issue #563.
+
+Verifies that validate_plan and gate_result_schema surface a schema-doc
+pointer when they reject input, so callers don't have to grep to find the
+authoritative schema.
+
+Rules:
+  T1: deterministic — pure string inspection
+  T3: isolated — no filesystem side effects beyond reading module state
+  T4: single behavior per test
+  T5: descriptive names
+  T6: docstrings cite the tracking issue
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import validate_plan  # noqa: E402
+from gate_result_schema import (  # noqa: E402
+    GateResultSchemaError,
+    SCHEMA_DOC as GATE_SCHEMA_DOC,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_plan.py — per-section schema pointers
+# ---------------------------------------------------------------------------
+
+
+def test_validate_plan_schema_doc_is_exported():
+    """Issue #563: SCHEMA_DOC constant is the authoritative doc pointer."""
+    assert validate_plan.SCHEMA_DOC == "skills/propose-process/refs/output-schema.md"
+
+
+def test_validate_plan_factors_pointer_has_factors_anchor():
+    """Issue #563: factors-shape violations should cite the factors section."""
+    ptr = validate_plan._schema_pointer_for("factors — missing required factor key 'novelty'")
+    assert validate_plan.SCHEMA_DOC in ptr
+    assert "factors" in ptr.lower()
+
+
+def test_validate_plan_tasks_pointer_strips_index_suffix():
+    """tasks[0].metadata violations route to the tasks section, not 'tasks[0]'."""
+    ptr = validate_plan._schema_pointer_for("tasks[0].metadata — missing required key 'chain_id'")
+    assert validate_plan.SCHEMA_DOC in ptr
+    assert "tasks" in ptr.lower()
+
+
+def test_validate_plan_unknown_section_still_returns_doc():
+    """Even an unrecognized section gets the top-level doc pointer (no anchor)."""
+    ptr = validate_plan._schema_pointer_for("newthing — invalid")
+    assert validate_plan.SCHEMA_DOC in ptr
+
+
+# ---------------------------------------------------------------------------
+# gate_result_schema.py — schema_doc attribute + str(exc)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_result_error_exposes_schema_doc_attribute():
+    """Issue #563: every GateResultSchemaError carries a schema_doc pointer."""
+    exc = GateResultSchemaError("test-reason", offending_field="reviewer")
+    assert exc.schema_doc == GATE_SCHEMA_DOC
+    assert "gate_result_schema.py" in exc.schema_doc
+
+
+def test_gate_result_error_str_includes_schema_doc():
+    """str(exc) surfaces the schema pointer so log lines self-cite the source."""
+    exc = GateResultSchemaError("invalid-verdict-enum:MAYBE", offending_field="verdict")
+    rendered = str(exc)
+    assert "invalid-verdict-enum:MAYBE" in rendered
+    assert "See:" in rendered
+    assert "gate_result_schema.py" in rendered
+
+
+def test_gate_result_error_respects_explicit_schema_doc_override():
+    """Callers can override schema_doc for dialect-specific references."""
+    exc = GateResultSchemaError(
+        "test-reason",
+        schema_doc="custom/path.md § Alt",
+    )
+    assert exc.schema_doc == "custom/path.md § Alt"
+    assert "custom/path.md" in str(exc)

--- a/tests/test_wicked_testing_probe.py
+++ b/tests/test_wicked_testing_probe.py
@@ -97,6 +97,15 @@ class TestIsVersionInRange:
     def test_non_numeric_parts(self):
         assert is_version_in_range("0.x.0", "^0.1.0") is False
 
+    def test_wildcard_pin_accepts_any_version(self):
+        assert is_version_in_range("0.1.0", "*") is True
+        assert is_version_in_range("9.9.9", "*") is True
+        assert is_version_in_range("0.1.1-beta.1", "*") is True
+        assert is_version_in_range("not-a-version", "*") is True
+
+    def test_wildcard_pin_rejects_empty(self):
+        assert is_version_in_range("", "*") is False
+
 
 # ---------------------------------------------------------------------------
 # read_pin_from_plugin_json


### PR DESCRIPTION
Five crew-path fixes from the agent-feedback batch, each with its own commit and regression tests. Counterpart to #567 (which closes #561 on its own branch).

## Commits

- **#562** — phase_manager approve/advance only prints "Project complete!" when is_complete; adds compute_project_completion(state) helper and remaining_phases surfaces in --json.
- **#566** — phase_manager adds a read-only phase-spec inspector (is_skippable, skip_complexity_threshold, valid_skip_reasons, gate_required, min_gate_score, required_deliverables, depends_on, gate_policy by tier). Works without a loaded project.
- **#563** — validate_plan.py and gate_result_schema.py both cite the authoritative schema doc on every rejection. validate_plan maps each section prefix to an anchor within skills/propose-process/refs/output-schema.md; GateResultSchemaError gains a schema_doc attribute and str(exc) includes it automatically.
- **#564** — gate_method in project state metadata is now HONORED (Option A from the issue discussion). _resolve_gate_reviewer gains an optional state parameter; per-project overrides layer on top of gate-policy.json defaults with precedence gate_overrides[gate_name] > gate_overrides["*"] > gate_method > policy default. Unknown modes and bad reviewers lists log a WARN and are ignored — never silently applied.
- **#565** — phase_manager adds adopt-clarify --from <memo> [--memo-as <label>]. Writes clarify deliverables from a source memo with adopted_from/adopted_at frontmatter, records a re-eval addendum citing the memo as the deliberation artifact, and does NOT auto-approve (user-confirm pause preserved). Refuses to clobber existing deliverables without --force.

## Test plan

- [x] All 37 new regression tests pass (10 adopt-clarify, 5 phase-spec, 5 completion, 7 schema-pointers, 10 gate-overrides)
- [x] Filtered crew suite (558 tests) still green — the 3 pre-existing collection errors in test_archetype_detect / test_facilitator_wicked_testing_check / test_reeval_addendum_schema are an unrelated pytest-ordering artifact present on main before this branch
- [x] CLI smoke: validate_plan.py emits "See: <doc> §<anchor>" on every violation
- [x] CLI smoke: phase_manager phase-spec --phase clarify returns the full spec in both --json and human modes

## Out of scope

- #561 (specialist_discovery.py --json clean stdout) is PR #567 on its own branch. Keeping it separate because it's a different file and already under review.

Closes #562, #563, #564, #565, #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)