### PR TITLE
fix: v8.3.x/v8.4.x post-merge polish bundle (resolves #667 #669)

### DIFF
--- a/agents/crew/gate-evaluator.md
+++ b/agents/crew/gate-evaluator.md
@@ -76,6 +76,6 @@ Your final message MUST end with a fenced JSON block:
 ## Failure Modes
 
 - Missing required deliverable → `verdict: REJECT`, `reason: "missing-deliverable: <name>"`.
-- Zero-byte deliverable → `verdict: REJECT`, `reason: "deliverable-too-small: <name>"`.
+- Zero-byte deliverable → `verdict: REJECT`, `reason: "executor-deliverable-too-small: <name>"`.
 - Banned reviewer authored a prior gate-result → `verdict: REJECT`, `reason: "banned-reviewer"`.
 - Ambiguous or subjective call → `verdict: CONDITIONAL` with explicit conditions.

--- a/agents/crew/phase-executor.md
+++ b/agents/crew/phase-executor.md
@@ -267,7 +267,7 @@ you write:
   phase-start bookend without producing deliverables. Halting with a named error is
   correct; silently returning `status: "ok"` with `files_written: []` is not.
 - **Deliverable outside `phases/{phase}/`** → rejected as `"deliverable-out-of-scope"`.
-- **Zero-byte deliverable** → rejected as `"deliverable-too-small"`.
+- **Zero-byte deliverable** → rejected as `"executor-deliverable-too-small"`.
 - **Addendum validator rejects record** → `"addendum-invalid: <reason>"`.
 - **`parallelization_check` missing with multi-sub-task run** → `"parallelization-check-missing"`.
 

--- a/agents/jam/quick-facilitator.md
+++ b/agents/jam/quick-facilitator.md
@@ -29,7 +29,9 @@ You run a single-pass focus group: 4 personas, 1 round, one synthesis. Fast and 
 - NO bus events — fire-and-forget session
 - NO multi-AI step — quick sessions are single-model only
 - NO evidence gathering — skip wicked-brain lookups
-- Synthesis: 3-5 sentences maximum
+- Synthesis: concise per section, target ≤200 words total (#669 — the 3-5 sentence
+  cap was inconsistent with the section template below; word budget is the actual
+  constraint)
 
 ## Session Flow
 
@@ -62,25 +64,26 @@ After all 4 personas, write a synthesis block. This is the primary deliverable.
 ```markdown
 ## Quick Jam: {Topic}
 
-### Persona Insights
+### Key Insights
 - **[Persona]**: {one-line takeaway}
 - **[Persona]**: {one-line takeaway}
 - **[Persona]**: {one-line takeaway}
 - **[Persona]**: {one-line takeaway}
 
-### Top Risks
-- {Risk 1 — the most important tension surfaces here}
-- {Risk 2 — second priority concern}
-
-### Recommendations
-1. {Primary recommendation with rationale in one sentence}
-2. {Secondary option or caveat}
+### Action Items
+1. {Primary recommendation with rationale in one sentence — fold the most
+   important risk/tension into this item}
+2. {Secondary option, caveat, or follow-up}
 
 ### Open Questions
 - {One unresolved question worth tracking if this goes deeper}
 ```
 
-Synthesis must include all four fields: `Persona Insights`, `Top Risks`, `Recommendations`, `Open Questions`. This keeps the output shape compatible with brainstorm-facilitator for callers that consume both.
+Synthesis must include exactly these three sections: `Key Insights`,
+`Action Items`, `Open Questions`. Heading vocabulary matches
+`brainstorm-facilitator` (#669 fix) so callers consuming either agent can read
+the same field names without branching. Risk/tension framing belongs inside
+Action Items, not in a separate section.
 
 ## Rules
 

--- a/scenarios/jam/quick-facilitator-shape.md
+++ b/scenarios/jam/quick-facilitator-shape.md
@@ -1,6 +1,10 @@
 ---
-id: jam-quick-facilitator-shape
+name: quick-facilitator-shape
 title: jam:quick dispatches quick-facilitator and produces correct synthesis shape
+description: Verify jam:quick dispatches the lightweight quick-facilitator (not brainstorm-facilitator) and emits the canonical 3-section synthesis shape (Key Insights / Action Items / Open Questions) shared with brainstorm-facilitator.
+type: workflow
+difficulty: basic
+estimated_minutes: 3
 tags: [jam, quick, synthesis-shape, context-budget]
 complexity: 2
 ---
@@ -36,26 +40,26 @@ The output must contain a section matching:
 ```markdown
 ## Quick Jam: {topic}
 
-### Persona Insights
-### Top Risks
-### Recommendations
+### Key Insights
+### Action Items
 ### Open Questions
 ```
 
-All four headings must be present. **FAIL** if any heading is missing.
+All three headings must be present. **FAIL** if any heading is missing.
 
 ### Step 4 — Assert: field shape matches brainstorm-facilitator
 
-The synthesis block must include all four fields that brainstorm-facilitator also produces:
+The synthesis block must include the same three section headings that
+`brainstorm-facilitator` produces — the heading vocabulary is the contract:
 
 | Field | quick-facilitator | brainstorm-facilitator |
 |-------|-------------------|------------------------|
-| Persona Insights | required | Key Insights section |
-| Top Risks | required | Open Questions / risk items |
-| Recommendations | required | Action Items |
-| Open Questions | required | Open Questions |
+| Key Insights | required | required |
+| Action Items | required | required |
+| Open Questions | required | required |
 
-Callers consuming both agents can map fields without branching. **FAIL** if any field is absent.
+Heading parity (#669 fix): callers consuming either agent read the same field
+names without branching. **FAIL** if any section heading is absent or renamed.
 
 ### Step 5 — Assert: exactly 4 personas
 
@@ -81,11 +85,14 @@ The output must NOT contain:
 
 **FAIL** if any storage or event emission appears.
 
-### Step 8 — Assert: wall time < 30s
+### Step 8 — Assert: wall time < 60s
 
-Record start time before dispatch. Synthesis must arrive within 30 seconds.
+Record start time before dispatch. Synthesis must arrive within 60 seconds —
+the documented "60-second flow" budget for `jam:quick` (#669 fix; the prior
+30-second threshold was a self-inflicted false-FAIL risk because real-world
+single-pass model latency can spike past 30s without indicating a regression).
 
-**WARN** (not FAIL) if between 30-60s. **FAIL** if > 60s.
+**WARN** if between 30-60s. **FAIL** if > 60s.
 
 ### Step 9 — Token cost comparison (rough check)
 
@@ -103,12 +110,12 @@ Compare total output character count (proxy for token cost):
 
 ```
 PASS: correct agent dispatched
-PASS: synthesis block present with all 4 headings
+PASS: synthesis block present with all 3 headings
 PASS: field shape matches brainstorm-facilitator contract
 PASS: exactly 4 personas
 PASS: single round only
 PASS: no storage calls
-PASS: wall time < 30s
+PASS: wall time < 60s
 PASS: token cost < 50% of brainstorm-facilitator
 ```
 

--- a/scripts/crew/verification_protocol.py
+++ b/scripts/crew/verification_protocol.py
@@ -108,6 +108,34 @@ class VerificationReport:
 # Utilities
 # ---------------------------------------------------------------------------
 
+def _phases_with_required_deliverables() -> set:
+    """Return the set of phase names that declare at least one required deliverable.
+
+    Reads .claude-plugin/phases.json directly so the list stays in sync as new
+    phases are added (#667 follow-up — replaces the previous hardcoded
+    {"clarify", "design", "build"} set in check_traceability that omitted
+    "ideate" and any future phases). Falls back to the historical hardcoded
+    set if phases.json is missing or unreadable, preserving prior behavior.
+    """
+    fallback = {"clarify", "design", "build"}
+    try:
+        # .claude-plugin/ sits at the plugin root, two parents above scripts/crew/.
+        phases_json = Path(__file__).resolve().parents[2] / ".claude-plugin" / "phases.json"
+        if not phases_json.exists():
+            return fallback
+        with phases_json.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        phases = data.get("phases", {})
+        result = {
+            name
+            for name, cfg in phases.items()
+            if isinstance(cfg, dict) and cfg.get("required_deliverables")
+        }
+        return result or fallback
+    except Exception:  # noqa: BLE001 — fail-safe: traceability check still runs
+        return fallback
+
+
 def _run_command(
     cmd: List[str],
     cwd: Optional[str] = None,
@@ -850,8 +878,11 @@ def check_traceability(
 
     # Check for broken chains: criteria with no build task linkage
     # Also verify that deliverable directories exist for each phase
+    # that declares required_deliverables in phases.json (#667 follow-up:
+    # was a hardcoded {"clarify", "design", "build"} set, now derived from
+    # phases.json so phases like "ideate" and any future phases are covered).
     phase_dirs = [d.name for d in phases_dir.iterdir() if d.is_dir()]
-    expected_phases = {"clarify", "design", "build"}
+    expected_phases = _phases_with_required_deliverables()
     missing_phases = expected_phases - set(phase_dirs)
 
     if missing_phases:

--- a/scripts/delivery/telemetry.py
+++ b/scripts/delivery/telemetry.py
@@ -64,6 +64,13 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_ROOT))
 
+# SCHEMA_VERSION intentionally remains at "1" through v8.3.x — see #667.
+# PR #663 renamed sample_window.task_files_scanned -> tasks_observed, but the
+# deprecated alias (also written into timeline.jsonl) preserves wire compat for
+# any consumer reading the old field name. Because the change is non-breaking
+# from a consumer's perspective, the schema version is held at "1" rather than
+# bumped to "1.1". Drop the alias (and bump the version) only when the old
+# field name is removed entirely.
 SCHEMA_VERSION = "1"
 # Per-session capture worst-case budget. We bail out rather than block session-end.
 _CAPTURE_BUDGET_SECONDS = 0.5

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -13,6 +13,7 @@ All tests are deterministic (no wall-clock, no random, no sleep).
 Stdlib-only.
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -1022,9 +1023,12 @@ class TestSyncGateFindingTask(unittest.TestCase):
                 },
             }
             task_file = self._write_task(tasks_dir, "task-gate-done", gate_task)
-            # Capture original content for comparison — avoids st_mtime flakiness
-            # on coarse-mtime filesystems (#660).
-            original_content = json.loads(task_file.read_text(encoding="utf-8"))
+            # Capture original bytes for comparison — avoids st_mtime flakiness
+            # on coarse-mtime filesystems (#660). Byte-level (sha256) rather
+            # than json.loads() equality so a formatting-only rewrite (#667)
+            # would also fail this assertion.
+            original_bytes = task_file.read_bytes()
+            original_sha = hashlib.sha256(original_bytes).hexdigest()
 
             state = _make_state(name="skip-proj")
             gate_result = {"verdict": "REJECT", "result": "REJECT", "score": 0.3}
@@ -1035,9 +1039,14 @@ class TestSyncGateFindingTask(unittest.TestCase):
             ):
                 pm._sync_gate_finding_task(state, "design", gate_result)
 
-            # File content must NOT have changed — already-completed task is skipped.
-            after_content = json.loads(task_file.read_text(encoding="utf-8"))
-            self.assertEqual(after_content, original_content)
+            # File bytes must NOT have changed — already-completed task is skipped.
+            after_bytes = task_file.read_bytes()
+            self.assertEqual(
+                hashlib.sha256(after_bytes).hexdigest(),
+                original_sha,
+                "task file was rewritten on a no-op path; even formatting-only "
+                "rewrites (whitespace, key order) would fail this byte check.",
+            )
 
     def test_sync_no_op_when_no_matching_task(self):
         """When no gate-finding task exists for the phase, sync is a no-op."""
@@ -1057,9 +1066,12 @@ class TestSyncGateFindingTask(unittest.TestCase):
                 },
             }
             task_file = self._write_task(tasks_dir, "task-other", other_task)
-            # Capture original content for comparison — avoids st_mtime flakiness
-            # on coarse-mtime filesystems (#660).
-            original_content = json.loads(task_file.read_text(encoding="utf-8"))
+            # Capture original bytes for comparison — avoids st_mtime flakiness
+            # on coarse-mtime filesystems (#660). Byte-level (sha256) rather
+            # than json.loads() equality so a formatting-only rewrite (#667)
+            # would also fail this assertion.
+            original_bytes = task_file.read_bytes()
+            original_sha = hashlib.sha256(original_bytes).hexdigest()
 
             state = _make_state(name="noop-proj")
             gate_result = {"verdict": "APPROVE", "score": 0.9}
@@ -1070,9 +1082,14 @@ class TestSyncGateFindingTask(unittest.TestCase):
             ):
                 pm._sync_gate_finding_task(state, "build", gate_result)
 
-            # coding-task file content must be unchanged — wrong event_type, no match.
-            after_content = json.loads(task_file.read_text(encoding="utf-8"))
-            self.assertEqual(after_content, original_content)
+            # coding-task file bytes must be unchanged — wrong event_type, no match.
+            after_bytes = task_file.read_bytes()
+            self.assertEqual(
+                hashlib.sha256(after_bytes).hexdigest(),
+                original_sha,
+                "non-matching task file was rewritten; even formatting-only "
+                "rewrites (whitespace, key order) would fail this byte check.",
+            )
 
     def test_sync_gate_result_none_does_not_close_pending_task(self):
         """gate_result=None must not close any gate-finding task (#660).

--- a/tests/delivery/test_telemetry.py
+++ b/tests/delivery/test_telemetry.py
@@ -176,9 +176,16 @@ class TelemetryCaptureTests(unittest.TestCase):
         regardless of path so the metric correctly reports how many tasks were
         actually observed.
 
-        This test exercises the direct-file-scan fallback (the test harness does
-        not install the daemon reader), confirming that the metric equals the
-        number of written task files.
+        How this test exercises the metric (#667 follow-up clarification):
+        telemetry.capture_session() always imports crew._task_reader.read_session_tasks
+        and calls it first. Under unit-test conditions no daemon is running, so
+        read_session_tasks returns an empty list and the function falls through
+        to the direct-file-scan path that reads ${tasks_dir}/*.json. The 3 task
+        files we write below are read by that fallback path. The assertion still
+        proves the bug fix because both the daemon path and the direct-scan path
+        flow through the same len(tasks) computation — the regression we are
+        guarding against (len(task_files) instead of len(tasks)) would surface
+        the same way on either path. Test name preserved for traceability to #660.
         """
         # Write 3 task files in the direct-scan path.
         for i in range(3):


### PR DESCRIPTION
## Summary

Bundles 10 post-merge bot findings from PR #663 (#667) and PR #666 (#669)
into one polish PR. Same late-bot-comment sweep pattern that previously
caught #647 — bots post real findings AFTER the merge button is hit and
they age out of attention if not captured. This drains the polish-issue
backlog from this arc.

## #667 — PR #663 follow-up (5 fixes)

- **F1 — SCHEMA_VERSION rationale:** Added a comment in `scripts/delivery/telemetry.py` explaining why the version stays at `"1"` despite the `task_files_scanned → tasks_observed` rename — the deprecated alias preserves wire compat for downstream consumers, so the change is non-breaking and no version bump is needed until the alias is removed.
- **F2 — Test docstring drift:** Rewrote `test_tasks_observed_reflects_task_count_not_file_count` docstring in `tests/delivery/test_telemetry.py` to accurately describe the test path: `capture_session()` always imports the daemon reader, but it returns empty when no daemon runs and the function falls through to direct-scan, which the 3 written task files exercise.
- **F3 — Reason-string drift:** Renamed `deliverable-too-small` → `executor-deliverable-too-small` in `agents/crew/phase-executor.md` Failure Modes table and `agents/crew/gate-evaluator.md` Failure Modes for consistency with the `executor-` prefix the pseudocode already emits.
- **F4 — JSON-equality test gap:** Replaced `json.loads()` equality with `hashlib.sha256` byte-comparison in two no-op tests in `tests/crew/test_phase_manager.py` — formatting-only rewrites (whitespace, key order) now also fail the assertion.
- **F5 — Hardcoded phase list:** Replaced the hardcoded `{"clarify","design","build"}` set in `verification_protocol.check_traceability` with a `phases.json`-driven derivation. Future phases that declare `required_deliverables` are now picked up automatically (e.g. `ideate` was previously omitted). Falls back to the historical set if `phases.json` is missing.

## #669 — PR #666 follow-up (5 fixes)

- **F6 — False parity claim resolved:** quick-facilitator synthesis headings renamed to match brainstorm-facilitator's vocabulary: `Persona Insights / Top Risks / Recommendations / Open Questions` → `Key Insights / Action Items / Open Questions`. The parity claim from PR #666 is now actually true — callers can read either agent's output without branching on heading names. Risk/tension framing folds into Action Items.
- **F7 — Constraint contradiction fixed:** Replaced "Synthesis: 3-5 sentences maximum" in `agents/jam/quick-facilitator.md` with "concise per section, target ≤200 words total" — the multi-section template never fit a 3-5 sentence cap.
- **F8 — Scenario frontmatter:** Updated `scenarios/jam/quick-facilitator-shape.md` frontmatter to canonical `name/description/type/title` shape so `/wg-test jam` discovery picks it up (was using `id/complexity` which don't match the discovery contract).
- **F9 — Wall-time threshold relaxed:** Changed scenario assertion from `<30s` to `<60s` to match the documented "60-second flow" budget for `jam:quick`. The 30s threshold was a self-inflicted false-FAIL risk because real-world single-pass model latency can spike past 30s without indicating a regression.
- **F10 — Scenario Step 4 parity:** Rewrote the parity table to assert the now-true three-heading parity instead of the prior false four-field claim. Same root cause as F6, naturally resolved by the F6 rename.

## Test plan

- [x] Full pytest — 1754 pass / 5 pre-existing failures (unchanged baseline; the 5 failures are about `crew:yolo` command aliases and a stub-audit on files this PR doesn't touch)
- [x] `measure_facilitator.py` — 10/10 PASS
- [x] F6 verified by re-reading both agent files: heading set is identical (`Key Insights`, `Action Items`, `Open Questions`)
- [x] F4 verified: `hashlib.sha256` byte-comparison present in both no-op tests
- [x] Scenario frontmatter inspected: `name`, `description`, `type`, `title` all present per `/wg-test jam` discovery shape

## Scope discipline

- No caller code touched; these are polish fixes
- Pattern A migrations from #666 (slimmed SKILLs, extracted agents) stay as-is
- Did not bundle still-open backlog (#664, #665) — different work streams

Closes #667
Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)