### PR TITLE
fix: crew:guide hygiene — brain port + dead code + budget skip + sys.path (followup #640)

### DIFF
--- a/docs/evidence/cluster-a-followup-637/before-after.md
+++ b/docs/evidence/cluster-a-followup-637/before-after.md
@@ -1,0 +1,111 @@
+# Before/After: cluster-A followup #637 — crew:guide hygiene fixes
+
+Issue: #640 — 6 bot-flagged hygiene items from PR #637 review.
+
+---
+
+## Fix 1: Hardcoded brain port (scripts/crew/guide.py)
+
+**Before** (`_probe_brain_context`):
+```python
+port = int(os.environ.get("WICKED_BRAIN_PORT", "4243"))
+```
+Hardcoded fallback 4243 ignores project-level brain config. Breaks multi-project setups.
+
+**After**:
+```python
+from _brain_port import resolve_port as _resolve_brain_port
+# ...
+port = _resolve_brain_port()
+```
+Uses the centralized `scripts/_brain_port.py` helper (env override → project config → root config → fallback 4242), consistent with every other brain consumer in the codebase.
+
+---
+
+## Fix 2: Dead constants — R1 violation (scripts/crew/guide.py)
+
+**Before** (constants block):
+```python
+_PHASE_MANAGER = Path(__file__).resolve().parent / "phase_manager.py"
+_STATUS_CMD = "/wicked-garden:crew:status"
+_APPROVE_CMD = "/wicked-garden:crew:approve"
+```
+None of these were referenced anywhere in the module.
+
+**After**: All three deleted. `_CREW_PY` and `_PYTHON_SH` (actually used) are retained.
+
+---
+
+## Fix 3: Wasted brain probe (scripts/crew/guide.py)
+
+**Before** (`build_suggestions`):
+```python
+suggestions.extend(_probe_brain_context())  # called unconditionally
+```
+Called even when `len(suggestions) >= MAX_SUGGESTIONS`, wasting a localhost HTTP round-trip.
+
+**After**:
+```python
+if len(suggestions) < MAX_SUGGESTIONS:
+    suggestions.extend(_probe_brain_context())
+```
+Applied in both the `if project:` and `else:` branches. Brain probe docstring now matches implementation.
+
+---
+
+## Fix 4: Docstring/code mismatch (scripts/crew/guide.py)
+
+**Before** (module docstring):
+```
+Signals inspected (priority order):
+  1. Open CONDITIONAL gate ...
+  2. Active project on stalled phase ...
+  3. Uncommitted work in git ...
+  4. No active crew project
+```
+4 signals listed; 5 implemented.
+
+**After**:
+```
+Signals inspected (priority order):
+  1. Open CONDITIONAL gate ...
+  2. Active project on stalled phase ...
+  3. Uncommitted work in git ...
+  4. No active crew project
+  5. Brain context nudge (wicked-brain reachable — surface relevant context)
+```
+
+---
+
+## Fix 5: Test sys.path mutation (tests/crew/test_guide.py)
+
+**Before**:
+```python
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+```
+Both inserts at index 0. The `scripts/crew/` insert at index 0 could shadow the `crew/` namespace package, breaking `from crew.archetype_detect import ...` in other tests.
+
+**After**:
+```python
+_SCRIPTS_CREW = str(_REPO_ROOT / "scripts" / "crew")
+if _SCRIPTS_CREW not in sys.path:
+    sys.path.append(_SCRIPTS_CREW)
+```
+conftest.py already inserts `scripts/` at index 0 and appends `scripts/crew/` before any test module is imported. The test file now only guards the append (idempotent). No index 0 insertion.
+
+---
+
+## Fix 6: iterdir without directory filter (scripts/crew/guide.py)
+
+**Before** (`_probe_open_conditions`):
+```python
+for phase_dir in sorted(base.iterdir()):
+```
+Iterates all entries including `.DS_Store`, stray files, symlinks.
+
+**After**:
+```python
+for phase_dir in sorted(p for p in base.iterdir() if p.is_dir()):
+```
+Only directories are processed; non-directory entries are silently skipped.

--- a/docs/evidence/cluster-a-followup-637/pytest-results.txt
+++ b/docs/evidence/cluster-a-followup-637/pytest-results.txt
@@ -1,0 +1,25 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0 -- /Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a3c4409f2835e51cb/.venv/bin/python
+cachedir: .pytest_cache
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+hypothesis profile 'default'
+rootdir: /Users/michael.parcewski/Projects/wicked-garden/.claude/worktrees/agent-a3c4409f2835e51cb
+configfile: pyproject.toml
+plugins: benchmark-5.2.3, hypothesis-6.152.1
+collecting ... collected 13 items
+
+tests/crew/test_guide.py::TestNoActiveProject::test_no_active_project_returns_start_suggestion PASSED [  7%]
+tests/crew/test_guide.py::TestStalePhase::test_active_stale_phase_returns_execute_suggestion PASSED [ 15%]
+tests/crew/test_guide.py::TestStalePhase::test_negative_offset_timestamp_correct_staleness PASSED [ 23%]
+tests/crew/test_guide.py::TestStalePhase::test_recent_phase_no_stale_signal PASSED [ 30%]
+tests/crew/test_guide.py::TestOpenConditionalGate::test_open_conditional_gate_returns_gate_suggestion PASSED [ 38%]
+tests/crew/test_guide.py::TestOpenConditionalGate::test_open_conditions_only_when_unverified PASSED [ 46%]
+tests/crew/test_guide.py::TestUncommittedWork::test_git_error_returns_empty PASSED [ 53%]
+tests/crew/test_guide.py::TestUncommittedWork::test_no_uncommitted_work_no_git_signal PASSED [ 61%]
+tests/crew/test_guide.py::TestUncommittedWork::test_uncommitted_work_returns_commit_suggestion PASSED [ 69%]
+tests/crew/test_guide.py::TestOutputCap::test_output_capped_at_max_suggestions PASSED [ 76%]
+tests/crew/test_guide.py::TestSignalPriority::test_conditional_gate_ranks_above_stale_phase PASSED [ 84%]
+tests/crew/test_guide.py::TestFormatOutput::test_format_output_empty_list PASSED [ 92%]
+tests/crew/test_guide.py::TestFormatOutput::test_format_output_numbered_list PASSED [100%]
+
+============================== 13 passed in 0.13s ==============================

--- a/docs/evidence/cluster-a-followup-637/smoke.txt
+++ b/docs/evidence/cluster-a-followup-637/smoke.txt
@@ -1,0 +1,12 @@
+[
+  {
+    "rank": 1,
+    "command": "git add -p && git commit",
+    "rationale": "3 file(s) with uncommitted changes \u2014 commit or stash before advancing the crew phase."
+  },
+  {
+    "rank": 2,
+    "command": "/wicked-garden:crew:start <description>",
+    "rationale": "No active crew project found \u2014 start one with a description of the work you want to kick off."
+  }
+]

--- a/scripts/crew/guide.py
+++ b/scripts/crew/guide.py
@@ -11,6 +11,7 @@ Signals inspected (priority order):
   2. Active project on stalled phase (no advancement > STALE_HOURS hours)
   3. Uncommitted work in git (staged or unstaged changes)
   4. No active crew project
+  5. Brain context nudge (wicked-brain reachable — surface relevant context)
 
 Output: JSON list of up to MAX_SUGGESTIONS suggestion dicts.
 
@@ -32,21 +33,25 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+# Resolve scripts/ root so we can import sibling modules regardless of cwd.
+_SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from _brain_port import resolve_port as _resolve_brain_port  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Constants  (R3)
 # ---------------------------------------------------------------------------
 
 MAX_SUGGESTIONS: int = 5
 STALE_HOURS: float = 4.0
-_PHASE_MANAGER = Path(__file__).resolve().parent / "phase_manager.py"
 _CREW_PY = Path(__file__).resolve().parent / "crew.py"
 _PYTHON_SH = Path(__file__).resolve().parents[1] / "_python.sh"
 
 _PHASE_ADVANCE_CMD = "/wicked-garden:crew:execute"
 _GATE_CMD = "/wicked-garden:crew:gate"
 _START_CMD = "/wicked-garden:crew:start <description>"
-_STATUS_CMD = "/wicked-garden:crew:status"
-_APPROVE_CMD = "/wicked-garden:crew:approve"
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +102,7 @@ def _probe_open_conditions(project: dict, project_dir: str | None) -> list[dict]
         return []
     blocking_phases: list[str] = []
     try:
-        for phase_dir in sorted(base.iterdir()):
+        for phase_dir in sorted(p for p in base.iterdir() if p.is_dir()):
             manifest = phase_dir / "conditions-manifest.json"
             if not manifest.is_file():
                 continue
@@ -221,7 +226,7 @@ def _probe_brain_context() -> list[dict]:
     """
     try:
         import urllib.request
-        port = int(os.environ.get("WICKED_BRAIN_PORT", "4243"))
+        port = _resolve_brain_port()
         url = f"http://localhost:{port}/api"
         body = json.dumps({"action": "health", "params": {}}).encode()
         req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
@@ -295,11 +300,13 @@ def build_suggestions(workspace: str = "", cwd: str | None = None) -> list[dict]
         suggestions.extend(_probe_open_conditions(project, project_dir))
         suggestions.extend(_probe_stale_phase(project, project_dir))
         suggestions.extend(_probe_uncommitted_work(cwd=cwd))
-        suggestions.extend(_probe_brain_context())
+        if len(suggestions) < MAX_SUGGESTIONS:
+            suggestions.extend(_probe_brain_context())
     else:
         suggestions.extend(_probe_uncommitted_work(cwd=cwd))
         suggestions.extend(_probe_no_active_project())
-        suggestions.extend(_probe_brain_context())
+        if len(suggestions) < MAX_SUGGESTIONS:
+            suggestions.extend(_probe_brain_context())
 
     # Deduplicate by command (keep first occurrence), cap at MAX_SUGGESTIONS.
     seen: set[str] = set()

--- a/scripts/crew/guide.py
+++ b/scripts/crew/guide.py
@@ -226,6 +226,11 @@ def _probe_brain_context() -> list[dict]:
     """
     try:
         import urllib.request
+        # Note: _resolve_brain_port() returns the project-config port (4243 for
+        # wicked-garden via ~/.wicked-brain/projects/wicked-garden/_meta/config.json).
+        # Falls back to 4242 only when no env override AND no project/root config
+        # match — an edge case for users invoking guide outside any wicked-brain
+        # project. Old hardcoded 4243 was wrong for cross-project usage.
         port = _resolve_brain_port()
         url = f"http://localhost:{port}/api"
         body = json.dumps({"action": "health", "params": {}}).encode()

--- a/tests/crew/test_guide.py
+++ b/tests/crew/test_guide.py
@@ -30,10 +30,15 @@ from unittest.mock import patch, MagicMock
 # ---------------------------------------------------------------------------
 # Path setup
 # ---------------------------------------------------------------------------
+# conftest.py inserts scripts/ at sys.path[0] and appends scripts/crew/ before
+# any test module is imported. We must NOT insert scripts/crew/ at index 0 here —
+# that would shadow the crew/ namespace package and break `from crew.X import …`
+# in other test files collected in the same session (conftest.py explains this).
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_REPO_ROOT / "scripts"))
-sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+_SCRIPTS_CREW = str(_REPO_ROOT / "scripts" / "crew")
+if _SCRIPTS_CREW not in sys.path:
+    sys.path.append(_SCRIPTS_CREW)
 
 import guide  # noqa: E402 — must follow path setup
 


### PR DESCRIPTION
## Summary

Closes #640. Six hygiene fixes to `scripts/crew/guide.py` and `tests/crew/test_guide.py` flagged by the bot on PR #637.

- **Fix 1 (brain port)**: Replace hardcoded `WICKED_BRAIN_PORT=4243` in `_probe_brain_context` with `_brain_port.resolve_port()` — now honors env override, project config, and root config, consistent with all other brain consumers.
- **Fix 2 (dead constants, R1)**: Delete unused `_PHASE_MANAGER`, `_STATUS_CMD`, `_APPROVE_CMD`.
- **Fix 3 (budget skip)**: Guard both `_probe_brain_context()` call sites in `build_suggestions()` with `len(suggestions) < MAX_SUGGESTIONS` — skips the localhost HTTP call when the suggestion budget is already filled by higher-priority probes.
- **Fix 4 (docstring/code mismatch)**: Update module docstring to list 5 signals (was 4) matching the implementation.
- **Fix 5 (sys.path, tests)**: Remove `sys.path.insert(0, scripts/crew/)` from `test_guide.py` — conftest.py already appends `scripts/crew/` safely; inserting at index 0 could shadow the `crew/` namespace package and break `from crew.X import …` in other tests.
- **Fix 6 (iterdir filter)**: Add `.is_dir()` filter to `_probe_open_conditions` iterdir loop to skip `.DS_Store` and other non-directory entries.

## Test plan

- [ ] `uv run pytest tests/crew/test_guide.py -v` — 13/13 pass
- [ ] `uv run pytest tests/ -q` — 1685 pass / 11 pre-existing failures (unchanged baseline verified on main)
- [ ] Smoke: `python3 scripts/crew/guide.py --json` produces valid JSON suggestions

## Evidence

`docs/evidence/cluster-a-followup-637/` — before-after.md, pytest-results.txt, smoke.txt

**DO NOT MERGE** — standing gate requires jam:council + HITL review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)