### PR TITLE
fix: cluster-A late bot findings — cc1, scenarios, evidence, smaht:onboard, qe alias (resolves #648)

### DIFF
--- a/commands/crew/status.md
+++ b/commands/crew/status.md
@@ -69,7 +69,7 @@ Only render `### Phase Progress` when the project has real phase progress to sho
 
 This fires for projects where the topology fallback populated the dict with all-pending entries — showing 9 rows of "pending" is noise, not signal.
 
-When the section is shown, render one row per phase from the actual `phases` dict (do not hardcode clarify/design/qe/build/review):
+When the section is shown, render one row per phase from the actual `phases` dict (do not hardcode clarify/design/test-strategy/build/review):
 
 ```markdown
 ### Phase Progress

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -67,7 +67,6 @@ The "brain" of the plugin. Intercepts every prompt via `UserPromptSubmit` and as
 | `smaht:briefing` | Session briefing — what happened since last time |
 | `smaht:events-import` | Import existing domain JSON records into the event log |
 | `smaht:collaborate` | Multi-AI CLI collaboration (discover, review, council) |
-| `smaht:onboard` | Intelligent codebase onboarding |
 | `smaht:help` | Show available smaht commands |
 
 **Behind the scenes**: four-tier routing keeps simple prompts fast and complex ones thorough:

--- a/docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt
+++ b/docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt
@@ -1,6 +1,6 @@
-././CHANGELOG.md:15:- `smaht:debug` renamed to `smaht:state` — name now reflects what the command does (snapshot + report session state). v5→v6 archaeology section deleted. (cluster-A P1, 2026-04-25)
-././CHANGELOG.md:16:- `smaht:events-query` relocated to `crew:activity` — project-infrastructure command belongs in the crew domain. All cross-references updated. (cluster-A P1, 2026-04-25)
-././CHANGELOG.md:703:- `/wicked-garden:smaht:debug` output shape changed — no more HOT/FAST/SLOW
-././CHANGELOG.md:1134:- feat: `smaht:events-query` command — cross-domain activity queries with --domain, --project, --since, --fts flags
-././docs/v9/audit.md:107:| `smaht:state` | DONE | Renamed from `smaht:debug` (cluster-A P1, 2026-04-25) — name now matches what the command does. | — |
-././docs/v9/audit.md:109:| `crew:activity` | DONE | Relocated from `smaht:events-query` (cluster-A P1, 2026-04-25) — project infrastructure belongs in crew domain. | — |
+./CHANGELOG.md:15:- `smaht:debug` renamed to `smaht:state` — name now reflects what the command does (snapshot + report session state). v5→v6 archaeology section deleted. (cluster-A P1, 2026-04-25)
+./CHANGELOG.md:16:- `smaht:events-query` relocated to `crew:activity` — project-infrastructure command belongs in the crew domain. All cross-references updated. (cluster-A P1, 2026-04-25)
+./CHANGELOG.md:703:- `/wicked-garden:smaht:debug` output shape changed — no more HOT/FAST/SLOW
+./CHANGELOG.md:1134:- feat: `smaht:events-query` command — cross-domain activity queries with --domain, --project, --since, --fts flags
+./docs/v9/audit.md:107:| `smaht:state` | DONE | Renamed from `smaht:debug` (cluster-A P1, 2026-04-25) — name now matches what the command does. | — |
+./docs/v9/audit.md:109:| `crew:activity` | DONE | Relocated from `smaht:events-query` (cluster-A P1, 2026-04-25) — project infrastructure belongs in crew domain. | — |

--- a/docs/evidence/issue-648-late-findings/fixes.json
+++ b/docs/evidence/issue-648-late-findings/fixes.json
@@ -1,0 +1,80 @@
+{
+  "issue": 648,
+  "title": "cluster-A late bot findings — cc1, scenarios, evidence, smaht:onboard, qe alias",
+  "resolved_at": "2026-04-25",
+  "source_prs": ["#629", "#630", "#633", "#642", "#645"],
+  "fixes": [
+    {
+      "id": 1,
+      "source_pr": "#629",
+      "file": "scripts/crew/factor_questionnaire.py",
+      "description": "cc1 wording synced to use 'humans' (was 'specialists') to match cc3 terminology",
+      "change": "Question cc1: 'specialists' → 'humans'"
+    },
+    {
+      "id": 2,
+      "source_pr": "#629",
+      "file": "scripts/crew/factor_questionnaire.py",
+      "description": "u1 calibration note replaced dead 'discovery-conventions audit' reference with concrete observed artifact",
+      "change": "Comment: 'See discovery-conventions audit' → 'Observed in cluster-A P1 smaht rename'"
+    },
+    {
+      "id": 3,
+      "source_pr": "#630",
+      "file": "scenarios/smaht/06-context7-integration.md",
+      "description": "Dead file reference replaced with brain memory citation",
+      "change": "'decision record: cluster-a-workflow-surface-review-v8-decision.md' → 'decision stored in wicked-brain memory: cluster-a-workflow-surface-review-v8-decision'"
+    },
+    {
+      "id": 4,
+      "source_pr": "#630",
+      "file": "scenarios/smaht/06-context7-integration.md",
+      "description": "Validation list made fully past-tense (scenario is retired tombstone)",
+      "change": "Items 2 and 3: 'degrade' → 'degraded', 'can search...has been stored' → 'could search...had been stored'"
+    },
+    {
+      "id": 5,
+      "source_pr": "#633",
+      "file": "docs/evidence/pr-v8-4/council-decision.json",
+      "description": "pr field converted from string to integer",
+      "change": "\"pr\": \"#615\" → \"pr\": 615"
+    },
+    {
+      "id": 6,
+      "source_pr": "#633",
+      "file": "docs/evidence/pr-v8-5/council-decision.json",
+      "description": "vote_count converted from string to structured tally object",
+      "change": "\"vote_count\": \"5-0\" → \"vote_count\": {\"APPROVE\": 5, \"CONDITIONAL\": 0, \"REJECT\": 0}"
+    },
+    {
+      "id": 7,
+      "source_pr": "#633",
+      "file": "docs/evidence/pr-4/council-decision.json",
+      "description": "HITL reason corrected to match actual tally (4 APPROVE / 1 CONDITIONAL, not unanimous)",
+      "change": "'unanimous council with min confidence 0.70: auto-proceed' → '4 APPROVE / 1 CONDITIONAL with min confidence 0.70: quorum met, auto-proceed'"
+    },
+    {
+      "id": 8,
+      "source_pr": "#642",
+      "file": "docs/domains.md",
+      "description": "Duplicate smaht:onboard entry removed; kept the more descriptive first occurrence",
+      "change": "Removed second smaht:onboard row ('Intelligent codebase onboarding') at former line 70"
+    },
+    {
+      "id": 9,
+      "source_pr": "#642",
+      "file": "docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt",
+      "description": "Redundant ./ prefix from PII sanitization collapsed",
+      "change": "All '././' occurrences → './'"
+    },
+    {
+      "id": 10,
+      "source_pr": "#645",
+      "file": "commands/crew/status.md",
+      "description": "Legacy qe phase alias updated to test-strategy in parenthetical example",
+      "change": "'clarify/design/qe/build/review' → 'clarify/design/test-strategy/build/review'"
+    }
+  ],
+  "scope_expansion": "None detected. No sibling factors with the same cc1/cc3 terminology drift found. All other coordination_cost questions (cc2, cc4) use generic language without domain-specific role terms.",
+  "test_baseline": "1685 pass / 11 pre-existing — no test changes expected for doc/comment fixes"
+}

--- a/docs/evidence/pr-4/council-decision.json
+++ b/docs/evidence/pr-4/council-decision.json
@@ -11,7 +11,7 @@
     "dissent_summary": "OpenCode CONDITIONAL: discovery-conventions.md at 324 lines exceeds R5 \u2264200 line limit",
     "hitl": {
       "pause": false,
-      "reason": "unanimous council with min confidence 0.70: auto-proceed",
+      "reason": "4 APPROVE / 1 CONDITIONAL with min confidence 0.70: quorum met, auto-proceed",
       "rule_id": "council.auto-proceed",
       "signals": {
         "vote_count": 5,

--- a/docs/evidence/pr-v8-4/council-decision.json
+++ b/docs/evidence/pr-v8-4/council-decision.json
@@ -1,6 +1,6 @@
 {
   "council_session": "council-pr615-reeval-20260424115554",
-  "pr": "#615",
+  "pr": 615,
   "branch": "v8/pr-4-council-daemon-binary",
   "fixup_commit": "80bfb3a",
   "evaluation_date": "2026-04-24",

--- a/docs/evidence/pr-v8-5/council-decision.json
+++ b/docs/evidence/pr-v8-5/council-decision.json
@@ -56,7 +56,7 @@
   ],
   "agreement_ratio": 1.0,
   "verdict": "APPROVE",
-  "vote_count": "5-0",
+  "vote_count": {"APPROVE": 5, "CONDITIONAL": 0, "REJECT": 0},
   "hitl_rule_id": "gate-reeval-convergent-condition-resolved",
   "hitl_result": "APPROVE \u2014 all conditions met, no new blockers",
   "primary_risk_convergence": "Dual/multiple AC-section heading edge case (first-match-only in _extract_ac_section_slice) \u2014 3/5 models cited; noted for future hardening, not a merge blocker",

--- a/scenarios/smaht/06-context7-integration.md
+++ b/scenarios/smaht/06-context7-integration.md
@@ -15,8 +15,8 @@ status: retired
 # Context7 External Documentation Integration (RETIRED)
 
 > **RETIRED 2026-04-25** — `smaht:learn` and `smaht:libs` were cut in
-> cluster-A P0 (decision record:
-> `cluster-a-workflow-surface-review-v8-decision.md`).
+> cluster-A P0 (decision stored in wicked-brain memory:
+> `cluster-a-workflow-surface-review-v8-decision`).
 > `smaht:learn` duplicated `wicked-brain:ingest`; `smaht:libs` was orphaned
 > by the v8 daemon-first refactor.
 >
@@ -33,8 +33,8 @@ or skills that need it — there is no automatic per-prompt enrichment.
 This scenario validated:
 
 1. Library detection + fetching still worked from the (now cut) `smaht:learn` command
-2. Failures degrade gracefully (missing MCP, timeouts) without stack traces
-3. Brain can search the resulting cheatsheet after it's been stored
+2. Failures degraded gracefully (missing MCP, timeouts) without stack traces
+3. Brain could search the resulting cheatsheet after it had been stored
 
 ## Setup
 

--- a/scripts/crew/factor_questionnaire.py
+++ b/scripts/crew/factor_questionnaire.py
@@ -103,7 +103,7 @@ QUESTIONNAIRE: Dict[str, FactorRubric] = {
         questions=(
             # u1 weight 2 (was 3) — calibrated 2026-04-25 after cluster-A field test:
             # a single visible change should land MEDIUM, not LOW. LOW reading requires
-            # multiple visible surfaces affected. See discovery-conventions audit.
+            # multiple visible surfaces affected. Observed in cluster-A P1 smaht rename.
             Question("u1", "Does this change produce a visible UI change, copy change, or new user-visible flow?", 2),
             Question("u2", "Does this change affect a public API response shape that callers consume directly?", 2),
             Question("u3", "Does this change affect an email, notification, or export format seen by end-users?", 2),
@@ -162,7 +162,7 @@ QUESTIONNAIRE: Dict[str, FactorRubric] = {
     "coordination_cost": FactorRubric(
         name="coordination_cost",
         questions=(
-            Question("cc1", "Does this change require 3 or more specialists to agree before it can ship?", 3),
+            Question("cc1", "Does this change require 3 or more humans to agree before it can ship?", 3),
             Question("cc2", "Does this change require a contract negotiation between two services or teams?", 2),
             # cc3 reworded 2026-04-25 after cluster-A field test: the original "across
             # different specialists" trips YES whenever the facilitator picks 2+ agents,


### PR DESCRIPTION
10 small fixes from issue #648 (late bot findings on cluster-A series). All PRs already merged; this is followup cleanup.

## Fixes

| # | File | Change |
|---|------|--------|
| 1 | `scripts/crew/factor_questionnaire.py` | cc1: 'specialists' → 'humans' (sync with cc3 framing) |
| 2 | `scripts/crew/factor_questionnaire.py` | u1 calibration note: dead 'discovery-conventions audit' ref → 'Observed in cluster-A P1 smaht rename' |
| 3 | `scenarios/smaht/06-context7-integration.md` | Retirement notice: dead .md ref → wicked-brain memory citation |
| 4 | `scenarios/smaht/06-context7-integration.md` | Validation list: mixed-tense → past-tense (matches retired tombstone) |
| 5 | `docs/evidence/pr-v8-4/council-decision.json` | `pr` field: '#615' (str) → 615 (int) |
| 6 | `docs/evidence/pr-v8-5/council-decision.json` | `vote_count` string → structured tally object |
| 7 | `docs/evidence/pr-4/council-decision.json` | HITL reason corrected to match tally (not 'unanimous') |
| 8 | `docs/domains.md` | Duplicate `smaht:onboard` row removed |
| 9 | `docs/evidence/cluster-a-p1-smaht-rename/cross-ref-grep-post.txt` | `././` → `./` (6 occurrences from PR #642 regex bug) |
| 10 | `commands/crew/status.md` | Parenthetical: 'qe' → 'test-strategy' |

## Scope check

Verified no scope expansion — sibling cc questions (cc2, cc4) use generic language and don't need the 'humans' rewording.

## Tests
1685 pass / 11 pre-existing — unchanged (docs + small wording fixes only).

## Standing gate
Awaiting jam:council + HITL review per cluster-A standing rule.

Resolves #648.