### PR TITLE
feat: wg-check conflation heuristic + slim-skill migration gate (#652 items 4+5)

### DIFF
--- a/.claude/commands/wg-check.md
+++ b/.claude/commands/wg-check.md
@@ -192,6 +192,133 @@ for skill in $(find "./skills" -name "SKILL.md" 2>/dev/null); do
 done
 ```
 
+### 3a. Agent Line Counts (#664)
+
+Agents that exceed 200 lines are conflation candidates: prompts that long usually
+encode rubrics, multi-step procedures, or persona archetype tables that belong in
+a sibling skill / refs file. Lessons from PR #666 (jam slim) and PR #670
+(propose-process slim) showed that bloated single-file agents accumulate the kind
+of content that should live behind progressive disclosure. Threshold rationale:
+warn at >200 (matches the skill ceiling); hard error at >400 (effectively
+two-skills-in-an-agent territory).
+
+```bash
+# Threshold rationale: see #664. Warn ≥ 200 (skill ceiling parity), error ≥ 400
+# (two-skills-in-an-agent). The error threshold is intentionally generous so the
+# existing roster only flips a small number of files; the warn threshold gives
+# authors a continuous nudge without blocking releases.
+AGENT_WARN_LINES=200
+AGENT_ERROR_LINES=400
+
+for agent in $(find "./agents" -name "*.md" 2>/dev/null); do
+  lines=$(wc -l < "$agent")
+  rel=$(echo "$agent" | sed 's|^\./||')
+  if [[ "$lines" -gt "$AGENT_ERROR_LINES" ]]; then
+    echo "ERROR: $rel is $lines lines (max ${AGENT_ERROR_LINES} — split rubric/persona content into a sibling skill, see #664)"
+  elif [[ "$lines" -gt "$AGENT_WARN_LINES" ]]; then
+    echo "WARNING: $rel is $lines lines (>${AGENT_WARN_LINES} — conflation candidate per #664; consider extracting refs/* or moving rubric steps to a skill)"
+  fi
+done
+```
+
+### 3b. Skill-as-Agent Conflation Heuristic (#664)
+
+For each skill, look for a sibling agent in the same domain and grep both files
+for shared content classes. If 3+ classes overlap, warn that the skill and the
+agent likely duplicate rubric / persona / mechanics content — this is the
+Pattern A migration smell from #652.
+
+The check is intentionally cheap (no LLM, no diff): four regex probes per file,
+domain-scoped pairing only. False positives are acceptable because the warning is
+informational; the cost of a missed conflation (twin sources of truth) is much
+higher than the cost of a false flag.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT:-.}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_conflation.py" 2>/dev/null \
+  || python3 -c "
+import os, re, sys
+from pathlib import Path
+
+# Conflation content classes — each is a regex probe. A class 'matches' a file
+# if the file contains the pattern at least once. If 3+ classes match BOTH the
+# SKILL.md and a sibling agent in the same domain, warn (#664 / #652 Pattern A).
+PROBES = {
+    'persona-archetype-list': re.compile(r'(persona[\s-]?archetype|archetype[\s-]?pool|persona pool|focus group personas?)', re.IGNORECASE),
+    'rubric-step-block': re.compile(r'(^|\n)(#{2,4}\s*)?step\s*[0-9]+\s*[-:—]', re.IGNORECASE),
+    'convergence-or-round-mechanics': re.compile(r'(convergence (check|mode|signal)|round\s*[0-9]+|after each round|next round)', re.IGNORECASE),
+    'transcript-event-bus-emit': re.compile(r'(save_transcript|store the full transcript|emit (a|an) (event|synthesis event)|event log|bus emit|emit_event)', re.IGNORECASE),
+}
+THRESHOLD = 3
+
+skills_root = Path('./skills')
+agents_root = Path('./agents')
+if not skills_root.is_dir() or not agents_root.is_dir():
+    sys.exit(0)
+
+def probe(text):
+    return {name for name, rx in PROBES.items() if rx.search(text)}
+
+def candidate_agents(domain, skill_name):
+    domain_dir = agents_root / domain
+    if not domain_dir.is_dir():
+        return []
+    out = []
+    sk = skill_name.lower().replace('_', '-')
+    for md in sorted(domain_dir.glob('*.md')):
+        stem = md.stem.lower()
+        if stem == sk or sk in stem or stem in sk:
+            out.append(md)
+            continue
+        if sk in ('skill', domain) and stem.endswith(('-facilitator', '-orchestrator', '-coordinator')):
+            out.append(md)
+    if not out:
+        for md in sorted(domain_dir.glob('*.md')):
+            out.append(md)
+    return out
+
+flagged = 0
+for skill_md in sorted(skills_root.rglob('SKILL.md')):
+    parts = skill_md.relative_to(skills_root).parts
+    if not parts:
+        continue
+    domain = parts[0]
+    skill_name = parts[1] if len(parts) >= 3 else domain
+    try:
+        skill_text = skill_md.read_text(errors='replace')
+    except Exception:
+        continue
+    skill_classes = probe(skill_text)
+    if len(skill_classes) < THRESHOLD:
+        continue
+    for agent_md in candidate_agents(domain, skill_name):
+        try:
+            agent_text = agent_md.read_text(errors='replace')
+        except Exception:
+            continue
+        agent_classes = probe(agent_text)
+        shared = skill_classes & agent_classes
+        if len(shared) >= THRESHOLD:
+            flagged += 1
+            rel_skill = skill_md.relative_to(Path('.'))
+            rel_agent = agent_md.relative_to(Path('.'))
+            print(f'WARNING: skill-as-agent conflation detected — {rel_skill} and {rel_agent} share {len(shared)} content classes ({sorted(shared)}). See #652 Pattern A migration.')
+
+if flagged == 0:
+    print('OK: no skill-as-agent conflation patterns detected (#664)')
+" 2>/dev/null || python -c "print('WARNING: could not run conflation heuristic')"
+```
+
+**What this catches**: A SKILL.md that still owns rubric steps + persona pools +
+convergence/round mechanics + transcript/bus emit instructions while a sibling
+agent in the same domain also encodes the same four classes. The fix is the
+Pattern A migration: keep the orchestration prose in the agent, slim the skill
+to navigation + entry-points (~50-100 lines).
+
+**Acceptable false positives**: any skill that legitimately documents what its
+sibling agent does (links + brief overview). The signal is most useful when both
+files contain *full* rubric / mechanics blocks — exactly the duplication that
+PRs #666 and #670 cleaned up.
+
 ### 4. Agent Frontmatter
 
 ```bash
@@ -726,6 +853,141 @@ for domain in domains:
 - Section 10a-10d (summary + warnings) runs as part of every quick check
 - Section 10e (detailed inventory) runs only with `--agents` or `--full` flags
 
+### 11. Pattern A Migration Validation Gate (#665)
+
+When a PR shrinks a `skills/**/SKILL.md` substantially AND adds a new
+`agents/**/*.md` in the same diff, that's the Pattern A migration shape from
+#666 (jam slim) and #670 (propose-process slim). The gate enforces the rule
+codified in #665: **every Pattern A migration must ship with a passing
+acceptance scenario** so reviewers can verify the new agent is wired correctly
+and the slimmed skill still delegates to the right place.
+
+**Signal**: a `SKILL.md` shrunk by ≥40% (lines-removed / lines-before) AND a new
+`agents/**/*.md` file added in the same `git diff origin/main...HEAD`.
+
+**Requirement on detection**: the same diff must add a scenario file matching
+one of these patterns (any domain):
+
+- `scenarios/**/*-pattern-a.md`
+- `scenarios/**/*-shape.md`
+- `scenarios/**/*-dispatch.md`
+- `scenarios/**/*pattern*.md`, `scenarios/**/*shape*.md`, `scenarios/**/*dispatch*.md`
+
+**Behavior**: ERROR (blocks CI) if signal detected and no matching scenario.
+Fail-open if `git diff origin/main...HEAD` returns empty (running on main with
+no PR context). The 40% threshold + same-PR new-agent requirement is calibrated
+so that incremental skill polish never trips the gate — only true Pattern A
+migrations do.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT:-.}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_pattern_a_gate.py" 2>/dev/null \
+  || python3 -c "
+import os, re, subprocess, sys
+from pathlib import Path
+
+# Threshold rationale: see #665. SKILL.md must shrink by >= SHRINK_RATIO of its
+# pre-diff size to count as 'slimmed'. Combined with a same-PR new agent file,
+# this is the Pattern A signal. Tuning lower would catch normal polish PRs;
+# tuning higher would miss legitimate slim migrations like PR #666 (jam went
+# from ~120 lines to 43, a 64% drop).
+SHRINK_RATIO = 0.40
+
+def run(cmd):
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return r.stdout if r.returncode == 0 else ''
+    except Exception:
+        return ''
+
+base_ref = os.environ.get('WG_PR_BASE_REF') or os.environ.get('GITHUB_BASE_REF') or 'origin/main'
+if base_ref and not base_ref.startswith('origin/') and base_ref != 'main':
+    base_ref = f'origin/{base_ref}'
+
+diff_range = f'{base_ref}...HEAD'
+
+name_status = run(['git', 'diff', '--name-status', diff_range])
+if not name_status.strip():
+    print('OK: no PR diff against ' + base_ref + ' — Pattern A gate skipped (fail-open)')
+    sys.exit(0)
+
+slimmed_skills = []
+new_agents = []
+new_scenarios = []
+
+for line in name_status.splitlines():
+    parts = line.split('\t')
+    if len(parts) < 2:
+        continue
+    status = parts[0].strip()
+    path = parts[-1].strip()
+    if status.startswith('A') and path.startswith('agents/') and path.endswith('.md'):
+        new_agents.append(path)
+    if status.startswith('A') and path.startswith('scenarios/') and path.endswith('.md'):
+        new_scenarios.append(path)
+    if path.startswith('skills/') and path.endswith('SKILL.md') and status.startswith(('M', 'R')):
+        numstat = run(['git', 'diff', '--numstat', diff_range, '--', path])
+        if not numstat.strip():
+            continue
+        for nl in numstat.splitlines():
+            np = nl.split('\t')
+            if len(np) < 3:
+                continue
+            try:
+                added = int(np[0]); deleted = int(np[1])
+            except ValueError:
+                continue
+            base_blob = run(['git', 'show', f'{base_ref}:{path}'])
+            base_lines = base_blob.count('\n') if base_blob else 0
+            if base_lines == 0:
+                continue
+            shrink = (deleted - added) / base_lines if base_lines else 0
+            if shrink >= SHRINK_RATIO:
+                slimmed_skills.append((path, base_lines, shrink))
+
+if not slimmed_skills or not new_agents:
+    if slimmed_skills:
+        for p, bl, sr in slimmed_skills:
+            print(f'INFO: {p} shrunk by {sr*100:.0f}% (was {bl} lines) — no new agent in this PR, not a Pattern A migration')
+    print('OK: no Pattern A migration signal in this PR (#665)')
+    sys.exit(0)
+
+SCENARIO_PATTERNS = [
+    re.compile(r'^scenarios/.+-pattern-a\.md$'),
+    re.compile(r'^scenarios/.+-shape\.md$'),
+    re.compile(r'^scenarios/.+-dispatch\.md$'),
+    re.compile(r'^scenarios/.*pattern.*\.md$', re.IGNORECASE),
+    re.compile(r'^scenarios/.*shape.*\.md$', re.IGNORECASE),
+    re.compile(r'^scenarios/.*dispatch.*\.md$', re.IGNORECASE),
+]
+
+matching = [s for s in new_scenarios if any(p.match(s) for p in SCENARIO_PATTERNS)]
+
+print('Pattern A migration detected:')
+for p, bl, sr in slimmed_skills:
+    print(f'  slimmed skill: {p} (was {bl} lines, shrunk {sr*100:.0f}%)')
+for a in new_agents:
+    print(f'  new agent:     {a}')
+
+if matching:
+    for s in matching:
+        print(f'OK: Pattern A migration covered by scenario: {s} (#665)')
+    sys.exit(0)
+
+print('ERROR: Pattern A migration detected but no matching scenario added in this PR (#665).')
+print('       Add a scenario in scenarios/{domain}/ matching one of:')
+print('         *-pattern-a.md, *-shape.md, *-dispatch.md, *pattern*.md, *shape*.md, *dispatch*.md')
+print('       Reference scenarios: scenarios/crew/process-facilitator-pattern-a.md (PR #670),')
+print('       scenarios/jam/quick-facilitator-shape.md (PR #666).')
+sys.exit(1)
+" 2>/dev/null || python -c "print('WARNING: Could not run Pattern A migration gate')"
+```
+
+**Override**: there is no env-var bypass. The gate is intentionally narrow
+(40% shrink + same-PR new agent) so genuine non-migration work never trips it.
+If a legitimate Pattern A migration ships with the scenario in a follow-up PR,
+add a placeholder scenario file (`scenarios/{domain}/{name}-pattern-a.md` with
+a short "TODO: implement" body) and replace it in the follow-up.
+
 ### Quick Check Output
 
 ```markdown
@@ -739,6 +1001,8 @@ for domain in domains:
 | gate-policy.json Tier-1 allowlist | ✓/✗ |
 | JSON validity | ✓/✗ |
 | Skills ≤200 lines | ✓/✗ |
+| Agent line counts (#664) | ✓/⚠/✗ |
+| Skill-as-agent conflation (#664) | ✓/⚠ |
 | Agent frontmatter | ✓/✗ |
 | Agent Skills 2.0 (allowed-tools, model) | ✓/✗ |
 | Agent tool-capabilities compliance | ✓/✗ |
@@ -752,6 +1016,7 @@ for domain in domains:
 | README freshness | ✓/✗ |
 | Self-referential integrity | ✓/✗ |
 | Agent trigger analysis | ✓/⚠ |
+| Pattern A migration gate (#665) | ✓/✗/skip |
 
 **Result**: PASS / FAIL
 

--- a/scripts/wg/check_conflation.py
+++ b/scripts/wg/check_conflation.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Skill-as-agent conflation heuristic for wg-check (#664).
+
+For each skill (skills/**/SKILL.md), look for sibling agents in agents/{domain}/
+and grep both files for shared content classes. If 3+ classes overlap in BOTH
+files, warn that the skill and the agent likely duplicate rubric / persona /
+mechanics content -- the Pattern A migration smell from #652.
+
+The heuristic is intentionally cheap (no LLM, no diff): four regex probes per
+file, domain-scoped pairing only. Acceptable false-positive rate; the warning
+is informational, not blocking.
+
+Background: PRs #666 (jam slim) and #670 (propose-process slim) showed the
+pattern -- a SKILL.md owning rubric steps + persona pools + convergence
+mechanics + transcript/bus emit instructions while a sibling agent in the same
+domain encodes the same content. The fix is the Pattern A migration: keep
+orchestration prose in the agent, slim the skill to navigation + entry-points
+(~50-100 lines).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Conflation content classes -- each is a regex probe. A class "matches" a file
+# if the file contains the pattern at least once. If 3+ classes match BOTH the
+# SKILL.md and a sibling agent in the same domain, warn (#664 / #652 Pattern A).
+PROBES = {
+    "persona-archetype-list": re.compile(
+        r"(persona[\s-]?archetype|archetype[\s-]?pool|persona pool|focus group personas?)",
+        re.IGNORECASE,
+    ),
+    "rubric-step-block": re.compile(
+        r"(^|\n)(#{2,4}\s*)?step\s*[0-9]+\s*[-:—]",
+        re.IGNORECASE,
+    ),
+    "convergence-or-round-mechanics": re.compile(
+        r"(convergence (check|mode|signal)|round\s*[0-9]+|after each round|next round)",
+        re.IGNORECASE,
+    ),
+    "transcript-event-bus-emit": re.compile(
+        r"(save_transcript|store the full transcript|"
+        r"emit (a|an) (event|synthesis event)|event log|bus emit|emit_event)",
+        re.IGNORECASE,
+    ),
+}
+
+THRESHOLD = 3  # classes shared between skill and agent before warning
+
+
+def probe(text: str) -> set[str]:
+    return {name for name, rx in PROBES.items() if rx.search(text)}
+
+
+def candidate_agents(agents_root: Path, domain: str, skill_name: str) -> list[Path]:
+    """Find agents in the same domain that look like siblings of this skill."""
+    domain_dir = agents_root / domain
+    if not domain_dir.is_dir():
+        return []
+    out: list[Path] = []
+    sk = skill_name.lower().replace("_", "-")
+    for md in sorted(domain_dir.glob("*.md")):
+        stem = md.stem.lower()
+        if stem == sk or sk in stem or stem in sk:
+            out.append(md)
+            continue
+        if sk in ("skill", domain) and stem.endswith(
+            ("-facilitator", "-orchestrator", "-coordinator")
+        ):
+            out.append(md)
+    # Single-skill domains (no name match): fall back to ALL agents in the domain.
+    if not out:
+        for md in sorted(domain_dir.glob("*.md")):
+            out.append(md)
+    return out
+
+
+def main(repo_root: Path = Path(".")) -> int:
+    skills_root = repo_root / "skills"
+    agents_root = repo_root / "agents"
+    if not skills_root.is_dir() or not agents_root.is_dir():
+        return 0
+
+    flagged = 0
+    for skill_md in sorted(skills_root.rglob("SKILL.md")):
+        try:
+            parts = skill_md.relative_to(skills_root).parts
+        except ValueError:
+            continue
+        if not parts:
+            continue
+        domain = parts[0]
+        # multi-skill: skills/{domain}/{skill}/SKILL.md
+        # single-skill: skills/{domain}/SKILL.md
+        skill_name = parts[1] if len(parts) >= 3 else domain
+        try:
+            skill_text = skill_md.read_text(errors="replace")
+        except OSError:
+            continue
+        skill_classes = probe(skill_text)
+        if len(skill_classes) < THRESHOLD:
+            # SKILL.md doesn't have enough rubric/persona content to bother --
+            # it's already slim or scoped to one concern.
+            continue
+        for agent_md in candidate_agents(agents_root, domain, skill_name):
+            try:
+                agent_text = agent_md.read_text(errors="replace")
+            except OSError:
+                continue
+            agent_classes = probe(agent_text)
+            shared = skill_classes & agent_classes
+            if len(shared) >= THRESHOLD:
+                flagged += 1
+                rel_skill = skill_md.relative_to(repo_root)
+                rel_agent = agent_md.relative_to(repo_root)
+                print(
+                    f"WARNING: skill-as-agent conflation detected -- {rel_skill} "
+                    f"and {rel_agent} share {len(shared)} content classes "
+                    f"({sorted(shared)}). See #652 Pattern A migration."
+                )
+
+    if flagged == 0:
+        print("OK: no skill-as-agent conflation patterns detected (#664)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wg/check_pattern_a_gate.py
+++ b/scripts/wg/check_pattern_a_gate.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Pattern A migration validation gate for wg-check (#665).
+
+When a PR shrinks a skills/**/SKILL.md substantially AND adds a new
+agents/**/*.md in the same diff, that's the Pattern A migration shape from
+PR #666 (jam slim) and PR #670 (propose-process slim). The gate enforces:
+**every Pattern A migration must ship with a passing acceptance scenario** so
+reviewers can verify the new agent is wired correctly and the slimmed skill
+still delegates to the right place.
+
+Signal: a SKILL.md shrunk by >= 40% (lines-removed / lines-before) AND a new
+agents/**/*.md file added in the same `git diff <base>...HEAD`.
+
+Requirement: the same diff must add a scenario file matching:
+    scenarios/**/*-pattern-a.md
+    scenarios/**/*-shape.md
+    scenarios/**/*-dispatch.md
+    scenarios/**/*pattern*.md, *shape*.md, *dispatch*.md
+
+Behavior: ERROR (exit 1, blocks CI) if signal detected and no matching
+scenario. Fail-open (exit 0) if `git diff` returns empty -- e.g. running on
+main with no PR context.
+
+Threshold rationale: 40% shrink + same-PR new agent is the safe combo.
+PR #666 went from ~120 to 43 lines (64% drop). Tuning lower would catch
+incremental polish; tuning higher would miss legitimate slim migrations.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+# See module docstring for tuning rationale.
+SHRINK_RATIO = 0.40
+
+SCENARIO_PATTERNS = [
+    re.compile(r"^scenarios/.+-pattern-a\.md$"),
+    re.compile(r"^scenarios/.+-shape\.md$"),
+    re.compile(r"^scenarios/.+-dispatch\.md$"),
+    re.compile(r"^scenarios/.*pattern.*\.md$", re.IGNORECASE),
+    re.compile(r"^scenarios/.*shape.*\.md$", re.IGNORECASE),
+    re.compile(r"^scenarios/.*dispatch.*\.md$", re.IGNORECASE),
+]
+
+
+def run(cmd: list[str]) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return r.stdout if r.returncode == 0 else ""
+    except Exception:  # noqa: BLE001 -- fail-open per design
+        return ""
+
+
+def resolve_base_ref() -> str:
+    """Resolve the PR base ref. CI sets GITHUB_BASE_REF; locally use origin/main."""
+    base = os.environ.get("WG_PR_BASE_REF") or os.environ.get("GITHUB_BASE_REF") or "origin/main"
+    if base and not base.startswith("origin/") and base != "main":
+        base = f"origin/{base}"
+    return base
+
+
+def main() -> int:
+    base_ref = resolve_base_ref()
+    diff_range = f"{base_ref}...HEAD"
+
+    name_status = run(["git", "diff", "--name-status", diff_range])
+    if not name_status.strip():
+        print(f"OK: no PR diff against {base_ref} -- Pattern A gate skipped (fail-open)")
+        return 0
+
+    slimmed_skills: list[tuple[str, int, float]] = []
+    new_agents: list[str] = []
+    new_scenarios: list[str] = []
+
+    for line in name_status.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0].strip()
+        path = parts[-1].strip()
+
+        if status.startswith("A") and path.startswith("agents/") and path.endswith(".md"):
+            new_agents.append(path)
+        if status.startswith("A") and path.startswith("scenarios/") and path.endswith(".md"):
+            new_scenarios.append(path)
+
+        # Modified or renamed SKILL.md files -- measure shrink.
+        if (
+            path.startswith("skills/")
+            and path.endswith("SKILL.md")
+            and status.startswith(("M", "R"))
+        ):
+            numstat = run(["git", "diff", "--numstat", diff_range, "--", path])
+            if not numstat.strip():
+                continue
+            for nl in numstat.splitlines():
+                np_ = nl.split("\t")
+                if len(np_) < 3:
+                    continue
+                try:
+                    added = int(np_[0])
+                    deleted = int(np_[1])
+                except ValueError:
+                    continue
+                base_blob = run(["git", "show", f"{base_ref}:{path}"])
+                base_lines = base_blob.count("\n") if base_blob else 0
+                if base_lines == 0:
+                    continue
+                shrink = (deleted - added) / base_lines if base_lines else 0
+                if shrink >= SHRINK_RATIO:
+                    slimmed_skills.append((path, base_lines, shrink))
+
+    if not slimmed_skills or not new_agents:
+        if slimmed_skills:
+            for p, bl, sr in slimmed_skills:
+                print(
+                    f"INFO: {p} shrunk by {sr * 100:.0f}% (was {bl} lines) -- "
+                    f"no new agent in this PR, not a Pattern A migration"
+                )
+        print("OK: no Pattern A migration signal in this PR (#665)")
+        return 0
+
+    matching = [s for s in new_scenarios if any(p.match(s) for p in SCENARIO_PATTERNS)]
+
+    print("Pattern A migration detected:")
+    for p, bl, sr in slimmed_skills:
+        print(f"  slimmed skill: {p} (was {bl} lines, shrunk {sr * 100:.0f}%)")
+    for a in new_agents:
+        print(f"  new agent:     {a}")
+
+    if matching:
+        for s in matching:
+            print(f"OK: Pattern A migration covered by scenario: {s} (#665)")
+        return 0
+
+    print("ERROR: Pattern A migration detected but no matching scenario added in this PR (#665).")
+    print("       Add a scenario in scenarios/{domain}/ matching one of:")
+    print("         *-pattern-a.md, *-shape.md, *-dispatch.md, *pattern*.md, *shape*.md, *dispatch*.md")
+    print("       Reference scenarios:")
+    print("         scenarios/crew/process-facilitator-pattern-a.md (PR #670)")
+    print("         scenarios/jam/quick-facilitator-shape.md (PR #666)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #664 and #665 — completes the #652 brainstorm.

Adds three new dev-tool checks to `.claude/commands/wg-check.md` and the two helper scripts (`scripts/wg/`) that back them. Both items address the same root cause surfaced by PRs #666 (jam slim) and #670 (propose-process slim): the codebase had no automated guard against skill-as-agent conflation or against landing a Pattern A migration without an acceptance scenario.

## #664 — Agent line-count + skill-as-agent conflation heuristic

**Section 3a** walks `agents/**/*.md` and warns at >200 lines, errors at >400. Threshold rationale captured inline: warn matches the skill ceiling; error is set generously so only obvious two-skills-in-an-agent files flip red. Initial run flags ~40 warning-tier agents and 9 error-tier (e.g. `agentic/pattern-advisor.md` at 899 lines) — visibility, not blocking churn.

**Section 3b** runs four cheap regex probes over each `SKILL.md` and its sibling agent in the same domain:

- persona-archetype-list
- rubric-step-block (`Step N — ...`)
- convergence-or-round-mechanics
- transcript-event-bus-emit

If 3+ classes appear in BOTH files, warn that the skill and agent likely duplicate orchestration content. Acceptable false-positive rate; informational, not blocking. Current repo: zero conflation warnings (post-#666/#670 cleanup).

## #665 — Pattern A migration validation gate

**Section 11** reads `git diff <base>...HEAD` and looks for the Pattern A shape:
- a `SKILL.md` shrunk by ≥40% AND
- a new `agents/**/*.md` added in the same diff

When detected, the gate REQUIRES a same-PR scenario file under `scenarios/**/*-pattern-a.md`, `*-shape.md`, `*-dispatch.md`, or any name containing pattern/shape/dispatch.

- Fail-open when `git diff` returns empty (running on main / no PR ctx).
- No env-var bypass — the signal is intentionally narrow so polish PRs never trip it.
- Threshold calibrated against PR #666 (jam went 120 → 43 lines, 64% drop) and PR #670 (propose-process slim).

## Files changed

- `.claude/commands/wg-check.md` (+265 lines) — new sections 3a, 3b, 11; updated output table
- `scripts/wg/check_conflation.py` (130 lines) — Section 3b helper, also runs standalone
- `scripts/wg/check_pattern_a_gate.py` (149 lines) — Section 11 helper, also runs standalone

The wg-check.md sections also have inline Python fallbacks (`|| python3 -c "..."`) so the checks work even without the helper scripts present, matching the rest of the file's style.

## Out of scope

- No changes to skills, agents, or scenarios. This PR adds CHECKS only.
- Not added to `wicked-testing` or `wicked-brain` plugins — `wg-check` is the in-repo dev tool and is not distributed to marketplace users.

## Test plan

- [x] Self-test on this PR: `python3 scripts/wg/check_conflation.py` → `OK: no skill-as-agent conflation patterns detected (#664)`
- [x] Self-test on this PR: `python3 scripts/wg/check_pattern_a_gate.py` → `OK: no Pattern A migration signal in this PR (#665)` (after fetch origin/main)
- [x] Injected-failure test: shrink `skills/multi-model/SKILL.md` to 50 lines (67% drop) + add fake agent → gate exits 1 with `Pattern A migration detected but no matching scenario added in this PR (#665)`
- [x] Recovery test: add `scenarios/agentic/_test-fake-pattern-a.md` → gate exits 0 with `OK: Pattern A migration covered by scenario`
- [x] Inline Python in both new sections of wg-check.md parses cleanly (validated via `ast.parse`)
- [x] Existing scenarios (6 files matching pattern/shape/dispatch) all legitimate Pattern A / dispatch acceptance tests — no false-positive surface
- [ ] CI green on `/wg-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)