### PR TITLE
fix: v8.4.x polish bundle — 20 fixes (resolves #675, #673+#674 sweep findings)

### DIFF
--- a/.claude/commands/wg-check.md
+++ b/.claude/commands/wg-check.md
@@ -210,9 +210,11 @@ two-skills-in-an-agent territory).
 AGENT_WARN_LINES=200
 AGENT_ERROR_LINES=400
 
-for agent in $(find "./agents" -name "*.md" 2>/dev/null); do
+# F13 (#675 sweep): use `-print0` + `read -d ''` so filenames with spaces or
+# special chars don't split the loop into garbage tokens.
+find "./agents" -name "*.md" -print0 2>/dev/null | while IFS= read -r -d '' agent; do
   lines=$(wc -l < "$agent")
-  rel=$(echo "$agent" | sed 's|^\./||')
+  rel="${agent#./}"
   if [[ "$lines" -gt "$AGENT_ERROR_LINES" ]]; then
     echo "ERROR: $rel is $lines lines (max ${AGENT_ERROR_LINES} — split rubric/persona content into a sibling skill, see #664)"
   elif [[ "$lines" -gt "$AGENT_WARN_LINES" ]]; then
@@ -873,11 +875,19 @@ one of these patterns (any domain):
 - `scenarios/**/*-dispatch.md`
 - `scenarios/**/*pattern*.md`, `scenarios/**/*shape*.md`, `scenarios/**/*dispatch*.md`
 
-**Behavior**: ERROR (blocks CI) if signal detected and no matching scenario.
-Fail-open if `git diff origin/main...HEAD` returns empty (running on main with
-no PR context). The 40% threshold + same-PR new-agent requirement is calibrated
-so that incremental skill polish never trips the gate — only true Pattern A
-migrations do.
+**Behavior**: ERROR locally (and surfaces in `wg-check` output) if signal
+detected and no matching scenario; fail-open if `git diff origin/main...HEAD`
+returns empty (running on main with no PR context). The 40% threshold + same-PR
+new-agent requirement is calibrated so that incremental skill polish never
+trips the gate — only true Pattern A migrations do.
+
+> **CI integration status (F12, #675 sweep)**: The Pattern A gate is currently
+> **advisory locally** — it surfaces during `wg-check` runs and prints an ERROR
+> exit code. The GitHub Actions workflow at `.github/workflows/validate.yml`
+> runs `python scripts/ci/validate.py`, which does NOT yet invoke
+> `check_pattern_a_gate.py`. Wiring the Pattern A gate into the CI workflow is
+> a follow-up (out of scope for this polish PR). Until then, the gate runs
+> only when an author runs `/wg-check` manually before opening a PR.
 
 ```bash
 sh "${CLAUDE_PLUGIN_ROOT:-.}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_pattern_a_gate.py" 2>/dev/null \
@@ -893,19 +903,34 @@ from pathlib import Path
 SHRINK_RATIO = 0.40
 
 def run(cmd):
+    # F10 (#675 sweep): return None on error so callers can distinguish a real
+    # git failure from a clean diff. Previously both returned ''.
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        return r.stdout if r.returncode == 0 else ''
-    except Exception:
-        return ''
+        if r.returncode != 0:
+            sys.stderr.write('WARNING: ' + ' '.join(cmd) + ' exited ' + str(r.returncode) + ': ' + (r.stderr or '').strip() + '\n')
+            return None
+        return r.stdout
+    except Exception as exc:
+        sys.stderr.write('WARNING: ' + ' '.join(cmd) + ' raised ' + repr(exc) + '\n')
+        return None
 
-base_ref = os.environ.get('WG_PR_BASE_REF') or os.environ.get('GITHUB_BASE_REF') or 'origin/main'
-if base_ref and not base_ref.startswith('origin/') and base_ref != 'main':
-    base_ref = f'origin/{base_ref}'
+# F11 (#675 sweep): always prepend origin/ when the ref has no remote prefix.
+# WG_PR_BASE_REF is treated as caller-authoritative (escape hatch).
+explicit = os.environ.get('WG_PR_BASE_REF')
+if explicit:
+    base_ref = explicit
+else:
+    base_ref = os.environ.get('GITHUB_BASE_REF') or 'origin/main'
+    if '/' not in base_ref:
+        base_ref = f'origin/{base_ref}'
 
 diff_range = f'{base_ref}...HEAD'
 
 name_status = run(['git', 'diff', '--name-status', diff_range])
+if name_status is None:
+    print('WARNING: git diff --name-status ' + diff_range + ' failed — Pattern A gate skipped (fail-open). Check that the base ref exists locally.')
+    sys.exit(0)
 if not name_status.strip():
     print('OK: no PR diff against ' + base_ref + ' — Pattern A gate skipped (fail-open)')
     sys.exit(0)
@@ -919,30 +944,33 @@ for line in name_status.splitlines():
     if len(parts) < 2:
         continue
     status = parts[0].strip()
-    path = parts[-1].strip()
+    # F9 (#675 sweep): renames look like `R<score>\told\tnew`. Use OLD against
+    # base_ref, NEW against HEAD; previously parts[-1] was used for both,
+    # silently skipping renamed SKILL.md files.
+    if status.startswith('R') and len(parts) >= 3:
+        old_path = parts[1].strip()
+        new_path = parts[2].strip()
+    else:
+        old_path = parts[-1].strip()
+        new_path = parts[-1].strip()
+    path = new_path
     if status.startswith('A') and path.startswith('agents/') and path.endswith('.md'):
         new_agents.append(path)
     if status.startswith('A') and path.startswith('scenarios/') and path.endswith('.md'):
         new_scenarios.append(path)
     if path.startswith('skills/') and path.endswith('SKILL.md') and status.startswith(('M', 'R')):
-        numstat = run(['git', 'diff', '--numstat', diff_range, '--', path])
-        if not numstat.strip():
+        # F9 (#675 sweep): direct line-count comparison handles renames cleanly
+        # without parsing ambiguous numstat output. base from old_path, head
+        # from new_path.
+        base_blob = run(['git', 'show', f'{base_ref}:{old_path}'])
+        head_blob = run(['git', 'show', f'HEAD:{new_path}'])
+        base_lines = base_blob.count('\n') if base_blob else 0
+        head_lines = head_blob.count('\n') if head_blob else 0
+        if base_lines == 0:
             continue
-        for nl in numstat.splitlines():
-            np = nl.split('\t')
-            if len(np) < 3:
-                continue
-            try:
-                added = int(np[0]); deleted = int(np[1])
-            except ValueError:
-                continue
-            base_blob = run(['git', 'show', f'{base_ref}:{path}'])
-            base_lines = base_blob.count('\n') if base_blob else 0
-            if base_lines == 0:
-                continue
-            shrink = (deleted - added) / base_lines if base_lines else 0
-            if shrink >= SHRINK_RATIO:
-                slimmed_skills.append((path, base_lines, shrink))
+        shrink = (base_lines - head_lines) / base_lines
+        if shrink >= SHRINK_RATIO:
+            slimmed_skills.append((path, base_lines, shrink))
 
 if not slimmed_skills or not new_agents:
     if slimmed_skills:

--- a/.claude/commands/wg-check.md
+++ b/.claude/commands/wg-check.md
@@ -876,10 +876,18 @@ one of these patterns (any domain):
 - `scenarios/**/*pattern*.md`, `scenarios/**/*shape*.md`, `scenarios/**/*dispatch*.md`
 
 **Behavior**: ERROR locally (and surfaces in `wg-check` output) if signal
-detected and no matching scenario; fail-open if `git diff origin/main...HEAD`
-returns empty (running on main with no PR context). The 40% threshold + same-PR
-new-agent requirement is calibrated so that incremental skill polish never
-trips the gate — only true Pattern A migrations do.
+detected and no matching scenario. The gate fail-opens (exits 0 with a
+non-blocking message) under TWO conditions:
+
+1. `git diff origin/main...HEAD` returns empty (running on main with no PR
+   context) — prints `OK: no PR diff against {base_ref} ...`.
+2. `git diff` itself fails (returns None) — e.g. missing base ref, shallow
+   clone, or other git failure. Prints a `WARNING: ...` line so the cause
+   is visible in CI logs.
+
+The 40% threshold + same-PR new-agent requirement is calibrated so that
+incremental skill polish never trips the gate — only true Pattern A
+migrations do.
 
 > **CI integration status (F12, #675 sweep)**: The Pattern A gate is currently
 > **advisory locally** — it surfaces during `wg-check` runs and prints an ERROR
@@ -915,19 +923,25 @@ def run(cmd):
         sys.stderr.write('WARNING: ' + ' '.join(cmd) + ' raised ' + repr(exc) + '\n')
         return None
 
-# F11 (#675 sweep): always prepend origin/ when the ref has no remote prefix.
+# F11 (#675 sweep): prepend origin/ when the ref has no remote prefix.
 # WG_PR_BASE_REF is treated as caller-authoritative (escape hatch).
+# Bug 1 (#676 sweep): use a startswith check on known remote/refs prefixes
+# instead of '/' not in base_ref, so branches like feature/migration or
+# releases/v8.4 still get the origin/ prefix prepended.
 explicit = os.environ.get('WG_PR_BASE_REF')
 if explicit:
     base_ref = explicit
 else:
     base_ref = os.environ.get('GITHUB_BASE_REF') or 'origin/main'
-    if '/' not in base_ref:
+    if not base_ref.startswith(('origin/', 'upstream/', 'refs/')):
         base_ref = f'origin/{base_ref}'
 
 diff_range = f'{base_ref}...HEAD'
 
-name_status = run(['git', 'diff', '--name-status', diff_range])
+# Bug 2 (#676 sweep): -c core.quotePath=false keeps paths with spaces or
+# non-ASCII characters unquoted, so subsequent path.startswith and git show
+# calls don't break on quoted '"...".
+name_status = run(['git', '-c', 'core.quotePath=false', 'diff', '--name-status', diff_range])
 if name_status is None:
     print('WARNING: git diff --name-status ' + diff_range + ' failed — Pattern A gate skipped (fail-open). Check that the base ref exists locally.')
     sys.exit(0)
@@ -964,8 +978,18 @@ for line in name_status.splitlines():
         # from new_path.
         base_blob = run(['git', 'show', f'{base_ref}:{old_path}'])
         head_blob = run(['git', 'show', f'HEAD:{new_path}'])
-        base_lines = base_blob.count('\n') if base_blob else 0
-        head_lines = head_blob.count('\n') if head_blob else 0
+        # Bug 4 (#676 sweep): if either git show returned None, skip the file
+        # with a warning -- treating None as '' produced false-positive shrink
+        # readings (looked like a 100% shrink when one side was missing).
+        if base_blob is None or head_blob is None:
+            missing = 'base' if base_blob is None else 'head'
+            sys.stderr.write('WARNING: skipping shrink check for ' + path + ' -- ' + missing + ' blob unavailable (git show failed)\n')
+            continue
+        # Bug 3 (#676 sweep): blob.count('\n') undercounts files lacking a
+        # trailing newline. splitlines() handles both 'foo\nbar' and
+        # 'foo\nbar\n' as 2 lines.
+        base_lines = len(base_blob.splitlines())
+        head_lines = len(head_blob.splitlines())
         if base_lines == 0:
             continue
         shrink = (base_lines - head_lines) / base_lines

--- a/agents/crew/process-facilitator.md
+++ b/agents/crew/process-facilitator.md
@@ -19,9 +19,10 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 
 This agent IS the rubric (extracted from `skills/propose-process/SKILL.md` in #652
 item 3). Every section below is instructional — you (Claude) follow it at call time.
-No rule tables. Reasoning about the work itself. The agent does not run Python
-itself; it MAY instruct the caller to invoke `archetype_detect.detect_archetype()`
-(see Step 6) and pass the result back through `metadata.archetype`.
+No rule tables. Reasoning about the work itself. The agent emits a
+`metadata.archetype` value via the rubric output (Step 6); the caller is
+responsible for invoking `archetype_detect.detect_archetype()` if a runtime
+archetype check is needed.
 
 ## Inputs
 
@@ -35,20 +36,22 @@ itself; it MAY instruct the caller to invoke `archetype_detect.detect_archetype(
 7. **`project_dir`** — REQUIRED. Absolute path to the project directory where the
    draft plan file is written. The caller (slim SKILL.md) reads it back from disk.
 8. **`project_slug`** — short snake_case identifier for the project. Forwarded by
-   the slim SKILL.md and used in `chain_id` assembly (`{slug}.root`,
-   `{slug}.{phase}`, `{slug}.{phase}.{gate}`) and in the JSON output's
-   `project_slug` field.
+   the slim SKILL.md and used in `chain_id` assembly (`{project_slug}.root`,
+   `{project_slug}.{phase}`, `{project_slug}.{phase}.{gate}`) and in the JSON
+   output's `project_slug` field.
 9. **`bookend`** (`phase-start` | `phase-end`) — required for `mode=re-evaluate`
    from `phase-executor`. Selects which side of the phase boundary the re-eval
    record applies to.
 10. **`phase`** — required for `mode=re-evaluate`: the crew phase being entered
     or completed. Must be a key in `.claude-plugin/phases.json`.
-11. **`output`** — `json` | unset. **The agent's behavior does NOT depend on this
-    value** — it ALWAYS writes a JSON plan to `${project_dir}/process-plan.draft.json`
-    matching `skills/propose-process/refs/output-schema.md`, and NEVER issues
-    `TaskCreate` calls. `output` is forwarded so the caller (slim SKILL.md) knows
-    whether to return the JSON content directly (`output=json`) or to render the
-    canonical `process-plan.md` + emit the task chain (default).
+11. **`output`** (caller-side only) — `json` | unset. The agent's behavior does
+    NOT depend on this value — the agent ALWAYS writes a JSON plan to
+    `${project_dir}/process-plan.draft.json` matching
+    `skills/propose-process/refs/output-schema.md`, and NEVER issues `TaskCreate`
+    calls. The caller (slim SKILL.md) uses `output` to decide whether to return
+    the JSON content directly (`output=json`) or to render the canonical
+    `process-plan.md` + emit the task chain (default). The Task() prompt does
+    NOT need to forward `output` to this agent.
 
 ## Outputs (file-handoff contract)
 
@@ -174,13 +177,16 @@ for auditability when rendered. Each task has top-level `phase` AND `specialist`
 {"name": "clarify", "why": "nail ambiguous scope", "primary": ["requirements-analyst"]}
 ```
 
-`event_type` MUST be exactly one of these four documented values (pick one — do
-NOT emit the pipe-separated list literally):
+`event_type` MUST be exactly one of these six documented values (pick one — do
+NOT emit the pipe-separated list literally). The full validator contract lives
+in `scripts/_event_schema.py`:
 
 - `task` — default for non-coding planning/handoff work.
 - `coding-task` — implementer work that lands code.
 - `gate-finding` — the per-phase quality gate task.
 - `phase-transition` — phase-boundary transition record.
+- `procedure-trigger` — task that triggers procedure injection (see SubagentStart hook).
+- `subtask` — child task spawned under another task in the same chain.
 
 ```json
 {
@@ -190,7 +196,7 @@ NOT emit the pipe-separated list literally):
   "specialist": "requirements-analyst",
   "blockedBy": [],
   "metadata": {
-    "chain_id": "{slug}.root",
+    "chain_id": "{project_slug}.root",
     "event_type": "task",
     "source_agent": "facilitator",
     "phase": "clarify",
@@ -202,9 +208,9 @@ NOT emit the pipe-separated list literally):
 }
 ```
 
-Substitute `{slug}` with the actual `project_slug` (e.g. for project slug
-`auth_rewrite` the `chain_id` is `"auth_rewrite.root"`). Do NOT emit the literal
-braces.
+Substitute `{project_slug}` with the actual `project_slug` value (e.g. for
+project slug `auth_rewrite` the `chain_id` is `"auth_rewrite.root"`). Do NOT
+emit the literal braces.
 
 `blockedBy: [<ids>]` sets dependencies; the chain is a DAG. Parallel-eligible tasks
 within a phase share a `blockedBy` pointing to the same upstream.

--- a/scripts/crew/verification_protocol.py
+++ b/scripts/crew/verification_protocol.py
@@ -116,6 +116,15 @@ def _phases_with_required_deliverables() -> set:
     {"clarify", "design", "build"} set in check_traceability that omitted
     "ideate" and any future phases). Falls back to the historical hardcoded
     set if phases.json is missing or unreadable, preserving prior behavior.
+
+    NOTE (#675 sweep, F8): the returned set narrows what `check_traceability`
+    inspects. Phases NOT in this set (e.g. custom phase dirs added by a project
+    that doesn't appear in `.claude-plugin/phases.json`, or phases with no
+    `required_deliverables` field) are skipped silently for the missing-dir
+    check — that's intentional, since the check is "every phase that DECLARES
+    deliverables must have a directory", not "every directory must declare
+    deliverables". Callers see a structured warning when this filtering may
+    drop a legitimate phase dir (see `check_traceability`).
     """
     fallback = {"clarify", "design", "build"}
     try:
@@ -134,6 +143,23 @@ def _phases_with_required_deliverables() -> set:
         return result or fallback
     except Exception:  # noqa: BLE001 — fail-safe: traceability check still runs
         return fallback
+
+
+def _normalize_phase_name(name: str) -> str:
+    """Normalize a phase name for cross-source comparison.
+
+    Different sources represent phase names slightly differently:
+      - `phases.json` uses canonical kebab-case (`test-strategy`).
+      - On-disk project layouts may use either kebab-case OR snake_case
+        depending on when the project was scaffolded (legacy projects may
+        have `test_strategy/` directories from before the kebab-case rename).
+      - Some older crew tooling lowercased phase names inconsistently.
+
+    Normalization rule (F7, #675 sweep): lowercase + replace `-` with `_`.
+    Both `test-strategy` and `test_strategy` collapse to `test_strategy`,
+    making set membership a cheap, deterministic comparison.
+    """
+    return name.lower().replace("-", "_")
 
 
 def _run_command(
@@ -881,16 +907,39 @@ def check_traceability(
     # that declares required_deliverables in phases.json (#667 follow-up:
     # was a hardcoded {"clarify", "design", "build"} set, now derived from
     # phases.json so phases like "ideate" and any future phases are covered).
+    #
+    # Normalization (F7, #675 sweep): phases.json stores canonical kebab-case
+    # phase names (e.g. `test-strategy`), but on-disk project layouts may use
+    # either kebab-case OR snake_case (e.g. `test_strategy/`) for legacy
+    # projects. Compare using `_normalize_phase_name` so both shapes match.
     phase_dirs = [d.name for d in phases_dir.iterdir() if d.is_dir()]
     expected_phases = _phases_with_required_deliverables()
-    missing_phases = expected_phases - set(phase_dirs)
+    expected_norm = {_normalize_phase_name(p) for p in expected_phases}
+    phase_dirs_norm = {_normalize_phase_name(d) for d in phase_dirs}
+    missing_norm = expected_norm - phase_dirs_norm
+    # Re-project missing names to their canonical (kebab-case) form for the message.
+    missing_phases = sorted(
+        {p for p in expected_phases if _normalize_phase_name(p) in missing_norm}
+    )
+
+    # F8 (#675 sweep): surface a structured note when a project has phase dirs
+    # that aren't in the filtered set — these are skipped by the traceability
+    # check by design (see _phases_with_required_deliverables docstring), but
+    # operators have asked for visibility. Logged via details, not failure.
+    extra_phase_dirs = sorted(
+        {d for d in phase_dirs if _normalize_phase_name(d) not in expected_norm}
+    )
 
     if missing_phases:
         return CheckResult(
             name=name,
             status="FAIL",
-            evidence=f"Broken traceability chain: missing phase directories: {', '.join(sorted(missing_phases))}",
-            details={"missing_phases": sorted(missing_phases), "criteria_count": len(criteria)},
+            evidence=f"Broken traceability chain: missing phase directories: {', '.join(missing_phases)}",
+            details={
+                "missing_phases": missing_phases,
+                "criteria_count": len(criteria),
+                "extra_phase_dirs_skipped": extra_phase_dirs,
+            },
         )
 
     # Check that each criterion has at least a test file reference
@@ -907,14 +956,19 @@ def check_traceability(
             name=name,
             status="FAIL",
             evidence=f"{linked}/{total} criteria have complete chains; broken: {', '.join(broken_chains[:10])}",
-            details={"broken_chains": broken_chains, "total": total, "complete": linked},
+            details={
+                "broken_chains": broken_chains,
+                "total": total,
+                "complete": linked,
+                "extra_phase_dirs_skipped": extra_phase_dirs,
+            },
         )
 
     return CheckResult(
         name=name,
         status="PASS",
         evidence=f"{total}/{total} criteria have complete requirement->test chains",
-        details={"total": total},
+        details={"total": total, "extra_phase_dirs_skipped": extra_phase_dirs},
     )
 
 

--- a/scripts/wg/check_pattern_a_gate.py
+++ b/scripts/wg/check_pattern_a_gate.py
@@ -18,8 +18,11 @@ Requirement: the same diff must add a scenario file matching:
     scenarios/**/*pattern*.md, *shape*.md, *dispatch*.md
 
 Behavior: ERROR (exit 1, blocks CI) if signal detected and no matching
-scenario. Fail-open (exit 0) if `git diff` returns empty -- e.g. running on
-main with no PR context.
+scenario. Fail-open (exit 0) under TWO conditions:
+    1. `git diff` returns empty -- e.g. running on main with no PR context.
+    2. `git diff` command fails (returns None) -- e.g. missing base ref,
+       shallow clone, or other git failure. A WARNING is printed in this case
+       so the cause is visible in CI logs.
 
 Threshold rationale: 40% shrink + same-PR new agent is the safe combo.
 PR #666 went from ~120 to 43 lines (64% drop). Tuning lower would catch
@@ -79,18 +82,24 @@ def resolve_base_ref() -> str:
 
     F11 (#675 sweep): the previous implementation special-cased the literal
     ``"main"`` as already-fully-qualified, but that left ambiguity between the
-    local branch and the remote-tracking ref. We now ALWAYS prepend ``origin/``
-    when the ref doesn't already include a remote prefix, matching the
-    "compare PR head to the remote base" semantics the gate is documented to
-    enforce. To opt out, set ``WG_PR_BASE_REF=main`` explicitly with a
-    pre-stripped value -- the env var wins regardless and short-circuits the
-    normalization (the env var is treated as caller-authoritative).
+    local branch and the remote-tracking ref. We now prepend ``origin/`` when
+    the ref doesn't already carry a recognised remote/refs prefix, matching
+    the "compare PR head to the remote base" semantics the gate is documented
+    to enforce. To opt out, set ``WG_PR_BASE_REF`` explicitly -- the env var
+    wins regardless and short-circuits the normalization (the env var is
+    treated as caller-authoritative).
+
+    Bug 1 (#676 sweep): the previous check used ``"/" not in base`` to detect
+    "needs origin prefix", but branches like ``feature/migration`` or
+    ``releases/v8.4`` already contain slashes and would skip the prefix --
+    causing git diff to look for a non-existent local ref. We now check for
+    explicit remote/refs prefixes instead.
     """
     explicit = os.environ.get("WG_PR_BASE_REF")
     if explicit:
         return explicit
     base = os.environ.get("GITHUB_BASE_REF") or "origin/main"
-    if "/" not in base:
+    if not base.startswith(("origin/", "upstream/", "refs/")):
         base = f"origin/{base}"
     return base
 
@@ -99,7 +108,13 @@ def main() -> int:
     base_ref = resolve_base_ref()
     diff_range = f"{base_ref}...HEAD"
 
-    name_status = run(["git", "diff", "--name-status", diff_range])
+    # Bug 2 (#676 sweep): pass `-c core.quotePath=false` so paths with spaces
+    # or non-ASCII characters are emitted verbatim. Default git quoting wraps
+    # such paths in `"..."` which then breaks subsequent `path.startswith` and
+    # `git show {ref}:{path}` calls.
+    name_status = run(
+        ["git", "-c", "core.quotePath=false", "diff", "--name-status", diff_range]
+    )
     if name_status is None:
         # F10 (#675 sweep): a real git error (missing ref, shallow checkout) --
         # surface explicitly instead of pretending the diff was empty. Still
@@ -161,8 +176,23 @@ def main() -> int:
             # Direct line-count comparison sidesteps both problems.
             base_blob = run(["git", "show", f"{base_ref}:{old_path}"])
             head_blob = run(["git", "show", f"HEAD:{new_path}"])
-            base_lines = base_blob.count("\n") if base_blob else 0
-            head_lines = head_blob.count("\n") if head_blob else 0
+            # Bug 4 (#676 sweep): if either git show failed (returned None),
+            # we can't compare line counts honestly -- treating None as "" gave
+            # 0 lines on the failing side and produced false-positive 100%
+            # shrink readings. Skip the file with a warning instead.
+            if base_blob is None or head_blob is None:
+                missing = "base" if base_blob is None else "head"
+                sys.stderr.write(
+                    f"WARNING: skipping shrink check for {path} -- {missing} blob "
+                    f"unavailable (git show failed for {old_path if missing == 'base' else new_path})\n"
+                )
+                continue
+            # Bug 3 (#676 sweep): blob.count('\n') undercounts files that lack
+            # a trailing newline (a 1-line file with no final \n returns 0 and
+            # is silently skipped). splitlines() handles both cases the same
+            # way: "foo\nbar" -> 2 lines, "foo\nbar\n" -> 2 lines, "" -> 0.
+            base_lines = len(base_blob.splitlines())
+            head_lines = len(head_blob.splitlines())
             if base_lines == 0:
                 continue
             shrink = (base_lines - head_lines) / base_lines

--- a/scripts/wg/check_pattern_a_gate.py
+++ b/scripts/wg/check_pattern_a_gate.py
@@ -46,18 +46,51 @@ SCENARIO_PATTERNS = [
 ]
 
 
-def run(cmd: list[str]) -> str:
+def run(cmd: list[str]) -> str | None:
+    """Run a git command and return stdout (possibly empty) on success, or None on error.
+
+    F10 (#675 sweep): the previous implementation collapsed both "command failed"
+    and "command succeeded with empty output" into the same empty-string return
+    value, so a missing `origin/main` ref looked identical to a clean diff. We
+    now return ``None`` on any non-zero exit (or exception) so the caller can
+    distinguish the two and surface a useful message.
+    """
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        return r.stdout if r.returncode == 0 else ""
-    except Exception:  # noqa: BLE001 -- fail-open per design
-        return ""
+        if r.returncode != 0:
+            stderr = (r.stderr or "").strip()
+            sys.stderr.write(
+                f"WARNING: `{' '.join(cmd)}` exited {r.returncode}: {stderr}\n"
+            )
+            return None
+        return r.stdout
+    except Exception as exc:  # noqa: BLE001 -- fail-open per design, but log the cause
+        sys.stderr.write(f"WARNING: `{' '.join(cmd)}` raised {exc!r}\n")
+        return None
 
 
 def resolve_base_ref() -> str:
-    """Resolve the PR base ref. CI sets GITHUB_BASE_REF; locally use origin/main."""
-    base = os.environ.get("WG_PR_BASE_REF") or os.environ.get("GITHUB_BASE_REF") or "origin/main"
-    if base and not base.startswith("origin/") and base != "main":
+    """Resolve the PR base ref for `git diff <base>...HEAD`.
+
+    Resolution order:
+      1. ``WG_PR_BASE_REF`` env var (escape hatch for local testing).
+      2. ``GITHUB_BASE_REF`` env var (set by GitHub Actions on pull_request).
+      3. Default: ``origin/main``.
+
+    F11 (#675 sweep): the previous implementation special-cased the literal
+    ``"main"`` as already-fully-qualified, but that left ambiguity between the
+    local branch and the remote-tracking ref. We now ALWAYS prepend ``origin/``
+    when the ref doesn't already include a remote prefix, matching the
+    "compare PR head to the remote base" semantics the gate is documented to
+    enforce. To opt out, set ``WG_PR_BASE_REF=main`` explicitly with a
+    pre-stripped value -- the env var wins regardless and short-circuits the
+    normalization (the env var is treated as caller-authoritative).
+    """
+    explicit = os.environ.get("WG_PR_BASE_REF")
+    if explicit:
+        return explicit
+    base = os.environ.get("GITHUB_BASE_REF") or "origin/main"
+    if "/" not in base:
         base = f"origin/{base}"
     return base
 
@@ -67,6 +100,19 @@ def main() -> int:
     diff_range = f"{base_ref}...HEAD"
 
     name_status = run(["git", "diff", "--name-status", diff_range])
+    if name_status is None:
+        # F10 (#675 sweep): a real git error (missing ref, shallow checkout) --
+        # surface explicitly instead of pretending the diff was empty. Still
+        # exit 0 so we don't break local `wg-check` runs that happen to be on
+        # main without the remote fetched, but the warning makes the cause
+        # visible.
+        print(
+            f"WARNING: `git diff --name-status {diff_range}` failed -- "
+            "Pattern A gate skipped (fail-open). Check that the base ref "
+            "exists locally (`git fetch origin`) and that the working tree "
+            "is not a shallow clone."
+        )
+        return 0
     if not name_status.strip():
         print(f"OK: no PR diff against {base_ref} -- Pattern A gate skipped (fail-open)")
         return 0
@@ -80,7 +126,20 @@ def main() -> int:
         if len(parts) < 2:
             continue
         status = parts[0].strip()
-        path = parts[-1].strip()
+
+        # F9 (#675 sweep): renames are reported as `R<score>\told_path\tnew_path`.
+        # Previously we only looked at parts[-1] (the new path) and then ran
+        # `git show base_ref:new_path` -- which fails silently if the file had
+        # a different name in the base ref. Result: renamed SKILL.md files were
+        # invisible to the shrink computation. We now keep both paths and use
+        # the OLD path against base_ref / NEW path against HEAD.
+        if status.startswith("R") and len(parts) >= 3:
+            old_path = parts[1].strip()
+            new_path = parts[2].strip()
+        else:
+            old_path = parts[-1].strip()
+            new_path = parts[-1].strip()
+        path = new_path
 
         if status.startswith("A") and path.startswith("agents/") and path.endswith(".md"):
             new_agents.append(path)
@@ -93,25 +152,22 @@ def main() -> int:
             and path.endswith("SKILL.md")
             and status.startswith(("M", "R"))
         ):
-            numstat = run(["git", "diff", "--numstat", diff_range, "--", path])
-            if not numstat.strip():
+            # F9 (#675 sweep): for a rename, the most reliable shrink estimate
+            # is comparing line counts directly: base_lines (from old_path in
+            # base_ref) vs head_lines (from new_path at HEAD). git's --numstat
+            # output is ambiguous for renames -- if you path-restrict it, you
+            # get bogus add-only / delete-only rows; if you don't restrict,
+            # you get the rename row but still need to parse the path arrow.
+            # Direct line-count comparison sidesteps both problems.
+            base_blob = run(["git", "show", f"{base_ref}:{old_path}"])
+            head_blob = run(["git", "show", f"HEAD:{new_path}"])
+            base_lines = base_blob.count("\n") if base_blob else 0
+            head_lines = head_blob.count("\n") if head_blob else 0
+            if base_lines == 0:
                 continue
-            for nl in numstat.splitlines():
-                np_ = nl.split("\t")
-                if len(np_) < 3:
-                    continue
-                try:
-                    added = int(np_[0])
-                    deleted = int(np_[1])
-                except ValueError:
-                    continue
-                base_blob = run(["git", "show", f"{base_ref}:{path}"])
-                base_lines = base_blob.count("\n") if base_blob else 0
-                if base_lines == 0:
-                    continue
-                shrink = (deleted - added) / base_lines if base_lines else 0
-                if shrink >= SHRINK_RATIO:
-                    slimmed_skills.append((path, base_lines, shrink))
+            shrink = (base_lines - head_lines) / base_lines
+            if shrink >= SHRINK_RATIO:
+                slimmed_skills.append((path, base_lines, shrink))
 
     if not slimmed_skills or not new_agents:
         if slimmed_skills:

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -126,7 +126,7 @@ Task(
     mode: propose
     current_chain: none
     auto_proceed: none
-    project_dir: ~/.something-wicked/wicked-garden/projects/{session-slug}/wicked-crew/projects/auth_rewrite
+    project_dir: /Users/alex/.something-wicked/wicked-garden/projects/2026-04-26-1430/wicked-crew/projects/auth_rewrite
     project_slug: auth_rewrite
     bookend: none
     phase: none

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -29,7 +29,7 @@ Thin shim. Full rubric lives in [`agents/crew/process-facilitator.md`](../../age
   real project calls; omit only on `output=json` measurement / no-project calls).
 - **`project_dir`** — absolute path; agent writes the draft plan here. If absent,
   the shim resolves it via the `resolve_path.py` subpath form:
-  `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/resolve_path.py" wicked-crew projects {slug}`.
+  `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/resolve_path.py" wicked-crew projects {project_slug}`.
   On `output=json` with no project context, an ephemeral tmp dir is used (see Step 0).
 - **`bookend`** (`phase-start` | `phase-end`) and **`phase`** — required for `re-evaluate` from `phase-executor`.
 - **`current_chain`** — required for `re-evaluate`: tasks created so far, status, evidence.
@@ -47,7 +47,7 @@ Two call shapes are supported:
 
 - **Real project call** (`mode=propose|re-evaluate`, `project_slug` or `project`
   provided): `${project_dir}` resolves under
-  `~/.something-wicked/wicked-garden/projects/{session-slug}/wicked-crew/projects/{slug}/`
+  `~/.something-wicked/wicked-garden/projects/{session-slug}/wicked-crew/projects/{project_slug}/`
   (the `{session-slug}` segment is the per-cwd slug from `_paths._get_project_slug()`).
   The draft persists at `${project_dir}/process-plan.draft.json`. The caller
   (`commands/crew/start.md` Step 7, etc.) is responsible for any subsequent
@@ -67,7 +67,7 @@ When invoked:
 0. **Resolve `project_dir`** (in order):
    - If `project_dir` is set, use it as-is and `mkdir -p` it.
    - Else if `project_slug` or `project` is set, resolve via
-     `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/resolve_path.py" wicked-crew projects {slug}`
+     `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/resolve_path.py" wicked-crew projects {project_slug}`
      (the `resolve_path.py` subpath form auto-creates intermediate dirs).
    - Else if `output=json` AND no project context was provided (measurement /
      no-project call), allocate an ephemeral dir
@@ -98,16 +98,19 @@ Task(
     project_slug: {project_slug}
     bookend: {bookend}
     phase: {phase}
-    output: {output}
 
     For any field whose value is `none`, treat it as absent (use the input's
     documented default).
 
-    Write the resulting JSON to ${project_dir}/process-plan.draft.json before
+    Write the resulting JSON to {project_dir}/process-plan.draft.json before
     returning. Do NOT issue TaskCreate calls — the caller emits the chain.
   """
 )
 ```
+
+   `output` is intentionally NOT forwarded — the agent always writes the draft
+   file regardless, and the shim (Steps 3 / 4 below) decides whether to render
+   `process-plan.md` based on the caller's `output` value.
 
    Concrete example for the `crew:start` Step 5 call (description elided):
 
@@ -123,16 +126,15 @@ Task(
     mode: propose
     current_chain: none
     auto_proceed: none
-    project_dir: /Users/.../wicked-crew/projects/auth_rewrite
+    project_dir: ~/.something-wicked/wicked-garden/projects/{session-slug}/wicked-crew/projects/auth_rewrite
     project_slug: auth_rewrite
     bookend: none
     phase: none
-    output: json
 
     For any field whose value is `none`, treat it as absent (use the input's
     documented default).
 
-    Write the resulting JSON to ${project_dir}/process-plan.draft.json before
+    Write the resulting JSON to {project_dir}/process-plan.draft.json before
     returning. Do NOT issue TaskCreate calls — the caller emits the chain.
   """
 )


### PR DESCRIPTION
## Summary

Drains the polish-issue backlog from this arc by bundling all 20 post-merge sweep findings (collapsed to 13 fixes) into a single PR. **Closes #675.** Also addresses 9 inline-documented findings from the #673 and #674 sweeps that did not have their own issues filed.

- 6 doc/contract fixes against PR #672 (the `{slug}` / `{project_slug}` placeholder consistency, `event_type` enum, Task() forwarding hygiene)
- 2 fixes against PR #673 (verification_protocol traceability check — phase-name normalization + filtering visibility)
- 7 fixes against PR #674 (wg-check Pattern A gate — rename handling, run() error sentinel, base-ref consistency, doc accuracy, find-with-spaces)

Files touched (5):
- `agents/crew/process-facilitator.md`
- `skills/propose-process/SKILL.md`
- `scripts/crew/verification_protocol.py`
- `scripts/wg/check_pattern_a_gate.py`
- `.claude/commands/wg-check.md`

## Fixes by source PR

### PR #672 follow-up (#675 issue)

| ID | Source | Fix |
|----|--------|-----|
| F1 | gemini, ×6 sites | Replace `{slug}` with `{project_slug}` in agent + skill files (chain_id template, resolve_path examples, output path docs) |
| F2 | gemini, HIGH | Reword "agent does not run Python" — agent now describes that it emits `metadata.archetype` via the rubric output and the caller is responsible for invoking `archetype_detect` if needed |
| F3 | gemini | Drop `output: {output}` from the `Task()` forwarding example. Agent doc says behavior is independent of `output`; added explanatory note that the shim uses it only for its own dispatch decision |
| F4 | Copilot | Replace `${project_dir}` (shell expansion) with `{project_dir}` (handlebars consistency) in the `Task()` prompt body |
| F5 | Copilot | Replace absolute `/Users/.../` path in concrete example with the canonical `~/.something-wicked/wicked-garden/projects/{session-slug}/wicked-crew/projects/{project_slug}` layout |
| F6 | Copilot | Extend `event_type` enumeration from 4 to 6 values (`procedure-trigger`, `subtask` were missing). Now matches `scripts/_event_schema.py` |

### PR #673 sweep (inline-documented; no separate issue)

#### F7 — Phase-name vs dir-name mismatch (Copilot, MEDIUM)

> `scripts/crew/verification_protocol.py` line 886: `_phases_with_required_deliverables()` returns canonical phase names from `phases.json` (e.g. `test-strategy`), but `check_traceability` compares them directly to on-disk directory names. Legacy projects may have different dir names (e.g. `test_strategy` underscore vs `test-strategy` hyphen).

Fix: added `_normalize_phase_name()` (lowercase + `-`→`_`). Both shapes collapse to `test_strategy`, making set membership a deterministic comparison. The "missing phases" message still uses the canonical kebab form.

#### F8 — Filtering may regress traceability (gemini, MEDIUM)

> `scripts/crew/verification_protocol.py` line 134: filtering for phases with required_deliverables narrows the set check_traceability inspects. If a project's deliverables exist in phases NOT in `_phases_with_required_deliverables()` (e.g. a custom phase), traceability skips them.

Fix: documented the intentional filtering behavior in `_phases_with_required_deliverables()` docstring. Added `extra_phase_dirs_skipped` to the check result `details` so operators can see which phase dirs were skipped (visibility, not failure).

### PR #674 sweep (inline-documented; no separate issue)

#### F9 — `R*` rename status broken (HIGH, ×2 same root cause)

> `scripts/wg/check_pattern_a_gate.py` line 108-114 (and inline Python fallback in `.claude/commands/wg-check.md` line 939): for `R*` git status lines, `path = parts[-1]` is the NEW path, but `git show {base_ref}:{path}` fails if the file had a different path in the base ref. Result: silent skip of renamed SKILL.md files in the diff.

Fix: parse `R<score>\told_path\tnew_path` correctly. Read the base blob via the OLD path, the head blob via the NEW path, and compute shrink directly from `(base_lines - head_lines) / base_lines`. Avoids the ambiguous numstat output for renames entirely. Verified end-to-end with a fake renamed SKILL scenario — gate fires correctly when scenario absent, passes when scenario present.

#### F10 — `run()` swallows non-zero exit (Copilot, MEDIUM)

> `scripts/wg/check_pattern_a_gate.py` line 54: `run()` returns empty string on any non-zero exit. Means `git diff` errors (missing `origin/main`, shallow checkout, bad ref) look identical to a truly-empty diff.

Fix: `run()` now returns `None` on non-zero exit (or exception). Stderr from the failed command is logged. The main loop emits a clear "git diff failed" warning when the sentinel comes back, instead of pretending the diff was empty. Verified with `WG_PR_BASE_REF=origin/nonexistent-branch-9999` — gate now surfaces the actual git error.

#### F11 — `resolve_base_ref()` local vs CI mismatch (Copilot, MEDIUM)

> `scripts/wg/check_pattern_a_gate.py` line 64: docstring says "locally use origin/main", but when `GITHUB_BASE_REF=main` it returns `main` (not `origin/main`); for other branches it forces an `origin/` prefix. Inconsistent.

Fix: always prepend `origin/` when the resolved ref has no remote prefix. `WG_PR_BASE_REF` remains caller-authoritative (escape hatch). Documented in the function docstring.

#### F12 — wg-check doc says "blocks CI" but real CI uses different script (Copilot, MEDIUM)

> `.claude/commands/wg-check.md` line 880: section says the Pattern A gate blocks CI, but the actual GitHub Actions workflow runs `python scripts/ci/validate.py` (with `actions/checkout@v4`). Either: (a) wire the Pattern A gate INTO `scripts/ci/validate.py`, OR (b) update the doc to honestly say "advisory locally; CI integration pending". Pick (b) — adding to validate.py is out of scope for a polish PR.

Fix: added an explicit "CI integration status" callout to `.claude/commands/wg-check.md` documenting that the gate is currently advisory-locally only. CI integration is documented as a follow-up.

#### F13 — `find ...` breaks on filenames with spaces (gemini, MEDIUM)

> `.claude/commands/wg-check.md` line 213: agent line-count check uses `for x in $(find ...)` which breaks on filenames with spaces. Fix: use `find ... -print0 | while IFS= read -r -d '' x` pattern.

Fix: replaced the `for` loop with the `-print0` + `read -d ''` pattern at the F13 target site (line 213, agent line-count check). Verified the loop still produces the expected warnings/errors.

## Test plan

- [x] `pytest tests/ -q` — 1754 passed, 5 pre-existing failures (no new regressions)
- [x] `python3 scripts/ci/measure_facilitator.py` — 10/10 facilitator-rubric PASS
- [x] `python3 scripts/wg/check_pattern_a_gate.py` — clean fail-open on current branch
- [x] F9 end-to-end test: fake renamed slimmed SKILL + new agent — gate fires (exit 1) without scenario, passes (exit 0) with scenario
- [x] F10 end-to-end test: `WG_PR_BASE_REF=origin/nonexistent-branch-9999` — surfaces the real git error in stderr
- [x] F13 end-to-end test: `find -print0 | while read -d ''` produces same warnings as the prior `for in $(find)` loop
- [x] Re-grep for `{slug}` in agent + SKILL files — zero matches
- [x] Re-compile both Python scripts — no syntax errors

## Scope discipline

- No caller code touched (commands/crew/start.md, execute.md, just-finish.md, agents/crew/phase-executor.md unchanged)
- New `check_conflation.py` from PR #674 untouched (no findings against it)
- No new wg-check checks added
- No prior design decisions re-litigated

## Notes

This is the FOURTH and (hopefully) final post-merge sweep this arc (#667, #669, #671, #675). Findings are converging on mechanical consistency (placeholder names, contradiction phrasing) rather than missing functionality — the Pattern A migration semantics from PRs #666 / #670 are correct, the docs around them just kept needing polish. This PR drains that backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)