### PR TITLE
fix: #587 AC literal-matcher cosmetic-rejection (normalize + parent-id + WARN)

### DIFF
--- a/scripts/crew/verification_protocol.py
+++ b/scripts/crew/verification_protocol.py
@@ -249,11 +249,31 @@ def check_acceptance_criteria(
         for py in d.glob("**/*.py"):
             deliverable_text += _read_text(py) + "\n"
 
+    # (A) Normalize deliverable text once: strip non-alphanumeric chars and lowercase.
+    # This makes AC-3, AC3, ac_3, and AC-3 all compare equal.
+    _norm = re.compile(r"[^a-z0-9]")
+    norm_text = _norm.sub("", deliverable_text.lower())
+
+    def _ac_matches(ac_id: str) -> bool:
+        """Return True if ac_id (or its parent) appears in normalised deliverable text."""
+        # (A) normalise the candidate id
+        norm_id = _norm.sub("", ac_id.lower())
+        if norm_id in norm_text:
+            return True
+        # (B) parent-id fallback: AC-3.1 → try AC-3
+        dot = ac_id.rfind(".")
+        if dot != -1:
+            parent_id = ac_id[:dot]
+            norm_parent = _norm.sub("", parent_id.lower())
+            if norm_parent in norm_text:
+                return True
+        return False
+
     # Check which ACs are referenced
     linked: List[str] = []
     unlinked: List[str] = []
     for ac_id in all_ac_ids:
-        if ac_id.lower() in deliverable_text.lower():
+        if _ac_matches(ac_id):
             linked.append(ac_id)
         else:
             unlinked.append(ac_id)
@@ -261,7 +281,19 @@ def check_acceptance_criteria(
     total = len(all_ac_ids)
     linked_count = len(linked)
 
+    # (C) Downgrade severity: >=80% coverage → WARN instead of FAIL
     if unlinked:
+        coverage = linked_count / total if total else 0.0
+        if coverage >= 0.80:
+            return CheckResult(
+                name=name,
+                status="WARN",
+                evidence=(
+                    f"{linked_count}/{total} AC linked (cosmetic mismatches only); "
+                    f"missing: {', '.join(unlinked)}"
+                ),
+                details={"linked": linked, "unlinked": unlinked, "total": total},
+            )
         return CheckResult(
             name=name,
             status="FAIL",

--- a/scripts/crew/verification_protocol.py
+++ b/scripts/crew/verification_protocol.py
@@ -161,16 +161,30 @@ def _read_text(path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 _AC_TABLE_ROW_RE = re.compile(
-    r"\|\s*(?P<id>AC-\d+|[A-Z]{1,4}-\d+|\d+)\s*\|"
+    r"\|\s*(?P<id>AC-\d+(?:\.\d+)*|[A-Z]{1,4}-\d+(?:\.\d+)*|\d+)\s*\|"
     r"\s*(?P<desc>[^|]+)\s*\|"
     r"\s*(?P<test>[^|]*)\s*\|",
     re.IGNORECASE,
 )
 
 _AC_LIST_RE = re.compile(
-    r"[-*]\s+(?:\*\*)?(?P<id>AC-\d+|[A-Z]{1,4}-\d+)(?:\*\*)?\s*[:\-]\s*(?P<desc>.+)",
+    r"[-*]\s+(?:\*\*)?(?P<id>AC-\d+(?:\.\d+)*|[A-Z]{1,4}-\d+(?:\.\d+)*)(?:\*\*)?\s*[:\-]\s*(?P<desc>.+)",
     re.IGNORECASE,
 )
+
+# Tokenize all AC references in deliverable text ONCE into a canonical set.
+# This makes verification = exact set membership, not substring scan.
+# AC-3 and AC-30 produce DISTINCT tokens; no false positives possible.
+_AC_TOKEN_RE = re.compile(r"\bAC[\s_-]*\d+(?:\.\d+)*\b", re.IGNORECASE)
+
+
+def _canonical_ac(value: str) -> str:
+    """Normalize AC identifier variants to canonical form: 'ac-3' or 'ac-3.1'.
+
+    Examples: 'AC-3' -> 'ac-3', 'AC3' -> 'ac-3', 'AC_3.1' -> 'ac-3.1', 'ac 3' -> 'ac-3'.
+    """
+    m = re.search(r"ac[\s_-]*(\d+(?:\.\d+)*)", value, re.IGNORECASE)
+    return f"ac-{m.group(1)}" if m else value.lower()
 
 
 def _extract_ac_ids(text: str) -> List[str]:
@@ -249,24 +263,23 @@ def check_acceptance_criteria(
         for py in d.glob("**/*.py"):
             deliverable_text += _read_text(py) + "\n"
 
-    # (A) Normalize deliverable text once: strip non-alphanumeric chars and lowercase.
-    # This makes AC-3, AC3, ac_3, and AC-3 all compare equal.
-    _norm = re.compile(r"[^a-z0-9]")
-    norm_text = _norm.sub("", deliverable_text.lower())
+    # Build the deliverable's set of canonical AC tokens (one pass over text).
+    # Set membership is exact — AC-3 and AC-30 are distinct tokens.
+    deliverable_ac_set: set = {
+        _canonical_ac(match.group(0))
+        for match in _AC_TOKEN_RE.finditer(deliverable_text)
+    }
 
     def _ac_matches(ac_id: str) -> bool:
-        """Return True if ac_id (or its parent) appears in normalised deliverable text."""
-        # (A) normalise the candidate id
-        norm_id = _norm.sub("", ac_id.lower())
-        if norm_id in norm_text:
+        """True if ac_id (or its parent for dotted IDs) appears in deliverable AC set."""
+        canon = _canonical_ac(ac_id)
+        if canon in deliverable_ac_set:
             return True
-        # (B) parent-id fallback: AC-3.1 → try AC-3
-        dot = ac_id.rfind(".")
-        if dot != -1:
-            parent_id = ac_id[:dot]
-            norm_parent = _norm.sub("", parent_id.lower())
-            if norm_parent in norm_text:
-                return True
+        # Parent-id fallback as a SET lookup (deliberate, not accidental substring).
+        # AC-3.1 is satisfied if deliverable references AC-3.
+        if "." in canon:
+            parent = canon.rsplit(".", 1)[0]
+            return parent in deliverable_ac_set
         return False
 
     # Check which ACs are referenced
@@ -289,8 +302,8 @@ def check_acceptance_criteria(
                 name=name,
                 status="WARN",
                 evidence=(
-                    f"{linked_count}/{total} AC linked (cosmetic mismatches only); "
-                    f"missing: {', '.join(unlinked)}"
+                    f"{linked_count}/{total} AC linked; high coverage threshold met; "
+                    f"treating as advisory; missing: {', '.join(unlinked)}"
                 ),
                 details={"linked": linked, "unlinked": unlinked, "total": total},
             )

--- a/tests/crew/test_verification_protocol_ac_linked.py
+++ b/tests/crew/test_verification_protocol_ac_linked.py
@@ -1,30 +1,31 @@
 #!/usr/bin/env python3
 """
-Regression tests for verification_protocol._check_ac_linked fixes (issue #587).
+Regression tests for verification_protocol.check_acceptance_criteria fixes (issue #587).
 
 Covers:
-  (A) Normalize both sides — AC-3 / AC3 / ac_3 / ac-3 all match
+  (A) Separator / case normalisation — AC-3 / AC3 / ac_3 / ac-3 all match
   (B) Parent-id fallback — AC-3.1 is satisfied by deliverable referencing AC-3
+      (end-to-end via filesystem; extractor now captures dotted IDs)
   (C) Severity downgrade — >=80% coverage yields WARN, not FAIL
+  (D) Data-shape distinctness — AC-3 and AC-30 are separate tokens (no false positives)
 
 Run with: pytest tests/crew/test_verification_protocol_ac_linked.py
 """
 
 import datetime
-import re
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Path setup — mirror pattern from other crew test files
+# Path setup — append rather than prepend to avoid shadowing the crew/ package
 # ---------------------------------------------------------------------------
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPTS_DIR = _REPO_ROOT / "scripts"
 _CREW_DIR = _SCRIPTS_DIR / "crew"
-sys.path.insert(0, str(_SCRIPTS_DIR))
-sys.path.insert(0, str(_CREW_DIR))
+sys.path.append(str(_SCRIPTS_DIR))
+sys.path.append(str(_CREW_DIR))
 
 from verification_protocol import check_acceptance_criteria, CheckResult, VerificationReport  # noqa: E402
 
@@ -87,65 +88,55 @@ class TestNormalisedMatch(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# (B) Parent-id fallback — tested via inline normalisation logic
+# (B) Parent-id fallback — end-to-end filesystem tests
 #
-# The AC extractor regex (`AC-\d+`) does not capture dotted IDs like `AC-3.1`
-# from markdown source, so end-to-end file-system tests for AC-3.1 would always
-# SKIP (no IDs extracted).  Instead we directly verify the normalisation helper
-# that _check_ac_linked inlines: strip non-alphanumeric chars and check parent.
+# The extractor now captures dotted IDs (AC-3.1) so these run end-to-end
+# through check_acceptance_criteria rather than replicating internal logic.
 # ---------------------------------------------------------------------------
 
 class TestParentIdFallbackLogic(unittest.TestCase):
-    """Verify the parent-id fallback normalisation logic (fix B) in isolation."""
+    """Parent-id fallback: AC-3.1 in clarify is satisfied by AC-3 in deliverable."""
 
-    # Mirror the exact helper from verification_protocol._check_ac_linked
-    _norm_re = re.compile(r"[^a-z0-9]")
-
-    def _ac_matches(self, ac_id: str, deliverable_text: str) -> bool:
-        """Replicate the _ac_matches closure from _check_ac_linked."""
-        norm_text = self._norm_re.sub("", deliverable_text.lower())
-        norm_id = self._norm_re.sub("", ac_id.lower())
-        if norm_id in norm_text:
-            return True
-        # Parent-id fallback
-        dot = ac_id.rfind(".")
-        if dot != -1:
-            parent_id = ac_id[:dot]
-            norm_parent = self._norm_re.sub("", parent_id.lower())
-            if norm_parent in norm_text:
-                return True
-        return False
+    def _run(self, clarify_text: str, deliverable_text: str):
+        with tempfile.TemporaryDirectory() as td:
+            phases = _make_phases(Path(td), clarify_text, deliverable_text)
+            return check_acceptance_criteria("proj", phases)
 
     def test_parent_reference_satisfies_child(self):
-        """AC-3 in deliverable satisfies AC-3.1 requirement."""
-        self.assertTrue(self._ac_matches("AC-3.1", "Login timeout covered under AC-3."))
+        """AC-3 in deliverable satisfies AC-3.1 requirement (end-to-end)."""
+        clarify = "- **AC-3.1**: Login timeout handling\n"
+        deliverable = "Login timeout covered under AC-3."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS", msg=f"Expected PASS, got {result.status}: {result.evidence}")
 
     def test_exact_child_still_works(self):
-        """AC-3.1 exact reference also matches."""
-        self.assertTrue(self._ac_matches("AC-3.1", "Implemented AC-3.1 timeout logic."))
+        """AC-3.1 exact reference also matches (end-to-end)."""
+        clarify = "- **AC-3.1**: Login timeout handling\n"
+        deliverable = "Implemented AC-3.1 timeout logic."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS")
 
-    def test_parent_normalised_ac3(self):
-        """Normalised parent 'AC3' in deliverable satisfies AC-3.1."""
-        self.assertTrue(self._ac_matches("AC-3.1", "See AC3 for all login criteria."))
+    def test_parent_normalised_ac3_satisfies_child(self):
+        """Normalised parent 'AC3' in deliverable satisfies AC-3.1 (end-to-end)."""
+        clarify = "- **AC-3.1**: Login timeout handling\n"
+        deliverable = "See AC3 for all login criteria."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS")
 
     def test_unrelated_id_does_not_match(self):
         """AC-5 does NOT satisfy AC-3.1 — only true parent does."""
-        self.assertFalse(self._ac_matches("AC-3.1", "Only references AC-5."))
+        clarify = "- **AC-3.1**: Login timeout handling\n"
+        deliverable = "Only references AC-5."
+        result = self._run(clarify, deliverable)
+        # AC-3.1 is unlinked; single AC, coverage = 0/1 = FAIL
+        self.assertEqual(result.status, "FAIL")
 
-    def test_no_false_partial_match(self):
-        """AC-3 should not match 'AC-30' when normalised (ac3 vs ac30)."""
-        # normalised: ac3 vs ac30 — 'ac3' is not in 'ac30 text' as a standalone token
-        # BUT it IS a substring. This is an accepted trade-off documented in issue #587.
-        # The fix is substring-based, not word-boundary-based.
-        # This test just documents the known behaviour.
-        result = self._ac_matches("AC-3", "See AC30 for details.")
-        # ac3 IS a substring of ac30, so this will return True — document it
-        self.assertTrue(result)  # known substring match; acceptable trade-off
-
-    def test_deep_nesting_ac_2_1_3(self):
-        """AC-2.1.3 parent fallback extracts AC-2.1 (immediate parent)."""
-        # Immediate parent is AC-2.1
-        self.assertTrue(self._ac_matches("AC-2.1.3", "Implements AC-2.1 feature."))
+    def test_deep_nesting_ac_2_1_3_parent_fallback(self):
+        """AC-2.1.3 in clarify: immediate parent AC-2.1 in deliverable satisfies it."""
+        clarify = "- **AC-2.1.3**: Sub-feature detail\n"
+        deliverable = "Implements AC-2.1 feature."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS")
 
 
 # ---------------------------------------------------------------------------
@@ -170,22 +161,22 @@ class TestCoverageThreshold(unittest.TestCase):
             return check_acceptance_criteria("proj", phases)
 
     def test_90_percent_coverage_is_warn(self):
-        """9/10 ACs linked (90%) → WARN, not FAIL."""
+        """9/10 ACs linked (90%) -> WARN, not FAIL."""
         result = self._run(10, list(range(1, 10)))  # AC-1..9 linked, AC-10 missing
         self.assertEqual(result.status, "WARN", msg=f"Expected WARN, got {result.status}: {result.evidence}")
 
     def test_80_percent_exact_is_warn(self):
-        """4/5 ACs linked (80%) → WARN."""
+        """4/5 ACs linked (80%) -> WARN."""
         result = self._run(5, [1, 2, 3, 4])  # AC-5 missing
         self.assertEqual(result.status, "WARN", msg=f"Expected WARN, got {result.status}: {result.evidence}")
 
     def test_below_80_percent_is_fail(self):
-        """3/5 ACs linked (60%) → FAIL."""
+        """3/5 ACs linked (60%) -> FAIL."""
         result = self._run(5, [1, 2, 3])  # AC-4, AC-5 missing
         self.assertEqual(result.status, "FAIL", msg=f"Expected FAIL, got {result.status}: {result.evidence}")
 
     def test_100_percent_is_pass(self):
-        """All ACs linked → PASS."""
+        """All ACs linked -> PASS."""
         result = self._run(5, [1, 2, 3, 4, 5])
         self.assertEqual(result.status, "PASS")
 
@@ -199,18 +190,84 @@ class TestCoverageThreshold(unittest.TestCase):
                 CheckResult(
                     name="acceptance_criteria",
                     status="WARN",
-                    evidence="9/10 AC linked (cosmetic mismatches only); missing: AC-10",
+                    evidence="9/10 AC linked; high coverage threshold met; treating as advisory; missing: AC-10",
                     details={},
                 ),
             ],
         )
         self.assertEqual(report.verdict, "PASS")
 
-    def test_warn_evidence_mentions_cosmetic(self):
-        """WARN evidence string identifies the nature of the mismatch."""
+    def test_warn_evidence_mentions_coverage_and_advisory(self):
+        """WARN evidence string accurately describes the situation — no 'cosmetic' claim."""
         result = self._run(10, list(range(1, 10)))
-        self.assertIn("cosmetic", result.evidence)
+        self.assertIn("high coverage threshold met", result.evidence)
+        self.assertIn("advisory", result.evidence)
         self.assertIn("missing", result.evidence)
+        # Old misleading wording must NOT appear
+        self.assertNotIn("cosmetic", result.evidence)
+
+
+# ---------------------------------------------------------------------------
+# (D) Data-shape distinctness — canonical-token-set guarantees
+# ---------------------------------------------------------------------------
+
+class TestDataShapeMatching(unittest.TestCase):
+    """Canonical-token-set data shape: AC-3 and AC-30 are distinct tokens."""
+
+    _CLARIFY_AC3 = "- **AC-3**: User can log in\n"
+    _CLARIFY_AC30 = "- **AC-30**: User can export data\n"
+    _CLARIFY_BOTH = "- **AC-3**: User can log in\n- **AC-30**: User can export data\n"
+
+    def _run(self, clarify_text: str, deliverable_text: str):
+        with tempfile.TemporaryDirectory() as td:
+            phases = _make_phases(Path(td), clarify_text, deliverable_text)
+            return check_acceptance_criteria("proj", phases)
+
+    def test_ac3_does_not_false_match_ac30(self):
+        """AC-3 in clarify should be UNLINKED when deliverable only contains AC-30."""
+        result = self._run(self._CLARIFY_AC3, "See AC-30 for details.")
+        # AC-3 is unlinked; 0/1 coverage -> FAIL
+        self.assertEqual(result.status, "FAIL",
+                         msg=f"AC-3 falsely matched AC-30: got {result.status}: {result.evidence}")
+        self.assertIn("AC-3", result.evidence)
+
+    def test_ac30_distinct_from_ac3(self):
+        """Both AC-3 and AC-30 extracted and verified independently."""
+        # Deliverable mentions both explicitly
+        result = self._run(self._CLARIFY_BOTH, "Implements AC-3 login. See AC-30 export.")
+        self.assertEqual(result.status, "PASS",
+                         msg=f"Expected both linked, got {result.status}: {result.evidence}")
+
+    def test_ac30_alone_does_not_satisfy_ac3(self):
+        """When both defined in clarify, AC-30 alone leaves AC-3 unlinked."""
+        result = self._run(self._CLARIFY_BOTH, "Only AC-30 is referenced.")
+        self.assertNotEqual(result.status, "PASS")
+        # AC-3 should appear as unlinked
+        self.assertIn("AC-3", result.evidence)
+
+    def test_dotted_id_extracted_and_matched(self):
+        """AC-3.1 in clarify, AC-3.1 in deliverable -> linked directly."""
+        clarify = "- **AC-3.1**: Login timeout\n"
+        deliverable = "Implements AC-3.1 timeout."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS")
+
+    def test_dotted_id_parent_fallback(self):
+        """AC-3.1 in clarify, only AC-3 in deliverable -> linked via parent fallback."""
+        clarify = "- **AC-3.1**: Login timeout\n"
+        deliverable = "Login behavior covered under AC-3."
+        result = self._run(clarify, deliverable)
+        self.assertEqual(result.status, "PASS",
+                         msg=f"Parent fallback failed: {result.status}: {result.evidence}")
+
+    def test_canonical_form_unifies_variants(self):
+        """AC-3, AC3, AC_3, ac 3 in deliverable all match AC-3 in clarify."""
+        clarify = "- **AC-3**: User can log in\n"
+        for variant in ("AC-3", "AC3", "AC_3", "ac 3"):
+            with self.subTest(variant=variant):
+                result = self._run(clarify, f"See {variant} for details.")
+                self.assertEqual(result.status, "PASS",
+                                 msg=f"Variant '{variant}' failed: {result.status}: {result.evidence}")
 
 
 if __name__ == "__main__":

--- a/tests/crew/test_verification_protocol_ac_linked.py
+++ b/tests/crew/test_verification_protocol_ac_linked.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Regression tests for verification_protocol._check_ac_linked fixes (issue #587).
+
+Covers:
+  (A) Normalize both sides — AC-3 / AC3 / ac_3 / ac-3 all match
+  (B) Parent-id fallback — AC-3.1 is satisfied by deliverable referencing AC-3
+  (C) Severity downgrade — >=80% coverage yields WARN, not FAIL
+
+Run with: pytest tests/crew/test_verification_protocol_ac_linked.py
+"""
+
+import datetime
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup — mirror pattern from other crew test files
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_CREW_DIR = _SCRIPTS_DIR / "crew"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+sys.path.insert(0, str(_CREW_DIR))
+
+from verification_protocol import check_acceptance_criteria, CheckResult, VerificationReport  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_phases(tmp: Path, clarify_text: str, deliverable_text: str) -> Path:
+    """Create a minimal phases/ tree and return its path."""
+    phases = tmp / "phases"
+    _write(phases / "clarify" / "ac.md", clarify_text)
+    _write(phases / "build" / "impl.md", deliverable_text)
+    return phases
+
+
+# ---------------------------------------------------------------------------
+# (A) Separator / case normalisation
+# ---------------------------------------------------------------------------
+
+class TestNormalisedMatch(unittest.TestCase):
+    """AC-3 in clarify must match cosmetic variants in deliverables."""
+
+    # Use list format: "- **AC-N**: <desc>" (no "criterion" in desc to avoid filter)
+    _CLARIFY = "- **AC-3**: User can log in\n"
+
+    def _run(self, deliverable_text: str):
+        with tempfile.TemporaryDirectory() as td:
+            phases = _make_phases(Path(td), self._CLARIFY, deliverable_text)
+            return check_acceptance_criteria("proj", phases)
+
+    def test_exact_match_still_passes(self):
+        result = self._run("Implements AC-3 login flow.")
+        self.assertEqual(result.status, "PASS")
+
+    def test_no_hyphen_ac3(self):
+        """AC3 (no separator) should match AC-3 in clarify."""
+        result = self._run("See AC3 for the login requirement.")
+        self.assertEqual(result.status, "PASS")
+
+    def test_underscore_ac_3(self):
+        """ac_3 (underscore separator) should match AC-3."""
+        result = self._run("Ref ac_3 implementation.")
+        self.assertEqual(result.status, "PASS")
+
+    def test_lowercase_ac_minus_3(self):
+        """ac-3 (lowercase + hyphen) should match AC-3."""
+        result = self._run("See ac-3 for details.")
+        self.assertEqual(result.status, "PASS")
+
+    def test_uppercase_no_sep(self):
+        """AC3 uppercase should match AC-3."""
+        result = self._run("Covered by AC3.")
+        self.assertEqual(result.status, "PASS")
+
+
+# ---------------------------------------------------------------------------
+# (B) Parent-id fallback — tested via inline normalisation logic
+#
+# The AC extractor regex (`AC-\d+`) does not capture dotted IDs like `AC-3.1`
+# from markdown source, so end-to-end file-system tests for AC-3.1 would always
+# SKIP (no IDs extracted).  Instead we directly verify the normalisation helper
+# that _check_ac_linked inlines: strip non-alphanumeric chars and check parent.
+# ---------------------------------------------------------------------------
+
+class TestParentIdFallbackLogic(unittest.TestCase):
+    """Verify the parent-id fallback normalisation logic (fix B) in isolation."""
+
+    # Mirror the exact helper from verification_protocol._check_ac_linked
+    _norm_re = re.compile(r"[^a-z0-9]")
+
+    def _ac_matches(self, ac_id: str, deliverable_text: str) -> bool:
+        """Replicate the _ac_matches closure from _check_ac_linked."""
+        norm_text = self._norm_re.sub("", deliverable_text.lower())
+        norm_id = self._norm_re.sub("", ac_id.lower())
+        if norm_id in norm_text:
+            return True
+        # Parent-id fallback
+        dot = ac_id.rfind(".")
+        if dot != -1:
+            parent_id = ac_id[:dot]
+            norm_parent = self._norm_re.sub("", parent_id.lower())
+            if norm_parent in norm_text:
+                return True
+        return False
+
+    def test_parent_reference_satisfies_child(self):
+        """AC-3 in deliverable satisfies AC-3.1 requirement."""
+        self.assertTrue(self._ac_matches("AC-3.1", "Login timeout covered under AC-3."))
+
+    def test_exact_child_still_works(self):
+        """AC-3.1 exact reference also matches."""
+        self.assertTrue(self._ac_matches("AC-3.1", "Implemented AC-3.1 timeout logic."))
+
+    def test_parent_normalised_ac3(self):
+        """Normalised parent 'AC3' in deliverable satisfies AC-3.1."""
+        self.assertTrue(self._ac_matches("AC-3.1", "See AC3 for all login criteria."))
+
+    def test_unrelated_id_does_not_match(self):
+        """AC-5 does NOT satisfy AC-3.1 — only true parent does."""
+        self.assertFalse(self._ac_matches("AC-3.1", "Only references AC-5."))
+
+    def test_no_false_partial_match(self):
+        """AC-3 should not match 'AC-30' when normalised (ac3 vs ac30)."""
+        # normalised: ac3 vs ac30 — 'ac3' is not in 'ac30 text' as a standalone token
+        # BUT it IS a substring. This is an accepted trade-off documented in issue #587.
+        # The fix is substring-based, not word-boundary-based.
+        # This test just documents the known behaviour.
+        result = self._ac_matches("AC-3", "See AC30 for details.")
+        # ac3 IS a substring of ac30, so this will return True — document it
+        self.assertTrue(result)  # known substring match; acceptable trade-off
+
+    def test_deep_nesting_ac_2_1_3(self):
+        """AC-2.1.3 parent fallback extracts AC-2.1 (immediate parent)."""
+        # Immediate parent is AC-2.1
+        self.assertTrue(self._ac_matches("AC-2.1.3", "Implements AC-2.1 feature."))
+
+
+# ---------------------------------------------------------------------------
+# (C) 80% coverage threshold → WARN not FAIL
+# ---------------------------------------------------------------------------
+
+class TestCoverageThreshold(unittest.TestCase):
+    """>=80% AC coverage should produce WARN; <80% should produce FAIL."""
+
+    def _build_clarify(self, count: int) -> str:
+        # Use "User can X" descriptions so "criterion" filter doesn't apply
+        return "\n".join(f"- **AC-{i}**: User action {i}" for i in range(1, count + 1))
+
+    def _build_deliverable(self, linked_ids: list) -> str:
+        return " ".join(f"AC-{i}" for i in linked_ids)
+
+    def _run(self, total: int, linked: list):
+        with tempfile.TemporaryDirectory() as td:
+            clarify = self._build_clarify(total)
+            deliverable = self._build_deliverable(linked)
+            phases = _make_phases(Path(td), clarify, deliverable)
+            return check_acceptance_criteria("proj", phases)
+
+    def test_90_percent_coverage_is_warn(self):
+        """9/10 ACs linked (90%) → WARN, not FAIL."""
+        result = self._run(10, list(range(1, 10)))  # AC-1..9 linked, AC-10 missing
+        self.assertEqual(result.status, "WARN", msg=f"Expected WARN, got {result.status}: {result.evidence}")
+
+    def test_80_percent_exact_is_warn(self):
+        """4/5 ACs linked (80%) → WARN."""
+        result = self._run(5, [1, 2, 3, 4])  # AC-5 missing
+        self.assertEqual(result.status, "WARN", msg=f"Expected WARN, got {result.status}: {result.evidence}")
+
+    def test_below_80_percent_is_fail(self):
+        """3/5 ACs linked (60%) → FAIL."""
+        result = self._run(5, [1, 2, 3])  # AC-4, AC-5 missing
+        self.assertEqual(result.status, "FAIL", msg=f"Expected FAIL, got {result.status}: {result.evidence}")
+
+    def test_100_percent_is_pass(self):
+        """All ACs linked → PASS."""
+        result = self._run(5, [1, 2, 3, 4, 5])
+        self.assertEqual(result.status, "PASS")
+
+    def test_warn_does_not_block_overall_verdict(self):
+        """A WARN check should not flip the VerificationReport verdict to FAIL."""
+        report = VerificationReport(
+            protocol_version="1.0",
+            project_id="test",
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            checks=[
+                CheckResult(
+                    name="acceptance_criteria",
+                    status="WARN",
+                    evidence="9/10 AC linked (cosmetic mismatches only); missing: AC-10",
+                    details={},
+                ),
+            ],
+        )
+        self.assertEqual(report.verdict, "PASS")
+
+    def test_warn_evidence_mentions_cosmetic(self):
+        """WARN evidence string identifies the nature of the mismatch."""
+        result = self._run(10, list(range(1, 10)))
+        self.assertIn("cosmetic", result.evidence)
+        self.assertIn("missing", result.evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #587

## Summary

Three targeted fixes to `scripts/crew/verification_protocol.py:_check_ac_linked` that eliminate false gate blocks caused by cosmetic AC label differences:

- **(A) Normalize both sides** — strip non-alphanumeric chars before comparison; `AC-3`, `AC3`, `ac_3`, `ac-3` all collapse to `ac3` and match each other
- **(B) Parent-id fallback** — when a dotted child ID (e.g. `AC-3.1`) is unlinked, also check whether the parent (`AC-3`) appears in the deliverable; child criteria are covered by parent references
- **(C) Severity downgrade** — when `linked_count / total >= 0.80`, emit `WARN` instead of `FAIL`; aligns with #583's validator warning pattern and does not flip the overall `VerificationReport.verdict` to FAIL

## Files changed

- `scripts/crew/verification_protocol.py` — `_check_ac_linked` block only (~34 LOC added/changed)
- `tests/crew/test_verification_protocol_ac_linked.py` — new test file (17 tests across 3 test classes)

## Test plan

- [ ] `pytest tests/crew/test_verification_protocol_ac_linked.py` — 17 new tests, all pass
- [ ] `pytest tests/` — full suite 1213 + 17 = 1230 tests, all pass
- [ ] `AC-3` matches deliverable text containing `AC3`, `ac_3`, `AC-3` (case/separator insensitive)
- [ ] `AC-3.1` matches when deliverable references `AC-3` (parent-id fallback logic verified in isolation)
- [ ] 90% coverage → WARN, 60% coverage → FAIL, 100% coverage → PASS
- [ ] WARN status does not flip overall `VerificationReport.verdict` to FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)