### PR TITLE
docs: cluster-A doc nits (followup #640 — PR #635 + #638)

### DIFF
--- a/docs/composition/crew.md
+++ b/docs/composition/crew.md
@@ -74,7 +74,7 @@ User has justification to skip normal gate cadence (minimal-rigor projects).
 /crew:auto-approve <project> --approve --justification "<text>"
 ```
 
-Full-rigor grants require justification + sentinel. Cooldown blocks re-grant after revoke. See yolo guardrails in CLAUDE.md.
+Full-rigor grants require justification + sentinel. Cooldown blocks re-grant after revoke. See yolo guardrails in `commands/crew/auto-approve.md` and the project README.
 
 ### 4. Jargon translation
 Non-specialist user encounters a gate finding or reviewer brief.
@@ -114,7 +114,7 @@ Links incident to the active project's requirements and code. Use `platform:inci
 ```
 crew
   calls →  jam:council              (challenge phase, complexity >= 4)
-  calls →  engineering, qe, etc.    (specialist gate reviewers via gate-policy.json)
+  calls →  engineering, wicked-testing, etc.    (specialist gate reviewers via gate-policy.json)
   calls →  wicked-brain:memory      (cross-session learning at completion + gate failures)
 
 smaht
@@ -124,7 +124,7 @@ smaht
 platform
   calls ←  crew:incident            (escalation from live incident triage)
 
-propose-process (root command)
+propose-process (skill, root)
   called by → crew:start            (facilitator rubric → phase plan)
 ```
 

--- a/scripts/crew/plugin-scope-calibration.md
+++ b/scripts/crew/plugin-scope-calibration.md
@@ -104,5 +104,5 @@ threshold arithmetic. Use the per-question guidance above instead.
 
 - Field-test descriptions: `docs/calibration/test-descriptions.md`
 - Field-test results: `docs/calibration/field-test-results.md`
-- Calibration tests: `tests/crew/test_factor_questionnaire.py` (search for "issue-628")
+- Calibration tests: `tests/crew/test_factor_questionnaire.py` (search for "Issue #628")
 - Prior calibration: PR #629

--- a/tests/crew/test_factor_questionnaire.py
+++ b/tests/crew/test_factor_questionnaire.py
@@ -583,9 +583,10 @@ def test_risk_level_inversion_correctness():
 # needed. These tests pin the observed correct behavior so a future accidental
 # recalibration of these weights fails loudly.
 #
-# For each candidate question, two tests:
+# Coverage per candidate question (8 tests total; b4=2, b5=3, sc4=3):
 #   - plugin_scope: the typical plugin-only answer must NOT produce an inflated reading
 #   - saas_scale: SaaS-scale all-signal answer must still produce the riskier reading
+#   - additional contribution/A-B tests where the question warrants extra rigor (e.g., sc4)
 # ---------------------------------------------------------------------------
 
 # --- b4 pinning ---


### PR DESCRIPTION
Small doc-only fixes from issue #640. Five edits across three files; no code changes; tests unchanged.

## PR #635 composition map (3 fixes in docs/composition/crew.md)
- Cross-domain: `qe` → `wicked-testing` (qe was extracted to peer plugin in v7.0)
- Cross-domain: `propose-process` labeled as skill (lives at skills/propose-process/)
- Yolo guardrails reference: `CLAUDE.md` (doesn't exist in repo root — `.claude/CLAUDE.md` is dev-only) → `commands/crew/auto-approve.md` + project README

## PR #638 followups (2 fixes)
- `tests/crew/test_factor_questionnaire.py` header comment count: was 'two tests per question' but actual is 2+3+3=8 with mixed coverage shape — corrected
- `scripts/crew/plugin-scope-calibration.md` cross-ref search term: 'issue-628' → 'Issue #628' to match actual test docstring strings

Standing gate: lightweight docs-only PR; happy to skip council if HITL agrees, or run quick council if rigor preferred. Recommend skip — no behavioral change.

Closes part of #640.