### PR TITLE
calibration: u1 weight + cc3 wording (post cluster-A field test)

### DIFF
--- a/scripts/crew/factor_questionnaire.py
+++ b/scripts/crew/factor_questionnaire.py
@@ -101,7 +101,10 @@ QUESTIONNAIRE: Dict[str, FactorRubric] = {
     "user_facing_impact": FactorRubric(
         name="user_facing_impact",
         questions=(
-            Question("u1", "Does this change produce a visible UI change, copy change, or new user-visible flow?", 3),
+            # u1 weight 2 (was 3) — calibrated 2026-04-25 after cluster-A field test:
+            # a single visible change should land MEDIUM, not LOW. LOW reading requires
+            # multiple visible surfaces affected. See discovery-conventions audit.
+            Question("u1", "Does this change produce a visible UI change, copy change, or new user-visible flow?", 2),
             Question("u2", "Does this change affect a public API response shape that callers consume directly?", 2),
             Question("u3", "Does this change affect an email, notification, or export format seen by end-users?", 2),
             Question("u4", "Does this change affect perceived latency, reliability, or cost in a way users will notice?", 1),
@@ -160,7 +163,11 @@ QUESTIONNAIRE: Dict[str, FactorRubric] = {
         questions=(
             Question("cc1", "Does this change require 3 or more specialists to agree before it can ship?", 3),
             Question("cc2", "Does this change require a contract negotiation between two services or teams?", 2),
-            Question("cc3", "Does this change require a design + build handoff across different specialists?", 2),
+            # cc3 reworded 2026-04-25 after cluster-A field test: the original "across
+            # different specialists" trips YES whenever the facilitator picks 2+ agents,
+            # even when one contributor dispatches all of them with no human handoff.
+            # Coordination cost is about humans negotiating, not agents being dispatched.
+            Question("cc3", "Does this change require a design + build handoff across different humans (not just different agents dispatched by the same person)?", 2),
             Question("cc4", "Does this change require a product + engineering alignment on scope or acceptance criteria?", 1),
         ),
         medium_threshold=1,

--- a/tests/crew/test_factor_questionnaire.py
+++ b/tests/crew/test_factor_questionnaire.py
@@ -125,6 +125,29 @@ def test_low_threshold_produces_low():
     assert "r1" in why
 
 
+# ---------------------------------------------------------------------------
+# Calibration regression guards (added 2026-04-25 per council on PR #629)
+# Pin the new u1=2 weight so a future bump back to 3 fails loudly.
+# Without these, the cluster-A integration test (which uses u1=False)
+# would not catch a silent regression of the calibration fix.
+# ---------------------------------------------------------------------------
+
+def test_user_facing_impact_u1_alone_is_medium():
+    """AC-2 calibration: single u1=YES must read MEDIUM (was LOW with weight=3)."""
+    rubric = _rubric_for("user_facing_impact")
+    # u1 weight=2, medium_threshold=1 → 2 pts → MEDIUM (not LOW: low_threshold=3)
+    reading, _ = score_factor(rubric, {"u1": True})
+    assert reading == "MEDIUM"
+
+
+def test_user_facing_impact_u1_plus_u2_is_low():
+    """AC-2 calibration: two visible-surface YES answers must still reach LOW."""
+    rubric = _rubric_for("user_facing_impact")
+    # u1 (2) + u2 (2) = 4 pts ≥ low_threshold=3 → LOW (confirms LOW remains reachable)
+    reading, _ = score_factor(rubric, {"u1": True, "u2": True})
+    assert reading == "LOW"
+
+
 def test_why_string_includes_yes_question_ids():
     """AC-2: why field lists the IDs of questions answered yes."""
     rubric = _rubric_for("reversibility")


### PR DESCRIPTION
## Summary

- Calibration fix to `scripts/crew/factor_questionnaire.py` after field-testing the just-shipped scorer (#625, PR #626) on the cluster-A workflow surface hardening description
- 6/9 → 8/9 agreement with manual scoring after fix
- The remaining 1 disagreement is intentional — the scorer correctly catches marketplace consumer breakage on r3+r4 that I (the human facilitator) hand-waved past

## Changes

- `user_facing_impact.u1`: weight 3 → 2 (single visible change should be MEDIUM, not LOW)
- `coordination_cost.cc3`: reworded to disqualify "different agents dispatched by the same person" — coordination cost is about humans negotiating, not agents being dispatched

## Verification

- 39/39 questionnaire tests pass
- 837/837 full crew suite passes, 0 regressions
- Re-run on cluster-A description: 8/9 agreement (was 6/9)

## Brain memory

- `scorer-cluster-a-field-test-calibration-2026-04-25.md` (decision, semantic) — full field-test write-up

## Follow-up

- Issue #628 tracks plugin-scope-aware weight calibration for future passes (b4, b5, sc4 are suspected calibration targets)

## Test plan

- [x] `uv run pytest tests/crew/test_factor_questionnaire.py` — 39/39
- [x] `uv run pytest tests/crew/` — 837/837
- [x] Re-run cluster-A field test, confirm 8/9 agreement
- [ ] jam:council review (per standing merge gate)
- [ ] HITL judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)