### PR TITLE
fix: gate-finding lifecycle validation (#570)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -289,7 +289,7 @@ Tasks carry agent-coordination fields in the `metadata` dict passed to `TaskCrea
 - **`source_agent`**: Agent that authored the event. Banned values: `just-finish-auto`, `fast-pass`, anything starting with `auto-approve-`.
 - **`phase`**: Crew phase name — must be a key in `.claude-plugin/phases.json`.
 
-`gate-finding` additionally requires `verdict` (APPROVE | CONDITIONAL | REJECT), `min_score`, `score`; CONDITIONAL requires `conditions_manifest_path`.
+`gate-finding` shell at plan time requires only `chain_id`, `event_type`, `source_agent`, `phase`. On completion (`status=completed`) it additionally requires `verdict` (APPROVE | CONDITIONAL | REJECT), `min_score`, `score`; CONDITIONAL requires `conditions_manifest_path` (Issue #570).
 
 **Enforcement mode**: `WG_TASK_METADATA=warn|strict|off` (default: `warn`). Warn emits a deprecation `systemMessage` on violations; strict denies via `permissionDecision: "deny"`.
 

--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -120,7 +120,10 @@ def _validate_event_metadata(tool_input: dict) -> "str | None":
 
     metadata = tool_input.get("metadata") or {}
     phases = set(_load_phases_config_hook().keys())
-    return validate_metadata(metadata, valid_phases=phases or None)
+    status = tool_input.get("status")
+    return validate_metadata(
+        metadata, valid_phases=phases or None, status=status,
+    )
 
 
 def _task_metadata_mode() -> str:

--- a/scripts/_event_schema.py
+++ b/scripts/_event_schema.py
@@ -69,11 +69,19 @@ SCHEMA: dict[str, dict[str, list[str]]] = {
         "optional": ["priority", "requirement_id", "blast_radius"],
     },
     "gate-finding": {
+        # Lifecycle: the facilitator emits the gate shell at plan time;
+        # the reviewer fills verdict/min_score/score at approve time
+        # (see skills/propose-process/refs/output-schema.md). So those
+        # three fields are required only when the task reaches a
+        # terminal ``completed`` state, not at creation.
         "required": [
-            "chain_id", "event_type", "source_agent",
-            "phase", "verdict", "min_score", "score",
+            "chain_id", "event_type", "source_agent", "phase",
         ],
-        "optional": ["conditions_manifest_path", "findings"],
+        "required_at_completion": ["verdict", "min_score", "score"],
+        "optional": [
+            "verdict", "min_score", "score",
+            "conditions_manifest_path", "findings",
+        ],
     },
     "phase-transition": {
         "required": [
@@ -104,6 +112,7 @@ def _is_banned_source_agent(source_agent: str) -> bool:
 def validate_metadata(
     metadata: dict,
     valid_phases: set[str] | None = None,
+    status: str | None = None,
 ) -> str | None:
     """Validate a TaskCreate/TaskUpdate metadata dict.
 
@@ -114,6 +123,12 @@ def validate_metadata(
     ``valid_phases`` — optional set of phase names from phases.json. When
     supplied, ``phase`` must be a member. When omitted, phase is only
     validated for presence per the event_type's required list.
+
+    ``status`` — optional task status (``pending`` | ``in_progress`` |
+    ``completed``). When ``"completed"``, event types with a
+    ``required_at_completion`` list enforce those fields too. This
+    matches the facilitator-emits-shell / reviewer-fills-verdict
+    lifecycle for gate-finding tasks (Issue #570).
     """
     if not isinstance(metadata, dict):
         return "metadata must be a dict"
@@ -131,7 +146,10 @@ def validate_metadata(
     spec = SCHEMA[event_type]
     # Presence check, not truthiness — score=0 and phase="" are legitimate
     # "missing" only when the key is absent or explicitly None.
-    missing = [f for f in spec["required"] if metadata.get(f) is None]
+    required_fields = list(spec["required"])
+    if status == "completed":
+        required_fields.extend(spec.get("required_at_completion", []))
+    missing = [f for f in required_fields if metadata.get(f) is None]
     if missing:
         return f"{event_type}: missing required metadata fields {missing}"
 
@@ -157,23 +175,33 @@ def validate_metadata(
         return f"phase {phase!r} not in phases.json catalog (sample: {sample})"
 
     if event_type == "gate-finding":
+        # verdict/min_score/score are filled in by the reviewer at approve
+        # time, not by the facilitator at plan time (Issue #570). Only
+        # apply the enum + ordering checks when the field is present, so a
+        # plan-time shell (verdict absent) validates cleanly. Completion
+        # enforcement is handled by the ``required_at_completion`` branch
+        # above when ``status="completed"``.
         verdict = metadata.get("verdict")
-        if verdict not in VALID_VERDICTS:
-            return (
-                f"gate-finding.verdict={verdict!r} invalid. "
-                f"Allowed: {sorted(VALID_VERDICTS)}"
-            )
-        if verdict == "CONDITIONAL" and not metadata.get("conditions_manifest_path"):
-            return "CONDITIONAL verdict requires metadata.conditions_manifest_path"
-        if verdict == "APPROVE":
-            try:
-                if float(metadata["score"]) < float(metadata["min_score"]):
-                    return (
-                        f"APPROVE verdict requires score >= min_score "
-                        f"({metadata['score']} < {metadata['min_score']})"
-                    )
-            except (TypeError, ValueError):
-                return "gate-finding.score and min_score must be numeric"
+        if verdict is not None:
+            if verdict not in VALID_VERDICTS:
+                return (
+                    f"gate-finding.verdict={verdict!r} invalid. "
+                    f"Allowed: {sorted(VALID_VERDICTS)}"
+                )
+            if verdict == "CONDITIONAL" and not metadata.get("conditions_manifest_path"):
+                return "CONDITIONAL verdict requires metadata.conditions_manifest_path"
+            if verdict == "APPROVE":
+                score = metadata.get("score")
+                min_score = metadata.get("min_score")
+                if score is not None and min_score is not None:
+                    try:
+                        if float(score) < float(min_score):
+                            return (
+                                f"APPROVE verdict requires score >= min_score "
+                                f"({score} < {min_score})"
+                            )
+                    except (TypeError, ValueError):
+                        return "gate-finding.score and min_score must be numeric"
 
     if event_type == "subtask":
         parent = metadata.get("parent_chain_id", "")

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -102,17 +102,21 @@ Each phase in the task chain should include a corresponding gate task with
 ```json
 {
   "event_type": "gate-finding",
+  "source_agent": "facilitator",
   "verdict": "APPROVE | CONDITIONAL | REJECT",
   "min_score": 0.7,
-  "score": 0.85,
-  "source_agent": "facilitator"
+  "score": 0.85
 }
 ```
 
-The facilitator emits the gate task shell at plan time; `verdict`, `min_score`,
-and `score` are filled in by the reviewer agent at approve time.
-`_resolve_gate_reviewer()` in `phase_manager.py` determines the reviewer from
-`gate-policy.json` — the plan embeds the gate name, not the reviewer name.
+The facilitator emits the gate task shell at plan time with only
+`chain_id`, `event_type`, `source_agent`, and `phase`. `verdict`,
+`min_score`, and `score` are filled in by the reviewer agent at approve
+time via `TaskUpdate(status="completed")`; the PreToolUse validator
+enforces their presence on that completion transition, not on the
+initial shell (Issue #570). `_resolve_gate_reviewer()` in
+`phase_manager.py` determines the reviewer from `gate-policy.json` —
+the plan embeds the gate name, not the reviewer name.
 
 **Yolo mode additions**:
 

--- a/tests/test_event_schema_gate_finding_lifecycle.py
+++ b/tests/test_event_schema_gate_finding_lifecycle.py
@@ -1,0 +1,157 @@
+"""tests/test_event_schema_gate_finding_lifecycle.py — gate-finding lifecycle validation (Issue #570).
+
+Provenance: Issue #570
+T1: deterministic — pure in-memory, no I/O
+T3: isolated — no shared state
+T4: single focus per test
+T5: descriptive names
+T6: each docstring cites its contract
+"""
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from _event_schema import validate_metadata  # noqa: E402
+
+
+_SHELL_METADATA = {
+    "chain_id": "proj.clarify.requirements-quality",
+    "event_type": "gate-finding",
+    "source_agent": "facilitator",
+    "phase": "clarify",
+}
+
+
+# ---------------------------------------------------------------------------
+# #570: facilitator shell at plan time validates without verdict/min_score/score
+# ---------------------------------------------------------------------------
+
+def test_gate_finding_shell_without_verdict_is_valid_at_creation():
+    """#570: facilitator-emitted shell (no verdict/min_score/score) must validate
+    at TaskCreate (status defaults to not-completed).
+    """
+    err = validate_metadata(_SHELL_METADATA)
+    assert err is None, f"plan-time shell should validate, got: {err}"
+
+
+def test_gate_finding_shell_validates_with_pending_status():
+    """#570: explicit status=pending must also validate without verdict fields."""
+    err = validate_metadata(_SHELL_METADATA, status="pending")
+    assert err is None, f"pending shell should validate, got: {err}"
+
+
+def test_gate_finding_shell_validates_with_in_progress_status():
+    """#570: in_progress gate task (reviewer running) must not require verdict yet."""
+    err = validate_metadata(_SHELL_METADATA, status="in_progress")
+    assert err is None, f"in_progress gate should validate, got: {err}"
+
+
+# ---------------------------------------------------------------------------
+# #570: completion transition enforces the full contract
+# ---------------------------------------------------------------------------
+
+def test_gate_finding_completion_without_verdict_fails():
+    """#570: TaskUpdate(status=completed) on a gate-finding missing verdict/scores
+    must fail validation — reviewer is contractually obligated to fill them.
+    """
+    err = validate_metadata(_SHELL_METADATA, status="completed")
+    assert err is not None, "completed gate without verdict must fail"
+    assert "verdict" in err and "min_score" in err and "score" in err, (
+        f"error should name all three missing fields, got: {err}"
+    )
+
+
+def test_gate_finding_completion_with_approve_fields_passes():
+    """#570: completed gate-finding with APPROVE verdict + satisfying score validates."""
+    metadata = {
+        **_SHELL_METADATA,
+        "verdict": "APPROVE",
+        "min_score": 0.7,
+        "score": 0.85,
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is None, f"completed APPROVE should validate, got: {err}"
+
+
+def test_gate_finding_completion_approve_below_min_score_fails():
+    """#570: completion still enforces APPROVE score >= min_score ordering."""
+    metadata = {
+        **_SHELL_METADATA,
+        "verdict": "APPROVE",
+        "min_score": 0.7,
+        "score": 0.5,
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is not None and "score" in err and "min_score" in err, (
+        f"sub-min_score APPROVE should fail, got: {err}"
+    )
+
+
+def test_gate_finding_completion_conditional_without_manifest_fails():
+    """#570: CONDITIONAL verdict at completion still requires conditions_manifest_path."""
+    metadata = {
+        **_SHELL_METADATA,
+        "verdict": "CONDITIONAL",
+        "min_score": 0.7,
+        "score": 0.65,
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is not None and "conditions_manifest_path" in err, (
+        f"CONDITIONAL without manifest should fail, got: {err}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #570: enum + type checks still fire whenever the field is present
+# ---------------------------------------------------------------------------
+
+def test_gate_finding_shell_with_invalid_verdict_fails_even_without_completion():
+    """#570: an invalid verdict value is rejected regardless of status —
+    you can't poison the shell with a bogus enum value.
+    """
+    metadata = {**_SHELL_METADATA, "verdict": "MAYBE"}
+    err = validate_metadata(metadata)
+    assert err is not None and "MAYBE" in err, (
+        f"invalid verdict should fail even pre-completion, got: {err}"
+    )
+
+
+def test_gate_finding_shell_with_only_score_is_valid():
+    """#570: partial fill (reviewer started but hasn't completed) must validate —
+    the plan shell accepts score-only writes during reviewer runs.
+    """
+    metadata = {**_SHELL_METADATA, "score": 0.9}
+    err = validate_metadata(metadata)
+    assert err is None, f"partial fill should validate pre-completion, got: {err}"
+
+
+def test_gate_finding_completion_with_non_numeric_score_fails():
+    """#570: numeric type check still fires at completion when verdict is APPROVE."""
+    metadata = {
+        **_SHELL_METADATA,
+        "verdict": "APPROVE",
+        "min_score": 0.7,
+        "score": "banana",
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is not None and "numeric" in err, (
+        f"non-numeric score should fail, got: {err}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #570: status param is backward compatible for other event types
+# ---------------------------------------------------------------------------
+
+def test_status_completed_does_not_affect_plain_task_event_type():
+    """#570: status=completed on event_type=task must not invent extra requirements."""
+    metadata = {
+        "chain_id": "proj.root",
+        "event_type": "task",
+        "source_agent": "researcher",
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is None, f"completed plain task should validate, got: {err}"


### PR DESCRIPTION
## Summary

- Move `verdict` / `min_score` / `score` from required-at-creation to required-at-completion for `gate-finding` TaskCreate/TaskUpdate envelopes
- `validate_metadata` now takes an optional `status` kwarg; `pre_tool.py` forwards `tool_input["status"]` through
- Enum + score-ordering + CONDITIONAL-manifest rules still fire whenever the fields are present — you can't poison the shell with a bogus enum
- Docs in `skills/propose-process/refs/output-schema.md` and `.claude/CLAUDE.md` updated to describe the two-step contract

## Why

`scripts/_event_schema.py:71` required `verdict` / `min_score` / `score` on every `gate-finding` TaskCreate, but `skills/propose-process/refs/output-schema.md:112` explicitly documents the facilitator emitting a shell at plan time and the reviewer filling those fields at approve time. Every plan-time gate task was emitting `WG_TASK_METADATA` warn output, and `WG_TASK_METADATA=strict` would hard-block the documented workflow.

## Test plan

- [x] `tests/test_event_schema_gate_finding_lifecycle.py` — 11 new tests covering shell-at-create, shell-with-pending/in_progress status, completion requires all three fields, APPROVE score ordering still enforced at completion, CONDITIONAL manifest still required at completion, invalid verdict rejected even pre-completion, partial fill valid pre-completion, non-numeric score still rejected, `status=completed` does not affect plain `event_type=task`
- [x] Existing archetype tests still pass
- [x] `tests/delivery/test_telemetry.py` still passes
- [x] `462 passed` in the non-crew suite; crew suite passes when invoked directly (existing collection-order issue on main, unrelated)

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)