### PR TITLE
fix: telemetry.py task_files undefined on happy path (resolves #647)

### DIFF
--- a/scripts/delivery/telemetry.py
+++ b/scripts/delivery/telemetry.py
@@ -282,6 +282,10 @@ def capture_session(
         # Task reading routed via _task_reader (#596 v8-PR-2).
         # WG_DAEMON_ENABLED=false → direct file scan (unchanged behaviour).
         tasks: List[Dict[str, Any]] = []
+        # task_files: initialised before try-block so the happy-path (daemon-routed
+        # read_session_tasks) doesn't leave it unbound when sample_window builds
+        # task_files_scanned at line ~325 (issue #647).
+        task_files: List[Path] = []
         try:
             _scripts_root = str(Path(__file__).resolve().parents[1])
             import sys as _sys


### PR DESCRIPTION
Caught by gemini-code-assist bot in late post-merge review on PR #642. **6 of 11 'pre-existing' test failures we've been logging across 10+ session PRs are caused by this single line bug.**

## Bug

`scripts/delivery/telemetry.py` line ~325:
```python
"task_files_scanned": len(task_files),
```

But `task_files` was only assigned in the `except` block (fallback path). When the daemon-routed `read_session_tasks()` succeeds, `task_files` was never bound → `UnboundLocalError: cannot access local variable 'task_files' where it is not associated with a value`.

## Fix

Initialise `task_files: List[Path] = []` before the try block. 1 line of code + 3 lines of comment explaining why.

## Verification

- Before: 11 baseline failures (6 in `tests/delivery/test_telemetry.py`)
- After: 5 baseline failures (telemetry suite green)

## Standing gate

Tiny surgical fix; happy to skip council if HITL agrees, or run quick council if rigor preferred. Recommend skip — the test diff (6 → 0) is the strongest verification possible.

Resolves #647.