### PR TITLE
fix: phase_manager approve UX + native task sync (resolves #650 #653)

### DIFF
--- a/docs/evidence/issue-650-653-phase-manager-approve/test-run.txt
+++ b/docs/evidence/issue-650-653-phase-manager-approve/test-run.txt
@@ -1,0 +1,37 @@
+Test run: issues #650 + #653 bundle
+Branch: fix/650-653-phase-manager-cluster
+Date: 2026-04-25
+
+=== New tests (7 added) ===
+
+TestScoreRequiredInSchema::test_missing_score_raises_schema_error
+  - Pins that validate_gate_result raises GateResultSchemaError with reason
+    containing "score" when score is missing.
+
+TestScoreRequiredInSchema::test_score_present_passes_schema
+  - Pins that a payload with score passes schema validation.
+
+TestScoreRequiredInSchema::test_approve_phase_surfaces_schema_error_not_threshold_error
+  - Regression pin: approve_phase must raise GateResultSchemaError
+    (missing-required-field:score), NOT ValueError("Gate score 0.00 below
+    threshold 0.60") — the old misleading threshold error.
+
+TestSyncGateFindingTask::test_sync_marks_gate_finding_task_completed
+  - A matching gate-finding task (event_type=gate-finding, phase=clarify,
+    chain_id starts with project.phase) is written to status=completed
+    with verdict + score stamped in metadata.
+
+TestSyncGateFindingTask::test_sync_skips_already_completed_tasks
+  - Tasks already completed are not re-written.
+
+TestSyncGateFindingTask::test_sync_no_op_when_no_matching_task
+  - No matching gate-finding task is a silent no-op.
+
+TestSyncGateFindingTask::test_sync_fail_open_no_session_id
+  - Missing CLAUDE_SESSION_ID is a silent no-op (fail-open).
+
+=== Full suite results ===
+
+11 failed, 1696 passed (pre-existing failures: 11 — unchanged)
+Baseline: 1689 passed / 11 failed
+Delta: +7 new passing tests

--- a/scripts/crew/gate_result_schema.py
+++ b/scripts/crew/gate_result_schema.py
@@ -537,7 +537,10 @@ def validate_gate_result(data: Any) -> None:
         _check_verdict_enum(data["result"], field="result")
 
     # AC-3: required fields beyond verdict/result.
-    for required in ("reviewer", "recorded_at"):
+    # ``score`` is required (#650) — a missing score silently became 0.0 in
+    # _validate_min_gate_score and triggered a misleading threshold error.
+    # Catching it here surfaces a clear schema violation at load time.
+    for required in ("reviewer", "recorded_at", "score"):
         if data.get(required) is None:
             raise GateResultSchemaError(
                 f"missing-required-field:{required}",

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3096,6 +3096,119 @@ def _record_complexity_snapshot(complexity: int) -> None:
         logger.debug("[approve] complexity snapshot producer skipped: %s", exc)
 
 
+def _sync_gate_finding_task(
+    state: "ProjectState",
+    phase: str,
+    gate_result: Optional[Dict],
+) -> None:
+    """Sync the native-task gate-finding entry on approve (#653).
+
+    Scans the current session's task store for a task whose metadata
+    matches ``event_type=gate-finding`` AND ``phase=phase`` AND whose
+    ``chain_id`` starts with the project name prefix.  When found, updates
+    the task file to ``status=completed`` and stamps the verdict + score
+    from ``gate_result`` into metadata.
+
+    This closes the dual-record divergence (#653): the DomainStore phase
+    record and the native task chain both reflect the gate outcome.
+
+    Fail-open on every error path — a task-store update failure must
+    never block phase advancement.
+
+    Supported path: direct file write only (not daemon).  The daemon
+    path is intentionally skipped here because ``approve_phase`` runs in
+    the same process as the agent calling TaskUpdate, and the daemon is
+    not a writable API surface for phase_manager (it is read-only).
+    """
+    import os
+
+    project_name = getattr(state, "name", None)
+    if not project_name:
+        return
+
+    # Resolve the chain_id prefix that gate-finding tasks carry for this project.
+    # Pattern: "{project}.{phase}.{gate}" or "{project}.{phase}".
+    # We match any chain_id starting with "{project}.{phase}".
+    expected_chain_prefix = f"{project_name}.{phase}"
+
+    verdict: Optional[str] = None
+    score: Optional[float] = None
+    if gate_result and isinstance(gate_result, dict):
+        verdict = gate_result.get("verdict") or gate_result.get("result")
+        raw_score = gate_result.get("score")
+        if raw_score is not None:
+            try:
+                score = float(raw_score)
+            except (TypeError, ValueError):
+                score = None
+
+    session_id = os.environ.get("CLAUDE_SESSION_ID", "")
+    if not session_id:
+        return
+
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    base = Path(config_dir) if config_dir else Path.home() / ".claude"
+    tasks_dir = base / "tasks" / session_id
+    if not tasks_dir.is_dir():
+        return
+
+    _MAX_TASKS_SCAN: int = 200  # R5: bounded scan — never iterate unbounded task dirs
+
+    try:
+        scanned = 0
+        for entry in tasks_dir.iterdir():
+            if scanned >= _MAX_TASKS_SCAN:
+                break
+            if entry.name.startswith(".") or entry.suffix != ".json":
+                continue
+            scanned += 1
+            try:
+                data = json.loads(entry.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            if data.get("status") == "completed":
+                continue
+
+            meta = data.get("metadata") or {}
+            if not isinstance(meta, dict):
+                continue
+            if meta.get("event_type") != "gate-finding":
+                continue
+            if meta.get("phase") != phase:
+                continue
+            chain_id = meta.get("chain_id", "")
+            if not isinstance(chain_id, str) or not chain_id.startswith(expected_chain_prefix):
+                continue
+
+            # Found a matching gate-finding task — stamp it completed.
+            data["status"] = "completed"
+            if verdict:
+                meta["verdict"] = verdict
+            if score is not None:
+                meta["score"] = score
+            data["metadata"] = meta
+            try:
+                entry.write_text(
+                    json.dumps(data, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                logger.debug(
+                    "[approve] synced gate-finding task %s → completed "
+                    "(phase=%s, verdict=%s, score=%s)",
+                    entry.stem, phase, verdict, score,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "[approve] gate-finding task sync write failed: %s", exc
+                )
+            # At most one gate-finding task per phase — stop after first match.
+            return
+    except Exception as exc:
+        logger.debug("[approve] _sync_gate_finding_task scan error: %s", exc)
+
+
 def _run_build_phase_guard(project_dir: Path) -> List[str]:
     """Run the guard pipeline at build-phase approval (#462, Item 2).
 
@@ -3640,6 +3753,10 @@ def approve_phase(
     phase_state.status = "approved"
     phase_state.approved_at = get_utc_timestamp()
     phase_state.approved_by = approver
+
+    # #653: sync gate-finding task in native chain to completed.
+    # Fail-open — a task-store write failure must never block approval.
+    _sync_gate_finding_task(state, phase, gate_result)
 
     # Emit rich event to unified event log
     try:

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -858,5 +858,225 @@ class TestExecuteCliStub(unittest.TestCase):
             self.assertIn("CLI execute", stderr.getvalue())
 
 
+# ---------------------------------------------------------------------------
+# Issue #650: score field required in gate_result_schema
+# ---------------------------------------------------------------------------
+
+
+class TestScoreRequiredInSchema(unittest.TestCase):
+    """Issue #650: gate_result_schema must reject a payload missing ``score``.
+
+    Previously a missing score silently became 0.0 in _validate_min_gate_score
+    and produced a misleading "Gate score 0.00 below threshold" hard error.
+    The schema now requires ``score`` so the violation surfaces at load time
+    with a clear "missing-required-field:score" reason.
+    """
+
+    def test_missing_score_raises_schema_error(self):
+        """A gate-result without ``score`` raises GateResultSchemaError."""
+        from gate_result_schema import GateResultSchemaError, validate_gate_result
+
+        payload = {
+            "verdict": "APPROVE",
+            "reviewer": "senior-engineer",
+            "recorded_at": "2026-04-25T10:00:00+00:00",
+            # score intentionally omitted
+        }
+        with self.assertRaises(GateResultSchemaError) as cm:
+            validate_gate_result(payload)
+        self.assertIn("score", cm.exception.reason)
+
+    def test_score_present_passes_schema(self):
+        """A gate-result with a valid ``score`` passes schema validation."""
+        from gate_result_schema import validate_gate_result
+
+        payload = {
+            "verdict": "APPROVE",
+            "reviewer": "senior-engineer",
+            "recorded_at": "2026-04-25T10:00:00+00:00",
+            "score": 0.85,
+        }
+        # Must not raise.
+        validate_gate_result(payload)
+
+    def test_approve_phase_surfaces_schema_error_not_threshold_error(self):
+        """approve_phase must surface the schema error (missing score) rather
+        than a misleading threshold error when gate-result.json has no score.
+
+        Regression pin for issue #650: the old code produced "Gate score
+        0.00 below threshold 0.60" because _validate_min_gate_score treated
+        a missing score as 0.0.  The fix raises at schema-validation time.
+        """
+        from gate_result_schema import GateResultSchemaError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir) / "score-proj"
+            phase_dir = project_dir / "phases" / "clarify"
+            phase_dir.mkdir(parents=True)
+
+            # Write a gate-result.json without a score field.
+            (phase_dir / "gate-result.json").write_text(
+                json.dumps({
+                    "verdict": "APPROVE",
+                    "result": "APPROVE",
+                    "reviewer": "senior-engineer",
+                    "recorded_at": "2026-04-25T10:00:00+00:00",
+                    # score omitted
+                })
+            )
+
+            state = _make_state(name="score-proj", rigor_tier="standard")
+            state.current_phase = "clarify"
+            state.phases["clarify"] = pm.PhaseState(
+                status="in_progress",
+                started_at="2026-04-25T00:00:00Z",
+            )
+
+            with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                 patch.object(pm, "_check_addendum_freshness", return_value=None), \
+                 patch.object(pm, "_check_phase_deliverables", return_value=[]), \
+                 patch.object(pm, "_validate_gate_policy_full_rigor"), \
+                 patch.object(pm, "load_phases_config", return_value={
+                     "clarify": {
+                         "gate_required": True,
+                         "depends_on": [],
+                         "blocks_next": True,
+                         "required_deliverables": [],
+                         "min_gate_score": 0.6,
+                     },
+                 }):
+                # Must raise GateResultSchemaError (missing-required-field:score)
+                # NOT ValueError("Gate score 0.00 below threshold 0.60").
+                with self.assertRaises(GateResultSchemaError) as cm:
+                    approve_phase(state, "clarify", approver="test-user")
+
+            self.assertIn("score", cm.exception.reason)
+            # Must NOT be the misleading threshold error message.
+            self.assertNotIn("below", cm.exception.reason)
+
+
+# ---------------------------------------------------------------------------
+# Issue #653: native task gate tracking sync on approve
+# ---------------------------------------------------------------------------
+
+
+class TestSyncGateFindingTask(unittest.TestCase):
+    """Issue #653: approve_phase must sync the gate-finding native task to
+    ``status=completed`` with verdict stamped in metadata.
+
+    The sync is fail-open: if no matching task exists or the write fails,
+    approve_phase continues normally.
+    """
+
+    def _write_task(self, tasks_dir: Path, task_id: str, data: dict) -> Path:
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        p = tasks_dir / f"{task_id}.json"
+        p.write_text(json.dumps(data, indent=2))
+        return p
+
+    def test_sync_marks_gate_finding_task_completed(self):
+        """A matching gate-finding task is updated to completed with verdict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-123"
+
+            gate_task = {
+                "id": "task-gate-1",
+                "subject": "Gate: clarify",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "clarify",
+                    "chain_id": "sync-proj.clarify.code-quality",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-1", gate_task)
+
+            state = _make_state(name="sync-proj")
+            gate_result = {"verdict": "APPROVE", "result": "APPROVE", "score": 0.82}
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-123", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "clarify", gate_result)
+
+            updated = json.loads(task_file.read_text())
+            self.assertEqual(updated["status"], "completed")
+            self.assertEqual(updated["metadata"]["verdict"], "APPROVE")
+            self.assertAlmostEqual(updated["metadata"]["score"], 0.82)
+
+    def test_sync_skips_already_completed_tasks(self):
+        """Tasks already in completed status are not re-written."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-skip"
+            gate_task = {
+                "id": "task-gate-done",
+                "subject": "Gate: design",
+                "status": "completed",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "design",
+                    "chain_id": "skip-proj.design.review",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-done", gate_task)
+            original_mtime = task_file.stat().st_mtime
+
+            state = _make_state(name="skip-proj")
+            gate_result = {"verdict": "REJECT", "result": "REJECT", "score": 0.3}
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-skip", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "design", gate_result)
+
+            # File must NOT have been modified.
+            self.assertEqual(task_file.stat().st_mtime, original_mtime)
+
+    def test_sync_no_op_when_no_matching_task(self):
+        """When no gate-finding task exists for the phase, sync is a no-op."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-noop"
+
+            # A task that does NOT match: different event_type
+            other_task = {
+                "id": "task-other",
+                "subject": "Build: feature",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "coding-task",
+                    "phase": "build",
+                    "chain_id": "noop-proj.build",
+                    "source_agent": "implementer",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-other", other_task)
+            original_mtime = task_file.stat().st_mtime
+
+            state = _make_state(name="noop-proj")
+            gate_result = {"verdict": "APPROVE", "score": 0.9}
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-noop", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "build", gate_result)
+
+            # coding-task file must be untouched.
+            self.assertEqual(task_file.stat().st_mtime, original_mtime)
+
+    def test_sync_fail_open_no_session_id(self):
+        """Missing CLAUDE_SESSION_ID is silently a no-op (fail-open)."""
+        state = _make_state(name="failopen-proj")
+        gate_result = {"verdict": "APPROVE", "score": 0.9}
+        # Remove CLAUDE_SESSION_ID from env; must not raise.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_SESSION_ID"}
+        with patch.dict(os.environ, env, clear=True):
+            pm._sync_gate_finding_task(state, "clarify", gate_result)  # no exception
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **#650**: `gate_result_schema.py` now requires the `score` field at schema-validation time. Previously, a missing `score` silently became `0.0` in `_validate_min_gate_score`, producing a misleading "Gate score 0.00 below threshold" hard error as the *third* sequential output instead of a clear diagnostic. Now a single `GateResultSchemaError("missing-required-field:score")` surfaces at `_load_gate_result` time.
- **#653**: `approve_phase` now calls `_sync_gate_finding_task()` after stamping `phase_state.status="approved"`. The helper scans the current session's native task store for a matching `gate-finding` task (by `event_type`, `phase`, and `chain_id` prefix) and writes `status=completed` with `verdict` + `score` from the gate result — closing the dual-record divergence between DomainStore phase state and the native task chain.

## Changes

| File | Change |
|------|--------|
| `scripts/crew/gate_result_schema.py` | Add `score` to the AC-3 required-fields list in `validate_gate_result` |
| `scripts/crew/phase_manager.py` | Add `_sync_gate_finding_task()` helper; call it from `approve_phase` after phase state is stamped |
| `tests/crew/test_phase_manager.py` | +7 tests: `TestScoreRequiredInSchema` (×3) + `TestSyncGateFindingTask` (×4) |
| `docs/evidence/issue-650-653-phase-manager-approve/test-run.txt` | Test evidence artifact |

## Design decisions

- **score required (not conditional)**: Every reviewer that emits an APPROVE/CONDITIONAL/REJECT must include a numeric score. This is already demanded by the `gate-finding` task metadata contract (Issue #570). Making it required in the schema closes the silent bypass.
- **dispatcher-missing stays as WARN**: The CLI `approve` path deliberately logs a warning and continues because pre-staging a `gate-result.json` is the documented supported path for CLI users. Fail-fast for dispatcher-missing would break all CLI approve flows without a dispatcher injected. The WARN is the right level.
- **_sync_gate_finding_task is fail-open**: Task-store writes are best-effort. A file permission error or missing session must never block phase advancement.
- **Direct file write only**: The daemon path (`WG_DAEMON_ENABLED`) is read-only from `phase_manager`'s perspective. The task file write uses the same direct-file pattern as the rest of the codebase.

## Test plan

- [ ] `TestScoreRequiredInSchema::test_missing_score_raises_schema_error` — schema rejects missing score
- [ ] `TestScoreRequiredInSchema::test_score_present_passes_schema` — valid score passes
- [ ] `TestScoreRequiredInSchema::test_approve_phase_surfaces_schema_error_not_threshold_error` — regression pin: no more "0.00 below threshold" error
- [ ] `TestSyncGateFindingTask::test_sync_marks_gate_finding_task_completed` — matching task is synced
- [ ] `TestSyncGateFindingTask::test_sync_skips_already_completed_tasks` — already-completed tasks untouched
- [ ] `TestSyncGateFindingTask::test_sync_no_op_when_no_matching_task` — no match is silent no-op
- [ ] `TestSyncGateFindingTask::test_sync_fail_open_no_session_id` — missing session ID is silent no-op
- [ ] Full suite: 1696 pass / 11 pre-existing failures unchanged

**Standing gate**: PR + council + HITL — DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)