### PR TITLE
docs: per-domain composition maps for jam, crew, smaht (P3 cluster-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Documentation
+- Added per-domain composition maps for jam, crew, and smaht at `docs/composition/{domain}.md`. One-page contributor reference showing surface inventory, workflow patterns, when to add new surfaces, cross-domain dependencies, and anti-patterns. Audience: contributors adding to or maintaining these domains. (cluster-A P3, 2026-04-25)
+
 ### Removed
 - `smaht:learn` command — duplicated `wicked-brain:ingest`; zero v8 role (cluster-A P0, 2026-04-25)
 - `smaht:libs` command — orphaned by v8 daemon-first architecture; zero v8 role (cluster-A P0, 2026-04-25)

--- a/docs/composition/crew.md
+++ b/docs/composition/crew.md
@@ -1,0 +1,136 @@
+# crew composition map
+
+Multi-phase SDLC workflow with specialist routing, gate enforcement, and convergence tracking.
+
+## Surface inventory
+
+| Type | Name | One-line purpose |
+|---|---|---|
+| command | /wicked-garden:crew:approve | Approve a phase and advance to next stage |
+| command | /wicked-garden:crew:archive | Archive a completed project (remove from active listings) |
+| command | /wicked-garden:crew:auto-approve | Grant or revoke APPROVE-verdict fast-lane for a project |
+| command | /wicked-garden:crew:convergence | Show artifact convergence states, stalls, and gate verdict |
+| command | /wicked-garden:crew:evidence | Show evidence summary for a task or project |
+| command | /wicked-garden:crew:execute | Execute current phase work with adaptive role engagement |
+| command | /wicked-garden:crew:explain | Translate jargon-heavy crew output into plain English |
+| command | /wicked-garden:crew:feedback | Capture user/stakeholder feedback linked to a crew project |
+| command | /wicked-garden:crew:gate | Run QE analysis on a target with configurable rigor |
+| command | /wicked-garden:crew:incident | Log a production incident with traceability to a project |
+| command | /wicked-garden:crew:just-finish | Execute remaining work with maximum autonomy and guardrails |
+| command | /wicked-garden:crew:operate | Enter and manage the operate phase |
+| command | /wicked-garden:crew:profile | Adjust autonomy level, verbosity, or plan mode |
+| command | /wicked-garden:crew:retro | Generate a retrospective from operate-phase data |
+| command | /wicked-garden:crew:start | Start a new project with outcome clarification |
+| command | /wicked-garden:crew:status | Show current project status, phase, and next steps |
+| command | /wicked-garden:crew:swarm | Check for quality-crisis swarm trigger and recommend coalition |
+| agent | wicked-garden:crew:contrarian | Maintains minority challenge position at complexity >= 4 |
+| agent | wicked-garden:crew:facilitator | Guides outcome clarification through structured inquiry |
+| agent | wicked-garden:crew:gate-adjudicator | Archetype-aware phase-boundary evidence evaluator |
+| agent | wicked-garden:crew:gate-evaluator | Fast-path self-check and advisory gate evaluator |
+| agent | wicked-garden:crew:implementer | Executes implementation tasks per approved designs |
+| agent | wicked-garden:crew:independent-reviewer | Cold-context phase deliverable auditor |
+| agent | wicked-garden:crew:phase-executor | Produces phase deliverables for full-rigor (mode-3) projects |
+| agent | wicked-garden:crew:qe-orchestrator | Routes to appropriate quality gate and consolidates results |
+| agent | wicked-garden:crew:researcher | Explores codebase and gathers context for decisions |
+| agent | wicked-garden:crew:reviewer | General code review when no domain specialist is available |
+| skill | wicked-garden:crew:adaptive | Autonomy and communication style configuration |
+| skill | wicked-garden:crew:change-type-detector | Classifies file paths as ui/api/both/unknown |
+| skill | wicked-garden:crew:crew-qe-gate | Value/strategy/execution quality gates at phase transitions |
+| skill | wicked-garden:crew:evidence-validation | Validates task completion evidence against complexity tier |
+| skill | wicked-garden:crew:explain | Plain-language translation of gate findings and phase summaries |
+| skill | wicked-garden:crew:issue-reporting | Automated GitHub issue detection and filing |
+| skill | wicked-garden:crew:test-task-factory | Generates test TaskCreate params from change-type output |
+
+## Workflow patterns
+
+### 1. Standard project lifecycle
+User wants to ship a feature through the full crew workflow.
+
+```
+/crew:start "<description>"          # facilitator → clarify → rubric → propose-process
+→ /crew:execute                      # phase-executor / implementer per phase
+→ /crew:gate [--rigor standard]      # qe-orchestrator → gate-adjudicator
+→ /crew:approve <phase>              # advance on APPROVE
+→ /crew:operate                      # post-ship monitoring
+→ /crew:retro                        # retrospective from operate data
+```
+
+Gate advancement requires score >= `min_gate_score` from `phases.json`. REJECT blocks; CONDITIONAL requires conditions-manifest resolution.
+
+### 2. Mid-flight status check
+User wants to know where the project stands.
+
+```
+/crew:status                         # phase, next steps, blocking findings
+→ /crew:evidence [task-id]           # inspect evidence for a specific task
+→ /crew:convergence status           # check artifact lifecycle states
+```
+
+### 3. Gate bypass / fast-lane
+User has justification to skip normal gate cadence (minimal-rigor projects).
+
+```
+/crew:auto-approve <project> --approve --justification "<text>"
+```
+
+Full-rigor grants require justification + sentinel. Cooldown blocks re-grant after revoke. See yolo guardrails in CLAUDE.md.
+
+### 4. Jargon translation
+Non-specialist user encounters a gate finding or reviewer brief.
+
+```
+/crew:explain "<text-or-path>"
+```
+
+Delegates to the `explain` skill. Outputs grade-8 English, no specialist vocab.
+
+### 5. Quality crisis response
+3+ BLOCK/REJECT findings have accumulated.
+
+```
+/crew:swarm                          # detect trigger, recommend Quality Coalition
+→ /crew:gate --rigor standard        # rerun with full panel
+```
+
+`swarm_trigger.py` monitors for the swarm condition. Coalition composition is determined at runtime from agents frontmatter.
+
+### 6. Production incident with crew traceability
+
+```
+/crew:incident "<description>" --severity high --components api,auth
+```
+
+Links incident to the active project's requirements and code. Use `platform:incident` for live triage without a crew project.
+
+## When to add a new surface
+
+- **New command** — when a user-facing lifecycle action is missing (a phase the user can trigger, a state they need to inspect). Do not add commands that wrap single script calls — expose those through existing commands with flags.
+- **New agent** — when a distinct specialist role is needed that is not covered by existing agents. Agents map to roles (facilitator, implementer, reviewer, gate evaluator); add when the role's decision logic is meaningfully different from all existing agents. Do not add agents for rigor-tier variations — those are handled by `gate-policy.json` dispatch.
+- **New skill** — when reusable logic is needed across multiple agents/commands and is too large for inline inclusion. Skills in this domain are mostly utilities (change-type-detector, test-task-factory) — add when a utility pattern recurs 2+ times.
+
+## Cross-domain dependencies
+
+```
+crew
+  calls →  jam:council              (challenge phase, complexity >= 4)
+  calls →  engineering, qe, etc.    (specialist gate reviewers via gate-policy.json)
+  calls →  wicked-brain:memory      (cross-session learning at completion + gate failures)
+  calls →  search:blast-radius      (impact analysis during design/research phases)
+
+smaht
+  reads ←  crew task events         (chain-aware scoring in events adapter)
+  reads ←  active_chain_id          (0.8+ score for matching events)
+
+platform
+  calls ←  crew:incident            (escalation from live incident triage)
+
+propose-process (root command)
+  called by → crew:start            (facilitator rubric → phase plan)
+```
+
+## Anti-patterns
+
+- **Calling `crew:approve` without gate evidence.** `approve` advances phase state; it does not evaluate evidence. Run `crew:gate` first and resolve findings before approving.
+- **Using `crew:just-finish` as the default mode.** `just-finish` is a guardrailed override for situations where autonomy is explicitly wanted. Default to `crew:execute` which respects `crew:profile` settings.
+- **Adding a static `enhances` map between agents.** v6 removed the static enhances map. Specialist discovery is dynamic — `propose-process` reads agents frontmatter at runtime. Keep agent descriptions accurate; the facilitator rubric does the routing.
+- **Hardcoding phase names in new code.** Phase names are keys in `.claude-plugin/phases.json`. Reference them from there; do not duplicate them in scripts or agents.

--- a/docs/composition/crew.md
+++ b/docs/composition/crew.md
@@ -6,6 +6,7 @@ Multi-phase SDLC workflow with specialist routing, gate enforcement, and converg
 
 | Type | Name | One-line purpose |
 |---|---|---|
+| command | /wicked-garden:crew:activity | Query the unified event log for cross-domain activity (FTS over SQLite) |
 | command | /wicked-garden:crew:approve | Approve a phase and advance to next stage |
 | command | /wicked-garden:crew:archive | Archive a completed project (remove from active listings) |
 | command | /wicked-garden:crew:auto-approve | Grant or revoke APPROVE-verdict fast-lane for a project |
@@ -115,7 +116,6 @@ crew
   calls →  jam:council              (challenge phase, complexity >= 4)
   calls →  engineering, qe, etc.    (specialist gate reviewers via gate-policy.json)
   calls →  wicked-brain:memory      (cross-session learning at completion + gate failures)
-  calls →  search:blast-radius      (impact analysis during design/research phases)
 
 smaht
   reads ←  crew task events         (chain-aware scoring in events adapter)

--- a/docs/composition/jam.md
+++ b/docs/composition/jam.md
@@ -1,0 +1,97 @@
+# jam composition map
+
+Structured brainstorming and multi-model evaluation — from quick gut-check to council verdict.
+
+## Surface inventory
+
+| Type | Name | One-line purpose |
+|---|---|---|
+| command | /wicked-garden:jam:brainstorm | Full multi-round session with evidence-backed personas |
+| command | /wicked-garden:jam:council | Structured evaluation using external LLM CLIs for a verdict |
+| command | /wicked-garden:jam:persona | Retrieve one persona's contributions across all rounds |
+| command | /wicked-garden:jam:perspectives | Raw viewpoints from 4-6 personas, no synthesis |
+| command | /wicked-garden:jam:quick | 60-second, 4-persona, 1-round gut-check |
+| command | /wicked-garden:jam:revisit | Record outcome of a past brainstorm decision |
+| command | /wicked-garden:jam:thinking | Show pre-synthesis perspectives (minority views, dissents) |
+| command | /wicked-garden:jam:transcript | Full chronological session record |
+| agent | wicked-garden:jam:brainstorm-facilitator | Role-plays focus-group personas and synthesizes discussion |
+| agent | wicked-garden:jam:council | Runs multi-model council evaluations via external LLM CLIs |
+| skill | wicked-garden:jam | Brainstorming orchestration — session tracking + brain storage |
+
+## Workflow patterns
+
+### 1. Quick idea sanity-check
+User wants a rapid gut-check before investing in a full session.
+
+```
+/jam:quick "<idea>"
+```
+
+One command, one dispatch to `brainstorm-facilitator`, result in ~60s. Use when you just need a temperature read.
+
+### 2. Full brainstorm
+User wants deep exploration with evidence-backed personas and synthesis.
+
+```
+/jam:brainstorm "<topic>" [--personas list] [--rounds n]
+→ /jam:thinking          # inspect pre-synthesis dissents if synthesis feels flat
+→ /jam:transcript        # audit full record
+```
+
+`brainstorm` delegates to `brainstorm-facilitator`. Outputs stored via `wicked-brain:memory`. Use `thinking` to surface what synthesis compressed.
+
+### 3. Decision evaluation with external LLMs
+User has defined options and needs an independent verdict, not ideation.
+
+```
+/jam:council "<topic>" --options "A, B, C" [--criteria "perf, cost, risk"]
+```
+
+`council` agent queries real external LLM CLIs (Codex, Gemini, etc.) independently, then synthesizes. Distinct from `brainstorm` — no persona role-play, just structured verdict.
+
+### 4. Perspective gathering without synthesis
+User wants raw expert viewpoints for their own reasoning or a discussion.
+
+```
+/jam:perspectives "<decision or question>"
+```
+
+No synthesis step. Returns position + key concern + what would change their mind per persona. Good for prep before a human conversation.
+
+### 5. Decision hygiene loop
+Track whether past decisions held up.
+
+```
+/jam:revisit "<topic keyword>"   # find + record outcome
+/jam:persona "<name>"            # trace how one voice evolved
+```
+
+Pulls from `wicked-brain:memory`. Closes the feedback loop on past sessions.
+
+## When to add a new surface
+
+- **New command** — when there is a user-facing workflow step that is not addressable by composing existing commands. The `quick → brainstorm → council` progression is the core; new commands extend it at the edges (new entry points, new retrieval modes).
+- **New agent** — when a new facilitation mode is fundamentally different in execution from `brainstorm-facilitator` (persona role-play) or `council` (structured multi-model). Do not add agents for minor variations in round count or persona set — drive those through command arguments.
+- **New skill** — jam has a single SKILL.md with two refs (`facilitation-patterns.md`, `synthesis-patterns.md`). Add a ref if synthesis or facilitation logic grows past ~200 lines. Do not add a top-level skill entry for jam sub-topics.
+
+## Cross-domain dependencies
+
+```
+jam
+  calls →  wicked-brain:memory   (store session outcomes, recall past decisions)
+  calls →  wicked-brain:search   (surface evidence during brainstorm rounds)
+
+crew
+  calls →  jam:council           (challenge phase at complexity >= 4)
+  calls →  jam:brainstorm        (ideation during design phase, optional)
+
+smaht
+  reads ←  jam session events    (events adapter surfaces recent sessions in context)
+```
+
+## Anti-patterns
+
+- **Using `brainstorm` when you need a verdict.** `brainstorm` is generative/exploratory; use `council` when you have defined options and need a decision.
+- **Adding a new agent per persona set.** Persona selection is a command argument (`--personas`), not an agent concern. One facilitator agent handles all persona configurations.
+- **Skipping `revisit` at the end of a project.** Decisions that are never revisited don't feed back into `wicked-brain:memory`, which degrades future session quality.
+- **Reading brain files directly.** Past session data lives in `wicked-brain:memory`. Use `jam:revisit`, `jam:transcript`, or `wicked-brain:memory` recall — never grep the brain store directly.

--- a/docs/composition/smaht.md
+++ b/docs/composition/smaht.md
@@ -1,0 +1,98 @@
+# smaht composition map
+
+Context assembly and session intelligence — briefings, live state inspection, event log, and contextual discovery.
+
+## Surface inventory
+
+| Type | Name | One-line purpose |
+|---|---|---|
+| command | /wicked-garden:smaht:briefing | Cross-domain catch-up since last session (recent events, active projects, memory updates) |
+| command | /wicked-garden:smaht:debug | Inspect live SessionState, adapter outputs, and smaht directive settings |
+| command | /wicked-garden:smaht:events-import | Import existing DomainStore JSON records into the unified event log |
+| command | /wicked-garden:smaht:events-query | Query the unified event log for cross-domain activity |
+| skill | wicked-garden:smaht:context-assembly | Pull-model context gathering from wicked-brain + search + domain state |
+| skill | wicked-garden:smaht:discovery | Contextual command discovery — suggests one related command after each run (Stop hook, not user-invocable) |
+
+Note: smaht has no agents on disk. Context intelligence is delivered via skills and hooks (`hooks/scripts/prompt_submit.py`).
+
+## Workflow patterns
+
+### 1. Session start catch-up
+User opens a new session and wants to orient quickly.
+
+```
+/smaht:briefing [--days N] [--project name]
+```
+
+Queries wicked-brain + events log + active crew projects. Returns recent activity summary, memory updates, and one discovery suggestion. Default window is 7 days.
+
+### 2. Diagnosing context assembly problems
+Context injected into a prompt seems wrong, stale, or missing.
+
+```
+/smaht:debug --state          # dump live SessionState
+/smaht:debug --events 20      # show last N events fed to adapters
+/smaht:debug --json           # machine-readable output for scripting
+```
+
+Use `debug`, not `briefing`, when the problem is live session state vs. historical catch-up.
+
+### 3. Cross-domain activity search
+User wants to understand what happened across domains over a time range.
+
+```
+/smaht:events-query --domain crew --since 7d --fts "gate finding"
+/smaht:events-query --project my-project --action phase-transition
+```
+
+FTS search runs over the unified event log (SQLite). Useful for auditing, debugging a crew run, or tracing a decision chain.
+
+### 4. Migrating legacy DomainStore records
+Historical JSON records predate the unified event log and need to be imported.
+
+```
+/smaht:events-import --domain jam --dry-run    # preview
+/smaht:events-import --domain jam              # commit
+```
+
+One-time operation per domain after migrating to the unified log. Run `--dry-run` first.
+
+### 5. On-demand context assembly (subagent use)
+A subagent or command needs a context briefing before acting.
+
+```
+# In agent/command markdown:
+Skill: wicked-garden:smaht:context-assembly
+```
+
+v6 pull-model: nothing is pushed onto every prompt. Subagents call this skill when they need background. The `prompt_submit.py` hook injects a short pull directive; complex/risky prompts get an expanded directive routing through `wicked-brain:query`.
+
+## When to add a new surface
+
+- **New command** — when there is a distinct user-facing inspection or data-management action not covered by `briefing`, `debug`, `events-query`, or `events-import`. smaht commands are operational tools, not workflow drivers; keep the surface small.
+- **New skill** — when a reusable context-gathering pattern is needed by 2+ agents/commands. `context-assembly` is the primary skill; add a new one only if the assembly logic for a new use case is fundamentally different (different sources, different output contract). `discovery` is hook-driven and not user-invocable — that pattern can extend via refs, not new skills.
+- **No agents needed** — smaht intelligence lives in skills and hooks. Do not add agents to this domain; if a dispatched subagent is needed, it belongs in the domain whose work it is doing.
+
+## Cross-domain dependencies
+
+```
+smaht
+  calls →  wicked-brain:query       (complex/risky prompt enrichment)
+  calls →  wicked-brain:search      (context-assembly skill)
+  calls →  search domain            (context-assembly skill, blast-radius)
+  reads ←  all domains              (events-query reads the unified log)
+
+hooks/scripts/prompt_submit.py
+  injects → pull directives on every UserPromptSubmit
+  reads   ← SessionState.active_chain_id (crew chain-aware scoring)
+
+hooks/scripts/stop.py
+  calls   → smaht:discovery skill (contextual suggestion after each Stop)
+```
+
+## Anti-patterns
+
+- **Using `smaht:briefing` for live session inspection.** `briefing` queries historical data (events log, brain memory). Use `smaht:debug --state` to inspect what is happening right now in the current session.
+- **Adding push-model context injection.** v5's per-prompt orchestrator was deleted in #428. Do not reintroduce it. Context assembly is pull-only — subagents call `context-assembly` when they need it.
+- **Querying brain files directly from a command.** Route through `wicked-brain:query` or `wicked-brain:search`. The `context-assembly` skill handles source fan-out and budget enforcement; do not replicate that logic in individual commands.
+- **Making `discovery` user-invocable.** The discovery skill is Stop-hook-driven by design. It produces one suggestion per Stop, not an on-demand catalog. Keep `user-invocable: false`.

--- a/docs/composition/smaht.md
+++ b/docs/composition/smaht.md
@@ -7,11 +7,12 @@ Context assembly and session intelligence — briefings, live state inspection, 
 | Type | Name | One-line purpose |
 |---|---|---|
 | command | /wicked-garden:smaht:briefing | Cross-domain catch-up since last session (recent events, active projects, memory updates) |
-| command | /wicked-garden:smaht:debug | Inspect live SessionState, adapter outputs, and smaht directive settings |
 | command | /wicked-garden:smaht:events-import | Import existing DomainStore JSON records into the unified event log |
-| command | /wicked-garden:smaht:events-query | Query the unified event log for cross-domain activity |
+| command | /wicked-garden:smaht:state | Inspect live SessionState, adapter outputs, and smaht directive settings |
 | skill | wicked-garden:smaht:context-assembly | Pull-model context gathering from wicked-brain + search + domain state |
 | skill | wicked-garden:smaht:discovery | Contextual command discovery — suggests one related command after each run (Stop hook, not user-invocable) |
+
+> Note: `smaht:events-query` was relocated to `crew:activity` in PR #636 — see the crew composition map for cross-domain activity search.
 
 Note: smaht has no agents on disk. Context intelligence is delivered via skills and hooks (`hooks/scripts/prompt_submit.py`).
 
@@ -30,24 +31,14 @@ Queries wicked-brain + events log + active crew projects. Returns recent activit
 Context injected into a prompt seems wrong, stale, or missing.
 
 ```
-/smaht:debug --state          # dump live SessionState
-/smaht:debug --events 20      # show last N events fed to adapters
-/smaht:debug --json           # machine-readable output for scripting
+/smaht:state --state          # dump live SessionState
+/smaht:state --events 20      # show last N events fed to adapters
+/smaht:state --json           # machine-readable output for scripting
 ```
 
-Use `debug`, not `briefing`, when the problem is live session state vs. historical catch-up.
+Use `state`, not `briefing`, when the problem is live session state vs. historical catch-up.
 
-### 3. Cross-domain activity search
-User wants to understand what happened across domains over a time range.
-
-```
-/smaht:events-query --domain crew --since 7d --fts "gate finding"
-/smaht:events-query --project my-project --action phase-transition
-```
-
-FTS search runs over the unified event log (SQLite). Useful for auditing, debugging a crew run, or tracing a decision chain.
-
-### 4. Migrating legacy DomainStore records
+### 3. Migrating legacy DomainStore records
 Historical JSON records predate the unified event log and need to be imported.
 
 ```
@@ -57,7 +48,7 @@ Historical JSON records predate the unified event log and need to be imported.
 
 One-time operation per domain after migrating to the unified log. Run `--dry-run` first.
 
-### 5. On-demand context assembly (subagent use)
+### 4. On-demand context assembly (subagent use)
 A subagent or command needs a context briefing before acting.
 
 ```
@@ -69,7 +60,7 @@ v6 pull-model: nothing is pushed onto every prompt. Subagents call this skill wh
 
 ## When to add a new surface
 
-- **New command** — when there is a distinct user-facing inspection or data-management action not covered by `briefing`, `debug`, `events-query`, or `events-import`. smaht commands are operational tools, not workflow drivers; keep the surface small.
+- **New command** — when there is a distinct user-facing inspection or data-management action not covered by `briefing`, `state`, or `events-import`. smaht commands are operational tools, not workflow drivers; keep the surface small. (Cross-domain activity search lives in `crew:activity` post-#636.)
 - **New skill** — when a reusable context-gathering pattern is needed by 2+ agents/commands. `context-assembly` is the primary skill; add a new one only if the assembly logic for a new use case is fundamentally different (different sources, different output contract). `discovery` is hook-driven and not user-invocable — that pattern can extend via refs, not new skills.
 - **No agents needed** — smaht intelligence lives in skills and hooks. Do not add agents to this domain; if a dispatched subagent is needed, it belongs in the domain whose work it is doing.
 
@@ -79,15 +70,17 @@ v6 pull-model: nothing is pushed onto every prompt. Subagents call this skill wh
 smaht
   calls →  wicked-brain:query       (complex/risky prompt enrichment)
   calls →  wicked-brain:search      (context-assembly skill)
-  calls →  search domain            (context-assembly skill, blast-radius)
-  reads ←  all domains              (events-query reads the unified log)
+  calls →  search domain            (context-assembly skill)
+  reads ←  all domains              (state inspector + crew:activity read the unified log)
 
 hooks/scripts/prompt_submit.py
-  injects → pull directives on every UserPromptSubmit
-  reads   ← SessionState.active_chain_id (crew chain-aware scoring)
+  injects  → pull directives on every UserPromptSubmit
+  reads    ← SessionState.active_chain_id (crew chain-aware scoring)
+  invokes  → smaht:discovery skill (contextual suggestion via _suggest_discovery())
 
 hooks/scripts/stop.py
-  calls   → smaht:discovery skill (contextual suggestion after each Stop)
+  emits    → wicked.fact.extracted events (brain auto-memorize ingestion path)
+            (Note: stop.py does NOT invoke the discovery skill; that's prompt_submit.py.)
 ```
 
 ## Anti-patterns


### PR DESCRIPTION
## Summary

- Adds `docs/composition/jam.md`, `docs/composition/crew.md`, `docs/composition/smaht.md`
- Audience: contributors adding to or maintaining these domains (not end users)
- Goal: lower the cognitive cost of "where does this thing go" for someone who hasn't memorized the repo
- Each map: surface inventory table, workflow patterns, when-to-add criteria, cross-domain dependency diagram, anti-patterns

## Surface counts

| Domain | Commands | Agents | Skills | Total |
|---|---|---|---|---|
| jam | 8 | 2 | 1 (SKILL.md + 2 refs) | 11 |
| crew | 17 | 10 | 7 | 34 |
| smaht | 4 | 0 | 2 (context-assembly + discovery) | 6 |

## Line counts

- `jam.md`: 97 lines
- `crew.md`: 136 lines
- `smaht.md`: 98 lines

All under the 200-line cap.

## Test plan

- [x] `wc -l docs/composition/*.md` — all three maps under 200 lines
- [x] All surface names verified against `ls commands/{domain}/`, `ls agents/{domain}/`, `ls skills/{domain}/`
- [x] `uv run pytest tests/ -q` — 1664 pass / 11 pre-existing failures (no test impact, docs-only change)
- [x] Branch based on `ca6752b` confirmed via `git log --oneline -5`

## Standing gate

PR + jam:council + HITL required. DO NOT MERGE without council sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)