### PR TITLE
feat: jam:quick has its own facilitator + slim jam SKILL.md (#652 items 1+2)

### DIFF
--- a/agents/jam/quick-facilitator.md
+++ b/agents/jam/quick-facilitator.md
@@ -1,0 +1,89 @@
+---
+name: quick-facilitator
+subagent_type: wicked-garden:jam:quick-facilitator
+description: |
+  Lightweight single-pass brainstorming facilitator for quick exploration sessions.
+  Use when: rapid gut-check, quick ideation, fast decision support, 60-second perspective sweep.
+
+  <example>
+  Context: Need a quick sanity check on an approach before diving in.
+  user: "Quick thoughts on using feature flags vs config files for toggling behavior."
+  <commentary>Use quick-facilitator for a fast single-round persona sweep with brief synthesis.</commentary>
+  </example>
+model: sonnet
+effort: low
+max-turns: 3
+color: cyan
+allowed-tools: Read
+---
+
+# Quick Facilitator
+
+You run a single-pass focus group: 4 personas, 1 round, one synthesis. Fast and ephemeral.
+
+## Constraints
+
+- EXACTLY 1 round — never extend, regardless of topic complexity
+- EXACTLY 4 personas — no more
+- NO transcript storage — output is ephemeral
+- NO bus events — fire-and-forget session
+- NO multi-AI step — quick sessions are single-model only
+- NO evidence gathering — skip wicked-brain lookups
+- Synthesis: 3-5 sentences maximum
+
+## Session Flow
+
+### 1. Pick 4 Personas
+
+Select 4 personas that best cover the topic's key tensions. Draw from these archetypes:
+
+- Technical: Architect, Debugger, Optimizer
+- User-Focused: Power User, Newcomer, Support Rep
+- Business: Product Manager, Skeptic, Cost Optimizer
+- Process: Maintainer, Tester, Release Manager
+
+Choose for diversity — cover at least 2 different archetype categories. Each persona must have a genuine concern, not a strawman position.
+
+### 2. Single Round
+
+Each persona gives their take in 2-4 sentences:
+
+```
+**[Persona Name]** ({archetype})
+{Position on topic. Key concern or trade-off. One concrete suggestion.}
+```
+
+No back-and-forth. No responses between personas. One pass only.
+
+### 3. Synthesis
+
+After all 4 personas, write a synthesis block. This is the primary deliverable.
+
+```markdown
+## Quick Jam: {Topic}
+
+### Persona Insights
+- **[Persona]**: {one-line takeaway}
+- **[Persona]**: {one-line takeaway}
+- **[Persona]**: {one-line takeaway}
+- **[Persona]**: {one-line takeaway}
+
+### Top Risks
+- {Risk 1 — the most important tension surfaces here}
+- {Risk 2 — second priority concern}
+
+### Recommendations
+1. {Primary recommendation with rationale in one sentence}
+2. {Secondary option or caveat}
+
+### Open Questions
+- {One unresolved question worth tracking if this goes deeper}
+```
+
+Synthesis must include all four fields: `Persona Insights`, `Top Risks`, `Recommendations`, `Open Questions`. This keeps the output shape compatible with brainstorm-facilitator for callers that consume both.
+
+## Rules
+
+- **No padding**: If the answer is obvious after 2 personas, the remaining 2 still speak — but synthesis stays concise
+- **No rounds**: The convergence check from brainstorm-facilitator does not apply here — there is nothing to converge after 1 round
+- **Ephemeral by design**: Callers wanting storage or multi-round depth should use `wicked-garden:jam:brainstorm-facilitator`

--- a/commands/jam/quick.md
+++ b/commands/jam/quick.md
@@ -7,20 +7,14 @@ argument-hint: "<idea or question>"
 
 Quick 60-second exploration with 4 personas and 1 round.
 
-> **Progression**: `quick` (60s gut-check) → `brainstorm` (full session with evidence) → `council` (structured verdict with external LLMs).
-> See also: `/wicked-garden:jam:brainstorm`, `/wicked-garden:jam:council` Still gathers available evidence and stores a lightweight decision record after synthesis.
+> **Progression**: `quick` (60s gut-check, ephemeral) → `brainstorm` (full session with evidence + decision storage) → `council` (structured verdict with external LLMs).
+> See also: `/wicked-garden:jam:brainstorm`, `/wicked-garden:jam:council`
 
 This command uses forced fast convergence: exactly 1 round, then immediately synthesize. Do NOT run additional rounds regardless of topic complexity. The point is speed to outcome.
 
-Delegate to the facilitator agent:
+Delegate to the quick facilitator agent:
 
 ```
-Task(subagent_type="wicked-garden:jam:brainstorm-facilitator",
-     prompt="Run a quick jam session on: {topic}. Use 4 personas, EXACTLY 1 round, then synthesize IMMEDIATELY. Do not run a second round under any circumstances — this is fast convergence mode. Brief synthesis with 2-3 insights max. Still gather evidence if available (but keep it fast — 2 sources max). Store a lightweight decision record after synthesis.
-
-Native-task tracking (fail open on any tool errors):
-1. Session start: TaskCreate(subject='Jam: {topic}', metadata={'event_type':'task','chain_id':'jam-{topic-slug}.root','source_agent':'jam-facilitator','initiative':'{topic-slug}'})
-2. After synthesis and on decision: TaskUpdate(taskId, description='append: Synthesis: {summary}' / 'Decision: {decision_record}')
-
-native task = process, wicked-brain:memory = outcome.")
+Task(subagent_type="wicked-garden:jam:quick-facilitator",
+     prompt="Run a quick jam session on: {topic}")
 ```

--- a/docs/evidence/issue-652-items-1-2/before-after.md
+++ b/docs/evidence/issue-652-items-1-2/before-after.md
@@ -1,0 +1,36 @@
+# Before/After: Issue #652 Items 1+2
+
+## File Sizes
+
+| File | Before | After | Change |
+|------|--------|-------|--------|
+| `agents/jam/quick-facilitator.md` | — (new) | 89 lines | +89 |
+| `agents/jam/brainstorm-facilitator.md` | 305 lines | 305 lines | unchanged |
+| `skills/jam/SKILL.md` | 191 lines | 42 lines | -149 (−78%) |
+| `commands/jam/quick.md` | 26 lines | 21 lines | -5 |
+
+## What Was Removed from SKILL.md
+
+- Persona archetype pool table (lives in `brainstorm-facilitator.md` lines 82-89)
+- Convergence mode table and mechanics (lives in `brainstorm-facilitator.md` lines 96-130)
+- Discussion round details (Round 1/2/3 structure — lives in agent)
+- Synthesis quality section ("Good synthesis / Bad synthesis" — lives in agent)
+- Multi-AI step details (lives in agent, quick-facilitator explicitly omits it)
+- Full native task code blocks (lives in agent and command)
+- wicked-brain integration code blocks (lives in agent)
+- Crew engagement table (crew reads agent frontmatter directly)
+
+## What Was Kept in SKILL.md
+
+- Frontmatter description
+- Session types: 3 one-liner bullets (quick / brainstorm / council)
+- Quick-start dispatch examples (one per session type)
+- Agent cross-references (`quick-facilitator.md`, `brainstorm-facilitator.md`)
+- refs/ cross-references
+
+## Dependency Check
+
+No bidirectional dependency found. `brainstorm-facilitator.md` does not reference
+`SKILL.md` content — all convergence/persona mechanics in the agent are self-contained.
+The SKILL.md archetype table was a duplicate of content already in the agent.
+Safe to remove from SKILL.md.

--- a/docs/evidence/issue-652-items-1-2/pytest-results.txt
+++ b/docs/evidence/issue-652-items-1-2/pytest-results.txt
@@ -1,0 +1,20 @@
+============================= test session info =================================
+branch: feat/652-items-1-2-jam-quick-facilitator
+base: origin/main (b5d05f0)
+run date: 2026-04-25
+
+============================= test results =====================================
+5 failed, 1752 passed, 3 deselected, 15 subtests passed in 17.90s
+
+============================= pre-existing failures (unchanged) ================
+FAILED tests/test_command_aliases.py::TestCrewYoloAliasStub::test_yolo_md_exists
+FAILED tests/test_command_aliases.py::TestCrewYoloAliasStub::test_yolo_md_is_short_stub
+FAILED tests/test_command_aliases.py::TestCrewYoloAliasStub::test_yolo_stub_references_auto_approve
+FAILED tests/test_command_cross_links.py::TestCrewAliasRedirect::test_yolo_mentions_auto_approve
+FAILED tests/test_stub_audit.py::TestStubAudit::test_no_bare_pass_in_scripts_overall
+
+============================= new failures introduced by this PR ===============
+none
+
+============================= verdict =========================================
+PASS — 1752 tests pass, 5 pre-existing failures unchanged, 0 new failures

--- a/docs/evidence/issue-652-items-1-2/smoke-output.md
+++ b/docs/evidence/issue-652-items-1-2/smoke-output.md
@@ -1,0 +1,77 @@
+# Smoke Test Output — Issue #652 Items 1+2
+
+## Test: jam:quick dispatch verification
+
+**Command**: `/wicked-garden:jam:quick "test topic"`
+**Expected agent**: `wicked-garden:jam:quick-facilitator`
+**Actual dispatch**: `wicked-garden:jam:quick-facilitator` ✓
+
+## Structural Assertion Results
+
+### quick-facilitator.md
+```
+[PASS] YAML frontmatter
+[PASS] subagent_type: wicked-garden:jam:quick-facilitator
+[PASS] model: sonnet
+[PASS] effort: low
+[PASS] max-turns: 3
+[PASS] EXACTLY 1 round constraint
+[PASS] EXACTLY 4 personas constraint
+[PASS] NO transcript storage
+[PASS] NO bus events
+[PASS] NO multi-AI step
+[PASS] Persona Insights section in synthesis template
+[PASS] Top Risks section in synthesis template
+[PASS] Recommendations section in synthesis template
+[PASS] Open Questions section in synthesis template
+[PASS] line count <= 120 (actual: 89)
+```
+
+### commands/jam/quick.md dispatch
+```
+[PASS] dispatches wicked-garden:jam:quick-facilitator
+[PASS] does NOT dispatch brainstorm-facilitator
+```
+
+### skills/jam/SKILL.md
+```
+[PASS] line count <= 80 (actual: 42)
+[PASS] references quick-facilitator.md
+[PASS] references brainstorm-facilitator.md
+[PASS] no persona archetype table
+[PASS] no convergence mechanics
+[PASS] no discussion round details
+[PASS] no native task code blocks
+[PASS] session types present (quick / brainstorm / council)
+```
+
+## Sample Output Shape
+
+The quick-facilitator agent produces this synthesis structure for topic
+"Should we use SQLite or flat JSON for local plugin state?":
+
+```markdown
+## Quick Jam: SQLite vs flat JSON for local plugin state
+
+### Persona Insights
+- **Technical Architect**: SQLite gives schema + query power but adds binary dep risk
+- **Newcomer**: JSON is readable and debuggable without tooling
+- **Product Manager**: SQLite scales to thousands of records; JSON risks corruption on partial writes
+- **Maintainer**: JSON files are easier to version-control and diff; SQLite needs tooling
+
+### Top Risks
+- SQLite binary corruption on partial writes is rare but hard to recover from
+- Flat JSON becomes unwieldy past ~500 records and concurrent-write unsafe
+
+### Recommendations
+1. Use SQLite for domains needing query/search (crew history, mem store) — the FTS5 payoff justifies the dependency
+2. Keep flat JSON for small, rarely-updated config (plugin settings, session flags) where human readability matters
+
+### Open Questions
+- What is the actual record-count ceiling where JSON becomes a bottleneck in practice?
+```
+
+## Result
+
+Smoke test: **ok**
+All 4 synthesis fields present. Single-round constraint enforced. No storage calls. No bus events.

--- a/scenarios/jam/quick-facilitator-shape.md
+++ b/scenarios/jam/quick-facilitator-shape.md
@@ -1,0 +1,123 @@
+---
+id: jam-quick-facilitator-shape
+title: jam:quick dispatches quick-facilitator and produces correct synthesis shape
+tags: [jam, quick, synthesis-shape, context-budget]
+complexity: 2
+---
+
+# Scenario: jam:quick Facilitator Shape
+
+Verify that `jam:quick` dispatches `wicked-garden:jam:quick-facilitator` (not `brainstorm-facilitator`)
+and that the output synthesis block has the required fields at lower token cost.
+
+## Setup
+
+No special setup required. This scenario runs against the live plugin.
+
+## Steps
+
+### Step 1 — Dispatch jam:quick
+
+Run:
+```
+/wicked-garden:jam:quick "Should we use SQLite or a flat JSON file for local plugin state?"
+```
+
+### Step 2 — Assert: correct agent dispatched
+
+The Task tool call must use `subagent_type="wicked-garden:jam:quick-facilitator"`.
+
+**FAIL** if `brainstorm-facilitator` appears in the dispatch.
+
+### Step 3 — Assert: synthesis block present
+
+The output must contain a section matching:
+
+```markdown
+## Quick Jam: {topic}
+
+### Persona Insights
+### Top Risks
+### Recommendations
+### Open Questions
+```
+
+All four headings must be present. **FAIL** if any heading is missing.
+
+### Step 4 — Assert: field shape matches brainstorm-facilitator
+
+The synthesis block must include all four fields that brainstorm-facilitator also produces:
+
+| Field | quick-facilitator | brainstorm-facilitator |
+|-------|-------------------|------------------------|
+| Persona Insights | required | Key Insights section |
+| Top Risks | required | Open Questions / risk items |
+| Recommendations | required | Action Items |
+| Open Questions | required | Open Questions |
+
+Callers consuming both agents can map fields without branching. **FAIL** if any field is absent.
+
+### Step 5 — Assert: exactly 4 personas
+
+Count `**[Name]** ({archetype})` patterns in the output. Must equal 4. **FAIL** if fewer or more.
+
+### Step 6 — Assert: single round only
+
+The output must NOT contain any of these markers:
+- `Round 2`
+- `Building & Responding`
+- `Second round`
+- `Convergence check`
+
+**FAIL** if any multi-round marker is present.
+
+### Step 7 — Assert: no storage calls
+
+The output must NOT contain:
+- `save_transcript.py`
+- `wicked-brain:memory` store calls
+- `EventStore.append`
+- `wicked-bus emit`
+
+**FAIL** if any storage or event emission appears.
+
+### Step 8 — Assert: wall time < 30s
+
+Record start time before dispatch. Synthesis must arrive within 30 seconds.
+
+**WARN** (not FAIL) if between 30-60s. **FAIL** if > 60s.
+
+### Step 9 — Token cost comparison (rough check)
+
+Run the same topic through `brainstorm-facilitator` with 1 forced round as a baseline.
+Compare total output character count (proxy for token cost):
+
+- quick-facilitator output chars: `N_quick`
+- brainstorm-facilitator output chars: `N_full`
+
+**PASS** if `N_quick < N_full * 0.5` (quick costs less than 50% of brainstorm).
+**WARN** if between 50-70%.
+**FAIL** if quick output is larger than brainstorm output.
+
+## Expected Outcome
+
+```
+PASS: correct agent dispatched
+PASS: synthesis block present with all 4 headings
+PASS: field shape matches brainstorm-facilitator contract
+PASS: exactly 4 personas
+PASS: single round only
+PASS: no storage calls
+PASS: wall time < 30s
+PASS: token cost < 50% of brainstorm-facilitator
+```
+
+## Failure Modes
+
+| Failure | Diagnosis |
+|---------|-----------|
+| Wrong agent dispatched | commands/jam/quick.md still references brainstorm-facilitator |
+| Missing synthesis heading | quick-facilitator output format diverged from spec |
+| Round 2 present | Agent ignored the single-round constraint |
+| Storage calls present | Agent carried over brainstorm-facilitator behavior |
+| Token cost > 50% | Agent loaded too much context or added rounds |

--- a/skills/jam/SKILL.md
+++ b/skills/jam/SKILL.md
@@ -2,9 +2,10 @@
 name: jam
 description: |
   Orchestrates AI-powered brainstorming sessions with dynamic focus groups.
+  quick sessions are ephemeral (no storage). brainstorm and council sessions
+  are tracked as native tasks (process) and stored in wicked-brain:memory (outcome).
   Use when: "brainstorm this", "explore ideas", "get different perspectives",
   "focus group", "what do you think about", "pros and cons", "quick check".
-  Sessions are tracked as native tasks (process) and stored in wicked-brain:memory (outcome).
 context: fork
 ---
 

--- a/skills/jam/SKILL.md
+++ b/skills/jam/SKILL.md
@@ -2,12 +2,9 @@
 name: jam
 description: |
   Orchestrates AI-powered brainstorming sessions with dynamic focus groups.
-  This skill should be used when the user wants to brainstorm, explore ideas,
-  get feedback on concepts, or run a focus group discussion.
-  Sessions are tracked as native tasks (process) and stored in wicked-brain:memory (outcome).
-
   Use when: "brainstorm this", "explore ideas", "get different perspectives",
-  "focus group", "what do you think about", "pros and cons"
+  "focus group", "what do you think about", "pros and cons", "quick check".
+  Sessions are tracked as native tasks (process) and stored in wicked-brain:memory (outcome).
 context: fork
 ---
 
@@ -15,177 +12,31 @@ context: fork
 
 Generate diverse perspectives through structured focus group sessions.
 
-## When to Use
-
-- User wants to explore an idea
-- Decision needs multiple viewpoints
-- Problem needs creative approaches
-- User says "brainstorm", "perspectives", "focus group", "what do you think about"
-
 ## Session Types
 
-### Full Brainstorm (`/brainstorm`)
+- **quick** (`/wicked-garden:jam:quick`) — 4 personas, 1 forced round, brief synthesis. Ephemeral. Best for gut-checks and rapid exploration.
+- **brainstorm** (`/wicked-garden:jam:brainstorm`) — 4-6 personas, 2-3 rounds, evidence gathering, decision record storage. Best for important decisions and complex problems.
+- **council** (`/wicked-garden:jam:council`) — Structured verdict with external LLMs. Best for high-stakes calls requiring external challenge.
 
-- 4-6 personas
-- 2-3 discussion rounds
-- Full synthesis with insights
-- Storage offered
-
-Best for: Important decisions, complex problems, strategic thinking
-
-### Quick Jam (`/jam`)
-
-- 4 personas
-- 1 round (forced — never extends)
-- Brief synthesis (2-3 insights max)
-- No storage prompt
-
-Best for: Quick decisions, gut checks, rapid exploration
-
-### Perspectives Only (`/perspectives`)
-
-- 4-6 personas
-- 1 round
-- No synthesis (user decides)
-- Raw viewpoints
-
-Best for: Gathering input, self-directed thinking, discussion prep
-
-## Persona Design
-
-### Archetypes
-
-| Type | Focus | Examples |
-|------|-------|----------|
-| Technical | How it works | Architect, Debugger, Security |
-| User | Who uses it | Power User, Newcomer, Support |
-| Business | Why it matters | PM, Skeptic, Evangelist |
-| Process | How it ships | Maintainer, Tester, Ops |
-
-### Selection Principles
-
-1. **Relevance**: Choose personas that care about the topic
-2. **Diversity**: Cover multiple angles
-3. **Genuine**: Each has legitimate concerns (no strawmen)
-4. **Buildable**: Personas can respond to each other
-
-## Convergence Modes
-
-| Mode | Flag | Behavior |
-|------|------|----------|
-| Normal | (default) | Run all planned rounds, then synthesize |
-| Fast | `--converge fast` | After each round, check if signal is sufficient; skip remaining rounds if yes |
-
-Fast convergence checks three criteria after each round: (1) at least 2 actionable insights, (2) directional agreement, (3) tensions are well-characterized. If all pass, synthesis begins immediately.
-
-Quick jam (`/jam`) always uses forced fast convergence (1 round, then synthesize).
-
-## Discussion Dynamics
-
-### Round 1: Initial Perspectives
-
-Each persona shares their view:
-- Position on the topic
-- Key concern
-- Suggestion or consideration
-
-*Convergence check (fast mode: synthesize if criteria met)*
-
-### Round 2: Building
-
-Personas respond to each other:
-- Build on good ideas
-- Challenge assumptions
-- Find connections
-
-*Convergence check (fast mode: synthesize if criteria met)*
-
-### Round 3: Convergence (optional)
-
-Find common ground:
-- Agreements
-- Remaining tensions
-- Key tradeoffs
-
-## Synthesis Quality
-
-Good synthesis:
-- **3-5 insights** (not 10)
-- **Confidence levels** (HIGH/MEDIUM/LOW)
-- **Action items** (prioritized)
-- **Open questions** (honest about unknowns)
-
-Bad synthesis:
-- Just summarizing what personas said
-- Too many insights (information overload)
-- No confidence assessment
-- No actionable next steps
-
-## Integration
-
-### With wicked-brain
-
-At session start:
-```python
-prior = mem_recall(topic)  # via wicked-brain:memory (recall mode)
-inject_context(prior)
-```
-
-At session end:
-```python
-if user_approves:
-    mem_store(insights, type="decision", tags=[topic])  # via wicked-brain:memory (store mode)
-```
-
-### With native tasks
-
-Sessions are tracked as native tasks for process visibility:
+## Quick-Start
 
 ```
-# On session start
-TaskCreate(
-  subject="Jam: {topic}",
-  metadata={
-    "event_type": "task",
-    "chain_id": "jam-{topic-slug}.root",
-    "source_agent": "jam-facilitator",
-    "initiative": "{topic-slug}"
-  }
-)
+# Fast gut-check (ephemeral, ~60s)
+/wicked-garden:jam:quick "Should we use feature flags or config files here?"
 
-# After each persona round — append to description
-TaskUpdate(taskId, description="{previous}\n\n{persona_name}: {key_insight}")
+# Full session with evidence and decision storage
+/wicked-garden:jam:brainstorm "Architecture approach for the new event bus"
 
-# After synthesis
-TaskUpdate(taskId, description="{previous}\n\nSynthesis: {summary}")
-
-# On decision
-TaskUpdate(taskId, description="{previous}\n\nDecision: {decision_record}")
+# High-stakes council with external LLM challenge
+/wicked-garden:jam:council "Go/no-go on the v9 storage migration"
 ```
 
-Wrap all task calls in graceful degradation — if TaskCreate/TaskUpdate fail, skip silently.
-Native tasks track process; wicked-brain:memory stores outcomes. Both can coexist.
+## Agents
 
-### With wicked-crew
-
-Called during clarify, design, and build phases. See "Crew Engagement" section below.
-
-## Crew Engagement
-
-| Phase | Mode | When |
-|-------|------|------|
-| Clarify | Quick jam (4 personas, 1 round) | Approach options, framing decisions |
-| Design | Full brainstorm (4-6 personas, 2-3 rounds) | Architecture decisions, complex tradeoffs |
-| Build checkpoint | Quick jam | Course corrections when unexpected complexity arises |
-
-Jam auto-engages when: ambiguity detected, complexity >= 4, architecture signals present,
-or content/documentation-heavy scope.
+- `agents/jam/quick-facilitator.md` — single-pass, 4 personas, no storage, no bus events
+- `agents/jam/brainstorm-facilitator.md` — multi-round, evidence gathering, transcript storage, decision record
 
 ## References
 
-- `refs/facilitation-patterns.md` — Match persona archetypes to problem types; session length guidance; anti-patterns to avoid
-- `refs/synthesis-patterns.md` — Synthesis structure, quality checklist, techniques (non-obvious connections, surprising agreements, productive tensions), decision record format, examples
-
-## Output Structure
-
-Synthesis-first: `## Brainstorm: {Topic}` → `### Key Insights` (read first) → `### Action Items` → `### Open Questions` → `### Session Details` (personas, rounds, summary).
+- `refs/facilitation-patterns.md` — persona archetype pool, session length guidance, anti-patterns
+- `refs/synthesis-patterns.md` — synthesis structure, quality checklist, decision record format


### PR DESCRIPTION
## Summary

- **Item 1**: Add `agents/jam/quick-facilitator.md` (89 lines, ceiling 120). Single-pass agent: 4 personas, 1 round, no transcript storage, no bus events, no multi-AI step. Synthesis shape (`Persona Insights / Top Risks / Recommendations / Open Questions`) is compatible with `brainstorm-facilitator` for caller interchangeability.
- **Item 2**: Slim `skills/jam/SKILL.md` from 191 → 42 lines. Removed persona archetype pool, convergence mechanics, round details, and native-task code blocks — all of which already live in the agent files. Kept: session-types summary (3 bullets), quick-start dispatch examples, agent cross-refs.
- Wire: `commands/jam/quick.md` now dispatches `wicked-garden:jam:quick-facilitator` instead of `brainstorm-facilitator`. Stale progression-note text updated.
- Scenario: `scenarios/jam/quick-facilitator-shape.md` asserts correct dispatch, synthesis shape parity, 4-persona count, single-round constraint, no-storage, wall-time <30s, token cost <50% vs brainstorm-facilitator.

## Evidence

- `docs/evidence/issue-652-items-1-2/before-after.md` — size table + dependency check
- `docs/evidence/issue-652-items-1-2/smoke-output.md` — structural assertions (all PASS) + sample output shape
- `docs/evidence/issue-652-items-1-2/pytest-results.txt` — 1752 pass / 5 pre-existing

## Test plan

- [ ] Confirm `jam:quick` dispatches `quick-facilitator`, not `brainstorm-facilitator`
- [ ] Confirm synthesis output contains all 4 required fields
- [ ] Confirm no transcript storage or bus events in quick-facilitator output
- [ ] Run `pytest tests/` — expect 1752 pass / 5 pre-existing (yolo stub + bare-pass, unrelated)
- [ ] Run `scenarios/jam/quick-facilitator-shape` scenario end-to-end

## Gate

Standing merge gate applies: jam:council + HITL. **DO NOT MERGE** without council review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)