### PR TITLE
fix: crew:activity domain placement + sanitize PII in evidence (followup #640)

### DIFF
--- a/commands/help.md
+++ b/commands/help.md
@@ -20,7 +20,7 @@ The Wicked Garden Marketplace — an AI-native SDLC workflow with 19 command dom
 | Domain | Description | Key Commands |
 |--------|-------------|--------------|
 | **agentic** | Design, review, and audit agentic AI systems | `agentic:design`, `agentic:review`, `agentic:audit` |
-| **crew** | Dynamic multi-phase workflow engine with specialist routing | `crew:start`, `crew:execute`, `crew:gate` |
+| **crew** | Dynamic multi-phase workflow engine with specialist routing | `crew:start`, `crew:execute`, `crew:gate`, `crew:activity` |
 | **data** | Data analysis and ontology recommendations | `data:analyze`, `data:pipeline`, `data:ml` |
 | **delivery** | Multi-perspective delivery reporting and metrics | `delivery:report`, `delivery:rollout`, `delivery:experiment` |
 | **engineering** | Architecture, code review, debugging, docs, planning, and code transformations | `engineering:review`, `engineering:debug`, `engineering:arch` |
@@ -29,7 +29,7 @@ The Wicked Garden Marketplace — an AI-native SDLC workflow with 19 command dom
 | **platform** | Security, infrastructure, compliance, CI/CD, incidents, and plugin diagnostics | `platform:security`, `platform:compliance`, `platform:incident` |
 | **product** | Requirements, customer feedback, strategy, UX, and design review | `product:acceptance`, `product:analyze`, `product:strategy` |
 | **search** | Structural code search, lineage, and codebase intelligence | `search:blast-radius`, `search:lineage`, `search:hotspots` |
-| **smaht** | Intelligent context assembly from all sources | `smaht:briefing`, `smaht:state`, `crew:activity` |
+| **smaht** | Intelligent context assembly from all sources | `smaht:briefing`, `smaht:state`, `smaht:events-import` |
 
 ## Quick Start
 

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -31,6 +31,7 @@ The orchestrator. Runs the facilitator (`skills/propose-process/`) to score 9 fa
 | `crew:profile` | Configure crew preferences |
 | `crew:cutover` | Cut an in-flight project to mode-3 formal dispatch |
 | `crew:migrate-gates` | Migrate in-flight projects to strict gate enforcement |
+| `crew:activity` | Query the unified event log for cross-domain project activity |
 | `crew:help` | Show available crew commands |
 
 **v6 Capabilities**:
@@ -64,7 +65,6 @@ The "brain" of the plugin. Intercepts every prompt via `UserPromptSubmit` and as
 | `smaht:context` | Build a structured context package for subagents |
 | `smaht:state` | Snapshot and report current session state |
 | `smaht:briefing` | Session briefing — what happened since last time |
-| `crew:activity` | Query the unified event log for cross-domain project activity |
 | `smaht:events-import` | Import existing domain JSON records into the event log |
 | `smaht:collaborate` | Multi-AI CLI collaboration (discover, review, council) |
 | `smaht:onboard` | Intelligent codebase onboarding |

--- a/docs/evidence/cluster-a-followup-636/help-md-diff.txt
+++ b/docs/evidence/cluster-a-followup-636/help-md-diff.txt
@@ -1,0 +1,23 @@
+diff --git a/commands/help.md b/commands/help.md
+index 642fcaa..976365a 100644
+--- a/commands/help.md
++++ b/commands/help.md
+@@ -20,7 +20,7 @@ The Wicked Garden Marketplace — an AI-native SDLC workflow with 19 command dom
+ | Domain | Description | Key Commands |
+ |--------|-------------|--------------|
+ | **agentic** | Design, review, and audit agentic AI systems | `agentic:design`, `agentic:review`, `agentic:audit` |
+-| **crew** | Dynamic multi-phase workflow engine with specialist routing | `crew:start`, `crew:execute`, `crew:gate` |
++| **crew** | Dynamic multi-phase workflow engine with specialist routing | `crew:start`, `crew:execute`, `crew:gate`, `crew:activity` |
+ | **data** | Data analysis and ontology recommendations | `data:analyze`, `data:pipeline`, `data:ml` |
+ | **delivery** | Multi-perspective delivery reporting and metrics | `delivery:report`, `delivery:rollout`, `delivery:experiment` |
+ | **engineering** | Architecture, code review, debugging, docs, planning, and code transformations | `engineering:review`, `engineering:debug`, `engineering:arch` |
+@@ -29,7 +29,7 @@ The Wicked Garden Marketplace — an AI-native SDLC workflow with 19 command dom
+ | **platform** | Security, infrastructure, compliance, CI/CD, incidents, and plugin diagnostics | `platform:security`, `platform:compliance`, `platform:incident` |
+ | **product** | Requirements, customer feedback, strategy, UX, and design review | `product:acceptance`, `product:analyze`, `product:strategy` |
+ | **search** | Structural code search, lineage, and codebase intelligence | `search:blast-radius`, `search:lineage`, `search:hotspots` |
+-| **smaht** | Intelligent context assembly from all sources | `smaht:briefing`, `smaht:state`, `crew:activity` |
++| **smaht** | Intelligent context assembly from all sources | `smaht:briefing`, `smaht:state`, `smaht:events-import` |
+
+Changes:
+- commands/help.md: crew row gains `crew:activity`; smaht row replaces `crew:activity` with `smaht:events-import`
+- docs/domains.md: `crew:activity` row moved from smaht command table to crew command table

--- a/docs/evidence/cluster-a-followup-636/pii-grep-post.txt
+++ b/docs/evidence/cluster-a-followup-636/pii-grep-post.txt
@@ -1,0 +1,17 @@
+PII sanitization verification — cluster-a-followup-636
+Generated: 2026-04-25
+
+Command: grep -rEn "/Users/" docs/evidence/cluster-a-p1-smaht-rename/
+Result: 0 hits (exit code 1)
+
+Files sanitized:
+  docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt
+  docs/evidence/cluster-a-p1-smaht-rename/pytest-results.txt
+
+Transformation applied:
+  s|/Users/[^/]+/Projects/wicked-garden/\.claude/worktrees/[^/]+/|./|g
+
+Out-of-scope note:
+  Additional /Users/ paths exist in other evidence directories (pr-v8-3, pr-v8-4, etc.).
+  These are pre-existing and were NOT touched in this PR — scope-limited per work order.
+  A broader sweep should be addressed in a dedicated follow-up issue.

--- a/docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt
+++ b/docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt
@@ -1,6 +1,6 @@
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./CHANGELOG.md:15:- `smaht:debug` renamed to `smaht:state` — name now reflects what the command does (snapshot + report session state). v5→v6 archaeology section deleted. (cluster-A P1, 2026-04-25)
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./CHANGELOG.md:16:- `smaht:events-query` relocated to `crew:activity` — project-infrastructure command belongs in the crew domain. All cross-references updated. (cluster-A P1, 2026-04-25)
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./CHANGELOG.md:703:- `/wicked-garden:smaht:debug` output shape changed — no more HOT/FAST/SLOW
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./CHANGELOG.md:1134:- feat: `smaht:events-query` command — cross-domain activity queries with --domain, --project, --since, --fts flags
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./docs/v9/audit.md:107:| `smaht:state` | DONE | Renamed from `smaht:debug` (cluster-A P1, 2026-04-25) — name now matches what the command does. | — |
-/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/./docs/v9/audit.md:109:| `crew:activity` | DONE | Relocated from `smaht:events-query` (cluster-A P1, 2026-04-25) — project infrastructure belongs in crew domain. | — |
+././CHANGELOG.md:15:- `smaht:debug` renamed to `smaht:state` — name now reflects what the command does (snapshot + report session state). v5→v6 archaeology section deleted. (cluster-A P1, 2026-04-25)
+././CHANGELOG.md:16:- `smaht:events-query` relocated to `crew:activity` — project-infrastructure command belongs in the crew domain. All cross-references updated. (cluster-A P1, 2026-04-25)
+././CHANGELOG.md:703:- `/wicked-garden:smaht:debug` output shape changed — no more HOT/FAST/SLOW
+././CHANGELOG.md:1134:- feat: `smaht:events-query` command — cross-domain activity queries with --domain, --project, --since, --fts flags
+././docs/v9/audit.md:107:| `smaht:state` | DONE | Renamed from `smaht:debug` (cluster-A P1, 2026-04-25) — name now matches what the command does. | — |
+././docs/v9/audit.md:109:| `crew:activity` | DONE | Relocated from `smaht:events-query` (cluster-A P1, 2026-04-25) — project infrastructure belongs in crew domain. | — |

--- a/docs/evidence/cluster-a-p1-smaht-rename/pytest-results.txt
+++ b/docs/evidence/cluster-a-p1-smaht-rename/pytest-results.txt
@@ -160,7 +160,7 @@ self = <tests.test_command_aliases.TestCrewYoloAliasStub object at 0x1097a7750>
 E       AssertionError: commands/crew/yolo.md was deleted. It must remain as an alias stub so that existing /wicked-garden:crew:yolo invocations continue to work.
 E       assert False
 E        +  where False = exists()
-E        +    where exists = (PosixPath('/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew') / 'yolo.md').exists
+E        +    where exists = (PosixPath('./commands/crew') / 'yolo.md').exists
 
 tests/test_command_aliases.py:26: AssertionError
 _______________ TestCrewYoloAliasStub.test_yolo_md_is_short_stub _______________
@@ -179,7 +179,7 @@ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-self = PosixPath('/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew/yolo.md')
+self = PosixPath('./commands/crew/yolo.md')
 mode = 'r', buffering = -1, encoding = 'utf-8', errors = None, newline = None
 
     def open(self, mode='r', buffering=-1, encoding=None,
@@ -192,7 +192,7 @@ mode = 'r', buffering = -1, encoding = 'utf-8', errors = None, newline = None
             encoding = io.text_encoding(encoding)
 >       return io.open(self, mode, buffering, encoding, errors, newline)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-E       FileNotFoundError: [Errno 2] No such file or directory: '/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew/yolo.md'
+E       FileNotFoundError: [Errno 2] No such file or directory: './commands/crew/yolo.md'
 
 /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib/__init__.py:771: FileNotFoundError
 _________ TestCrewYoloAliasStub.test_yolo_stub_references_auto_approve _________
@@ -211,7 +211,7 @@ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-self = PosixPath('/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew/yolo.md')
+self = PosixPath('./commands/crew/yolo.md')
 mode = 'r', buffering = -1, encoding = 'utf-8', errors = None, newline = None
 
     def open(self, mode='r', buffering=-1, encoding=None,
@@ -224,7 +224,7 @@ mode = 'r', buffering = -1, encoding = 'utf-8', errors = None, newline = None
             encoding = io.text_encoding(encoding)
 >       return io.open(self, mode, buffering, encoding, errors, newline)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-E       FileNotFoundError: [Errno 2] No such file or directory: '/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew/yolo.md'
+E       FileNotFoundError: [Errno 2] No such file or directory: './commands/crew/yolo.md'
 
 /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib/__init__.py:771: FileNotFoundError
 ____________ TestCrewAliasRedirect.test_yolo_mentions_auto_approve _____________
@@ -250,7 +250,7 @@ domain = 'crew', command = 'yolo'
 E       AssertionError: Command file not found: commands/crew/yolo.md
 E       assert False
 E        +  where False = exists()
-E        +    where exists = PosixPath('/Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a2abd7d630c974b8a/commands/crew/yolo.md').exists
+E        +    where exists = PosixPath('./commands/crew/yolo.md').exists
 
 tests/test_command_cross_links.py:37: AssertionError
 ______________ TestStubAudit.test_no_bare_pass_in_scripts_overall ______________


### PR DESCRIPTION
## Summary

- **Fix 1 (P2)**: `crew:activity` was listed under the **smaht** domain row in `commands/help.md` and `docs/domains.md` after PR #636 moved it from `smaht:events-query`. Moved to the crew domain row in both files; smaht row now correctly shows `smaht:events-import` as the third key command.
- **Fix 2 (P3)**: Two evidence files from PR #636 contained absolute `/Users/michael.parcewski/...` paths. Sanitized to repo-relative `./` paths using `re.sub(r'/Users/[^/]+/Projects/wicked-garden/\.claude/worktrees/[^/]+/', './', content)`.
- **Evidence captured** to `docs/evidence/cluster-a-followup-636/`: `help-md-diff.txt` (before/after diff), `pii-grep-post.txt` (0-hit grep proof).

## Scope note

A broader PII sweep of all evidence files (pr-v8-3, pr-v8-4, etc.) found additional `/Users/` paths in other evidence directories. These are pre-existing and out of scope for this surgical fix — recommend a separate follow-up issue.

## Test plan

- [x] `uv run pytest tests/ -q` — 1685 pass / 11 pre-existing failures (unchanged)
- [x] `grep -rEn "/Users/" docs/evidence/cluster-a-p1-smaht-rename/` — 0 hits
- [x] `crew:activity` no longer appears in the smaht domain row in `commands/help.md`
- [x] `crew:activity` no longer appears in the smaht command table in `docs/domains.md`
- [x] `crew:activity` appears in the crew domain row in `commands/help.md`
- [x] `crew:activity` row present in the crew command table in `docs/domains.md`

Closes #640 (cluster-A followups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)