### PR TITLE
feat: wicked.steer.* event family + tail subscriber (PR-1 of steering detector epic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Steering detector event family — `wicked.steer.*` on the bus, reference tail subscriber (`scripts/crew/steering_tail.py`), schema validator (`scripts/crew/steering_event_schema.py`). No detectors yet (PR-1 of epic).
+
 ## [8.4.0] - 2026-04-26
 
 ### Features

--- a/docs/steering-detectors.md
+++ b/docs/steering-detectors.md
@@ -1,0 +1,217 @@
+# Steering Detectors
+
+Bus-first design for the steering detector registry. Detectors observe what's
+happening across a crew run and emit `wicked.steer.*` events when something
+crosses a threshold worth flagging. Bus events ARE the audit trail — there is
+no shadow ledger.
+
+> **Status:** PR-1 of the epic. This PR ships the **event family + reference
+> tail subscriber + schema validator only**. No detectors. No behavior
+> subscribers. The wiring proof is what's being landed first.
+>
+> Decision record: `~/.wicked-brain/projects/wicked-garden/memory/steering-detector-registry-v1-design-decision.md`
+> (semantic tier, importance 9).
+
+---
+
+## Event family
+
+Locked by the `wicked-bus:naming` skill.
+
+| Field         | Value                                              |
+|---------------|----------------------------------------------------|
+| `event_type`  | `wicked.steer.escalated` or `wicked.steer.advised` |
+| `domain`      | `wicked-garden`                                    |
+| `subdomain`   | `crew.detector.<detector-name>`                    |
+
+`wicked.steer.escalated` carries a **rigor recommendation** (the detector
+thinks something downstream should change — escalate review tier, regenerate
+test strategy, force a council, etc.).
+
+`wicked.steer.advised` is **informational only** — the detector observed
+something noteworthy but is not asking anyone to change behavior.
+
+---
+
+## Payload schema
+
+All required fields, regardless of severity:
+
+| Field                 | Type   | Notes                                                  |
+|-----------------------|--------|--------------------------------------------------------|
+| `detector`            | string | Must be in the v1 allowlist (see below).              |
+| `signal`              | string | Human-readable observation.                            |
+| `threshold`           | object | The config that fired (free-form per detector).       |
+| `recommended_action`  | string | E.g. `force-full-rigor`. Loose set; warns on unknown. |
+| `evidence`            | object | At least one key. Should reference session + project. |
+| `session_id`          | string | The session that produced the signal.                 |
+| `project_slug`        | string | The crew project slug.                                |
+| `timestamp`           | string | ISO8601 (`2026-04-27T10:00:00Z`).                     |
+
+Validator: `scripts/crew/steering_event_schema.py::validate_payload(event_type, payload)`
+
+### Example payload
+
+```json
+{
+  "detector": "sensitive-path",
+  "signal": "auth/login.py touched in this phase",
+  "threshold": {
+    "extensions": [".py", ".ts", ".go"],
+    "globs": ["auth/**", "billing/**"]
+  },
+  "recommended_action": "force-full-rigor",
+  "evidence": {
+    "file": "auth/login.py",
+    "session_id": "sess-001",
+    "project_slug": "fix-auth-redirect",
+    "phase": "build"
+  },
+  "session_id": "sess-001",
+  "project_slug": "fix-auth-redirect",
+  "timestamp": "2026-04-27T10:00:00Z"
+}
+```
+
+---
+
+## v1 detector allowlist
+
+These five names are reserved at the schema layer in PR-1. The detectors
+themselves ship in later PRs.
+
+| Detector              | Planned `recommended_action`              |
+|-----------------------|-------------------------------------------|
+| `sensitive-path`      | `force-full-rigor`                        |
+| `blast-radius`        | `force-full-rigor`                        |
+| `council-split`       | `require-council-review`                  |
+| `test-failure-spike`  | `regen-test-strategy`                     |
+| `cross-domain-edits`  | `notify-only` (advised, not escalated)    |
+
+Calibration notes from the design decision:
+
+- **sensitive-path** — content-aware path matching (extension filter, not
+  directory-only). Highest signal, easiest to calibrate via audit data.
+- **blast-radius** — fires when `observed > 2 × estimate AND observed > 8 files`.
+  The absolute floor prevents small-task noise.
+- **test-failure-spike** — N=3 consecutive non-zero exits after the first green
+  baseline. Confirm the pytest exit-code signal source exists before
+  implementing.
+- **council-split** — ship as-is, optionally soften to a 2nd HITL confirmation.
+- **cross-domain-edits** — demoted to `wicked.steer.advised` (not escalated).
+  Structural proxy, not a risk signal — revisit after 30 days of data.
+
+Adding a new detector requires (a) adding the name to
+`KNOWN_DETECTORS` in `scripts/crew/steering_event_schema.py`, (b) shipping the
+detector implementation, and (c) updating this table.
+
+---
+
+## Recommended actions
+
+Loose set — unknown values pass validation with a warning string, not an
+error. Initial values:
+
+- `force-full-rigor`
+- `regen-test-strategy`
+- `require-council-review`
+- `notify-only`
+
+---
+
+## Subscribers (planned consumers)
+
+Three known consumers. None of them ship in PR-1 — the table documents the
+filter contract each will use.
+
+### `crew:rigor-escalator` (in-plugin)
+
+Filter: `wicked.steer.escalated@wicked-garden`
+
+Acts on escalation recommendations. Reads `recommended_action` and applies the
+corresponding rigor change (e.g. flips the active phase to `full` tier when
+action is `force-full-rigor`).
+
+### Audit log
+
+Filter: `wicked.steer.*@wicked-garden`
+
+Captures every steering event (both escalated and advised) into a persistent
+audit record per the design decision's
+`detector_fire.jsonl` schema:
+
+```
+detector_name, timestamp, session_id, signal_raw, threshold,
+action_recommended, action_taken, override_rationale
+```
+
+The audit log is the **first deliverable** before any detector implementation
+ships, per all three personas (Principal Engineer, Senior IC, Compliance
+Auditor) ratifying the design.
+
+### `wicked-testing:qe-engager` (cross-plugin)
+
+Filter: `wicked.steer.*@wicked-garden` with a payload-level filter for
+`subdomain == crew.detector.test-failure-spike`.
+
+Reacts to test-failure spikes by triggering a wicked-testing strategy
+regeneration.
+
+---
+
+## Reference tail subscriber
+
+`scripts/crew/steering_tail.py` is the live debug stream — it does **not**
+take action, just prints incoming events as one-line JSON:
+
+```bash
+# All steering events
+python3 scripts/crew/steering_tail.py
+
+# Escalations only
+python3 scripts/crew/steering_tail.py --severity=escalated
+
+# A specific detector
+python3 scripts/crew/steering_tail.py --detector=sensitive-path
+
+# Resume from a known cursor
+python3 scripts/crew/steering_tail.py --from-cursor=<cursor_id>
+```
+
+Use this to verify wiring for any new emit point before writing a behavior
+subscriber.
+
+---
+
+## Manual emit (for verification during PR-1)
+
+```bash
+npx wicked-bus emit \
+  --type wicked.steer.escalated \
+  --domain wicked-garden \
+  --subdomain crew.detector.sensitive-path \
+  --payload '{
+    "detector": "sensitive-path",
+    "signal": "auth/login.py touched",
+    "threshold": {"extensions": [".py"]},
+    "recommended_action": "force-full-rigor",
+    "evidence": {"file": "auth/login.py"},
+    "session_id": "test-001",
+    "project_slug": "test",
+    "timestamp": "2026-04-27T10:00:00Z"
+  }'
+```
+
+In another shell, run the tail and watch the event arrive:
+
+```bash
+python3 scripts/crew/steering_tail.py --severity=escalated
+```
+
+---
+
+## Design pointer
+
+Full design decision (rationale, alternatives, persona votes, threshold
+calibration):
+`~/.wicked-brain/projects/wicked-garden/memory/steering-detector-registry-v1-design-decision.md`

--- a/docs/steering-detectors.md
+++ b/docs/steering-detectors.md
@@ -50,6 +50,11 @@ All required fields, regardless of severity:
 
 Validator: `scripts/crew/steering_event_schema.py::validate_payload(event_type, payload)`
 
+Returns a `(errors, warnings)` tuple. Hard errors live in `errors`; advisory
+notes (e.g. unknown `recommended_action` values, since the action set is
+loose) live in `warnings`. A payload is valid when `errors` is empty —
+warnings are informational only.
+
 ### Example payload
 
 ```json
@@ -151,11 +156,21 @@ Auditor) ratifying the design.
 
 ### `wicked-testing:qe-engager` (cross-plugin)
 
-Filter: `wicked.steer.*@wicked-garden` with a payload-level filter for
-`subdomain == crew.detector.test-failure-spike`.
+Filter: `wicked.steer.*@wicked-garden`.
 
-Reacts to test-failure spikes by triggering a wicked-testing strategy
-regeneration.
+The wicked-bus subscribe CLI filter syntax is `event_type@domain` only — it
+does not have a `--subdomain` flag (see `scripts/_bus.py` and `wicked-bus
+subscribe --help`). Subscribers that care about a specific detector must
+apply a client-side filter on the event's top-level `subdomain` field after
+receiving it. The reference subscriber `scripts/crew/steering_tail.py`
+demonstrates this pattern via its `--detector` flag (matches
+`subdomain == crew.detector.<name>` in Python after the bus delivers the
+event).
+
+For `qe-engager`, that means: subscribe to the broad `wicked.steer.*@wicked-garden`
+filter, then in the consumer code drop any event whose top-level `subdomain`
+is not `crew.detector.test-failure-spike`. Reacts to those by triggering a
+wicked-testing strategy regeneration.
 
 ---
 

--- a/scripts/crew/steering_event_schema.py
+++ b/scripts/crew/steering_event_schema.py
@@ -23,9 +23,12 @@ Usage::
         validate_payload,
     )
 
-    errors = validate_payload("wicked.steer.escalated", payload_dict)
+    errors, warnings = validate_payload("wicked.steer.escalated", payload_dict)
     if errors:
         # reject — see errors list for details
+        ...
+    for w in warnings:
+        # log/surface warnings but do not block
         ...
 
 PR-1 of the steering detector epic ships ONLY the event family wiring. No
@@ -35,7 +38,8 @@ detectors, no behavior subscribers — see ``docs/steering-detectors.md``.
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List
+from datetime import datetime
+from typing import Any, List, Tuple
 
 # ---------------------------------------------------------------------------
 # Allowlists — locked at PR-1, intentionally narrow.
@@ -89,24 +93,34 @@ _ISO8601_RE = re.compile(
 )
 
 
-def validate_payload(event_type: str, payload: Dict[str, Any]) -> List[str]:
+def validate_payload(
+    event_type: str,
+    payload: Any,
+) -> Tuple[List[str], List[str]]:
     """Validate a steering event payload.
 
-    Returns a list of error strings. Empty list = valid.
+    Returns a ``(errors, warnings)`` tuple. Empty errors list = valid (the
+    payload may still produce warnings — those are advisory only).
 
-    Unknown ``recommended_action`` values are reported as warning strings
-    (prefix ``warning:``) rather than hard errors — actions are loose by
-    design (see ``KNOWN_ACTIONS`` docstring). Callers that want to treat
-    warnings as errors can do so explicitly.
+    Unknown ``recommended_action`` values are reported as warnings rather than
+    hard errors — actions are loose by design (see ``KNOWN_ACTIONS``
+    docstring). Callers that want strict mode can treat warnings as errors.
+
+    The ``payload`` parameter is typed as ``Any`` because the validator
+    intentionally handles non-dict inputs (it reports them as a hard error
+    rather than crashing on attribute access).
 
     Args:
         event_type: Bus event_type (e.g. ``wicked.steer.escalated``).
-        payload: The payload dict.
+        payload: The payload (expected to be a dict; non-dicts produce a
+            hard error and short-circuit the rest of the checks).
 
     Returns:
-        List of error/warning strings. Empty if fully valid.
+        ``(errors, warnings)`` — both lists are empty when the payload is
+        fully valid with no advisory notes.
     """
     errors: List[str] = []
+    warnings: List[str] = []
 
     # event_type validation is independent of payload shape.
     if event_type not in KNOWN_EVENT_TYPES:
@@ -117,7 +131,7 @@ def validate_payload(event_type: str, payload: Dict[str, Any]) -> List[str]:
 
     if not isinstance(payload, dict):
         errors.append(f"payload must be a dict, got {type(payload).__name__}")
-        return errors  # nothing more we can validate
+        return errors, warnings  # nothing more we can validate
 
     # Required field presence.
     for field in _REQUIRED_FIELDS:
@@ -153,8 +167,8 @@ def validate_payload(event_type: str, payload: Dict[str, Any]) -> List[str]:
             )
         elif action not in KNOWN_ACTIONS:
             # WARNING, not error — actions are loose by design.
-            errors.append(
-                f"warning: unknown recommended_action: {action!r} "
+            warnings.append(
+                f"unknown recommended_action: {action!r} "
                 f"(known: {sorted(KNOWN_ACTIONS)}; loose set, will not block)"
             )
 
@@ -187,8 +201,20 @@ def validate_payload(event_type: str, payload: Dict[str, Any]) -> List[str]:
             errors.append(
                 f"timestamp must be ISO8601 (e.g. 2026-04-27T10:00:00Z), got {ts!r}"
             )
+        else:
+            # Shape passed. Now confirm the components are real calendar/clock
+            # values — the regex alone accepts e.g. 2026-99-99T99:99:99Z.
+            # datetime.fromisoformat() in Py3.9 doesn't accept the trailing
+            # 'Z' literal, so normalize it to '+00:00' before parsing.
+            normalized = ts[:-1] + "+00:00" if ts.endswith("Z") else ts
+            try:
+                datetime.fromisoformat(normalized)
+            except ValueError as exc:
+                errors.append(
+                    f"timestamp is not a real ISO8601 datetime: {ts!r} ({exc})"
+                )
 
-    return errors
+    return errors, warnings
 
 
 __all__ = [

--- a/scripts/crew/steering_event_schema.py
+++ b/scripts/crew/steering_event_schema.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+crew/steering_event_schema.py — Schema validator for the wicked.steer.* event family.
+
+The steering detector registry (epic) emits two event types on the bus:
+
+  * ``wicked.steer.escalated`` — a detector recommends a rigor change
+  * ``wicked.steer.advised``   — a detector observed something but is informational only
+
+Both share the same payload shape. This module is the single source of truth for
+that shape so that emitters, the reference tail subscriber, and any future
+behavior subscriber (e.g. ``crew:rigor-escalator``) all agree on what valid
+looks like.
+
+Pure stdlib. Importable from any other crew script.
+
+Usage::
+
+    from crew.steering_event_schema import (
+        KNOWN_DETECTORS,
+        KNOWN_EVENT_TYPES,
+        KNOWN_ACTIONS,
+        validate_payload,
+    )
+
+    errors = validate_payload("wicked.steer.escalated", payload_dict)
+    if errors:
+        # reject — see errors list for details
+        ...
+
+PR-1 of the steering detector epic ships ONLY the event family wiring. No
+detectors, no behavior subscribers — see ``docs/steering-detectors.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+# ---------------------------------------------------------------------------
+# Allowlists — locked at PR-1, intentionally narrow.
+# ---------------------------------------------------------------------------
+
+#: Event types in the wicked.steer.* family. Locked by ``wicked-bus:naming``.
+KNOWN_EVENT_TYPES: frozenset = frozenset({
+    "wicked.steer.escalated",
+    "wicked.steer.advised",
+})
+
+#: Detectors planned for v1 of the registry. New detectors require a PR that
+#: adds the name here AND ships the detector implementation.
+KNOWN_DETECTORS: frozenset = frozenset({
+    "sensitive-path",
+    "blast-radius",
+    "council-split",
+    "test-failure-spike",
+    "cross-domain-edits",
+})
+
+#: Recommended actions a detector may suggest. This set is loose — unknown
+#: values produce a warning string, not a hard error, so we don't have to gate
+#: action vocabulary growth on a schema bump.
+KNOWN_ACTIONS: frozenset = frozenset({
+    "force-full-rigor",
+    "regen-test-strategy",
+    "require-council-review",
+    "notify-only",
+})
+
+#: Required top-level payload keys.
+_REQUIRED_FIELDS: tuple = (
+    "detector",
+    "signal",
+    "threshold",
+    "recommended_action",
+    "evidence",
+    "session_id",
+    "project_slug",
+    "timestamp",
+)
+
+# ISO8601 — accept the common subset:
+#   - 2026-04-27T10:00:00Z
+#   - 2026-04-27T10:00:00+00:00
+#   - 2026-04-27T10:00:00.123456+00:00
+# Intentionally strict-ish: we don't accept space separator or naive timestamps.
+_ISO8601_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def validate_payload(event_type: str, payload: Dict[str, Any]) -> List[str]:
+    """Validate a steering event payload.
+
+    Returns a list of error strings. Empty list = valid.
+
+    Unknown ``recommended_action`` values are reported as warning strings
+    (prefix ``warning:``) rather than hard errors — actions are loose by
+    design (see ``KNOWN_ACTIONS`` docstring). Callers that want to treat
+    warnings as errors can do so explicitly.
+
+    Args:
+        event_type: Bus event_type (e.g. ``wicked.steer.escalated``).
+        payload: The payload dict.
+
+    Returns:
+        List of error/warning strings. Empty if fully valid.
+    """
+    errors: List[str] = []
+
+    # event_type validation is independent of payload shape.
+    if event_type not in KNOWN_EVENT_TYPES:
+        errors.append(
+            f"unknown event_type: {event_type!r} "
+            f"(known: {sorted(KNOWN_EVENT_TYPES)})"
+        )
+
+    if not isinstance(payload, dict):
+        errors.append(f"payload must be a dict, got {type(payload).__name__}")
+        return errors  # nothing more we can validate
+
+    # Required field presence.
+    for field in _REQUIRED_FIELDS:
+        if field not in payload:
+            errors.append(f"missing required field: {field!r}")
+
+    # Type checks for present fields.
+    if "detector" in payload:
+        detector = payload["detector"]
+        if not isinstance(detector, str):
+            errors.append(f"detector must be a string, got {type(detector).__name__}")
+        elif detector not in KNOWN_DETECTORS:
+            errors.append(
+                f"unknown detector: {detector!r} "
+                f"(known: {sorted(KNOWN_DETECTORS)})"
+            )
+
+    if "signal" in payload and not isinstance(payload["signal"], str):
+        errors.append(
+            f"signal must be a string, got {type(payload['signal']).__name__}"
+        )
+
+    if "threshold" in payload and not isinstance(payload["threshold"], dict):
+        errors.append(
+            f"threshold must be a dict, got {type(payload['threshold']).__name__}"
+        )
+
+    if "recommended_action" in payload:
+        action = payload["recommended_action"]
+        if not isinstance(action, str):
+            errors.append(
+                f"recommended_action must be a string, got {type(action).__name__}"
+            )
+        elif action not in KNOWN_ACTIONS:
+            # WARNING, not error — actions are loose by design.
+            errors.append(
+                f"warning: unknown recommended_action: {action!r} "
+                f"(known: {sorted(KNOWN_ACTIONS)}; loose set, will not block)"
+            )
+
+    if "evidence" in payload:
+        evidence = payload["evidence"]
+        if not isinstance(evidence, dict):
+            errors.append(
+                f"evidence must be a dict, got {type(evidence).__name__}"
+            )
+        elif not evidence:
+            errors.append("evidence must contain at least one key")
+
+    if "session_id" in payload:
+        sid = payload["session_id"]
+        if not isinstance(sid, str) or not sid.strip():
+            errors.append("session_id must be a non-empty string")
+
+    if "project_slug" in payload:
+        slug = payload["project_slug"]
+        if not isinstance(slug, str) or not slug.strip():
+            errors.append("project_slug must be a non-empty string")
+
+    if "timestamp" in payload:
+        ts = payload["timestamp"]
+        if not isinstance(ts, str):
+            errors.append(
+                f"timestamp must be a string, got {type(ts).__name__}"
+            )
+        elif not _ISO8601_RE.match(ts):
+            errors.append(
+                f"timestamp must be ISO8601 (e.g. 2026-04-27T10:00:00Z), got {ts!r}"
+            )
+
+    return errors
+
+
+__all__ = [
+    "KNOWN_DETECTORS",
+    "KNOWN_EVENT_TYPES",
+    "KNOWN_ACTIONS",
+    "validate_payload",
+]

--- a/scripts/crew/steering_tail.py
+++ b/scripts/crew/steering_tail.py
@@ -48,18 +48,41 @@ _DETECTOR_SUBDOMAIN_PREFIX = "crew.detector."
 _SUBSCRIBER_PLUGIN = "wicked-garden:steering-tail"
 
 
+#: Probe timeout for the wicked-bus reachability check (seconds). Mirrors the
+#: 5s budget used by ``scripts/_bus.py:_EMIT_TIMEOUT_SECONDS`` so the probe
+#: matches what the rest of the plugin considers "fast" for the bus.
+_BUS_PROBE_TIMEOUT_SECONDS = 5.0
+
+
 def _resolve_bus_command() -> Optional[list]:
     """Find the wicked-bus binary or fall back to npx. Returns argv prefix.
 
-    Mirrors the resolution in ``scripts/_bus.py:_resolve_binary``.
+    Mirrors the resolution in ``scripts/_bus.py:_resolve_binary`` — including
+    the actual reachability probe (``wicked-bus status --json``) for the npx
+    path so we don't treat "npx exists" as "wicked-bus reachable" (npx will
+    download the package on first use, which can hang for tens of seconds).
     """
     direct = shutil.which("wicked-bus")
     if direct:
         return [direct]
     npx = shutil.which("npx")
-    if npx:
-        return [npx, "wicked-bus"]
-    return None
+    if npx is None:
+        return None
+    # npx is on PATH — confirm wicked-bus is actually installed/reachable by
+    # running a fast status probe. If this hangs/fails, treat the bus as
+    # unreachable rather than letting `subscribe` block on a package install.
+    try:
+        result = subprocess.run(
+            [npx, "wicked-bus", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=_BUS_PROBE_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [npx, "wicked-bus"]
 
 
 def _parse_args(argv: Optional[list] = None) -> argparse.Namespace:
@@ -159,10 +182,15 @@ def _stream(args: argparse.Namespace) -> int:
     signal.signal(signal.SIGINT, _on_sigint)
 
     try:
+        # IMPORTANT: stream stderr directly to our stderr instead of buffering
+        # to a PIPE. The subscribe child can write enough to stderr to fill the
+        # OS pipe buffer; if we only drain stderr at exit, the child blocks
+        # mid-stream and the tail appears to hang. Routing it straight through
+        # also gives the user live error visibility.
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=sys.stderr,
             text=True,
         )
     except FileNotFoundError:
@@ -200,13 +228,19 @@ def _stream(args: argparse.Namespace) -> int:
                 proc.kill()
         return 0
     finally:
-        # Drain stderr if the child exited with a non-zero status — surface
-        # the bus error to the user instead of swallowing it.
-        rc = proc.poll()
-        if rc is not None and rc != 0 and proc.stderr is not None:
-            err = proc.stderr.read()
-            if err:
-                sys.stderr.write(err)
+        # Ensure the child is fully reaped before we read returncode. proc.poll()
+        # alone can return None for a process that has just exited but hasn't
+        # been waited on yet, masking a non-zero exit. wait(timeout=2) blocks
+        # briefly for the reap; if the child somehow refuses to exit we kill
+        # it so we don't leave an orphan around.
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass  # last-resort: caller will see returncode=None below
 
     return proc.returncode if proc.returncode is not None else 0
 

--- a/scripts/crew/steering_tail.py
+++ b/scripts/crew/steering_tail.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+crew/steering_tail.py — Reference debug subscriber for the wicked.steer.* family.
+
+Streams steering events from wicked-bus and prints each as one-line JSON to
+stdout. Intended for live debugging during the steering detector epic build-out.
+
+This is a *reference* subscriber. It does not act on events — it just shows
+that the wiring works end-to-end. The actual behavior subscribers
+(``crew:rigor-escalator``, ``wicked-testing:qe-engager``, audit log) ship in
+later PRs.
+
+Usage::
+
+    python3 scripts/crew/steering_tail.py
+    python3 scripts/crew/steering_tail.py --severity=escalated
+    python3 scripts/crew/steering_tail.py --severity=advised
+    python3 scripts/crew/steering_tail.py --detector=sensitive-path
+    python3 scripts/crew/steering_tail.py --from-cursor=<cursor_id>
+
+Exit codes:
+    0  — clean exit (SIGINT or stream end)
+    1  — wicked-bus not installed / unreachable
+    2  — invalid CLI arguments
+
+The tail invokes the ``wicked-bus subscribe`` CLI as a subprocess (matching how
+``scripts/_bus.py`` integrates) and parses NDJSON. Each event is filtered
+locally so the script can apply detector-name filters that the bus filter
+syntax doesn't natively express.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import signal
+import subprocess
+import sys
+from typing import Optional
+
+_FILTER = "wicked.steer.*@wicked-garden"
+_VALID_SEVERITY = ("all", "escalated", "advised")
+_DETECTOR_SUBDOMAIN_PREFIX = "crew.detector."
+# Subscriber identity — `wicked-bus subscribe` requires a non-null plugin name
+# to register a cursor. Each `--from-cursor` invocation reuses the existing
+# cursor; without `--from-cursor` we register a fresh one under this plugin.
+_SUBSCRIBER_PLUGIN = "wicked-garden:steering-tail"
+
+
+def _resolve_bus_command() -> Optional[list]:
+    """Find the wicked-bus binary or fall back to npx. Returns argv prefix.
+
+    Mirrors the resolution in ``scripts/_bus.py:_resolve_binary``.
+    """
+    direct = shutil.which("wicked-bus")
+    if direct:
+        return [direct]
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, "wicked-bus"]
+    return None
+
+
+def _parse_args(argv: Optional[list] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="steering_tail",
+        description=(
+            "Tail wicked.steer.* events from wicked-bus. Prints one JSON "
+            "object per line. SIGINT (Ctrl-C) for clean exit."
+        ),
+    )
+    parser.add_argument(
+        "--severity",
+        choices=_VALID_SEVERITY,
+        default="all",
+        help=(
+            "Filter by severity. 'escalated' = wicked.steer.escalated only, "
+            "'advised' = wicked.steer.advised only, 'all' (default) = both."
+        ),
+    )
+    parser.add_argument(
+        "--detector",
+        default=None,
+        help=(
+            "Filter by detector name. Matches subdomain "
+            f"'{_DETECTOR_SUBDOMAIN_PREFIX}<name>'. "
+            "Example: --detector=sensitive-path"
+        ),
+    )
+    parser.add_argument(
+        "--from-cursor",
+        default=None,
+        help=(
+            "Resume from a known cursor id. Optional — without this the bus "
+            "registers a fresh subscription and tails from latest."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _matches(event: dict, severity: str, detector: Optional[str]) -> bool:
+    """Return True if event passes the local filter set."""
+    event_type = event.get("event_type", "")
+
+    if severity == "escalated" and event_type != "wicked.steer.escalated":
+        return False
+    if severity == "advised" and event_type != "wicked.steer.advised":
+        return False
+
+    if detector is not None:
+        expected = f"{_DETECTOR_SUBDOMAIN_PREFIX}{detector}"
+        if event.get("subdomain") != expected:
+            return False
+
+    return True
+
+
+def _print_event(event: dict) -> None:
+    """Emit one event as a single-line JSON record."""
+    sys.stdout.write(json.dumps(event, default=str, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def _build_subscribe_cmd(bus_cmd: list, cursor: Optional[str]) -> list:
+    """Build the wicked-bus subscribe argv.
+
+    `wicked-bus subscribe` requires a `--plugin` value to register a new
+    cursor. When `--from-cursor` is supplied we still pass `--plugin` so the
+    bus can resolve the subscription consistently.
+    """
+    cmd = list(bus_cmd) + [
+        "subscribe",
+        "--plugin", _SUBSCRIBER_PLUGIN,
+        "--filter", _FILTER,
+    ]
+    if cursor:
+        cmd += ["--cursor-id", cursor]
+    return cmd
+
+
+def _stream(args: argparse.Namespace) -> int:
+    bus_cmd = _resolve_bus_command()
+    if not bus_cmd:
+        sys.stderr.write(
+            "error: wicked-bus is not installed. "
+            "Install via 'npm install -g wicked-bus' or ensure 'npx' is on PATH.\n"
+        )
+        return 1
+
+    cmd = _build_subscribe_cmd(bus_cmd, args.from_cursor)
+
+    # Clean SIGINT — let the child terminate, then exit 0.
+    def _on_sigint(signum, frame):  # noqa: ARG001 — signal API
+        # Subprocess is in the same process group; default behavior will
+        # propagate SIGINT. We just exit cleanly when the loop unwinds.
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _on_sigint)
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        sys.stderr.write(
+            f"error: failed to launch wicked-bus subscribe: {' '.join(cmd)!r}\n"
+        )
+        return 1
+
+    try:
+        assert proc.stdout is not None  # for type checkers
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                # Forward malformed lines to stderr so the user can see them
+                # without contaminating the JSON-line stdout stream.
+                sys.stderr.write(f"warn: skipping non-JSON line: {line!r}\n")
+                continue
+
+            if not isinstance(event, dict):
+                continue
+
+            if _matches(event, args.severity, args.detector):
+                _print_event(event)
+    except KeyboardInterrupt:
+        # Clean exit path — terminate child if still running.
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        return 0
+    finally:
+        # Drain stderr if the child exited with a non-zero status — surface
+        # the bus error to the user instead of swallowing it.
+        rc = proc.poll()
+        if rc is not None and rc != 0 and proc.stderr is not None:
+            err = proc.stderr.read()
+            if err:
+                sys.stderr.write(err)
+
+    return proc.returncode if proc.returncode is not None else 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = _parse_args(argv)
+    return _stream(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/crew/test_steering_event_schema.py
+++ b/tests/crew/test_steering_event_schema.py
@@ -1,12 +1,15 @@
 """Tests for ``scripts/crew/steering_event_schema.py``.
 
 Covers PR-1 schema validator for the wicked.steer.* event family:
-  * valid escalated/advised payloads pass
+  * valid escalated/advised payloads pass (errors empty, warnings empty)
   * each required field is enforced individually
   * unknown detector / event_type are rejected
   * unknown action produces a warning (loose set), not an error
-  * malformed timestamp is rejected
+  * malformed timestamp shape is rejected
+  * shape-valid but calendar-invalid timestamps (e.g. 2026-99-99T99:99:99Z)
+    are rejected after the datetime parse step
   * empty evidence object is rejected
+  * validate_payload returns a (errors, warnings) tuple
 
 Pure stdlib + unittest — no fixtures, no mocks. Deterministic.
 """
@@ -47,36 +50,34 @@ def _valid_payload() -> dict:
     }
 
 
-def _has_warning(errors: list) -> bool:
-    return any(e.startswith("warning:") for e in errors)
-
-
-def _hard_errors(errors: list) -> list:
-    return [e for e in errors if not e.startswith("warning:")]
-
-
 class ValidPayloads(unittest.TestCase):
     def test_valid_escalated_payload_passes(self):
-        errors = validate_payload("wicked.steer.escalated", _valid_payload())
+        errors, warnings = validate_payload(
+            "wicked.steer.escalated", _valid_payload()
+        )
         self.assertEqual(errors, [], f"unexpected errors: {errors}")
+        self.assertEqual(warnings, [], f"unexpected warnings: {warnings}")
 
     def test_valid_advised_payload_passes(self):
         payload = _valid_payload()
         payload["recommended_action"] = "notify-only"
-        errors = validate_payload("wicked.steer.advised", payload)
+        errors, warnings = validate_payload("wicked.steer.advised", payload)
         self.assertEqual(errors, [], f"unexpected errors: {errors}")
+        self.assertEqual(warnings, [], f"unexpected warnings: {warnings}")
 
     def test_iso8601_with_offset_passes(self):
         payload = _valid_payload()
         payload["timestamp"] = "2026-04-27T10:00:00+00:00"
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, warnings = validate_payload("wicked.steer.escalated", payload)
         self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
 
     def test_iso8601_with_microseconds_passes(self):
         payload = _valid_payload()
         payload["timestamp"] = "2026-04-27T10:00:00.123456+00:00"
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, warnings = validate_payload("wicked.steer.escalated", payload)
         self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
 
 
 class RequiredFieldEnforcement(unittest.TestCase):
@@ -85,7 +86,8 @@ class RequiredFieldEnforcement(unittest.TestCase):
     def _missing(self, field: str) -> list:
         payload = _valid_payload()
         del payload[field]
-        return validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
+        return errors
 
     def test_missing_detector_fails(self):
         errors = self._missing("detector")
@@ -124,30 +126,33 @@ class AllowlistEnforcement(unittest.TestCase):
     def test_unknown_detector_fails(self):
         payload = _valid_payload()
         payload["detector"] = "some-future-detector-not-yet-allowlisted"
-        errors = validate_payload("wicked.steer.escalated", payload)
-        hard = _hard_errors(errors)
+        errors, warnings = validate_payload(
+            "wicked.steer.escalated", payload
+        )
         self.assertTrue(
-            any("unknown detector" in e for e in hard),
-            f"expected hard 'unknown detector' error, got: {errors}",
+            any("unknown detector" in e for e in errors),
+            f"expected hard 'unknown detector' error, got errors={errors} "
+            f"warnings={warnings}",
         )
 
     def test_unknown_event_type_fails(self):
-        errors = validate_payload("wicked.steer.frobnicated", _valid_payload())
-        hard = _hard_errors(errors)
+        errors, _warnings = validate_payload(
+            "wicked.steer.frobnicated", _valid_payload()
+        )
         self.assertTrue(
-            any("unknown event_type" in e for e in hard),
+            any("unknown event_type" in e for e in errors),
             f"expected hard 'unknown event_type' error, got: {errors}",
         )
 
     def test_unknown_action_warns_does_not_reject(self):
         payload = _valid_payload()
         payload["recommended_action"] = "summon-a-cthulhu"
-        errors = validate_payload("wicked.steer.escalated", payload)
-        # No HARD errors — only the action warning.
-        self.assertEqual(_hard_errors(errors), [])
+        errors, warnings = validate_payload("wicked.steer.escalated", payload)
+        # No HARD errors — the unknown action lives in the warnings list now.
+        self.assertEqual(errors, [], f"unexpected hard errors: {errors}")
         self.assertTrue(
-            _has_warning(errors),
-            f"expected warning for unknown action, got: {errors}",
+            any("unknown recommended_action" in w for w in warnings),
+            f"expected warning for unknown action, got: {warnings}",
         )
 
 
@@ -155,7 +160,7 @@ class FieldShapeChecks(unittest.TestCase):
     def test_bad_timestamp_format_fails(self):
         payload = _valid_payload()
         payload["timestamp"] = "yesterday at noon"
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("timestamp" in e and "ISO8601" in e for e in errors),
             f"expected ISO8601 error, got: {errors}",
@@ -164,16 +169,36 @@ class FieldShapeChecks(unittest.TestCase):
     def test_naive_timestamp_no_zone_fails(self):
         payload = _valid_payload()
         payload["timestamp"] = "2026-04-27T10:00:00"  # missing zone
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("timestamp" in e for e in errors),
             f"expected timestamp error for naive ts, got: {errors}",
         )
 
+    def test_calendar_invalid_timestamp_fails(self):
+        # Regex shape passes (4-2-2 T 2:2:2 Z) but the components are nonsense.
+        # The datetime.fromisoformat() check after the regex must catch this.
+        payload = _valid_payload()
+        payload["timestamp"] = "2026-99-99T99:99:99Z"
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("timestamp" in e for e in errors),
+            f"expected timestamp error for calendar-invalid ts, got: {errors}",
+        )
+
+    def test_calendar_invalid_timestamp_with_offset_fails(self):
+        payload = _valid_payload()
+        payload["timestamp"] = "2026-13-40T25:61:99+00:00"
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("timestamp" in e for e in errors),
+            f"expected timestamp error for calendar-invalid ts, got: {errors}",
+        )
+
     def test_empty_evidence_fails(self):
         payload = _valid_payload()
         payload["evidence"] = {}
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("evidence" in e and "at least one" in e for e in errors),
             f"expected empty-evidence error, got: {errors}",
@@ -182,7 +207,7 @@ class FieldShapeChecks(unittest.TestCase):
     def test_evidence_must_be_dict(self):
         payload = _valid_payload()
         payload["evidence"] = "a string is not a dict"
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("evidence" in e and "dict" in e for e in errors),
             f"expected evidence-type error, got: {errors}",
@@ -191,24 +216,46 @@ class FieldShapeChecks(unittest.TestCase):
     def test_threshold_must_be_dict(self):
         payload = _valid_payload()
         payload["threshold"] = ["a", "list"]
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("threshold" in e and "dict" in e for e in errors),
             f"expected threshold-type error, got: {errors}",
         )
 
     def test_payload_not_a_dict_short_circuits(self):
-        errors = validate_payload("wicked.steer.escalated", "not a dict")  # type: ignore[arg-type]
+        errors, _ = validate_payload("wicked.steer.escalated", "not a dict")
         self.assertTrue(any("payload must be a dict" in e for e in errors))
 
     def test_blank_session_id_fails(self):
         payload = _valid_payload()
         payload["session_id"] = "   "
-        errors = validate_payload("wicked.steer.escalated", payload)
+        errors, _ = validate_payload("wicked.steer.escalated", payload)
         self.assertTrue(
             any("session_id" in e for e in errors),
             f"expected session_id error, got: {errors}",
         )
+
+
+class ReturnShape(unittest.TestCase):
+    """Validator must always return a (errors, warnings) tuple."""
+
+    def test_returns_tuple_of_two_lists(self):
+        result = validate_payload("wicked.steer.escalated", _valid_payload())
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        errors, warnings = result
+        self.assertIsInstance(errors, list)
+        self.assertIsInstance(warnings, list)
+
+    def test_returns_tuple_even_on_non_dict_payload(self):
+        # Short-circuit path must still return the tuple shape.
+        result = validate_payload("wicked.steer.escalated", 42)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        errors, warnings = result
+        self.assertIsInstance(errors, list)
+        self.assertIsInstance(warnings, list)
+        self.assertTrue(errors, "expected hard error for non-dict payload")
 
 
 class AllowlistContents(unittest.TestCase):
@@ -252,6 +299,22 @@ class DeepCopyImmunity(unittest.TestCase):
         snapshot = deepcopy(original)
         validate_payload("wicked.steer.escalated", original)
         self.assertEqual(original, snapshot)
+
+
+class NonDictPayloadTypes(unittest.TestCase):
+    """validate_payload accepts Any — non-dicts must short-circuit cleanly."""
+
+    def test_none_payload(self):
+        errors, _ = validate_payload("wicked.steer.escalated", None)
+        self.assertTrue(any("payload must be a dict" in e for e in errors))
+
+    def test_list_payload(self):
+        errors, _ = validate_payload("wicked.steer.escalated", [1, 2, 3])
+        self.assertTrue(any("payload must be a dict" in e for e in errors))
+
+    def test_int_payload(self):
+        errors, _ = validate_payload("wicked.steer.escalated", 42)
+        self.assertTrue(any("payload must be a dict" in e for e in errors))
 
 
 if __name__ == "__main__":

--- a/tests/crew/test_steering_event_schema.py
+++ b/tests/crew/test_steering_event_schema.py
@@ -1,0 +1,258 @@
+"""Tests for ``scripts/crew/steering_event_schema.py``.
+
+Covers PR-1 schema validator for the wicked.steer.* event family:
+  * valid escalated/advised payloads pass
+  * each required field is enforced individually
+  * unknown detector / event_type are rejected
+  * unknown action produces a warning (loose set), not an error
+  * malformed timestamp is rejected
+  * empty evidence object is rejected
+
+Pure stdlib + unittest — no fixtures, no mocks. Deterministic.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from crew.steering_event_schema import (  # noqa: E402
+    KNOWN_ACTIONS,
+    KNOWN_DETECTORS,
+    KNOWN_EVENT_TYPES,
+    validate_payload,
+)
+
+
+def _valid_payload() -> dict:
+    """Return a minimal, fully valid escalated payload."""
+    return {
+        "detector": "sensitive-path",
+        "signal": "auth/login.py touched",
+        "threshold": {"extensions": [".py"]},
+        "recommended_action": "force-full-rigor",
+        "evidence": {
+            "file": "auth/login.py",
+            "session_id": "sess-001",
+            "project_slug": "test",
+        },
+        "session_id": "sess-001",
+        "project_slug": "test",
+        "timestamp": "2026-04-27T10:00:00Z",
+    }
+
+
+def _has_warning(errors: list) -> bool:
+    return any(e.startswith("warning:") for e in errors)
+
+
+def _hard_errors(errors: list) -> list:
+    return [e for e in errors if not e.startswith("warning:")]
+
+
+class ValidPayloads(unittest.TestCase):
+    def test_valid_escalated_payload_passes(self):
+        errors = validate_payload("wicked.steer.escalated", _valid_payload())
+        self.assertEqual(errors, [], f"unexpected errors: {errors}")
+
+    def test_valid_advised_payload_passes(self):
+        payload = _valid_payload()
+        payload["recommended_action"] = "notify-only"
+        errors = validate_payload("wicked.steer.advised", payload)
+        self.assertEqual(errors, [], f"unexpected errors: {errors}")
+
+    def test_iso8601_with_offset_passes(self):
+        payload = _valid_payload()
+        payload["timestamp"] = "2026-04-27T10:00:00+00:00"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertEqual(errors, [])
+
+    def test_iso8601_with_microseconds_passes(self):
+        payload = _valid_payload()
+        payload["timestamp"] = "2026-04-27T10:00:00.123456+00:00"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertEqual(errors, [])
+
+
+class RequiredFieldEnforcement(unittest.TestCase):
+    """One test per required field — proves none can be silently dropped."""
+
+    def _missing(self, field: str) -> list:
+        payload = _valid_payload()
+        del payload[field]
+        return validate_payload("wicked.steer.escalated", payload)
+
+    def test_missing_detector_fails(self):
+        errors = self._missing("detector")
+        self.assertTrue(any("detector" in e for e in errors), errors)
+
+    def test_missing_signal_fails(self):
+        errors = self._missing("signal")
+        self.assertTrue(any("signal" in e for e in errors), errors)
+
+    def test_missing_threshold_fails(self):
+        errors = self._missing("threshold")
+        self.assertTrue(any("threshold" in e for e in errors), errors)
+
+    def test_missing_recommended_action_fails(self):
+        errors = self._missing("recommended_action")
+        self.assertTrue(any("recommended_action" in e for e in errors), errors)
+
+    def test_missing_evidence_fails(self):
+        errors = self._missing("evidence")
+        self.assertTrue(any("evidence" in e for e in errors), errors)
+
+    def test_missing_session_id_fails(self):
+        errors = self._missing("session_id")
+        self.assertTrue(any("session_id" in e for e in errors), errors)
+
+    def test_missing_project_slug_fails(self):
+        errors = self._missing("project_slug")
+        self.assertTrue(any("project_slug" in e for e in errors), errors)
+
+    def test_missing_timestamp_fails(self):
+        errors = self._missing("timestamp")
+        self.assertTrue(any("timestamp" in e for e in errors), errors)
+
+
+class AllowlistEnforcement(unittest.TestCase):
+    def test_unknown_detector_fails(self):
+        payload = _valid_payload()
+        payload["detector"] = "some-future-detector-not-yet-allowlisted"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        hard = _hard_errors(errors)
+        self.assertTrue(
+            any("unknown detector" in e for e in hard),
+            f"expected hard 'unknown detector' error, got: {errors}",
+        )
+
+    def test_unknown_event_type_fails(self):
+        errors = validate_payload("wicked.steer.frobnicated", _valid_payload())
+        hard = _hard_errors(errors)
+        self.assertTrue(
+            any("unknown event_type" in e for e in hard),
+            f"expected hard 'unknown event_type' error, got: {errors}",
+        )
+
+    def test_unknown_action_warns_does_not_reject(self):
+        payload = _valid_payload()
+        payload["recommended_action"] = "summon-a-cthulhu"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        # No HARD errors — only the action warning.
+        self.assertEqual(_hard_errors(errors), [])
+        self.assertTrue(
+            _has_warning(errors),
+            f"expected warning for unknown action, got: {errors}",
+        )
+
+
+class FieldShapeChecks(unittest.TestCase):
+    def test_bad_timestamp_format_fails(self):
+        payload = _valid_payload()
+        payload["timestamp"] = "yesterday at noon"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("timestamp" in e and "ISO8601" in e for e in errors),
+            f"expected ISO8601 error, got: {errors}",
+        )
+
+    def test_naive_timestamp_no_zone_fails(self):
+        payload = _valid_payload()
+        payload["timestamp"] = "2026-04-27T10:00:00"  # missing zone
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("timestamp" in e for e in errors),
+            f"expected timestamp error for naive ts, got: {errors}",
+        )
+
+    def test_empty_evidence_fails(self):
+        payload = _valid_payload()
+        payload["evidence"] = {}
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("evidence" in e and "at least one" in e for e in errors),
+            f"expected empty-evidence error, got: {errors}",
+        )
+
+    def test_evidence_must_be_dict(self):
+        payload = _valid_payload()
+        payload["evidence"] = "a string is not a dict"
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("evidence" in e and "dict" in e for e in errors),
+            f"expected evidence-type error, got: {errors}",
+        )
+
+    def test_threshold_must_be_dict(self):
+        payload = _valid_payload()
+        payload["threshold"] = ["a", "list"]
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("threshold" in e and "dict" in e for e in errors),
+            f"expected threshold-type error, got: {errors}",
+        )
+
+    def test_payload_not_a_dict_short_circuits(self):
+        errors = validate_payload("wicked.steer.escalated", "not a dict")  # type: ignore[arg-type]
+        self.assertTrue(any("payload must be a dict" in e for e in errors))
+
+    def test_blank_session_id_fails(self):
+        payload = _valid_payload()
+        payload["session_id"] = "   "
+        errors = validate_payload("wicked.steer.escalated", payload)
+        self.assertTrue(
+            any("session_id" in e for e in errors),
+            f"expected session_id error, got: {errors}",
+        )
+
+
+class AllowlistContents(unittest.TestCase):
+    """Lock the v1 allowlist contents — additions need explicit PR review."""
+
+    def test_known_detectors_v1_set(self):
+        self.assertEqual(
+            KNOWN_DETECTORS,
+            frozenset({
+                "sensitive-path",
+                "blast-radius",
+                "council-split",
+                "test-failure-spike",
+                "cross-domain-edits",
+            }),
+        )
+
+    def test_known_event_types_v1_set(self):
+        self.assertEqual(
+            KNOWN_EVENT_TYPES,
+            frozenset({"wicked.steer.escalated", "wicked.steer.advised"}),
+        )
+
+    def test_known_actions_v1_set(self):
+        self.assertEqual(
+            KNOWN_ACTIONS,
+            frozenset({
+                "force-full-rigor",
+                "regen-test-strategy",
+                "require-council-review",
+                "notify-only",
+            }),
+        )
+
+
+class DeepCopyImmunity(unittest.TestCase):
+    """Validator must not mutate the caller's payload."""
+
+    def test_payload_is_not_mutated(self):
+        original = _valid_payload()
+        snapshot = deepcopy(original)
+        validate_payload("wicked.steer.escalated", original)
+        self.assertEqual(original, snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-1 of the steering detector registry epic (#679, addressing #680). Establishes the `wicked.steer.*` event family on wicked-bus + a reference debug subscriber. **No detectors. No behavior subscribers.** Just the wiring proof — bus events ARE the audit trail per the design decision.

## Deliverables

- **`scripts/crew/steering_event_schema.py`** — pure-stdlib payload validator. Exports `KNOWN_DETECTORS` (5-name allowlist), `KNOWN_EVENT_TYPES` (`wicked.steer.escalated` / `wicked.steer.advised`), `KNOWN_ACTIONS` (loose set), and `validate_payload(event_type, payload) -> list[str]`. Importable from any other crew script.
- **`scripts/crew/steering_tail.py`** — CLI debug subscriber:
  ```bash
  python3 scripts/crew/steering_tail.py [--severity=escalated|advised|all] [--detector=<name>] [--from-cursor=<id>]
  ```
  Tails `wicked.steer.*@wicked-garden` via `wicked-bus subscribe` subprocess, prints each event as one-line JSON, clean SIGINT exit, exit 1 if wicked-bus is unreachable.
- **`docs/steering-detectors.md`** — documents the event family, payload schema with example, the 5 v1 detectors + planned `recommended_action`s, subscriber filter contract for the three known consumers (`crew:rigor-escalator` in-plugin, audit log, `wicked-testing:qe-engager` cross-plugin), and a pointer to the brain memory decision record.
- **`tests/crew/test_steering_event_schema.py`** — 26 unit tests (pytest, stdlib-only): valid escalated/advised payloads, one missing-field test per required field, unknown detector/event_type rejection, unknown action warning (loose set), ISO8601 validation including naive timestamp rejection, empty-evidence rejection, payload-immutability.
- **`CHANGELOG.md`** — `[Unreleased]` `### Added` entry.

## Event family (locked)

| Field         | Value                                              |
|---------------|----------------------------------------------------|
| `event_type`  | `wicked.steer.escalated` or `wicked.steer.advised` |
| `domain`      | `wicked-garden`                                    |
| `subdomain`   | `crew.detector.<detector-name>`                    |

V1 detector allowlist: `sensitive-path`, `blast-radius`, `council-split`, `test-failure-spike`, `cross-domain-edits`.

## Out of scope (intentionally NOT in this PR)

- No detector implementations
- No `crew:rigor-escalator` subscriber
- No emit() calls from any production path (manual emit only for verification)
- No slash command at `commands/crew/steering-tail.md`

## Verification

**Schema validator tests:**
```
tests/crew/test_steering_event_schema.py ........................== 26 passed in 0.47s
```

**Manual emit + tail end-to-end:**

Tail running:
```bash
$ python3 scripts/crew/steering_tail.py --severity=escalated
```

Emit:
```bash
$ wicked-bus emit \
  --type wicked.steer.escalated \
  --domain wicked-garden \
  --subdomain crew.detector.sensitive-path \
  --payload '{"detector":"sensitive-path","signal":"auth/login.py touched","threshold":{"extensions":[".py"]},"recommended_action":"force-full-rigor","evidence":{"file":"auth/login.py"},"session_id":"test-001","project_slug":"test","timestamp":"2026-04-27T10:00:00Z"}'
{"event_id":45026,"idempotency_key":"2ac48e58-4992-4587-914c-45332bd7bf24"}
```

Tail received:
```json
{"event_id":45026,"event_type":"wicked.steer.escalated","domain":"wicked-garden","subdomain":"crew.detector.sensitive-path","payload":"{\"detector\":\"sensitive-path\",\"signal\":\"auth/login.py touched\",\"threshold\":{\"extensions\":[\".py\"]},\"recommended_action\":\"force-full-rigor\",\"evidence\":{\"file\":\"auth/login.py\"},\"session_id\":\"test-001\",\"project_slug\":\"test\",\"timestamp\":\"2026-04-27T10:00:00Z\"}","schema_version":"1.0.0",...,"metadata":null}
```

`--severity=advised` filter also verified — only the advised event passed when both severities were emitted.

## Test plan

- [x] `pytest tests/crew/test_steering_event_schema.py` (26/26 pass)
- [x] Manual `wicked-bus emit` + `steering_tail.py` round-trip
- [x] Severity filter (`--severity=advised` excludes escalated events)
- [x] `python3 -m json.tool .claude-plugin/plugin.json` (JSON intact)
- [x] Python syntax check on all new files
- [ ] Reviewer: confirm `wicked-bus:naming` skill is happy with `crew.detector.<name>` subdomain pattern

## References

- Epic: #679
- This PR: #680
- Decision record: `~/.wicked-brain/projects/wicked-garden/memory/steering-detector-registry-v1-design-decision.md` (semantic tier, importance 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)