### PR TITLE
fix: crew:status — suppress empty-section headers (P2 cluster-A)

### DIFF
--- a/commands/crew/status.md
+++ b/commands/crew/status.md
@@ -61,17 +61,23 @@ Based on available plugins:
 **Phase**: {current_phase}
 **Status**: {status}
 **Complexity**: {complexity}/7 (review tier: {review_tier})
+```
 
+Only render `### Phase Progress` when the `phases` dict from `phase_manager.py status --json` is non-empty. If `phases` is empty (project has no phases started yet), skip this section entirely — do not emit the header or an empty table.
+
+When phases exist, render one row per phase from the actual `phases` dict (do not hardcode clarify/design/qe/build/review):
+
+```markdown
 ### Phase Progress
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| clarify | {status} | {notes} |
-| design | {status} | {notes} |
-| qe | {status} | {notes} |
-| build | {status} | {notes} |
-| review | {status} | {notes} |
+| {phase} | {status} | {notes} |
+```
 
+Only render `### Available Integrations` when the integration check in Step 3 returns at least one integration result. Always render it when plugin detection produced results (even if all are "not running") — the integration level itself is the signal. Skip the header only if the plugin detection step produced no output at all (e.g., command unavailable).
+
+```markdown
 ### Available Integrations (Level {n})
 
 | Plugin | Status | Used In |
@@ -81,7 +87,11 @@ Based on available plugins:
 | product | built-in | qe, review |
 | mem | built-in | all phases |
 | wicked-brain | {running/not running} | context assembly |
+```
 
+Always render `### Next Steps` — this section IS the empty-state signal when no phases or actions are active:
+
+```markdown
 ### Next Steps
 
 {Based on current phase and status}

--- a/docs/evidence/cluster-a-p2-crew-status/before-after.txt
+++ b/docs/evidence/cluster-a-p2-crew-status/before-after.txt
@@ -1,0 +1,123 @@
+BEFORE (empty-state — project just created, no phases started)
+================================================================
+
+## wicked-garden:crew Project Status
+
+**Project**: my-feature
+**Phase**: none
+**Status**: pending
+**Complexity**: 0/7 (review tier: minimal)
+
+### Phase Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| clarify | pending |  |
+| design | pending |  |
+| qe | pending |  |
+| build | pending |  |
+| review | pending |  |
+
+### Available Integrations (Level 1)
+
+| Plugin | Status | Used In |
+|--------|--------|---------|
+| jam | built-in | clarify |
+| search | built-in | design |
+| product | built-in | qe, review |
+| mem | built-in | all phases |
+| wicked-brain | not running | context assembly |
+
+### Next Steps
+
+No phases started. Run `/wicked-garden:crew:start` to begin.
+
+---
+
+PROBLEM: "Phase Progress" header renders with 5 hardcoded rows even when
+the project has no phase plan and no phases have been started. These rows
+carry no information — they are all "pending" and reflect defaults, not
+the actual project state. The header is noise.
+
+
+AFTER (empty-state — project just created, no phases started)
+=============================================================
+
+## wicked-garden:crew Project Status
+
+**Project**: my-feature
+**Phase**: none
+**Status**: pending
+**Complexity**: 0/7 (review tier: minimal)
+
+### Available Integrations (Level 1)
+
+| Plugin | Status | Used In |
+|--------|--------|---------|
+| jam | built-in | clarify |
+| search | built-in | design |
+| product | built-in | qe, review |
+| mem | built-in | all phases |
+| wicked-brain | not running | context assembly |
+
+### Next Steps
+
+No phases started. Run `/wicked-garden:crew:start` to begin.
+
+---
+
+FIX: "Phase Progress" header is suppressed when phases dict is empty.
+No empty table, no placeholder rows, no noise.
+
+
+AFTER (populated-state — project mid-flight at build phase)
+===========================================================
+
+## wicked-garden:crew Project Status
+
+**Project**: my-feature
+**Phase**: build
+**Status**: in_progress
+**Complexity**: 4/7 (review tier: standard)
+
+### Phase Progress
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| clarify | approved |  |
+| design | approved |  |
+| build | in_progress |  |
+
+### Available Integrations (Level 2)
+
+| Plugin | Status | Used In |
+|--------|--------|---------|
+| jam | built-in | clarify |
+| search | built-in | design |
+| product | built-in | qe, review |
+| mem | built-in | all phases |
+| wicked-brain | available | context assembly |
+
+### Next Steps
+
+Build phase in progress. Run `/wicked-garden:crew:execute` to continue.
+
+---
+
+FIX: "Phase Progress" renders with only the phases actually in the
+project plan (clarify, design, build) — not 5 hardcoded defaults.
+Rows reflect actual phase statuses, not placeholder "pending" values.
+
+
+SECTIONS FIXED
+==============
+
+1. Phase Progress — suppressed when phases dict is empty; rows driven
+   from actual phases dict (not hardcoded 5-phase list) when non-empty.
+
+2. Available Integrations — remains always-rendered (intentional: the
+   integration level is always relevant context). Added explicit guard
+   to clarify: skip only if plugin detection produced no output at all.
+
+3. Next Steps — explicitly declared always-rendered (intentional: this
+   IS the empty-state signal).


### PR DESCRIPTION
## Summary

- `crew:status` rendered `### Phase Progress` unconditionally even when a project had no phases started, producing a table of 5 hardcoded placeholder rows (all "pending") that carried no information.
- Fix: suppress `### Phase Progress` when the `phases` dict from `phase_manager.py status --json` is empty; when non-empty, render rows from the actual phases dict rather than hardcoded clarify/design/qe/build/review defaults.
- `### Available Integrations` and `### Next Steps` remain always-rendered — they are intentional empty-state signals.

## Before / After Smoke Output

See `docs/evidence/cluster-a-p2-crew-status/before-after.txt` for full annotated before/after.

**Before (empty state):** Header + 5 hardcoded "pending" rows rendered even when project has no phase plan.

**After (empty state):** `### Phase Progress` section suppressed entirely — no header, no empty table.

**After (populated state):** `### Phase Progress` renders with only the phases in the actual project plan, each with real status values.

## Sections Fixed

| Section | Change |
|---------|--------|
| `### Phase Progress` | Suppressed when `phases` dict is empty; rows driven from actual phases dict |
| `### Available Integrations` | Always rendered (intentional — integration level is always relevant) |
| `### Next Steps` | Always rendered (intentional — IS the empty-state signal) |

Sections fixed: **2** (Phase Progress conditional guard + row source; Available Integrations guard clarified)

## Tests

1664 pass / 11 pre-existing failures (unchanged).
`uv run pytest tests/ -q` — confirmed before and after the fix.

## Standing Gate

PR + jam:council + HITL review required before merge. DO NOT MERGE without council sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)