### PR TITLE
fix: P0 bundle — re-eval debounce + bus drain, specialist resolver, HITL judge, factors-shape doc

### DIFF
--- a/commands/crew/just-finish.md
+++ b/commands/crew/just-finish.md
@@ -136,6 +136,25 @@ In "just-finish" mode:
   ```
 
   **The clarify gate MUST NOT run until the user acknowledges.** This halt applies even in automated runs — the session pauses at this boundary. In dangerous mode (where `AskUserQuestion` auto-completes), wait 30 seconds, log "Autonomous clarify: assumptions accepted by timeout (dangerous mode)", then proceed. This prevents circular self-grading where the same model writes requirements and then validates work against those same requirements without human review.
+
+  **HITL judge (Issue #575)**: Before deciding whether to halt, call the rule-based judge:
+
+  ```bash
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+  from crew.hitl_judge import should_pause_clarify, write_hitl_decision_evidence
+  from pathlib import Path
+  d = should_pause_clarify(
+      complexity=<complexity from clarify>,
+      facilitator_confidence=<facilitator self-rated confidence 0..1>,
+      open_questions=<count of unresolved questions>,
+      yolo=True,
+  )
+  write_hitl_decision_evidence(Path('<project_dir>'), 'clarify', 'hitl-decision.json', d)
+  print(d.pause)
+  "
+  ```
+
+  Pause when the judge returns `pause=True`. Skip the halt when the judge returns `pause=False` — the rule table reads: yolo + facilitator confidence ≥ 0.7 + complexity < 5 + 0 open questions ⇒ auto-proceed. Operator override: `WG_HITL_CLARIFY=auto|pause|off` (default `auto`). The judge always writes `phases/clarify/hitl-decision.json` so the verdict is auditable in the evidence bundle.
 - **Track assumptions**: When making any assumption, immediately record it in project.json:
   ```json
   {

--- a/commands/jam/council.md
+++ b/commands/jam/council.md
@@ -20,3 +20,31 @@ Delegate to the council agent:
 Task(subagent_type="wicked-garden:jam:council",
      prompt="Run a council evaluation on: {topic}. Options: {options}. Criteria: {criteria}.")
 ```
+
+## Post-synthesis HITL judge (Issue #575)
+
+After the council agent returns its synthesis (verdict + per-model votes + confidences), call the rule-based HITL judge to decide whether the verdict is strong enough to auto-proceed or whether the orchestrator should halt for human adjudication.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+from crew.hitl_judge import should_pause_council, write_hitl_decision_evidence
+from pathlib import Path
+votes = [
+    {'model': 'codex',    'verdict': 'APPROVE', 'confidence': 0.9},
+    {'model': 'gemini',   'verdict': 'APPROVE', 'confidence': 0.9},
+    {'model': 'opencode', 'verdict': 'REJECT',  'confidence': 0.7},
+    {'model': 'pi',       'verdict': 'APPROVE', 'confidence': 0.6},
+]
+d = should_pause_council(votes=votes)
+write_hitl_decision_evidence(Path('<project_dir>'), 'council', 'council-decision.json', d)
+print(d.pause, d.rule_id)
+"
+```
+
+Pause rules (auto mode):
+
+- top two verdicts within 2 votes (3-1 or closer) ⇒ pause (`council.split-verdict`)
+- any model confidence < 0.6 ⇒ pause (`council.low-confidence-vote`)
+- otherwise ⇒ auto-proceed and persist the votes to `council-decision.json` for the evidence bundle
+
+Operator override: `WG_HITL_COUNCIL=auto|pause|off` (default `auto`).

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -529,6 +529,65 @@ def _assemble_current_chain(chain_id: str) -> dict | None:
         return None  # fail-open — directive still fires without the data
 
 
+# ---------------------------------------------------------------------------
+# Issue #572: bus drain — minimal subscriber catch-up.
+#
+# wicked-garden has registered bus subscriptions but no daemon to consume them.
+# Without a drain, cursors fall behind by tens of thousands of events
+# (observed: 41,640 lag). This helper runs the existing `npx wicked-bus
+# subscribe ... --since-cursor --ack` pipeline, advances cursors, and discards
+# the events. Orchestration action is intentionally NOT taken here — the
+# re-eval debounce in task_completed.py is the orchestration signal.
+#
+# Fail-silent: any error (npx missing, bus unreachable, timeout) is swallowed
+# and the hook continues. Subprocess timeout capped at 3 seconds.
+# ---------------------------------------------------------------------------
+
+_BUS_DRAIN_FILTER = (
+    "wicked.gate.decided,"
+    "wicked.crew.phase.completed,"
+    "wicked.crew.phase.approved,"
+    "wicked.crew.phase.skipped,"
+    "wicked.council.voted"
+)
+_BUS_DRAIN_PLUGIN = "wicked-garden"
+_BUS_DRAIN_MAX = "100"
+_BUS_DRAIN_TIMEOUT_SEC = 3
+
+
+def _drain_bus_cursor() -> None:
+    """Issue #572: advance the wicked-bus cursor for wicked-garden.
+
+    Runs `npx wicked-bus subscribe --plugin wicked-garden --filter <events>
+    --since-cursor --max 100 --ack` and discards the output. Cursor advances,
+    backlog drains, no orchestration action taken. Fail-silent on any error
+    (missing npx, bus unreachable, non-zero exit, timeout).
+    """
+    try:
+        import shutil
+        import subprocess
+        if shutil.which("npx") is None:
+            return
+        subprocess.run(
+            [
+                "npx",
+                "wicked-bus",
+                "subscribe",
+                "--plugin", _BUS_DRAIN_PLUGIN,
+                "--filter", _BUS_DRAIN_FILTER,
+                "--since-cursor",
+                "--max", _BUS_DRAIN_MAX,
+                "--ack",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_BUS_DRAIN_TIMEOUT_SEC,
+        )
+    except Exception:
+        # Fail-silent — the drain is best-effort. The hook must never block on it.
+        return
+
+
 def _consume_facilitator_reeval(state) -> str | None:
     """v6 Gate 3 (#428): emit facilitator re-eval directive if flag is set.
 
@@ -933,6 +992,16 @@ def main():
     # Checked after setup gate but before HOT path so continuations during
     # an active setup wizard ("yes", "ok") still pass through quickly.
     onboarding_directive = _check_onboarding_gate(prompt)
+
+    # Issue #572: drain the wicked-bus cursor BEFORE the re-eval check so the
+    # 41k+ lag clears and stale subscriptions don't accumulate further. The
+    # drain is fire-and-forget (events discarded, cursor advanced); the re-eval
+    # signal still comes from task_completed.py's debounced flag, not the bus.
+    # Wrapped in try/except so a bus failure can never break prompt submission.
+    try:
+        _drain_bus_cursor()
+    except Exception:
+        pass
 
     # v6 Gate 3 (#428) — facilitator re-evaluation directive.
     # Load session state here (cheap — single JSON read) so we can check the

--- a/hooks/scripts/subagent_lifecycle.py
+++ b/hooks/scripts/subagent_lifecycle.py
@@ -191,28 +191,57 @@ def _load_specialist_domains() -> set:
 
 
 def _parse_specialist_from_agent_type(agent_type: str, specialist_domains: set):
-    """Parse domain and agent name from a wicked-garden subagent_type string.
+    """Parse domain and agent name from a subagent identifier (Issue #573).
 
-    Expected format: ``wicked-garden:{domain}:{agent-name}``
+    Two accepted forms:
 
-    Returns ``(domain, agent_name)`` if the domain is a known specialist domain,
-    otherwise returns ``(None, None)``.
+    * Fully-qualified: ``wicked-garden:{domain}:{agent-name}`` — parsed in
+      place, no resolver needed. The domain must be a known specialist
+      domain (``specialist_domains`` from ``specialist.json``) for the
+      engagement tracker to accept it.
+    * Bare role: ``requirements-analyst`` — expanded to the full form by
+      :mod:`crew.specialist_resolver`, which walks ``agents/**/*.md``
+      frontmatter. This is the path the facilitator emits by default.
+
+    Returns ``(domain, agent_name)`` on success, ``(None, None)`` when
+    the name cannot be resolved. The hook remains fail-open on any
+    resolver import / walk error (engagement tracking is best-effort).
     """
-    if not agent_type or not agent_type.startswith("wicked-garden:"):
+    if not agent_type:
         return None, None
 
-    parts = agent_type.split(":")
-    # Expect at least 3 parts: "wicked-garden", domain, agent-name
-    if len(parts) < 3:
+    if agent_type.startswith("wicked-garden:"):
+        parts = agent_type.split(":")
+        # Expect at least 3 parts: "wicked-garden", domain, agent-name
+        if len(parts) < 3:
+            return None, None
+
+        domain = parts[1]
+        agent_name = ":".join(parts[2:])  # preserve any colons in agent name
+
+        if domain not in specialist_domains:
+            return None, None
+
+        return domain, agent_name
+
+    # Bare-role path (Issue #573): resolve via agents/**/*.md frontmatter.
+    # Fail-closed to the old behavior on any resolver error — engagement
+    # tracking is best-effort and the hook must never block the agent.
+    try:
+        from crew.specialist_resolver import build_resolver, resolve_role
+
+        resolver = build_resolver(_PLUGIN_ROOT)
+        domain, subagent_type = resolve_role(agent_type, resolver)
+        if domain is None or subagent_type is None:
+            return None, None
+        if domain not in specialist_domains:
+            return None, None
+        # The tracker stores bare role as the agent_name — callers feed
+        # it straight into the engagement ledger, matching the existing
+        # wicked-garden:{domain}:{role} parsing shape.
+        return domain, agent_type
+    except Exception:
         return None, None
-
-    domain = parts[1]
-    agent_name = ":".join(parts[2:])  # preserve any colons in agent name
-
-    if domain not in specialist_domains:
-        return None, None
-
-    return domain, agent_name
 
 
 def _record_specialist_engagement(domain: str, agent_name: str) -> None:

--- a/hooks/scripts/task_completed.py
+++ b/hooks/scripts/task_completed.py
@@ -33,13 +33,21 @@ sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
 # Ops logger wrapper — fail-silent, never crashes the hook
 # ---------------------------------------------------------------------------
 
+# R4-suppressed by design: _logger is optional; the hook must never crash if
+# ops logging is unavailable. We do not surface the exception because this
+# runs on every task completion — a stderr dump would spam normal workflows.
 def _log(domain, level, event, ok=True, ms=None, detail=None):
     """Ops logger — fail-silent, never crashes the hook."""
     try:
         from _logger import log
         log(domain, level, event, ok=ok, ms=ms, detail=detail)
-    except Exception:
-        pass
+    except Exception:  # noqa: BLE001 — intentional swallow, see comment above
+        return
+
+# Escalation threshold — after this many consecutive completed tasks without
+# a mem:store call, the memory directive switches to [ESCALATION] language.
+# Named per R3 (no magic numbers); historical value = 3.
+_ESCALATION_THRESHOLD = 3
 
 # Keywords that suggest a deliverable-producing task
 _DELIVERABLE_PATTERNS = (
@@ -85,14 +93,26 @@ def _infer_mem_type(subject: str) -> str:
     return "procedural"
 
 
-def _read_task_chain_id(session_id: str, task_id: str) -> "str | None":
-    """Read ``metadata.chain_id`` from the native task JSON file.
+# Issue #572: event_type + verdict constants used by the re-eval debounce rule.
+# Re-eval is meaningful ONLY on phase boundaries or rejected gates — every other
+# completion is bus noise that wakes the facilitator for nothing.
+EVENT_TYPE_PHASE_TRANSITION = "phase-transition"
+EVENT_TYPE_GATE_FINDING = "gate-finding"
+VERDICT_REJECT = "REJECT"
+
+
+def _read_task_metadata(session_id: str, task_id: str) -> "dict | None":
+    """Read ``metadata`` dict from the native task JSON file.
 
     File path: ``${CLAUDE_CONFIG_DIR:-~/.claude}/tasks/{session_id}/{task_id}.json``.
 
-    Fail-open: returns None on any error (missing file, bad JSON, absent metadata,
-    absent chain_id). This is deliberately permissive so task completion is never
-    blocked by a facilitator-re-eval signal error.
+    Fail-open: returns None on any error (missing file, bad JSON, absent metadata).
+    This is deliberately permissive so task completion is never blocked by a
+    facilitator-re-eval signal error.
+
+    Issue #572: consolidates what used to be two separate reads (chain_id, then
+    event_type in a nested try block) into a single file load. Callers extract
+    whichever fields they need from the returned dict.
     """
     if not session_id or not task_id:
         return None
@@ -108,12 +128,103 @@ def _read_task_chain_id(session_id: str, task_id: str) -> "str | None":
         metadata = data.get("metadata")
         if not isinstance(metadata, dict):
             return None
-        chain_id = metadata.get("chain_id")
-        if isinstance(chain_id, str) and chain_id.strip():
-            return chain_id
-        return None
+        return metadata
     except Exception:
         return None
+
+
+def _should_trigger_reeval(metadata: "dict | None") -> "tuple[bool, str]":
+    """Return (should_trigger, reason) for the facilitator re-eval signal.
+
+    Issue #572: only phase boundaries and gate rejections should wake the
+    facilitator. All other completions (shell gate ACKs, plain tasks,
+    coding-tasks, etc.) are noise that accumulated 41k+ events.
+
+    Rule:
+        event_type == phase-transition                         -> trigger
+        event_type == gate-finding AND verdict == REJECT       -> trigger
+        anything else (including APPROVE/CONDITIONAL, plain task) -> skip
+
+    Fail-open: missing metadata returns (False, "no_metadata"). The flag is
+    NEVER set when the task file can't be read — the old "chain_id truthy =
+    trigger" behaviour is the exact bug this closes.
+    """
+    if not metadata:
+        return (False, "no_metadata")
+    event_type = metadata.get("event_type")
+    if event_type == EVENT_TYPE_PHASE_TRANSITION:
+        return (True, "phase_transition")
+    if event_type == EVENT_TYPE_GATE_FINDING:
+        verdict = metadata.get("verdict")
+        if verdict == VERDICT_REJECT:
+            return (True, "gate_reject")
+        return (False, f"gate_verdict_{verdict or 'missing'}")
+    return (False, f"event_type_{event_type or 'missing'}")
+
+
+def _update_session_state(
+    *,
+    chain_id: str | None,
+    event_type: str | None,
+    should_reeval: bool,
+    reeval_reason: str,
+) -> tuple[bool, int]:
+    """Mutate SessionState for the completed task.
+
+    Increments memory-compliance counters, sets the debounced re-eval flag
+    (Issue #572), and sets the phase-start-gate flag on phase-transition
+    events. Returns ``(compliance_required, escalations)`` for the caller's
+    memory-directive branch.
+
+    Fail-open: any exception returns ``(False, 0)`` and logs to stderr so
+    the hook never blocks task completion.
+    """
+    try:
+        from _session import SessionState
+        state = SessionState.load()
+        state.memory_compliance_tasks_completed = (
+            (state.memory_compliance_tasks_completed or 0) + 1
+        )
+        compliance_required = bool(state.memory_compliance_required)
+        state.memory_compliance_escalations = (
+            (state.memory_compliance_escalations or 0) + 1
+        )
+        escalations = state.memory_compliance_escalations
+
+        # v6 facilitator re-evaluation signal (Gate 3, epic #428, debounced
+        # by Issue #572). prompt_submit.py consumes this on the next
+        # UserPromptSubmit. The old "any chain_id => trigger" rule was the
+        # root cause of 41k+ queued bus events and spurious re-eval
+        # directives after every gate ACK.
+        if should_reeval and chain_id:
+            state.facilitator_reeval_due = True
+            state.facilitator_reeval_chain = chain_id
+            _log("task", "info", "reeval.scheduled", detail={
+                "reason": reeval_reason,
+                "event_type": event_type,
+                "chain_id": chain_id,
+            })
+        else:
+            _log("task", "debug", "reeval.skipped", detail={
+                "reason": reeval_reason,
+                "event_type": event_type,
+                "chain_id": chain_id,
+            })
+
+        # Phase-start gate signal: set when the completed task is a
+        # phase-transition event so prompt_submit.py can dispatch
+        # phase_start_gate.check() before the next phase's specialists engage.
+        if event_type == EVENT_TYPE_PHASE_TRANSITION:
+            state.phase_start_gate_due = True
+
+        state.save()
+        return compliance_required, escalations
+    except Exception as exc:
+        print(
+            f"[wicked-garden] task_completed session state error: {exc}",
+            file=sys.stderr,
+        )
+        return False, 0
 
 
 def main():
@@ -133,62 +244,24 @@ def main():
 
         _log("task", "debug", "hook.start")
 
-        # Look up metadata.chain_id from the native task file (fail-open).
-        # Gate 3 (v6): surface re-eval signal so prompt_submit.py can tell Claude
-        # to invoke propose-process in re-evaluation mode on the next turn.
-        chain_id = _read_task_chain_id(session_id, task_id)
+        # Issue #572: load metadata ONCE and derive all downstream signals from
+        # it. The old code read the task file twice (chain_id, then event_type
+        # in a nested try block) and set facilitator_reeval_due on any truthy
+        # chain_id — including gate-finding shell completions the orchestrator
+        # just acked. Debounce is now: phase-transition OR (gate-finding AND
+        # verdict=REJECT).
+        metadata = _read_task_metadata(session_id, task_id) or {}
+        chain_id_val = metadata.get("chain_id") if isinstance(metadata, dict) else None
+        chain_id = chain_id_val if isinstance(chain_id_val, str) and chain_id_val.strip() else None
+        event_type = metadata.get("event_type") if isinstance(metadata, dict) else None
 
-        # Load session state, increment counters, and read escalation level
-        escalations = 0
-        try:
-            from _session import SessionState
-            state = SessionState.load()
-            state.memory_compliance_tasks_completed = (
-                (state.memory_compliance_tasks_completed or 0) + 1
-            )
-            compliance_required = bool(state.memory_compliance_required)
-            # Increment escalation counter (reset by post_tool.py on mem:store)
-            state.memory_compliance_escalations = (
-                (state.memory_compliance_escalations or 0) + 1
-            )
-            escalations = state.memory_compliance_escalations
-
-            # v6 facilitator re-evaluation signal (Gate 3, epic #428).
-            # Set flag when the completed task carries a chain_id. prompt_submit.py
-            # consumes this on the next UserPromptSubmit, emits a systemMessage
-            # directive, and clears the flag. Fail-open: a missing chain_id is
-            # a no-op (most native tasks don't have metadata).
-            if chain_id:
-                state.facilitator_reeval_due = True
-                state.facilitator_reeval_chain = chain_id
-
-            # Phase-start gate signal: set when the completed task is a
-            # phase-transition event so prompt_submit.py can dispatch
-            # phase_start_gate.check() before the next phase's specialists engage.
-            # Fires ONLY for phase-transition event_type to avoid OQ-5 noise.
-            # Fail-open: missing metadata is a no-op; never blocks completion.
-            try:
-                event_type = None
-                if session_id and task_id:
-                    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
-                    base = Path(config_dir) if config_dir else Path.home() / ".claude"
-                    task_file = base / "tasks" / session_id / f"{task_id}.json"
-                    if task_file.is_file():
-                        task_data = json.loads(task_file.read_text(encoding="utf-8"))
-                        event_type = (
-                            task_data.get("metadata", {}).get("event_type")
-                            if isinstance(task_data, dict)
-                            else None
-                        )
-                if event_type == "phase-transition":
-                    state.phase_start_gate_due = True
-            except Exception:
-                pass  # fail-open: gate-due flag is best-effort
-
-            state.save()
-        except Exception as e:
-            print(f"[wicked-garden] task_completed session state error: {e}", file=sys.stderr)
-            compliance_required = False
+        should_reeval, reeval_reason = _should_trigger_reeval(metadata)
+        compliance_required, escalations = _update_session_state(
+            chain_id=chain_id,
+            event_type=event_type,
+            should_reeval=should_reeval,
+            reeval_reason=reeval_reason,
+        )
 
         # Emit a memory directive for any deliverable-producing task.
         # Crew projects get stronger "REQUIRED" language; normal sessions
@@ -198,7 +271,9 @@ def main():
             mem_type = _infer_mem_type(subject)
             task_label = f'"{subject}"' if subject else f"task {task_id}"
             if compliance_required:
-                escalation_prefix = "[ESCALATION] " if escalations >= 3 else ""
+                escalation_prefix = (
+                    "[ESCALATION] " if escalations >= _ESCALATION_THRESHOLD else ""
+                )
                 system_message = (
                     f"{escalation_prefix}[Memory] Task {task_label} completed. "
                     f"REQUIRED: Call /wicked-garden:mem:store with type={mem_type} "

--- a/scripts/crew/hitl_judge.py
+++ b/scripts/crew/hitl_judge.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""HITL Judge -- rule-based decisions for when crew should pause for review.
+
+Issue #575.
+
+"HITL" (human-in-the-loop) is the *absence* of a decision rule that asks:
+is there enough signal to proceed autonomously?  Today wicked-garden has two
+opposite frictions in the same system:
+
+* ``--yolo`` + the clarify halt unconditionally pauses, even on a crisp
+  high-signal bugfix where the crew has every signal it needs.
+* The council verdict auto-proceeds even on a 3-1 split or a low-confidence
+  vote -- the very cases where a second look is most valuable.
+
+This module exposes three pure decision functions that are called at the
+relevant gate sites.  Each call returns a :class:`JudgeDecision` carrying
+``pause`` (True = halt for human review), ``reason`` (human-readable line
+that ends up in evidence files + logs), ``rule_id`` (stable identifier for
+analytics + tests), and ``signals`` (the scored inputs that produced the
+decision so an auditor can reproduce the verdict).
+
+Stdlib-only.  Cross-platform.  Importable from any callsite.
+
+Env overrides
+-------------
+
+Each callable consults a single env var (default ``auto``):
+
+* ``WG_HITL_CLARIFY``   -- clarify halt
+* ``WG_HITL_COUNCIL``   -- council synthesis
+* ``WG_HITL_CHALLENGE`` -- challenge charter selection
+
+Values:
+
+* ``auto``  -- apply the rule table (the default).
+* ``pause`` -- force ``pause=True`` regardless of inputs.
+* ``off``   -- force ``pause=False`` regardless of inputs.
+
+When an override fires, the override is folded into ``reason`` and
+``signals['env_override']`` so evidence remains auditable.
+
+Wiring status (Issue #575)
+--------------------------
+
+* B1 (clarify halt): documented in ``commands/crew/just-finish.md`` -- the
+  halt today is enforced by the orchestrating skill, not by Python, so
+  the integration is a documentation paragraph + the recommendation to
+  call :func:`should_pause_clarify` and persist the result to
+  ``phases/clarify/hitl-decision.json`` via
+  :func:`write_hitl_decision_evidence`.
+* B2 (challenge charter): the contrarian agent is dispatched by the
+  facilitator/orchestrator from a Markdown skill (no single Python
+  callsite).  Selecting the charter therefore happens at the prompt-build
+  step.  See the ``# TODO(Issue #575): dispatch integration`` marker in
+  :func:`challenge_charter` -- the helper is ready; the wiring is left to
+  whichever orchestrator next touches contrarian dispatch.
+* B3 (council synthesis): documented in ``commands/jam/council.md``.
+  ``scripts/jam/consensus.py`` synthesises agreement structurally but
+  does not enforce a pause.  The recommended integration is to call
+  :func:`should_pause_council` after consensus synthesis and persist the
+  result via :func:`write_hitl_decision_evidence` as
+  ``council-decision.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+
+# ---------------------------------------------------------------------------
+# Threshold constants
+#
+# Centralised so an auditor reading a verdict can map every signal back to a
+# named rule.  WHY comments capture the design intent so the next reader does
+# not have to re-derive it from issue history.
+# ---------------------------------------------------------------------------
+
+#: Minimum facilitator confidence required to auto-proceed past clarify.
+#: WHY: below 0.7 the facilitator is signalling that the spec leaves room for
+#: divergent interpretations -- the *exact* moment a human glance pays back.
+CLARIFY_MIN_CONFIDENCE: float = 0.7
+
+#: Complexity score at which clarify always pauses regardless of yolo.
+#: WHY: phases.json review-tier mapping treats >=5 as the "full" rigor band;
+#: full rigor implies multi-reviewer gates downstream, so we should not skip
+#: the human eyeball at the entry gate either.
+CLARIFY_COMPLEXITY_PAUSE: int = 5
+
+#: Open-question count above which clarify pauses.
+#: WHY: any unresolved question is, by definition, missing signal.  We treat
+#: ``>0`` as "pause" rather than "warn" so the halt is binary and testable.
+CLARIFY_OPEN_QUESTIONS_PAUSE: int = 0
+
+#: Minimum per-model confidence required to count a council vote as "high
+#: confidence".  WHY: 0.6 is the inflection point where models start hedging;
+#: below that the verdict is more vibe than analysis and merits human review.
+COUNCIL_MIN_VOTE_CONFIDENCE: float = 0.6
+
+#: Vote-margin threshold considered "split".  Two leading verdicts within
+#: ``<= COUNCIL_SPLIT_MARGIN`` votes of each other count as split.
+#: WHY: Issue #575 calls out "3-1 or closer" as split.  On a 4-model council
+#: that means ``margin <= 2`` (4-0 = margin 4 unanimous; 3-1 = margin 2 split;
+#: 2-2 = margin 0 split).  Leaving headroom for larger councils: a 5-1 vote
+#: (margin 4) would not be split, but 5-3 (margin 2) would.
+COUNCIL_SPLIT_MARGIN: int = 2
+
+#: Complexity at which the challenge phase auto-runs (non-skippable).
+#: Mirrors the existing v6.1 propose-process trigger.
+CHALLENGE_RUN_THRESHOLD: int = 4
+
+#: Complexity at which BOTH integration-sweep and full-steelman charters apply
+#: even on a unanimous council (the "high stakes" band).
+#: WHY: at >=6 the blast radius is large enough that we want the steelman in
+#: addition to the cheaper integration sweep.
+CHALLENGE_BOTH_THRESHOLD: int = 6
+
+
+# ---------------------------------------------------------------------------
+# Env override constants
+# ---------------------------------------------------------------------------
+
+ENV_CLARIFY: str = "WG_HITL_CLARIFY"
+ENV_COUNCIL: str = "WG_HITL_COUNCIL"
+ENV_CHALLENGE: str = "WG_HITL_CHALLENGE"
+
+OVERRIDE_AUTO: str = "auto"
+OVERRIDE_PAUSE: str = "pause"
+OVERRIDE_OFF: str = "off"
+
+_VALID_OVERRIDES = {OVERRIDE_AUTO, OVERRIDE_PAUSE, OVERRIDE_OFF}
+
+
+# ---------------------------------------------------------------------------
+# Charter identifiers
+# ---------------------------------------------------------------------------
+
+CHARTER_INTEGRATION_SWEEP: str = "charter.integration-sweep"
+CHARTER_FULL_STEELMAN: str = "charter.full-steelman"
+CHARTER_BOTH: str = "charter.both"
+
+
+# ---------------------------------------------------------------------------
+# Decision record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JudgeDecision:
+    """Decision record returned by every ``should_pause_*`` / charter call.
+
+    Attributes:
+        pause: True when the crew should halt for human review.
+        reason: Single human-readable line suitable for logs + evidence files.
+        rule_id: Stable identifier (e.g. ``clarify.low-confidence``) used by
+            tests and analytics so verdicts can be correlated across runs.
+        signals: The scored inputs that produced the decision, plus any env
+            override that was applied.  Always serialisable to JSON.
+    """
+
+    pause: bool
+    reason: str
+    rule_id: str
+    signals: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable dict (helper for evidence-file emit)."""
+        return {
+            "pause": self.pause,
+            "reason": self.reason,
+            "rule_id": self.rule_id,
+            "signals": dict(self.signals),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_override(
+    env_var: str,
+    env: Mapping[str, str] | None,
+) -> str:
+    """Read and validate an env override.  Unknown values fall back to auto.
+
+    We deliberately do not raise on unknown values -- the judge must never
+    be the cause of a crew halt because someone typo'd an env var.  Unknown
+    values are logged into the decision signals for auditability.
+    """
+    source = env if env is not None else os.environ
+    raw = (source.get(env_var) or OVERRIDE_AUTO).strip().lower()
+    if raw not in _VALID_OVERRIDES:
+        return OVERRIDE_AUTO
+    return raw
+
+
+def _apply_override(
+    override: str,
+    base: JudgeDecision,
+    env_var: str,
+) -> JudgeDecision:
+    """Fold an env override into a base decision.
+
+    ``pause`` and ``off`` flip ``pause`` and prefix the reason so reviewers
+    can immediately see that the verdict came from an override rather than
+    the rule table.  ``auto`` is the no-op path.
+    """
+    if override == OVERRIDE_AUTO:
+        return base
+
+    new_signals = dict(base.signals)
+    new_signals["env_override"] = {"var": env_var, "value": override}
+
+    if override == OVERRIDE_PAUSE:
+        return JudgeDecision(
+            pause=True,
+            reason=(
+                f"env override {env_var}=pause forced halt "
+                f"(would otherwise be: {base.reason})"
+            ),
+            rule_id=f"{base.rule_id}.override-pause",
+            signals=new_signals,
+        )
+
+    # override == OVERRIDE_OFF
+    return JudgeDecision(
+        pause=False,
+        reason=(
+            f"env override {env_var}=off skipped halt "
+            f"(would otherwise be: {base.reason})"
+        ),
+        rule_id=f"{base.rule_id}.override-off",
+        signals=new_signals,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API: clarify
+# ---------------------------------------------------------------------------
+
+
+def should_pause_clarify(
+    *,
+    complexity: int,
+    facilitator_confidence: float,
+    open_questions: int,
+    yolo: bool,
+    env: Mapping[str, str] | None = None,
+) -> JudgeDecision:
+    """Decide whether the clarify gate should halt for human acknowledgment.
+
+    Rule table (auto mode):
+
+    * ``yolo=False``                              -> pause (safety baseline)
+    * ``facilitator_confidence < 0.7``            -> pause (low-confidence)
+    * ``complexity >= 5``                         -> pause (complexity-threshold)
+    * ``open_questions > 0``                      -> pause (open-questions)
+    * otherwise (yolo + clean signals)            -> auto-proceed
+
+    Args:
+        complexity: Facilitator-rated complexity (0-7, ``phases.json`` band).
+        facilitator_confidence: Facilitator self-rated confidence in [0, 1].
+        open_questions: Count of unresolved clarifying questions.
+        yolo: True when the user passed ``--yolo`` (autonomous mode).
+        env: Optional env mapping (testing seam; defaults to ``os.environ``).
+
+    Returns:
+        JudgeDecision -- ``pause`` True when crew must halt.
+    """
+    signals = {
+        "complexity": complexity,
+        "facilitator_confidence": facilitator_confidence,
+        "open_questions": open_questions,
+        "yolo": yolo,
+    }
+
+    if not yolo:
+        base = JudgeDecision(
+            pause=True,
+            reason="non-yolo mode always pauses clarify for confirmation",
+            rule_id="clarify.non-yolo-baseline",
+            signals=signals,
+        )
+    elif facilitator_confidence < CLARIFY_MIN_CONFIDENCE:
+        base = JudgeDecision(
+            pause=True,
+            reason=(
+                f"facilitator confidence {facilitator_confidence:.2f} below "
+                f"threshold {CLARIFY_MIN_CONFIDENCE:.2f}"
+            ),
+            rule_id="clarify.low-confidence",
+            signals=signals,
+        )
+    elif complexity >= CLARIFY_COMPLEXITY_PAUSE:
+        base = JudgeDecision(
+            pause=True,
+            reason=(
+                f"complexity {complexity} at or above threshold "
+                f"{CLARIFY_COMPLEXITY_PAUSE}"
+            ),
+            rule_id="clarify.complexity-threshold",
+            signals=signals,
+        )
+    elif open_questions > CLARIFY_OPEN_QUESTIONS_PAUSE:
+        base = JudgeDecision(
+            pause=True,
+            reason=f"{open_questions} unresolved clarify question(s) remain",
+            rule_id="clarify.open-questions",
+            signals=signals,
+        )
+    else:
+        base = JudgeDecision(
+            pause=False,
+            reason=(
+                f"yolo + confidence {facilitator_confidence:.2f} + complexity "
+                f"{complexity} + 0 open questions: auto-proceed"
+            ),
+            rule_id="clarify.auto-proceed",
+            signals=signals,
+        )
+
+    override = _read_override(ENV_CLARIFY, env)
+    return _apply_override(override, base, ENV_CLARIFY)
+
+
+# ---------------------------------------------------------------------------
+# Public API: council
+# ---------------------------------------------------------------------------
+
+
+def _tally_votes(votes: list[dict]) -> dict[str, int]:
+    """Count verdicts.  Ignores entries missing a verdict field."""
+    tally: dict[str, int] = {}
+    for vote in votes:
+        verdict = vote.get("verdict")
+        if not verdict:
+            continue
+        tally[verdict] = tally.get(verdict, 0) + 1
+    return tally
+
+
+def _is_split(tally: dict[str, int]) -> bool:
+    """True when the top two verdicts are within ``COUNCIL_SPLIT_MARGIN``."""
+    if len(tally) < 2:
+        return False
+    counts = sorted(tally.values(), reverse=True)
+    return (counts[0] - counts[1]) <= COUNCIL_SPLIT_MARGIN
+
+
+def _lowest_confidence(votes: list[dict]) -> tuple[float, str | None]:
+    """Return (lowest_confidence, model_name) across all votes.
+
+    Returns (1.0, None) when no confidence values are present so the caller
+    short-circuits the low-confidence branch rather than blowing up.
+    """
+    lowest: float = 1.0
+    who: str | None = None
+    for vote in votes:
+        conf = vote.get("confidence")
+        if conf is None:
+            continue
+        try:
+            conf_f = float(conf)
+        except (TypeError, ValueError):
+            continue
+        if conf_f < lowest:
+            lowest = conf_f
+            who = vote.get("model")
+    return lowest, who
+
+
+def should_pause_council(
+    *,
+    votes: list[dict],
+    synthesize_quorum: int = 3,
+    env: Mapping[str, str] | None = None,
+) -> JudgeDecision:
+    """Decide whether council synthesis should halt for human adjudication.
+
+    Rule table (auto mode):
+
+    * fewer than ``synthesize_quorum`` votes              -> pause (no-quorum)
+    * top two verdicts within ``COUNCIL_SPLIT_MARGIN``    -> pause (split-verdict)
+    * any vote with ``confidence < 0.6``                  -> pause (low-confidence-vote)
+    * otherwise (unanimous + high confidence)             -> auto-proceed
+
+    Args:
+        votes: List of ``{"model": str, "verdict": str, "confidence": float}``
+            dicts, one per council participant.
+        synthesize_quorum: Minimum votes required to even attempt synthesis.
+        env: Optional env mapping (testing seam).
+
+    Returns:
+        JudgeDecision -- ``pause`` True when crew must halt for review.
+    """
+    tally = _tally_votes(votes)
+    lowest_conf, lowest_model = _lowest_confidence(votes)
+    signals: dict[str, Any] = {
+        "vote_count": len(votes),
+        "tally": tally,
+        "lowest_confidence": lowest_conf,
+        "lowest_confidence_model": lowest_model,
+        "synthesize_quorum": synthesize_quorum,
+    }
+
+    if len(votes) < synthesize_quorum:
+        base = JudgeDecision(
+            pause=True,
+            reason=(
+                f"only {len(votes)} council vote(s); quorum is "
+                f"{synthesize_quorum}"
+            ),
+            rule_id="council.no-quorum",
+            signals=signals,
+        )
+    elif _is_split(tally):
+        base = JudgeDecision(
+            pause=True,
+            reason=(
+                f"split verdict (top two within {COUNCIL_SPLIT_MARGIN} vote): "
+                f"{tally}"
+            ),
+            rule_id="council.split-verdict",
+            signals=signals,
+        )
+    elif lowest_conf < COUNCIL_MIN_VOTE_CONFIDENCE:
+        base = JudgeDecision(
+            pause=True,
+            reason=(
+                f"model {lowest_model!r} confidence {lowest_conf:.2f} below "
+                f"threshold {COUNCIL_MIN_VOTE_CONFIDENCE:.2f}"
+            ),
+            rule_id="council.low-confidence-vote",
+            signals=signals,
+        )
+    else:
+        base = JudgeDecision(
+            pause=False,
+            reason=(
+                f"unanimous council with min confidence {lowest_conf:.2f}: "
+                f"auto-proceed"
+            ),
+            rule_id="council.auto-proceed",
+            signals=signals,
+        )
+
+    override = _read_override(ENV_COUNCIL, env)
+    return _apply_override(override, base, ENV_COUNCIL)
+
+
+# ---------------------------------------------------------------------------
+# Public API: challenge charter
+# ---------------------------------------------------------------------------
+
+
+def challenge_charter(
+    *,
+    complexity: int,
+    council_outcome: Literal["unanimous", "split", "none"],
+    env: Mapping[str, str] | None = None,
+) -> JudgeDecision:
+    """Pick the contrarian charter to use at the challenge phase.
+
+    Challenge is **not skippable** at ``complexity >= CHALLENGE_RUN_THRESHOLD``
+    -- evidence in wicked-brain memory ``unanimous-council-does-not-skip-
+    challenge-phase`` shows a 4-0 council can still miss a wiring consequence
+    that the contrarian catches.  The charter shifts based on council outcome:
+
+    * unanimous + complexity in [4, 5]   -> ``charter.integration-sweep``
+    * split, any complexity >= 4          -> ``charter.full-steelman``
+    * unanimous + complexity >= 6        -> ``charter.both``
+    * split + complexity >= 6             -> ``charter.full-steelman``
+    * complexity < 4                      -> skipped below threshold
+
+    Always returns ``pause=False`` -- challenge runs as part of the workflow,
+    not as a halt.  The ``reason`` field carries the charter id so callsites
+    can dispatch the correct contrarian prompt.
+
+    Args:
+        complexity: Facilitator-rated complexity (0-7).
+        council_outcome: ``unanimous``, ``split``, or ``none`` (no council ran).
+        env: Optional env mapping (testing seam).
+
+    Returns:
+        JudgeDecision -- ``pause`` False (always); ``reason`` carries charter id.
+
+    Note (Issue #575):
+        # TODO(Issue #575): dispatch integration -- the contrarian agent is
+        # currently dispatched from the facilitator skill, not from a single
+        # Python callsite.  When the dispatch path moves into Python, call
+        # this helper and feed ``decision.signals['charter']`` into the
+        # Task() prompt builder.
+    """
+    signals: dict[str, Any] = {
+        "complexity": complexity,
+        "council_outcome": council_outcome,
+    }
+
+    if complexity < CHALLENGE_RUN_THRESHOLD:
+        signals["charter"] = None
+        base = JudgeDecision(
+            pause=False,
+            reason=(
+                f"complexity {complexity} below challenge threshold "
+                f"{CHALLENGE_RUN_THRESHOLD}: challenge skipped"
+            ),
+            rule_id="challenge.skipped-below-threshold",
+            signals=signals,
+        )
+    else:
+        if council_outcome == "split":
+            charter = CHARTER_FULL_STEELMAN
+            rule = "challenge.split-steelman"
+        elif council_outcome == "unanimous" and complexity >= CHALLENGE_BOTH_THRESHOLD:
+            charter = CHARTER_BOTH
+            rule = "challenge.unanimous-both"
+        elif council_outcome == "unanimous":
+            charter = CHARTER_INTEGRATION_SWEEP
+            rule = "challenge.unanimous-integration-sweep"
+        elif complexity >= CHALLENGE_BOTH_THRESHOLD:
+            # No council ran (council_outcome == "none") at high complexity --
+            # treat like a split to be safe; the steelman is the conservative
+            # default when we lack a unanimous signal.
+            charter = CHARTER_FULL_STEELMAN
+            rule = "challenge.no-council-steelman"
+        else:
+            # No council ran at moderate complexity -- still run the steelman.
+            charter = CHARTER_FULL_STEELMAN
+            rule = "challenge.no-council-steelman"
+
+        signals["charter"] = charter
+        base = JudgeDecision(
+            pause=False,
+            reason=(
+                f"{charter} (council={council_outcome}, complexity={complexity})"
+            ),
+            rule_id=rule,
+            signals=signals,
+        )
+
+    override = _read_override(ENV_CHALLENGE, env)
+    if override == OVERRIDE_AUTO:
+        return base
+
+    # For challenge overrides we keep the original charter in signals so the
+    # auditor can see what would have run.  Pause-override flips pause; off-
+    # override is a no-op at challenge (challenge already returns pause=False)
+    # but still recorded so reviewers see the env was set.
+    new_signals = dict(base.signals)
+    new_signals["env_override"] = {"var": ENV_CHALLENGE, "value": override}
+
+    if override == OVERRIDE_PAUSE:
+        return JudgeDecision(
+            pause=True,
+            reason=(
+                f"env override {ENV_CHALLENGE}=pause forced halt "
+                f"(would otherwise be: {base.reason})"
+            ),
+            rule_id=f"{base.rule_id}.override-pause",
+            signals=new_signals,
+        )
+
+    # OVERRIDE_OFF on challenge: explicit no-op acknowledgment.
+    return JudgeDecision(
+        pause=False,
+        reason=(
+            f"env override {ENV_CHALLENGE}=off acknowledged "
+            f"(challenge already proceeds without halt: {base.reason})"
+        ),
+        rule_id=f"{base.rule_id}.override-off",
+        signals=new_signals,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence-file emit helper
+# ---------------------------------------------------------------------------
+
+
+def write_hitl_decision_evidence(
+    project_dir: Path,
+    phase: str,
+    filename: str,
+    decision: JudgeDecision,
+) -> Path:
+    """Write a :class:`JudgeDecision` to ``phases/{phase}/{filename}``.
+
+    Small, single-purpose helper so callsites do not have to know the JSON
+    schema.  The path mirrors the existing conditions-manifest convention so
+    auditors find HITL evidence in the same place as gate evidence.
+
+    Args:
+        project_dir: Project root directory.
+        phase: Phase name (e.g. ``clarify``, ``challenge``).
+        filename: Evidence-file name (e.g. ``hitl-decision.json``).
+        decision: The decision to persist.
+
+    Returns:
+        Absolute path to the written evidence file.
+
+    Raises:
+        OSError: If the parent directory cannot be created or the write fails.
+            We deliberately do not swallow the error -- evidence loss must be
+            visible.
+    """
+    target_dir = project_dir / "phases" / phase
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / filename
+    target_path.write_text(
+        json.dumps(decision.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return target_path

--- a/scripts/crew/specialist_resolver.py
+++ b/scripts/crew/specialist_resolver.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Specialist name resolver for the wicked-garden plugin (Issue #573).
+
+Three naming systems used to collide for the same concept:
+
+1. ``.claude-plugin/specialist.json`` lists 8 **domains**
+   (``engineering``, ``platform``, ``product``, ``qe``, ``data``,
+   ``delivery``, ``jam``, ``agentic``).
+2. The facilitator rubric (``skills/propose-process/SKILL.md`` Step 4)
+   picks bare **role** names like ``requirements-analyst`` or
+   ``solution-architect``.
+3. Actual subagents are keyed ``wicked-garden:{domain}:{role}`` — for
+   example ``wicked-garden:product:requirements-analyst``.
+
+This module is the single source of truth that bridges the three. It
+walks ``agents/**/*.md``, parses the YAML-like frontmatter by simple
+line scanning (stdlib only — hooks can import it), and returns lookup
+maps keyed by both bare role and full subagent_type.
+
+Public API:
+    build_resolver(plugin_root: Path) -> dict
+    resolve_role(role_name: str, resolver: dict) -> tuple[str, str] | tuple[None, None]
+
+The builder is cached per ``plugin_root`` string so repeated calls from
+hooks or scripts do not re-walk the agent tree.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import re
+from pathlib import Path
+from typing import Optional, Tuple
+
+# The canonical subagent_type prefix used throughout the plugin. Callers
+# may pass either a bare role (``requirements-analyst``) or the full
+# prefixed form — the resolver handles both.
+_SUBAGENT_PREFIX = "wicked-garden:"
+
+# Frontmatter fences: a leading ``---`` starts the YAML-like block and a
+# trailing ``---`` closes it. We stop at the second fence so nothing in
+# the agent body can accidentally masquerade as frontmatter.
+_FRONTMATTER_FENCE = "---"
+
+# Only these two keys are consumed. We deliberately do not pull in a YAML
+# library — hooks are stdlib-only, and the frontmatter in this repo is
+# always a flat, top-level ``key: value`` pattern for these two fields.
+_RE_NAME = re.compile(r"^name:\s*(.+?)\s*$")
+_RE_SUBAGENT_TYPE = re.compile(r"^subagent_type:\s*(.+?)\s*$")
+
+
+def _parse_agent_frontmatter(path: Path) -> dict:
+    """Return ``{"name": ..., "subagent_type": ...}`` for an agent file.
+
+    Missing keys are omitted from the returned dict (callers treat that
+    as "skip this file"). Unreadable files return ``{}``.
+
+    This is NOT a general YAML parser. It scans line-by-line between the
+    first two ``---`` fences, matching only the two keys we care about.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
+        return {}
+
+    result: dict = {}
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == _FRONTMATTER_FENCE:
+            break
+        name_match = _RE_NAME.match(line)
+        if name_match and "name" not in result:
+            result["name"] = name_match.group(1).strip()
+            continue
+        subagent_match = _RE_SUBAGENT_TYPE.match(line)
+        if subagent_match and "subagent_type" not in result:
+            result["subagent_type"] = subagent_match.group(1).strip()
+            continue
+    return result
+
+
+def _load_domains(plugin_root: Path) -> list:
+    """Return the list of specialist-domain names from specialist.json.
+
+    Returns an empty list on any error so the resolver stays usable even
+    if the manifest is briefly malformed during development.
+    """
+    manifest = plugin_root / ".claude-plugin" / "specialist.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    names = []
+    for entry in data.get("specialists", []):
+        if isinstance(entry, dict) and entry.get("name"):
+            names.append(entry["name"])
+    return names
+
+
+@functools.lru_cache(maxsize=32)
+def _build_resolver_cached(plugin_root_str: str) -> dict:
+    """Cached worker — keyed on the stringified plugin root."""
+    plugin_root = Path(plugin_root_str)
+    agents_dir = plugin_root / "agents"
+
+    role_to_subagent: dict = {}
+    role_to_domain: dict = {}
+    subagent_to_role: dict = {}
+    warnings: list = []
+
+    if agents_dir.is_dir():
+        # Sort for deterministic collision resolution: earlier (alphabetical
+        # by path) wins, later entries become warnings. ``rglob`` order is
+        # filesystem-dependent on some platforms, so we sort explicitly.
+        for agent_path in sorted(agents_dir.rglob("*.md")):
+            meta = _parse_agent_frontmatter(agent_path)
+            name = meta.get("name")
+            subagent_type = meta.get("subagent_type")
+            if not name or not subagent_type:
+                continue
+            # The domain is the middle segment of wicked-garden:{domain}:{role}
+            # — fall back to the parent directory name if the subagent_type
+            # is malformed (keeps lookup working even for drifted files).
+            if subagent_type.startswith(_SUBAGENT_PREFIX):
+                tail = subagent_type[len(_SUBAGENT_PREFIX):]
+                parts = tail.split(":", 1)
+                domain = parts[0] if len(parts) == 2 else agent_path.parent.name
+            else:
+                domain = agent_path.parent.name
+
+            if name in role_to_subagent:
+                existing = role_to_subagent[name]
+                if existing != subagent_type:
+                    warnings.append(
+                        f"role collision: '{name}' maps to both "
+                        f"'{existing}' and '{subagent_type}' — keeping first"
+                    )
+                # Do not overwrite — first match wins.
+                continue
+
+            role_to_subagent[name] = subagent_type
+            role_to_domain[name] = domain
+            subagent_to_role[subagent_type] = name
+
+    return {
+        "role_to_subagent": role_to_subagent,
+        "role_to_domain": role_to_domain,
+        "subagent_to_role": subagent_to_role,
+        "domains": _load_domains(plugin_root),
+        "warnings": warnings,
+    }
+
+
+def build_resolver(plugin_root: Path) -> dict:
+    """Build the resolver by walking ``agents/**/*.md`` under ``plugin_root``.
+
+    Returns a dict with:
+
+    * ``role_to_subagent`` — bare role -> full ``wicked-garden:{domain}:{role}``
+    * ``role_to_domain`` — bare role -> domain (e.g. ``product``)
+    * ``subagent_to_role`` — full subagent_type -> bare role (reverse map)
+    * ``domains`` — list of specialist-domain names from ``specialist.json``
+    * ``warnings`` — list of human-readable strings for collisions
+
+    The result is cached per plugin_root string, so subsequent calls from
+    the same process are O(1).
+    """
+    return _build_resolver_cached(str(plugin_root))
+
+
+def resolve_role(
+    role_name: str, resolver: dict
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(domain, subagent_type)`` for a role, or ``(None, None)``.
+
+    Accepts either a bare role (``requirements-analyst``) or an already-
+    qualified subagent_type (``wicked-garden:product:requirements-analyst``)
+    — idempotent for the latter.
+
+    Unknown roles return ``(None, None)`` without raising. Callers that
+    want close-match suggestions should drive ``difflib.get_close_matches``
+    off ``resolver["role_to_subagent"].keys()``.
+    """
+    if not role_name or not isinstance(role_name, str):
+        return None, None
+    role_name = role_name.strip()
+    if not role_name:
+        return None, None
+
+    # Full subagent_type path: look up the bare role via the reverse map
+    # and then use the forward maps for the domain. This keeps the return
+    # shape consistent regardless of which form the caller passed in.
+    if role_name.startswith(_SUBAGENT_PREFIX):
+        bare = resolver.get("subagent_to_role", {}).get(role_name)
+        if bare is None:
+            return None, None
+        domain = resolver.get("role_to_domain", {}).get(bare)
+        if domain is None:
+            return None, None
+        return domain, role_name
+
+    subagent_type = resolver.get("role_to_subagent", {}).get(role_name)
+    if subagent_type is None:
+        return None, None
+    domain = resolver.get("role_to_domain", {}).get(role_name)
+    if domain is None:
+        return None, None
+    return domain, subagent_type
+
+
+def clear_cache() -> None:
+    """Drop the module-level cache. Useful for tests that mutate agents/."""
+    _build_resolver_cached.cache_clear()

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -9,9 +9,32 @@ Exit 0 on valid, exit 1 on invalid or selftest failure.
 """
 
 import argparse
+import difflib
 import json
 import sys
 from pathlib import Path
+
+# Resolver import is best-effort — validate_plan is used in CI where the
+# repo layout is guaranteed, but the import is guarded so a malformed
+# agents/ tree surfaces a readable warning instead of a hard crash.
+try:
+    from crew.specialist_resolver import build_resolver, resolve_role
+    _RESOLVER_AVAILABLE = True
+except Exception:  # pragma: no cover - import-time safety net
+    _RESOLVER_AVAILABLE = False
+    build_resolver = None  # type: ignore[assignment]
+    resolve_role = None  # type: ignore[assignment]
+
+# Plugin root for resolver lookups. Mirrors the convention used in
+# hooks/scripts/*: prefer the env var, fall back to the repo tree above
+# this file. Kept module-level so tests can patch it if needed.
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+
+# Close-match cutoff chosen by difflib's default (0.6). Issue #573 asks
+# for suggestions on unknown roles; three is enough to narrow without
+# drowning the reader in look-alikes.
+_CLOSE_MATCHES_N = 3
+_CLOSE_MATCHES_CUTOFF = 0.6
 
 VALID_RIGOR_TIERS = {"minimal", "standard", "full"}
 VALID_FACTOR_READINGS = {"LOW", "MEDIUM", "HIGH"}
@@ -120,14 +143,87 @@ def _check_specialists(plan: dict, violations: list) -> None:
     if not isinstance(specialists, list) or len(specialists) == 0:
         violations.append("specialists — must be a non-empty list")
         return
+
+    # Issue #573: every pick must resolve via the agent-frontmatter
+    # resolver. Build the resolver once and re-use it across entries.
+    resolver = None
+    if _RESOLVER_AVAILABLE:
+        try:
+            resolver = build_resolver(_PLUGIN_ROOT)  # type: ignore[misc]
+        except Exception:  # pragma: no cover - defensive
+            resolver = None
+
     for i, entry in enumerate(specialists):
         if not isinstance(entry, dict):
             violations.append(f"specialists[{i}] — must be a dict")
             continue
-        if not entry.get("name") or not str(entry["name"]).strip():
+        name = entry.get("name")
+        if not name or not str(name).strip():
             violations.append(f"specialists[{i}].name — must be a non-empty string")
         if not entry.get("why") or not str(entry["why"]).strip():
             violations.append(f"specialists[{i}].why — must be a non-empty string")
+
+        # Resolver check — applied only when the name is present and the
+        # resolver loaded successfully. Unknown picks become blocking
+        # errors with difflib suggestions so the facilitator can
+        # self-correct a typo without re-running the rubric.
+        if name and str(name).strip() and resolver is not None:
+            role_name = str(name).strip()
+            domain, subagent_type = resolve_role(role_name, resolver)  # type: ignore[misc]
+            if domain is None or subagent_type is None:
+                suggestions = difflib.get_close_matches(
+                    role_name,
+                    list(resolver.get("role_to_subagent", {}).keys()),
+                    n=_CLOSE_MATCHES_N,
+                    cutoff=_CLOSE_MATCHES_CUTOFF,
+                )
+                if suggestions:
+                    hint = ", ".join(suggestions)
+                    violations.append(
+                        f"specialists[{i}].name — unknown specialist "
+                        f"'{role_name}'; did you mean: {hint}?"
+                    )
+                else:
+                    violations.append(
+                        f"specialists[{i}].name — unknown specialist "
+                        f"'{role_name}'; no close matches found in "
+                        f"agents/**/*.md"
+                    )
+
+        # Expanded-form (Issue #573): validators accept picks emitted as
+        # either a bare string (via ``name``) or the full triple
+        # {name, domain, subagent_type}. When domain/subagent_type are
+        # present, they must agree with the resolver — silent drift
+        # between the expanded form and the agent frontmatter would
+        # reintroduce the original engagement-tracker bug.
+        if (
+            isinstance(entry.get("domain"), str)
+            or isinstance(entry.get("subagent_type"), str)
+        ) and resolver is not None and name:
+            role_name = str(name).strip()
+            expected_domain, expected_subagent = resolve_role(role_name, resolver)  # type: ignore[misc]
+            if expected_domain is not None and expected_subagent is not None:
+                declared_domain = entry.get("domain")
+                declared_subagent = entry.get("subagent_type")
+                if (
+                    isinstance(declared_domain, str)
+                    and declared_domain != expected_domain
+                ):
+                    violations.append(
+                        f"specialists[{i}].domain — '{declared_domain}' does "
+                        f"not match resolved domain '{expected_domain}' for "
+                        f"role '{role_name}'"
+                    )
+                if (
+                    isinstance(declared_subagent, str)
+                    and declared_subagent != expected_subagent
+                ):
+                    violations.append(
+                        f"specialists[{i}].subagent_type — "
+                        f"'{declared_subagent}' does not match resolved "
+                        f"subagent_type '{expected_subagent}' for role "
+                        f"'{role_name}'"
+                    )
 
 
 def _check_phases(plan: dict, violations: list) -> None:

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -57,21 +57,10 @@ gotchas) over wiki and chunks for planning. Record up to 3 priors that change th
 
 ### 3. Score the 9 factors (one sentence each)
 
-Prose reasoning, not numbers — but the output **must** be a dict per factor, not a
-bare string. Each factor emits `{"reading": "LOW|MEDIUM|HIGH", "why": "one
-sentence"}`. The validator (`scripts/crew/validate_plan.py`) rejects flat-string
-shapes on first emission and forces a retry. See `refs/factor-definitions.md` for
-what LOW/MEDIUM/HIGH mean per factor; see `refs/output-schema.md` for the full JSON
-envelope.
-
-**Minimal inline example — use this shape, not a flat string (Issue #574)**:
-
-```json
-"factors": {
-  "reversibility": {"reading": "HIGH", "why": "pure doc edit, git revert undoes it"},
-  "blast_radius":  {"reading": "LOW",  "why": "scoped to one skill file"}
-}
-```
+Prose, not numbers — but each factor emits the dict shape
+`{"reading": "LOW|MEDIUM|HIGH", "why": "..."}`, not a flat string (Issue #574).
+See `refs/factor-definitions.md` for calibration and `refs/output-schema.md`
+for the envelope.
 
 Factors: **reversibility** (undo without customer impact?), **blast_radius** (who/how
 many affected if broken?), **compliance_scope** (GDPR/PCI/HIPAA/SOC2?),
@@ -82,29 +71,11 @@ state, migrations), **operational_risk** (production runtime change),
 
 ### 4. Select specialists
 
-Read `agents/**/*.md` frontmatter (descriptions + "Use when"). Pick the smallest set
-that covers the factor scores. One sentence of WHY per pick. Prefer ≤5 for standard,
-≤10 for full. See `refs/specialist-selection.md` for the ~70-agent roster map and
-tie-breakers.
+Read `agents/**/*.md` frontmatter. Pick the smallest set that covers the
+factor scores with one-sentence WHY each (≤5 for standard, ≤10 for full).
+Roster map + core archetypes in `refs/specialist-selection.md`.
 
-Core archetypes: `requirements-analyst`, `product-manager`, `solution-architect`, `senior-engineer`, `backend-engineer`, `frontend-engineer`, `migration-engineer`, `test-strategist`, `test-designer`, `security-engineer`, `compliance-officer`, `privacy-expert`, `auditor`, `sre`, `release-engineer`, `data-engineer`, `technical-writer`, `ux-designer`, `ui-reviewer`.
-
-**Pick shape (Issue #573)**: Each entry in `specialists[]` may be emitted in either
-form, and both are accepted by `scripts/crew/validate_plan.py`:
-
-- **Short form** — `{"name": "requirements-analyst", "why": "..."}`. The resolver
-  (`scripts/crew/specialist_resolver.py`) expands the bare role to the full
-  `wicked-garden:{domain}:{role}` subagent_type at validation and dispatch time.
-- **Expanded form** — `{"name": "requirements-analyst", "domain": "product",
-  "subagent_type": "wicked-garden:product:requirements-analyst", "why": "..."}`.
-  When `domain` or `subagent_type` is present, it must agree with what the resolver
-  derives from `agents/**/*.md` frontmatter — silent drift between the expanded form
-  and the on-disk agent is rejected.
-
-Picks whose `name` does not resolve via the frontmatter index are rejected as
-validation errors. The validator runs `difflib.get_close_matches` and surfaces the
-three closest matches so the facilitator can correct a typo without re-running the
-whole rubric.
+Pick shape: short (`{"name", "why"}`) or expanded with `domain`/`subagent_type`; the resolver expands bare roles and rejects unresolvable names with close-match suggestions (Issue #573). Schema in `refs/output-schema.md`.
 
 ### 5. Select phases
 
@@ -219,12 +190,10 @@ Interaction mode (`normal` | `yolo` / `auto_proceed=true` / `/wicked-garden:crew
 
 ## Navigation
 
-- [`refs/inputs.md`](refs/inputs.md) — prior-fetch queries, session state reads; [`refs/process-memory.md`](refs/process-memory.md) — process memory + uncertainty gate
-- [`refs/factor-definitions.md`](refs/factor-definitions.md) — the 9 factors + calibration
-- [`refs/specialist-selection.md`](refs/specialist-selection.md) — roster map
-- [`refs/phase-catalog.md`](refs/phase-catalog.md) — phase templates, soft deps
-- [`refs/evidence-framing.md`](refs/evidence-framing.md) — functional evidence rubric + per-archetype contracts
-- [`refs/ambiguity.md`](refs/ambiguity.md) — when to stop and ask
-- [`refs/plan-template.md`](refs/plan-template.md) — `process-plan.md` template; [`refs/output-schema.md`](refs/output-schema.md) — JSON shape for measurement
-- [`refs/interaction-mode.md`](refs/interaction-mode.md) — normal vs. yolo, banned values; [`refs/gate-policy.md`](refs/gate-policy.md) — Gate × Rigor reviewer matrix
-- [`refs/re-eval-addendum-schema.md`](refs/re-eval-addendum-schema.md) — JSONL addendum schema; [`refs/spec-quality-rubric.md`](refs/spec-quality-rubric.md) — spec quality rubric
+`refs/` — `inputs.md` (prior-fetch + session state), `process-memory.md`
+(uncertainty gate), `factor-definitions.md` (9 factors), `specialist-selection.md`
+(roster), `phase-catalog.md` (phase templates), `evidence-framing.md`
+(per-archetype contracts), `ambiguity.md` (when to stop), `plan-template.md`
+(process-plan), `output-schema.md` (JSON shape), `interaction-mode.md`
+(yolo + banned values), `gate-policy.md` (reviewer matrix),
+`re-eval-addendum-schema.md`, `spec-quality-rubric.md`.

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -57,7 +57,22 @@ gotchas) over wiki and chunks for planning. Record up to 3 priors that change th
 
 ### 3. Score the 9 factors (one sentence each)
 
-Prose, not numbers. See `refs/factor-definitions.md` for meaning + calibration.
+Prose reasoning, not numbers — but the output **must** be a dict per factor, not a
+bare string. Each factor emits `{"reading": "LOW|MEDIUM|HIGH", "why": "one
+sentence"}`. The validator (`scripts/crew/validate_plan.py`) rejects flat-string
+shapes on first emission and forces a retry. See `refs/factor-definitions.md` for
+what LOW/MEDIUM/HIGH mean per factor; see `refs/output-schema.md` for the full JSON
+envelope.
+
+**Minimal inline example — use this shape, not a flat string (Issue #574)**:
+
+```json
+"factors": {
+  "reversibility": {"reading": "HIGH", "why": "pure doc edit, git revert undoes it"},
+  "blast_radius":  {"reading": "LOW",  "why": "scoped to one skill file"}
+}
+```
+
 Factors: **reversibility** (undo without customer impact?), **blast_radius** (who/how
 many affected if broken?), **compliance_scope** (GDPR/PCI/HIPAA/SOC2?),
 **user_facing_impact** (human-visible?), **novelty** (done before in this codebase —
@@ -73,6 +88,23 @@ that covers the factor scores. One sentence of WHY per pick. Prefer ≤5 for sta
 tie-breakers.
 
 Core archetypes: `requirements-analyst`, `product-manager`, `solution-architect`, `senior-engineer`, `backend-engineer`, `frontend-engineer`, `migration-engineer`, `test-strategist`, `test-designer`, `security-engineer`, `compliance-officer`, `privacy-expert`, `auditor`, `sre`, `release-engineer`, `data-engineer`, `technical-writer`, `ux-designer`, `ui-reviewer`.
+
+**Pick shape (Issue #573)**: Each entry in `specialists[]` may be emitted in either
+form, and both are accepted by `scripts/crew/validate_plan.py`:
+
+- **Short form** — `{"name": "requirements-analyst", "why": "..."}`. The resolver
+  (`scripts/crew/specialist_resolver.py`) expands the bare role to the full
+  `wicked-garden:{domain}:{role}` subagent_type at validation and dispatch time.
+- **Expanded form** — `{"name": "requirements-analyst", "domain": "product",
+  "subagent_type": "wicked-garden:product:requirements-analyst", "why": "..."}`.
+  When `domain` or `subagent_type` is present, it must agree with what the resolver
+  derives from `agents/**/*.md` frontmatter — silent drift between the expanded form
+  and the on-disk agent is rejected.
+
+Picks whose `name` does not resolve via the frontmatter index are rejected as
+validation errors. The validator runs `difflib.get_close_matches` and surfaces the
+three closest matches so the facilitator can correct a typo without re-running the
+whole rubric.
 
 ### 5. Select phases
 

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -33,7 +33,12 @@ rubric against a scenario's expected-outcome block.
   },
   "specialists": [
     {"name": "requirements-analyst", "why": "one sentence"},
-    {"name": "backend-engineer",     "why": "one sentence"}
+    {
+      "name": "backend-engineer",
+      "domain": "engineering",
+      "subagent_type": "wicked-garden:engineering:backend-engineer",
+      "why": "one sentence"
+    }
   ],
   "phases": [
     {"name": "clarify", "why": "one sentence", "primary": ["requirements-analyst"]},
@@ -86,6 +91,27 @@ rubric against a scenario's expected-outcome block.
 
 - `project_slug`, `summary`, `factors`, `specialists`, `phases`, `rigor_tier`,
   `complexity`, `tasks`.
+
+### Specialist pick forms (Issue #573)
+
+Each entry in `specialists[]` may be emitted in either form; both are accepted by
+`scripts/crew/validate_plan.py`:
+
+| Form          | Shape                                                              |
+|---------------|--------------------------------------------------------------------|
+| Short         | `{"name": "<role>", "why": "..."}`                                 |
+| Expanded      | `{"name": "<role>", "domain": "<d>", "subagent_type": "<st>", "why": "..."}` |
+
+**Resolution rules**:
+
+- The short form is expanded at validation time by
+  `scripts/crew/specialist_resolver.py`, which walks `agents/**/*.md` frontmatter
+  and maps bare role → `wicked-garden:{domain}:{role}`.
+- In the expanded form, any declared `domain` / `subagent_type` must agree with the
+  resolver's reading of the on-disk agent. Silent drift is rejected to preserve the
+  invariant the engagement tracker depends on (Issue #573: bare roles used to leak
+  past `_parse_specialist_from_agent_type` and drop engagement events).
+- Unknown `name` values are rejected with `difflib.get_close_matches` suggestions.
 
 **Present when applicable**:
 

--- a/tests/test_hitl_judge.py
+++ b/tests/test_hitl_judge.py
@@ -1,0 +1,278 @@
+"""Tests for ``scripts/crew/hitl_judge.py`` (Issue #575).
+
+T1-T6:
+
+* Deterministic -- no sleeps, no randomness, env passed via mapping fixtures.
+* Single-focus -- each test asserts one rule branch.
+* Descriptive names -- ``test_<callable>_<rule>_<expected>``.
+* Provenance -- every docstring cites Issue #575.
+"""
+
+from __future__ import annotations
+
+from crew.hitl_judge import (
+    CHARTER_BOTH,
+    CHARTER_FULL_STEELMAN,
+    CHARTER_INTEGRATION_SWEEP,
+    JudgeDecision,
+    challenge_charter,
+    should_pause_clarify,
+    should_pause_council,
+)
+
+
+# ---------------------------------------------------------------------------
+# Clarify
+# ---------------------------------------------------------------------------
+
+
+def test_clarify_yolo_clean_signals_auto_proceeds() -> None:
+    """Issue #575: yolo + high confidence + low complexity + 0 open Qs -> auto-proceed."""
+    decision = should_pause_clarify(
+        complexity=2,
+        facilitator_confidence=0.9,
+        open_questions=0,
+        yolo=True,
+        env={},
+    )
+    assert decision.pause is False
+    assert decision.rule_id == "clarify.auto-proceed"
+
+
+def test_clarify_low_confidence_pauses_even_under_yolo() -> None:
+    """Issue #575: yolo + facilitator confidence 0.5 -> pause (low-confidence)."""
+    decision = should_pause_clarify(
+        complexity=2,
+        facilitator_confidence=0.5,
+        open_questions=0,
+        yolo=True,
+        env={},
+    )
+    assert decision.pause is True
+    assert decision.rule_id == "clarify.low-confidence"
+
+
+def test_clarify_complexity_threshold_pauses_even_under_yolo() -> None:
+    """Issue #575: yolo + complexity 5 -> pause (complexity-threshold)."""
+    decision = should_pause_clarify(
+        complexity=5,
+        facilitator_confidence=0.9,
+        open_questions=0,
+        yolo=True,
+        env={},
+    )
+    assert decision.pause is True
+    assert decision.rule_id == "clarify.complexity-threshold"
+
+
+def test_clarify_open_questions_pauses_even_under_yolo() -> None:
+    """Issue #575: yolo + 2 open questions -> pause (open-questions)."""
+    decision = should_pause_clarify(
+        complexity=2,
+        facilitator_confidence=0.9,
+        open_questions=2,
+        yolo=True,
+        env={},
+    )
+    assert decision.pause is True
+    assert decision.rule_id == "clarify.open-questions"
+
+
+def test_clarify_non_yolo_always_pauses() -> None:
+    """Issue #575: yolo=False always pauses, even on otherwise-clean signals."""
+    decision = should_pause_clarify(
+        complexity=1,
+        facilitator_confidence=0.99,
+        open_questions=0,
+        yolo=False,
+        env={},
+    )
+    assert decision.pause is True
+    assert decision.rule_id == "clarify.non-yolo-baseline"
+
+
+def test_clarify_env_off_overrides_low_confidence() -> None:
+    """Issue #575: WG_HITL_CLARIFY=off forces pause=False even with low confidence."""
+    decision = should_pause_clarify(
+        complexity=2,
+        facilitator_confidence=0.4,
+        open_questions=0,
+        yolo=True,
+        env={"WG_HITL_CLARIFY": "off"},
+    )
+    assert decision.pause is False
+    assert decision.rule_id.endswith(".override-off")
+    assert decision.signals["env_override"] == {
+        "var": "WG_HITL_CLARIFY",
+        "value": "off",
+    }
+    # Original verdict is preserved in the reason for audit.
+    assert "facilitator confidence" in decision.reason
+
+
+def test_clarify_env_pause_overrides_clean_signals() -> None:
+    """Issue #575: WG_HITL_CLARIFY=pause forces pause=True even on clean signals."""
+    decision = should_pause_clarify(
+        complexity=1,
+        facilitator_confidence=0.95,
+        open_questions=0,
+        yolo=True,
+        env={"WG_HITL_CLARIFY": "pause"},
+    )
+    assert decision.pause is True
+    assert decision.rule_id.endswith(".override-pause")
+    assert decision.signals["env_override"] == {
+        "var": "WG_HITL_CLARIFY",
+        "value": "pause",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Council
+# ---------------------------------------------------------------------------
+
+
+def _vote(model: str, verdict: str, confidence: float) -> dict:
+    return {"model": model, "verdict": verdict, "confidence": confidence}
+
+
+def test_council_unanimous_high_confidence_auto_proceeds() -> None:
+    """Issue #575: 4 unanimous APPROVE @ 0.9 -> auto-proceed."""
+    votes = [
+        _vote("codex", "APPROVE", 0.9),
+        _vote("gemini", "APPROVE", 0.9),
+        _vote("opencode", "APPROVE", 0.9),
+        _vote("pi", "APPROVE", 0.9),
+    ]
+    decision = should_pause_council(votes=votes, env={})
+    assert decision.pause is False
+    assert decision.rule_id == "council.auto-proceed"
+
+
+def test_council_three_to_one_split_pauses() -> None:
+    """Issue #575: 3-1 split -> pause (split-verdict)."""
+    votes = [
+        _vote("codex", "APPROVE", 0.9),
+        _vote("gemini", "APPROVE", 0.9),
+        _vote("opencode", "APPROVE", 0.9),
+        _vote("pi", "REJECT", 0.9),
+    ]
+    decision = should_pause_council(votes=votes, env={})
+    assert decision.pause is True
+    assert decision.rule_id == "council.split-verdict"
+
+
+def test_council_unanimous_one_low_confidence_pauses() -> None:
+    """Issue #575: unanimous APPROVE but one model confidence 0.5 -> pause."""
+    votes = [
+        _vote("codex", "APPROVE", 0.9),
+        _vote("gemini", "APPROVE", 0.9),
+        _vote("opencode", "APPROVE", 0.9),
+        _vote("pi", "APPROVE", 0.5),
+    ]
+    decision = should_pause_council(votes=votes, env={})
+    assert decision.pause is True
+    assert decision.rule_id == "council.low-confidence-vote"
+    assert decision.signals["lowest_confidence_model"] == "pi"
+
+
+def test_council_env_off_overrides_split() -> None:
+    """Issue #575: WG_HITL_COUNCIL=off forces pause=False on a split verdict."""
+    votes = [
+        _vote("codex", "APPROVE", 0.9),
+        _vote("gemini", "APPROVE", 0.9),
+        _vote("opencode", "REJECT", 0.9),
+        _vote("pi", "REJECT", 0.9),
+    ]
+    decision = should_pause_council(
+        votes=votes,
+        env={"WG_HITL_COUNCIL": "off"},
+    )
+    assert decision.pause is False
+    assert decision.rule_id.endswith(".override-off")
+    assert decision.signals["env_override"] == {
+        "var": "WG_HITL_COUNCIL",
+        "value": "off",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Challenge charter
+# ---------------------------------------------------------------------------
+
+
+def test_challenge_below_threshold_skipped() -> None:
+    """Issue #575: complexity 3 -> rule_id 'challenge.skipped-below-threshold'."""
+    decision = challenge_charter(
+        complexity=3,
+        council_outcome="unanimous",
+        env={},
+    )
+    assert decision.pause is False
+    assert decision.rule_id == "challenge.skipped-below-threshold"
+    assert decision.signals["charter"] is None
+
+
+def test_challenge_complexity_4_unanimous_uses_integration_sweep() -> None:
+    """Issue #575: complexity 4 + unanimous -> 'integration-sweep' charter."""
+    decision = challenge_charter(
+        complexity=4,
+        council_outcome="unanimous",
+        env={},
+    )
+    assert decision.pause is False
+    assert "integration-sweep" in decision.reason
+    assert decision.signals["charter"] == CHARTER_INTEGRATION_SWEEP
+
+
+def test_challenge_complexity_4_split_uses_full_steelman() -> None:
+    """Issue #575: complexity 4 + split -> 'full-steelman' charter."""
+    decision = challenge_charter(
+        complexity=4,
+        council_outcome="split",
+        env={},
+    )
+    assert decision.pause is False
+    assert "full-steelman" in decision.reason
+    assert decision.signals["charter"] == CHARTER_FULL_STEELMAN
+
+
+def test_challenge_complexity_6_unanimous_uses_both() -> None:
+    """Issue #575: complexity 6 + unanimous -> 'both' charter."""
+    decision = challenge_charter(
+        complexity=6,
+        council_outcome="unanimous",
+        env={},
+    )
+    assert decision.pause is False
+    assert "both" in decision.reason
+    assert decision.signals["charter"] == CHARTER_BOTH
+
+
+def test_challenge_complexity_6_split_uses_full_steelman() -> None:
+    """Issue #575: complexity 6 + split -> 'full-steelman' charter."""
+    decision = challenge_charter(
+        complexity=6,
+        council_outcome="split",
+        env={},
+    )
+    assert decision.pause is False
+    assert "full-steelman" in decision.reason
+    assert decision.signals["charter"] == CHARTER_FULL_STEELMAN
+
+
+def test_challenge_env_pause_overrides_but_records_charter() -> None:
+    """Issue #575: WG_HITL_CHALLENGE=pause flips pause but keeps original charter in signals."""
+    decision = challenge_charter(
+        complexity=4,
+        council_outcome="unanimous",
+        env={"WG_HITL_CHALLENGE": "pause"},
+    )
+    assert decision.pause is True
+    assert decision.rule_id.endswith(".override-pause")
+    # Original charter must remain visible for audit.
+    assert decision.signals["charter"] == CHARTER_INTEGRATION_SWEEP
+    assert decision.signals["env_override"] == {
+        "var": "WG_HITL_CHALLENGE",
+        "value": "pause",
+    }

--- a/tests/test_specialist_resolver.py
+++ b/tests/test_specialist_resolver.py
@@ -1,0 +1,291 @@
+"""Tests for scripts/crew/specialist_resolver.py and its two call sites.
+
+Issue #573: Three naming systems (domain / bare role / full subagent_type)
+used to collide. The facilitator emits bare roles, the engagement tracker
+expected the full form, and the mismatch silently dropped events.
+
+These tests cover the seven acceptance behaviors from the issue:
+
+1. ``build_resolver()`` covers every agent in ``agents/**/*.md``.
+2. ``resolve_role("requirements-analyst")`` returns the product triple.
+3. ``resolve_role(full_subagent_type)`` is idempotent.
+4. Unknown roles return ``(None, None)`` without raising.
+5. ``_parse_specialist_from_agent_type`` now accepts bare roles.
+6. ``validate_plan`` rejects unknown picks and suggests close matches.
+7. (meta) these tests exist — covered by pytest collection.
+
+Every test docstring cites Issue #573 per T1-T6.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+# Hooks and scripts use different sys.path conventions; tests reach into
+# both. conftest.py has already inserted scripts/ at position 0, so all
+# we need here is the hooks directory for the subagent_lifecycle test.
+_HOOKS_SCRIPTS = str(_REPO_ROOT / "hooks" / "scripts")
+if _HOOKS_SCRIPTS not in sys.path:
+    sys.path.append(_HOOKS_SCRIPTS)
+
+from crew import specialist_resolver
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache():
+    """Drop the lru_cache between tests so agents/ edits are re-read.
+
+    Issue #573: the resolver is cached per plugin_root string for
+    production-path O(1) lookups. Tests that swap plugin_root (or rely
+    on the real repo tree being walked fresh) must clear between cases.
+    """
+    specialist_resolver.clear_cache()
+    yield
+    specialist_resolver.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #1: build_resolver covers every agent file
+# ---------------------------------------------------------------------------
+
+def test_build_resolver_covers_every_agent_file():
+    """Every agents/**/*.md with a subagent_type is in the map (Issue #573)."""
+    resolver = specialist_resolver.build_resolver(_REPO_ROOT)
+
+    agents_dir = _REPO_ROOT / "agents"
+    expected_subagent_types: set = set()
+    for md in agents_dir.rglob("*.md"):
+        text = md.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            continue
+        for line in text.splitlines()[1:]:
+            if line.strip() == "---":
+                break
+            if line.startswith("subagent_type:"):
+                expected_subagent_types.add(line.split(":", 1)[1].strip())
+                break
+
+    missing = expected_subagent_types - set(resolver["subagent_to_role"].keys())
+    # Allow collisions (same bare role in two domains) to be absent from
+    # the forward map, but every subagent_type must appear in reverse.
+    # Any remaining missing entries would be a resolver defect.
+    assert not missing, (
+        f"resolver missing {len(missing)} subagent_type(s) from agents/: "
+        f"{sorted(missing)[:5]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #2: bare role resolves to the expected triple
+# ---------------------------------------------------------------------------
+
+def test_resolve_role_bare_returns_domain_and_subagent_type():
+    """Bare role 'requirements-analyst' -> product triple (Issue #573)."""
+    resolver = specialist_resolver.build_resolver(_REPO_ROOT)
+    domain, subagent_type = specialist_resolver.resolve_role(
+        "requirements-analyst", resolver
+    )
+    assert domain == "product"
+    assert subagent_type == "wicked-garden:product:requirements-analyst"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #3: resolve_role is idempotent on full subagent_type
+# ---------------------------------------------------------------------------
+
+def test_resolve_role_idempotent_on_full_subagent_type():
+    """Full subagent_type round-trips to the same tuple (Issue #573)."""
+    resolver = specialist_resolver.build_resolver(_REPO_ROOT)
+    first = specialist_resolver.resolve_role("requirements-analyst", resolver)
+    second = specialist_resolver.resolve_role(
+        "wicked-garden:product:requirements-analyst", resolver
+    )
+    assert first == second
+    assert first == ("product", "wicked-garden:product:requirements-analyst")
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #4: unknown roles return (None, None) without raising
+# ---------------------------------------------------------------------------
+
+def test_resolve_role_unknown_returns_none_none():
+    """Unknown role name returns (None, None), never raises (Issue #573)."""
+    resolver = specialist_resolver.build_resolver(_REPO_ROOT)
+    assert specialist_resolver.resolve_role("does-not-exist", resolver) == (
+        None,
+        None,
+    )
+
+
+def test_resolve_role_empty_string_returns_none_none():
+    """Empty / whitespace input returns (None, None) (Issue #573)."""
+    resolver = specialist_resolver.build_resolver(_REPO_ROOT)
+    assert specialist_resolver.resolve_role("", resolver) == (None, None)
+    assert specialist_resolver.resolve_role("   ", resolver) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #5: hook parser accepts bare roles
+# ---------------------------------------------------------------------------
+
+def test_parse_specialist_accepts_bare_role():
+    """Hook's _parse_specialist_from_agent_type accepts bare role (Issue #573)."""
+    from subagent_lifecycle import (
+        _load_specialist_domains,
+        _parse_specialist_from_agent_type,
+    )
+
+    domains = _load_specialist_domains()
+    assert "product" in domains, (
+        "specialist.json must list 'product' as a domain for this test"
+    )
+
+    domain, agent_name = _parse_specialist_from_agent_type(
+        "requirements-analyst", domains
+    )
+    assert domain == "product"
+    assert agent_name == "requirements-analyst"
+
+
+def test_parse_specialist_preserves_qualified_behavior():
+    """Fully-qualified subagent_type still parses directly (Issue #573)."""
+    from subagent_lifecycle import _parse_specialist_from_agent_type
+
+    # Simulate the legacy path: the hook passes in its loaded domain set.
+    domains = {"product", "engineering", "platform"}
+    domain, agent_name = _parse_specialist_from_agent_type(
+        "wicked-garden:product:requirements-analyst", domains
+    )
+    assert domain == "product"
+    assert agent_name == "requirements-analyst"
+
+
+def test_parse_specialist_rejects_unknown_bare_role():
+    """Bare role with no agent file still returns (None, None) (Issue #573)."""
+    from subagent_lifecycle import _parse_specialist_from_agent_type
+
+    domains = {"product", "engineering", "platform"}
+    assert _parse_specialist_from_agent_type("made-up-role", domains) == (
+        None,
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #6: validate_plan rejects unknown picks with close-match hints
+# ---------------------------------------------------------------------------
+
+def _valid_plan_with_specialist(name: str) -> dict:
+    """Return a minimal valid plan whose specialists list contains ``name``.
+
+    Mirrors the self-test fixture in validate_plan.py but parameterized
+    on the specialist name so tests can inject known-good and known-bad
+    values.
+    """
+    return {
+        "project_slug": "test-project",
+        "summary": "A test plan.",
+        "rigor_tier": "standard",
+        "complexity": 3,
+        "factors": {
+            key: {"reading": "LOW", "why": "because reasons"}
+            for key in (
+                "reversibility",
+                "blast_radius",
+                "compliance_scope",
+                "user_facing_impact",
+                "novelty",
+                "scope_effort",
+                "state_complexity",
+                "operational_risk",
+                "coordination_cost",
+            )
+        },
+        "specialists": [{"name": name, "why": "writes the code"}],
+        "phases": [{"name": "build", "why": "do the work", "primary": [name]}],
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "Implement feature",
+                "phase": "build",
+                "blockedBy": [],
+                "metadata": {
+                    "chain_id": "test-project.root",
+                    "event_type": "coding-task",
+                    "source_agent": "facilitator",
+                    "phase": "build",
+                    "rigor_tier": "standard",
+                },
+            }
+        ],
+    }
+
+
+def test_validate_plan_accepts_known_specialist():
+    """A resolvable bare role produces zero violations (Issue #573)."""
+    from crew import validate_plan
+
+    plan = _valid_plan_with_specialist("backend-engineer")
+    violations = validate_plan.validate(plan)
+    assert violations == []
+
+
+def test_validate_plan_rejects_unknown_specialist_with_suggestions():
+    """Unknown pick surfaces close-match suggestions (Issue #573)."""
+    from crew import validate_plan
+
+    # Typo: missing 'r' in requirements
+    plan = _valid_plan_with_specialist("equirements-analyst")
+    violations = validate_plan.validate(plan)
+
+    specialist_errors = [
+        v for v in violations if v.startswith("specialists[0].name")
+    ]
+    assert specialist_errors, (
+        f"expected specialists[0].name violation, got: {violations}"
+    )
+    joined = " ".join(specialist_errors)
+    assert "unknown specialist" in joined
+    assert "requirements-analyst" in joined, (
+        f"expected 'requirements-analyst' in suggestions, got: {joined}"
+    )
+
+
+def test_validate_plan_expanded_form_drift_rejected():
+    """Expanded-form drift (wrong domain) is caught (Issue #573)."""
+    from crew import validate_plan
+
+    plan = _valid_plan_with_specialist("backend-engineer")
+    # Lie about the domain: backend-engineer lives in engineering, not platform.
+    plan["specialists"][0]["domain"] = "platform"
+    plan["specialists"][0]["subagent_type"] = (
+        "wicked-garden:platform:backend-engineer"
+    )
+
+    violations = validate_plan.validate(plan)
+    assert any(
+        "does not match resolved domain" in v for v in violations
+    ), f"expected domain-drift violation, got: {violations}"
+    assert any(
+        "does not match resolved subagent_type" in v for v in violations
+    ), f"expected subagent_type-drift violation, got: {violations}"
+
+
+def test_validate_plan_expanded_form_agreement_accepted():
+    """Expanded-form that matches the resolver is accepted (Issue #573)."""
+    from crew import validate_plan
+
+    plan = _valid_plan_with_specialist("backend-engineer")
+    plan["specialists"][0]["domain"] = "engineering"
+    plan["specialists"][0]["subagent_type"] = (
+        "wicked-garden:engineering:backend-engineer"
+    )
+
+    violations = validate_plan.validate(plan)
+    assert violations == [], (
+        f"expected no violations for matching expanded form, got: {violations}"
+    )

--- a/tests/test_task_completed_reeval_debounce.py
+++ b/tests/test_task_completed_reeval_debounce.py
@@ -1,0 +1,284 @@
+"""tests/test_task_completed_reeval_debounce.py — re-eval debounce rule (Issue #572).
+
+Provenance: Issue #572 — wicked-garden's task_completed hook used to set
+``facilitator_reeval_due`` on every task completion that carried a chain_id,
+including gate-finding shell completions the orchestrator just acked. That
+caused the facilitator re-evaluation directive to fire on every prompt for
+meaningless state changes (observed: 3 re-eval fires in ~10 minutes during a
+single ``crew:just-finish`` run, plus 41,640 events of accumulated bus lag).
+
+The new rule debounces the trigger so re-eval fires ONLY when the completed
+task's metadata satisfies one of:
+    1. event_type == phase-transition
+    2. event_type == gate-finding AND verdict == REJECT
+
+T1: deterministic — pure in-memory, no I/O for the rule tests
+T3: isolated — each test builds its own metadata dict
+T4: single focus per test (one event_type/verdict combination)
+T5: descriptive names — each name spells out the input and expected outcome
+T6: each docstring cites Issue #572
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The hook script is not on sys.path by default — add it before import.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HOOK_SCRIPTS = _REPO_ROOT / "hooks" / "scripts"
+if str(_HOOK_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_HOOK_SCRIPTS))
+
+from task_completed import (  # noqa: E402
+    EVENT_TYPE_GATE_FINDING,
+    EVENT_TYPE_PHASE_TRANSITION,
+    VERDICT_REJECT,
+    _read_task_metadata,
+    _should_trigger_reeval,
+)
+
+
+# ---------------------------------------------------------------------------
+# Issue #572 — _should_trigger_reeval rule (the four AC combinations)
+# ---------------------------------------------------------------------------
+
+def test_plain_task_with_chain_id_does_not_trigger_reeval():
+    """Issue #572 AC-1: a completed event_type=task with a chain_id must NOT
+    set facilitator_reeval_due. The old rule (any chain_id => trigger) was the
+    root cause of 41k+ queued bus events and spurious re-eval directives.
+    """
+    metadata = {
+        "chain_id": "proj.root",
+        "event_type": "task",
+        "source_agent": "researcher",
+        "phase": "discovery",
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is False, f"plain task must not trigger; reason={reason}"
+    assert reason == "event_type_task"
+
+
+def test_gate_finding_with_approve_verdict_does_not_trigger_reeval():
+    """Issue #572 AC-2: a completed gate-finding with verdict=APPROVE must NOT
+    set the flag. This was the dominant noise source — gate auto-approvals
+    fired re-eval twice in a single just-finish run for no reason.
+    """
+    metadata = {
+        "chain_id": "proj.clarify.requirements-quality",
+        "event_type": EVENT_TYPE_GATE_FINDING,
+        "source_agent": "facilitator",
+        "phase": "clarify",
+        "verdict": "APPROVE",
+        "min_score": 0.7,
+        "score": 0.85,
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is False, f"APPROVE must not trigger; reason={reason}"
+    assert reason == "gate_verdict_APPROVE"
+
+
+def test_gate_finding_with_reject_verdict_triggers_reeval():
+    """Issue #572 AC-3: a completed gate-finding with verdict=REJECT MUST set
+    the flag — a rejection is a meaningful state change that warrants the
+    facilitator re-planning the chain.
+    """
+    metadata = {
+        "chain_id": "proj.design.architecture-quality",
+        "event_type": EVENT_TYPE_GATE_FINDING,
+        "source_agent": "senior-engineer",
+        "phase": "design",
+        "verdict": VERDICT_REJECT,
+        "min_score": 0.7,
+        "score": 0.4,
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is True, f"REJECT must trigger; reason={reason}"
+    assert reason == "gate_reject"
+
+
+def test_phase_transition_event_triggers_reeval():
+    """Issue #572 AC-4: a completed event_type=phase-transition MUST set the
+    flag — phase boundaries are exactly when the facilitator should re-plan.
+    """
+    metadata = {
+        "chain_id": "proj.design",
+        "event_type": EVENT_TYPE_PHASE_TRANSITION,
+        "source_agent": "facilitator",
+        "phase": "design",
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is True, f"phase-transition must trigger; reason={reason}"
+    assert reason == "phase_transition"
+
+
+# ---------------------------------------------------------------------------
+# Issue #572 — additional rule edges (fail-open, conditional verdicts)
+# ---------------------------------------------------------------------------
+
+def test_gate_finding_with_conditional_verdict_does_not_trigger_reeval():
+    """Issue #572: CONDITIONAL is not REJECT — the conditions-manifest path
+    handles its own follow-up; the facilitator should not be re-invoked.
+    """
+    metadata = {
+        "chain_id": "proj.build.evidence-quality",
+        "event_type": EVENT_TYPE_GATE_FINDING,
+        "source_agent": "qe-reviewer",
+        "phase": "build",
+        "verdict": "CONDITIONAL",
+        "min_score": 0.7,
+        "score": 0.65,
+        "conditions_manifest_path": "phases/build/conditions-manifest.json",
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is False, f"CONDITIONAL must not trigger; reason={reason}"
+    assert reason == "gate_verdict_CONDITIONAL"
+
+
+def test_missing_metadata_does_not_trigger_reeval():
+    """Issue #572: fail-open rule — if metadata is unreadable, do NOT set the
+    flag. The old behaviour (set on truthy chain_id) was the root cause; the
+    new rule requires positive evidence of a phase-transition or REJECT.
+    """
+    should, reason = _should_trigger_reeval(None)
+    assert should is False
+    assert reason == "no_metadata"
+
+    should, reason = _should_trigger_reeval({})
+    assert should is False
+    assert reason == "no_metadata"
+
+
+def test_gate_finding_without_verdict_does_not_trigger_reeval():
+    """Issue #572: a gate-finding shell with no verdict (mid-review) must not
+    fire re-eval — the reviewer is still working.
+    """
+    metadata = {
+        "chain_id": "proj.review.quality",
+        "event_type": EVENT_TYPE_GATE_FINDING,
+        "source_agent": "reviewer",
+        "phase": "review",
+    }
+    should, reason = _should_trigger_reeval(metadata)
+    assert should is False
+    assert reason == "gate_verdict_missing"
+
+
+# ---------------------------------------------------------------------------
+# Issue #572 — _read_task_metadata fail-open behaviour
+# ---------------------------------------------------------------------------
+
+def test_read_task_metadata_returns_none_for_missing_session():
+    """Issue #572: empty session_id must return None — not raise."""
+    assert _read_task_metadata("", "task-id") is None
+
+
+def test_read_task_metadata_returns_none_for_missing_task_id():
+    """Issue #572: empty task_id must return None — not raise."""
+    assert _read_task_metadata("session-id", "") is None
+
+
+def test_read_task_metadata_returns_none_for_missing_file(tmp_path, monkeypatch):
+    """Issue #572: missing task file must return None — fail-open."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    # No file written under tmp_path/tasks/<session>/<task>.json
+    assert _read_task_metadata("sess-1", "task-1") is None
+
+
+def test_read_task_metadata_returns_metadata_dict_when_present(tmp_path, monkeypatch):
+    """Issue #572: when the task file exists with a metadata dict, it is
+    returned exactly so a single read serves both event_type and verdict.
+    """
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    task_dir = tmp_path / "tasks" / "sess-1"
+    task_dir.mkdir(parents=True)
+    payload = {
+        "task_id": "task-1",
+        "subject": "Phase: design",
+        "status": "completed",
+        "metadata": {
+            "chain_id": "proj.design",
+            "event_type": EVENT_TYPE_PHASE_TRANSITION,
+            "source_agent": "facilitator",
+            "phase": "design",
+        },
+    }
+    (task_dir / "task-1.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    metadata = _read_task_metadata("sess-1", "task-1")
+    assert metadata == payload["metadata"]
+
+
+def test_read_task_metadata_returns_none_for_corrupt_json(tmp_path, monkeypatch):
+    """Issue #572: corrupt JSON must return None — task completion is never
+    blocked by a re-eval signal error.
+    """
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    task_dir = tmp_path / "tasks" / "sess-1"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task-1.json").write_text("{not valid json", encoding="utf-8")
+    assert _read_task_metadata("sess-1", "task-1") is None
+
+
+def test_read_task_metadata_returns_none_when_metadata_field_missing(tmp_path, monkeypatch):
+    """Issue #572: a task file with no metadata key must return None — the
+    rule explicitly requires positive evidence to trigger re-eval.
+    """
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    task_dir = tmp_path / "tasks" / "sess-1"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task-1.json").write_text(
+        json.dumps({"task_id": "task-1", "status": "completed"}),
+        encoding="utf-8",
+    )
+    assert _read_task_metadata("sess-1", "task-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #572 — bus drain helper in prompt_submit.py is fail-silent
+# ---------------------------------------------------------------------------
+
+def test_drain_bus_cursor_never_raises_when_npx_missing(monkeypatch):
+    """Issue #572: the bus drain must fail-silent when npx is unavailable.
+    A missing wicked-bus install must never break prompt submission.
+    """
+    import importlib
+
+    # prompt_submit lives in hooks/scripts — import it via the same path setup
+    if "prompt_submit" in sys.modules:
+        prompt_submit = importlib.reload(sys.modules["prompt_submit"])
+    else:
+        import prompt_submit  # noqa: F401
+        prompt_submit = sys.modules["prompt_submit"]
+
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda _name: None)
+
+    # Must not raise
+    prompt_submit._drain_bus_cursor()
+
+
+def test_drain_bus_cursor_swallows_subprocess_exceptions(monkeypatch):
+    """Issue #572: even if npx exists but the subprocess explodes (timeout,
+    non-zero exit, OSError), the drain must swallow the failure.
+    """
+    import importlib
+    import subprocess as _subprocess
+
+    if "prompt_submit" in sys.modules:
+        prompt_submit = importlib.reload(sys.modules["prompt_submit"])
+    else:
+        import prompt_submit  # noqa: F401
+        prompt_submit = sys.modules["prompt_submit"]
+
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda _name: "/usr/local/bin/npx")
+
+    def _boom(*_args, **_kwargs):
+        raise _subprocess.TimeoutExpired(cmd="npx", timeout=3)
+
+    monkeypatch.setattr(_subprocess, "run", _boom)
+
+    # Must not raise
+    prompt_submit._drain_bus_cursor()


### PR DESCRIPTION
## Summary

Four coordinated changes from a triage pass against live agent feedback. Shared theme: the system was firing hooks, emitting directives, and failing validation on signals it should have debounced, resolved, or classified.

### #572 — Re-eval debounce + bus drain
- `task_completed.py`: flag no longer fires on every chain_id'd completion. New rule: `phase-transition` OR `gate-finding` with `verdict=REJECT`.
- `prompt_submit.py`: 3-second `npx wicked-bus subscribe ... --since-cursor --max 100 --ack` drain runs before the re-eval check. Fail-silent when `npx` / bus unavailable.
- Expected impact: 41k+ cursor lag drains to 0 on first fire; re-eval prompts drop from once-per-task-tick to once-per-phase-boundary.

### #573 — Specialist resolver
- New `scripts/crew/specialist_resolver.py` builds `role → (domain, subagent_type)` maps by parsing `agents/**/*.md` frontmatter.
- `_parse_specialist_from_agent_type` now resolves bare roles instead of returning `(None, None)`.
- `validate_plan.py` rejects unresolvable picks with `difflib.get_close_matches` suggestions; rejects expanded-form drift between the plan and on-disk frontmatter.
- Facilitator output schema accepts both short and expanded pick forms.

### #574 — Factors-shape inline example
- `SKILL.md` Step 3 inlines the `{reading, why}` dict example so first-run facilitators don't emit flat strings and cost a retry turn.

### #575 — HITL judge
- New `scripts/crew/hitl_judge.py` with three decisions: `should_pause_clarify`, `should_pause_council`, `challenge_charter`.
- Critical design rule: **unanimous council does NOT justify skipping the challenge phase** — shared blind spots are the class of bug unanimous verdicts produce. Evidence: a live run where a 4-0 council missed a wiring consequence the challenge subagent caught.
- Env overrides: `WG_HITL_CLARIFY`, `WG_HITL_COUNCIL`, `WG_HITL_CHALLENGE` (each `auto|pause|off`), recorded in the decision's `signals` dict for audit.
- Wiring: clarify + council callsites wired via documentation + evidence-file emit. Challenge dispatch left as `TODO(Issue #575)` because contrarian is dispatched from a Markdown skill and the brief forbade editing `agents/crew/contrarian.md`.

## Test plan

- [x] 44 new tests across 3 new test files (`test_task_completed_reeval_debounce.py`, `test_specialist_resolver.py`, `test_hitl_judge.py`)
- [x] Full non-crew suite: **506 passed, 0 failed** (up from 462)
- [x] Existing event-schema + telemetry + archetype tests still pass
- [x] R1-R6 cleanup on `task_completed.py`: named constants (`_ESCALATION_THRESHOLD`), extracted `_update_session_state` helper, annotated intentional `_log` fallback swallow

## Out of scope (filed as follow-ups)

- Task-store drift between Claude TaskList and garden chain (#579 — design)
- `/wicked-garden:where-am-i` path manifest (#576)
- `approved_by` sentinel mutation (#580)
- Yolo auto-revoke 49% rate — instrument first (#581)
- Brain memory indexing ack (#577)
- Context Assembly eager hook (#578)

## Closes

- Closes #572
- Closes #573
- Closes #574
- Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)