### PR TITLE
feat: rigor-escalator subscriber — closes the steering loop end-to-end (PR-3 of epic #679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Steering detector event family — `wicked.steer.*` on the bus, reference tail subscriber (`scripts/crew/steering_tail.py`), schema validator (`scripts/crew/steering_event_schema.py`). No detectors yet (PR-1 of epic).
 - First steering detector: `detect_sensitive_path_touch` — emits `wicked.steer.escalated` when sessions touch auth/payments/migration/secrets code (PR-2 of epic #679). Detector + emitter are separated for testability; every emitted payload is re-validated against the PR-1 schema; bus-unreachable is fail-open.
+- Rigor escalator subscriber: `crew:rigor-escalator` mutates project `rigor_tier` in response to `wicked.steer.escalated` events. Closes the steering loop end-to-end (PR-3 of epic #679). Action -> tier mapping is `force-full-rigor → full`; `regen-test-strategy` and `require-council-review` keep tier and append history; `notify-only` is pure no-op. Enforces never-de-escalate rule, in-session idempotency by `(project_slug, event_id)`, and emits `wicked.steer.applied` audit events on every decision branch (escalated/redundant/no-op/error). Adds `wicked.steer.applied` to `KNOWN_EVENT_TYPES`.
 
 ## [8.4.0] - 2026-04-26
 

--- a/scenarios/crew/rigor-escalator-end-to-end.md
+++ b/scenarios/crew/rigor-escalator-end-to-end.md
@@ -1,0 +1,386 @@
+---
+name: rigor-escalator-end-to-end
+title: Rigor Escalator — End-to-End Loop Closure
+description: |
+  Acceptance scenario for PR-3 of the steering detector epic (#679). Closes the
+  steering loop end-to-end with no LLM in the path:
+
+    1. Project at rigor=minimal exists.
+    2. Sensitive-path detector (PR-2) runs against an auth path fixture.
+    3. Detector emits `wicked.steer.escalated` (PR-1 + PR-2 wiring).
+    4. Subscriber (PR-3) receives the event and bumps rigor_tier to full.
+    5. Subscriber emits `wicked.steer.applied` audit event.
+    6. Project state — verified via phase_manager.load_project_state — shows
+       rigor_tier=full and a populated rigor_escalation_history.
+
+  Cases 1-3 are deterministic (apply_steering_event invoked directly with a
+  fake phase_manager). Case 4 is the fail-open guard for an unreachable bus.
+  Cases 5-6 exercise the bus path only when wicked-bus is present (gated by
+  reachability probe).
+type: integration
+difficulty: intermediate
+estimated_minutes: 5
+covers:
+  - epic #679 (steering detector registry)
+  - PR-3 (rigor-escalator subscriber)
+  - scripts/crew/rigor_escalator.py
+  - scripts/crew/detectors/sensitive_path.py (loop source)
+  - scripts/crew/steering_event_schema.py (validator integration)
+---
+
+# Rigor Escalator — End-to-End Loop Closure
+
+Verifies that the steering loop closes: a detector signal mutates project
+rigor in a way the next gate dispatch will read. All assertions are structural
+(JSON shape + string equality) — no LLM in the loop.
+
+---
+
+## Setup
+
+```bash
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export DETECTOR="${PLUGIN_ROOT}/scripts/crew/detectors/sensitive_path.py"
+export SUBSCRIBER="${PLUGIN_ROOT}/scripts/crew/rigor_escalator.py"
+```
+
+---
+
+## Case 1: Detector payload + apply_steering_event raises rigor_tier to full
+
+**Verifies**: a `wicked.steer.escalated` payload built by the sensitive-path
+detector is accepted by the subscriber and bumps a minimal-tier project to
+full. No live bus required — the subscriber is invoked in-process via its
+public Python API with an in-memory fake phase_manager.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from crew.detectors.sensitive_path import detect_sensitive_path_touch
+from crew import rigor_escalator as escalator
+from datetime import datetime, timezone
+
+# 1. Detector produces a real schema-valid payload from a sensitive path.
+payloads = detect_sensitive_path_touch(
+    ['src/auth/login.py'],
+    session_id='scenario-001',
+    project_slug='loop-demo',
+    now=datetime(2026, 4, 27, 10, 0, 0, tzinfo=timezone.utc),
+)
+assert len(payloads) == 1, f'expected 1 payload, got {len(payloads)}'
+
+# 2. Set up a fake phase_manager with project at rigor=minimal.
+class FakeProject:
+    def __init__(self):
+        self.name = 'loop-demo'
+        self.extras = {'rigor_tier': 'minimal'}
+
+class FakePM:
+    def __init__(self):
+        self.proj = FakeProject()
+        self.update_calls = []
+    def load_project_state(self, slug):
+        return self.proj if slug == 'loop-demo' else None
+    def update_project(self, state, data):
+        for k, v in data.items():
+            state.extras[k] = v
+        self.update_calls.append(dict(data))
+        return state, list(data.keys())
+
+pm = FakePM()
+
+# 3. Build a bus-style envelope and feed it to the subscriber's public API.
+event = {
+    'id': 'evt-loop-1',
+    'event_type': 'wicked.steer.escalated',
+    'payload': payloads[0],
+}
+
+# Suppress the audit emit (Case 1 is the in-process loop assertion only).
+class _NoEmit:
+    call_count = 0
+    @staticmethod
+    def patched(*a, **kw):
+        _NoEmit.call_count += 1
+        return True
+
+import unittest.mock as mock
+with mock.patch.object(escalator, '_emit_applied_event', side_effect=_NoEmit.patched):
+    decision = escalator.apply_steering_event(event, pm=pm)
+
+print('ACTION_TAKEN:', decision['action_taken'])
+print('PREVIOUS_TIER:', decision['previous_tier'])
+print('NEW_TIER:', decision['new_tier'])
+print('PROJECT_TIER_AFTER:', pm.proj.extras['rigor_tier'])
+print('HISTORY_LEN:', len(pm.proj.extras.get('rigor_escalation_history', [])))
+print('AUDIT_EMIT_CALLS:', _NoEmit.call_count)
+"
+```
+
+**Expected**:
+
+```
+ACTION_TAKEN: escalated
+PREVIOUS_TIER: minimal
+NEW_TIER: full
+PROJECT_TIER_AFTER: full
+HISTORY_LEN: 1
+AUDIT_EMIT_CALLS: 1
+```
+
+---
+
+## Case 2: Never-de-escalate — second event on a full project is redundant
+
+**Verifies**: a second `force-full-rigor` recommendation against an
+already-full project does not de-escalate, returns `redundant`, and still
+records the event in history (for false-positive metrics).
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from crew import rigor_escalator as escalator
+
+class FakeProject:
+    def __init__(self):
+        self.name = 'loop-demo'
+        self.extras = {'rigor_tier': 'full'}
+
+class FakePM:
+    def __init__(self):
+        self.proj = FakeProject()
+    def load_project_state(self, slug):
+        return self.proj
+    def update_project(self, state, data):
+        for k, v in data.items():
+            state.extras[k] = v
+        return state, list(data.keys())
+
+pm = FakePM()
+event = {
+    'id': 'evt-redundant',
+    'event_type': 'wicked.steer.escalated',
+    'payload': {
+        'detector': 'sensitive-path',
+        'signal': 'auth path touched',
+        'threshold': {'glob': '**/auth/**'},
+        'recommended_action': 'force-full-rigor',
+        'evidence': {'file': 'src/auth/login.py'},
+        'session_id': 'scenario-002',
+        'project_slug': 'loop-demo',
+        'timestamp': '2026-04-27T10:00:00Z',
+    },
+}
+
+import unittest.mock as mock
+with mock.patch.object(escalator, '_emit_applied_event', return_value=True):
+    decision = escalator.apply_steering_event(event, pm=pm)
+
+print('ACTION_TAKEN:', decision['action_taken'])
+print('PROJECT_TIER_AFTER:', pm.proj.extras['rigor_tier'])
+print('NEVER_DE_ESCALATED:', pm.proj.extras['rigor_tier'] == 'full')
+print('HISTORY_RECORDED:', len(pm.proj.extras.get('rigor_escalation_history', [])) == 1)
+"
+```
+
+**Expected**:
+
+```
+ACTION_TAKEN: redundant
+PROJECT_TIER_AFTER: full
+NEVER_DE_ESCALATED: True
+HISTORY_RECORDED: True
+```
+
+---
+
+## Case 3: In-session idempotency — same event twice is processed once
+
+**Verifies**: the subscriber's process-local idempotency set short-circuits a
+duplicate event so we don't double-mutate.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from crew import rigor_escalator as escalator
+
+class FakeProject:
+    def __init__(self):
+        self.name = 'loop-demo'
+        self.extras = {'rigor_tier': 'minimal'}
+
+class FakePM:
+    def __init__(self):
+        self.proj = FakeProject()
+        self.update_count = 0
+    def load_project_state(self, slug):
+        return self.proj
+    def update_project(self, state, data):
+        for k, v in data.items():
+            state.extras[k] = v
+        self.update_count += 1
+        return state, list(data.keys())
+
+pm = FakePM()
+event = {
+    'id': 'evt-dup',
+    'event_type': 'wicked.steer.escalated',
+    'payload': {
+        'detector': 'sensitive-path',
+        'signal': 'x', 'threshold': {'glob': '**/auth/**'},
+        'recommended_action': 'force-full-rigor',
+        'evidence': {'file': 'src/auth/login.py'},
+        'session_id': 's1', 'project_slug': 'loop-demo',
+        'timestamp': '2026-04-27T10:00:00Z',
+    },
+}
+
+seen = set()
+import unittest.mock as mock
+with mock.patch.object(escalator, '_emit_applied_event', return_value=True):
+    d1 = escalator.apply_steering_event(event, pm=pm, seen_event_ids=seen)
+    d2 = escalator.apply_steering_event(event, pm=pm, seen_event_ids=seen)
+
+print('FIRST_ACTION:', d1['action_taken'])
+print('SECOND_ACTION:', d2['action_taken'])
+print('UPDATE_CALL_COUNT:', pm.update_count)
+print('IDEMPOTENT:', d2['action_taken'] == 'no-op' and pm.update_count == 1)
+"
+```
+
+**Expected**:
+
+```
+FIRST_ACTION: escalated
+SECOND_ACTION: no-op
+UPDATE_CALL_COUNT: 1
+IDEMPOTENT: True
+```
+
+---
+
+## Case 4: Bus unreachable — subscriber CLI exits 1 cleanly
+
+**Verifies**: the CLI cannot subscribe without the bus, but it fails clean
+(exit 1, no traceback) so a calling workflow can detect the condition.
+
+### Test
+
+```bash
+# Restrict PATH so wicked-bus and npx are not findable.
+env PATH="/usr/bin:/bin" sh "${PLUGIN_ROOT}/scripts/_python.sh" "${SUBSCRIBER}" --dry-run \
+  > /tmp/rigor-escalator-busfail.out 2> /tmp/rigor-escalator-busfail.err
+RC=$?
+echo "EXIT_CODE: $RC"
+echo "STDERR_MENTIONS_NOT_INSTALLED: $(grep -c 'wicked-bus is not installed' /tmp/rigor-escalator-busfail.err || true)"
+echo "NO_TRACEBACK: $(grep -c 'Traceback' /tmp/rigor-escalator-busfail.err || true)"
+rm -f /tmp/rigor-escalator-busfail.out /tmp/rigor-escalator-busfail.err
+```
+
+**Expected**:
+
+```
+EXIT_CODE: 1
+STDERR_MENTIONS_NOT_INSTALLED: 1
+NO_TRACEBACK: 0
+```
+
+---
+
+## Case 5: Audit payload validates against the PR-1 schema
+
+**Verifies**: the `wicked.steer.applied` audit payload built by the subscriber
+passes `validate_payload`. Catches schema drift between PR-1 and PR-3.
+
+### Test
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys, json
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+from crew import rigor_escalator as escalator
+from crew.steering_event_schema import validate_payload
+
+class FakeProject:
+    def __init__(self):
+        self.name = 'audit-demo'
+        self.extras = {'rigor_tier': 'minimal'}
+
+class FakePM:
+    def load_project_state(self, slug): return FakeProject()
+    def update_project(self, state, data):
+        return state, list(data.keys())
+
+pm = FakePM()
+event = {
+    'id': 'evt-audit',
+    'event_type': 'wicked.steer.escalated',
+    'payload': {
+        'detector': 'sensitive-path',
+        'signal': 'x', 'threshold': {'glob': '**/auth/**'},
+        'recommended_action': 'force-full-rigor',
+        'evidence': {'file': 'src/auth/login.py'},
+        'session_id': 's1', 'project_slug': 'audit-demo',
+        'timestamp': '2026-04-27T10:00:00Z',
+    },
+}
+
+captured = {}
+class _OkProc:
+    returncode = 0
+    stderr = ''
+
+def _capture(cmd, *a, **kw):
+    if '--payload' in cmd:
+        idx = cmd.index('--payload')
+        captured['payload'] = json.loads(cmd[idx + 1])
+        captured['type'] = cmd[cmd.index('--type') + 1]
+    return _OkProc()
+
+import unittest.mock as mock
+with mock.patch.object(escalator, '_resolve_bus_command', return_value=['wicked-bus']), \
+     mock.patch.object(escalator.subprocess, 'run', side_effect=_capture):
+    decision = escalator.apply_steering_event(event, pm=pm)
+
+errors, warnings = validate_payload('wicked.steer.applied', captured.get('payload', {}))
+print('AUDIT_TYPE:', captured.get('type'))
+print('SCHEMA_ERRORS:', len(errors))
+print('SCHEMA_WARNINGS:', len(warnings))
+print('ACTION_TAKEN_RECORDED:', captured['payload']['evidence'].get('action_taken'))
+print('SCHEMA_VALID:', not errors)
+"
+```
+
+**Expected**:
+
+```
+AUDIT_TYPE: wicked.steer.applied
+SCHEMA_ERRORS: 0
+SCHEMA_WARNINGS: 0
+ACTION_TAKEN_RECORDED: escalated
+SCHEMA_VALID: True
+```
+
+---
+
+## Success Criteria
+
+- [ ] Case 1 — detector payload mutates a minimal project to full; history populated
+- [ ] Case 2 — never-de-escalate guard returns redundant; tier stays full; history still recorded
+- [ ] Case 3 — same event twice produces one mutation; second decision is no-op
+- [ ] Case 4 — CLI fails clean (exit 1, no traceback) when wicked-bus is unreachable
+- [ ] Case 5 — `wicked.steer.applied` audit payload passes the PR-1 schema validator
+
+## Cleanup
+
+(No persistent state to clean — all five cases use in-memory fake phase_manager
+or temp files that are removed inline.)

--- a/scripts/crew/rigor_escalator.py
+++ b/scripts/crew/rigor_escalator.py
@@ -1,0 +1,813 @@
+#!/usr/bin/env python3
+"""
+crew/rigor_escalator.py — First behavior subscriber for ``wicked.steer.escalated``.
+
+PR-3 of the steering detector epic (#679). Closes the loop end-to-end:
+
+    detector emits  -->  bus delivers  -->  THIS subscriber mutates rigor_tier
+                                            on the active project, then emits
+                                            ``wicked.steer.applied`` for audit.
+
+Design constraints (mirroring PR-1 and PR-2):
+
+  * Pure stdlib. No external deps.
+  * The decision logic (``apply_steering_event``) is a pure function of
+    ``(event, project_state)`` so it can be unit-tested without a live bus.
+  * The CLI subscriber wraps ``apply_steering_event`` and streams events from
+    ``wicked-bus subscribe`` (same pattern as ``steering_tail.py``).
+  * Every decision branch (escalated, redundant, no-op, error) emits a
+    follow-up ``wicked.steer.applied`` audit event so the Auditor persona can
+    trace what the subscriber did. ``--dry-run`` suppresses the audit emit.
+  * **Never de-escalate** — a project that is already at ``rigor_tier=full``
+    stays full. A second ``force-full-rigor`` recommendation logs a redundant
+    decision, emits an audit event, and does not mutate the project. This is
+    the brainstorm-mandated guardrail.
+  * **In-session idempotency** — the subscriber tracks
+    ``(project_slug, event_id)`` pairs in a process-local set. Cross-session
+    idempotency is the bus's job (cursor-poll); we only protect against the
+    bus replaying an event within the same subscriber lifetime.
+  * **Fail-open** — phase_manager errors, schema errors, missing projects,
+    bus emit failures — all log to stderr and continue. The subscriber must
+    never crash the steering loop.
+
+Action -> mutation mapping:
+
+  =========================  ====================================================
+  recommended_action          effect on project state
+  =========================  ====================================================
+  force-full-rigor            set rigor_tier = "full" (unless already full)
+  regen-test-strategy         keep tier; mark a regen-test-strategy task in
+                              ``rigor_escalation_history`` (no schema change)
+  require-council-review      keep tier; record a pending council-mode upgrade
+                              for the next gate dispatch
+  notify-only                 no mutation; log only
+  =========================  ====================================================
+
+Usage (CLI)::
+
+    python3 scripts/crew/rigor_escalator.py
+    python3 scripts/crew/rigor_escalator.py --dry-run
+    python3 scripts/crew/rigor_escalator.py --from-cursor=<id>
+
+Usage (programmatic)::
+
+    from crew.rigor_escalator import apply_steering_event
+    decision = apply_steering_event(event, dry_run=True)
+    # decision = {"action_taken": "escalated", "previous_tier": "minimal", ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+# Allow running directly as a script. When imported as a package the package
+# import already resolved sys.path, so this is a no-op in that case.
+_REPO_SCRIPTS = Path(__file__).resolve().parents[1]
+if str(_REPO_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_REPO_SCRIPTS))
+
+from crew.steering_event_schema import (  # noqa: E402  (sys.path tweak above)
+    KNOWN_EVENT_TYPES,
+    validate_payload,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Subscriber identity — passed to ``wicked-bus subscribe --plugin``.
+SUBSCRIBER_PLUGIN = "wicked-garden:crew:rigor-escalator"
+
+#: Filter applied at the bus layer. Only ``escalated`` events drive mutations;
+#: ``advised`` is informational and ignored by this subscriber.
+BUS_FILTER = "wicked.steer.escalated@wicked-garden"
+
+#: The audit event type emitted after every decision. This is how the
+#: Auditor persona traces what the subscriber did.
+APPLIED_EVENT_TYPE = "wicked.steer.applied"
+APPLIED_EVENT_DOMAIN = "wicked-garden"
+APPLIED_EVENT_SUBDOMAIN = "crew.rigor-escalator"
+
+#: Rigor tier ordering — higher = stricter. Used by the never-de-escalate
+#: guard and by the (action -> tier) mapping.
+_TIER_RANK: Dict[str, int] = {
+    "minimal": 1,
+    "standard": 2,
+    "full": 3,
+}
+
+#: Default action -> rigor tier mapping. ``None`` means "do not change tier".
+#: Tests can override this via ``apply_steering_event(... action_map=...)``.
+DEFAULT_ACTION_TO_TIER: Dict[str, Optional[str]] = {
+    "force-full-rigor": "full",
+    "regen-test-strategy": None,        # keep tier; record task
+    "require-council-review": None,     # keep tier; record gate-mode upgrade
+    "notify-only": None,                # log only
+}
+
+#: Decision action_taken vocabulary — also reused as the audit-event tag.
+ACTION_ESCALATED = "escalated"          # tier was bumped
+ACTION_REDUNDANT = "redundant"          # already at recommended tier (no-op)
+ACTION_NO_OP = "no-op"                  # action does not change tier
+ACTION_ERROR = "error"                  # validation/load/persist failed
+
+#: Probe / emit timeouts mirror PR-1/PR-2 (5s probe budget, 10s emit budget).
+_BUS_PROBE_TIMEOUT_SECONDS = 5.0
+_BUS_EMIT_TIMEOUT_SECONDS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Bus resolution (mirrors steering_tail.py / sensitive_path.py for consistency)
+# ---------------------------------------------------------------------------
+
+def _resolve_bus_command() -> Optional[List[str]]:
+    """Find the wicked-bus binary or fall back to npx. Returns argv prefix.
+
+    Mirrors ``scripts/_bus.py:_resolve_binary`` — direct binary first, then
+    npx with a status probe so we don't accidentally trigger an npx package
+    download on a slow first run.
+    """
+    direct = shutil.which("wicked-bus")
+    if direct:
+        return [direct]
+    npx = shutil.which("npx")
+    if npx is None:
+        return None
+    try:
+        result = subprocess.run(
+            [npx, "wicked-bus", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=_BUS_PROBE_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [npx, "wicked-bus"]
+
+
+# ---------------------------------------------------------------------------
+# Decision core — pure(-ish) function used by both the CLI and unit tests
+# ---------------------------------------------------------------------------
+
+def _utc_now_iso() -> str:
+    """ISO8601 UTC ``Z`` timestamp matching the steering-event schema regex."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_decision(
+    *,
+    action_taken: str,
+    previous_tier: Optional[str],
+    new_tier: Optional[str],
+    project_slug: str,
+    event_id: str,
+    reason: str,
+    recommended_action: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a structured decision record.
+
+    Centralized so the CLI and the audit emitter both see the same fields.
+    """
+    return {
+        "action_taken": action_taken,
+        "previous_tier": previous_tier,
+        "new_tier": new_tier,
+        "project_slug": project_slug,
+        "event_id": event_id,
+        "reason": reason,
+        "recommended_action": recommended_action,
+        "decided_at": _utc_now_iso(),
+    }
+
+
+def _event_id(event: Dict[str, Any]) -> str:
+    """Best-effort stable id for an event.
+
+    wicked-bus stamps ``event_id`` (integer) and ``idempotency_key`` (uuid)
+    on every event before delivery — we prefer ``idempotency_key`` because the
+    bus uses it for cross-session dedup and it's already a string. Falls back
+    to ``event_id``, then ``id`` (legacy / test envelopes), then a synthetic
+    id from payload timestamp + detector + signal so events that arrive
+    without any envelope still have a stable idempotency key.
+    """
+    for key in ("idempotency_key", "event_id", "id"):
+        raw = event.get(key)
+        if raw is not None and str(raw):
+            return str(raw)
+    # No envelope id at all — synthesize from payload.
+    payload = event.get("payload")
+    if not isinstance(payload, dict):
+        payload = event
+    parts = [
+        str(payload.get("timestamp", "")),
+        str(payload.get("detector", "")),
+        str(payload.get("signal", "")),
+    ]
+    return "|".join(parts) or "<unknown>"
+
+
+def _extract_payload(event: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Return ``(event_type, payload_dict)`` from a bus event envelope.
+
+    wicked-bus delivers events on the wire as a JSON envelope where ``payload``
+    is itself a **JSON-encoded string** (not a nested object). Examples:
+
+      * Live bus delivery::
+
+            {"event_id": 45098, "event_type": "wicked.steer.escalated",
+             "payload": "{\\"detector\\": \\"sensitive-path\\", ...}",
+             "idempotency_key": "...", ...}
+
+      * In-process test envelope (already-parsed dict)::
+
+            {"id": "evt-1", "event_type": "wicked.steer.escalated",
+             "payload": {"detector": "sensitive-path", ...}}
+
+      * Bare payload (programmatic caller skipping the envelope)::
+
+            {"detector": "sensitive-path", ...}
+
+    All three shapes resolve to the same ``(event_type, payload_dict)`` tuple.
+    A payload string that fails to parse is returned as an empty dict so the
+    schema validator produces a clear "missing required field" error rather
+    than a swallowed exception.
+    """
+    if "payload" in event:
+        raw_payload = event["payload"]
+        event_type = str(event.get("event_type", "wicked.steer.escalated"))
+        if isinstance(raw_payload, dict):
+            return event_type, raw_payload
+        if isinstance(raw_payload, str):
+            try:
+                parsed = json.loads(raw_payload)
+            except (json.JSONDecodeError, ValueError):
+                return event_type, {}
+            return (
+                event_type,
+                parsed if isinstance(parsed, dict) else {},
+            )
+        # Unrecognized payload type — fall through to validator as empty.
+        return event_type, {}
+    # Bare payload — assume escalated.
+    return "wicked.steer.escalated", event
+
+
+def _emit_applied_event(
+    decision: Dict[str, Any],
+    original_payload: Dict[str, Any],
+    *,
+    bus_cmd: Optional[List[str]] = None,
+) -> bool:
+    """Emit ``wicked.steer.applied`` to the bus. Fail-open.
+
+    Builds a payload that satisfies ``validate_payload(APPLIED_EVENT_TYPE, ...)``
+    by reusing the original detector/signal/threshold/session metadata and
+    stuffing the decision record into ``evidence`` (the catch-all dict).
+
+    Returns True on a successful subprocess exit, False otherwise. The
+    subscriber NEVER raises out of this — bus emit failures are observed via
+    stderr only.
+    """
+    if bus_cmd is None:
+        bus_cmd = _resolve_bus_command()
+    if bus_cmd is None:
+        sys.stderr.write(
+            "warn: wicked-bus is not installed or unreachable; "
+            "skipping wicked.steer.applied audit emit. "
+            f"decision={decision['action_taken']} project={decision['project_slug']}\n"
+        )
+        return False
+
+    # Build an audit payload that mirrors the original event structure but
+    # adds the decision record under evidence. The schema validator accepts
+    # any non-empty evidence dict, so this stays compliant.
+    evidence: Dict[str, Any] = dict(original_payload.get("evidence") or {})
+    evidence["action_taken"] = decision["action_taken"]
+    evidence["previous_tier"] = decision["previous_tier"]
+    evidence["new_tier"] = decision["new_tier"]
+    evidence["reason"] = decision["reason"]
+    evidence["decided_at"] = decision["decided_at"]
+    evidence["subscriber"] = SUBSCRIBER_PLUGIN
+
+    audit_payload = {
+        "detector": original_payload.get("detector", "unknown"),
+        "signal": original_payload.get(
+            "signal", f"rigor-escalator decision: {decision['action_taken']}"
+        ),
+        "threshold": original_payload.get("threshold") or {"action": decision["action_taken"]},
+        "recommended_action": original_payload.get(
+            "recommended_action", decision.get("recommended_action") or "notify-only"
+        ),
+        "evidence": evidence,
+        "session_id": original_payload.get("session_id", "rigor-escalator"),
+        "project_slug": decision["project_slug"],
+        "timestamp": decision["decided_at"],
+    }
+
+    # Defense-in-depth — refuse to emit a payload that would fail validation.
+    errors, _warnings = validate_payload(APPLIED_EVENT_TYPE, audit_payload)
+    if errors:
+        sys.stderr.write(
+            "warn: rigor-escalator built an invalid wicked.steer.applied payload; "
+            f"dropping audit emit. errors={errors}\n"
+        )
+        return False
+
+    cmd = list(bus_cmd) + [
+        "emit",
+        "--type", APPLIED_EVENT_TYPE,
+        "--domain", APPLIED_EVENT_DOMAIN,
+        "--subdomain", APPLIED_EVENT_SUBDOMAIN,
+        "--payload", json.dumps(audit_payload, default=str, separators=(",", ":")),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_BUS_EMIT_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        sys.stderr.write(
+            f"warn: wicked.steer.applied emit failed: {exc}\n"
+        )
+        return False
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"warn: wicked.steer.applied emit returned {result.returncode}: "
+            f"{result.stderr.strip() or '(no stderr)'}\n"
+        )
+        return False
+    return True
+
+
+def _phase_manager():
+    """Lazy import — avoids paying phase_manager's import cost in unit tests
+    that mock the whole module out via ``sys.modules`` injection.
+
+    Tests that need to exercise the persistence path inject a fake
+    ``phase_manager`` module via ``apply_steering_event(... pm=fake)``.
+    """
+    from crew import phase_manager  # noqa: WPS433 (deliberate lazy import)
+    return phase_manager
+
+
+def apply_steering_event(
+    event: Dict[str, Any],
+    *,
+    dry_run: bool = False,
+    seen_event_ids: Optional[Set[Tuple[str, str]]] = None,
+    action_map: Optional[Dict[str, Optional[str]]] = None,
+    pm: Any = None,
+    bus_cmd: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Apply a single steering event to the target project.
+
+    Args:
+        event: The event envelope (or bare payload — see ``_extract_payload``).
+        dry_run: If True, no project state is mutated and no audit event is
+            emitted. The decision record is still returned so callers can log
+            what *would* have happened.
+        seen_event_ids: Optional in-session idempotency set. The CLI passes a
+            single shared set per process; tests typically pass ``None``.
+        action_map: Override the default ``DEFAULT_ACTION_TO_TIER`` mapping.
+            Useful for tests that want to assert custom action wiring without
+            modifying the module-level dict.
+        pm: Optional phase_manager module override (for tests). Defaults to
+            the lazily-imported ``crew.phase_manager``.
+        bus_cmd: Optional precomputed bus argv prefix (avoids re-probing
+            wicked-bus on every event).
+
+    Returns:
+        A decision record dict with keys:
+          * ``action_taken``: one of ``escalated``, ``redundant``, ``no-op``, ``error``
+          * ``previous_tier``: tier before the decision (None if unknown / error)
+          * ``new_tier``: tier after the decision (None when unchanged)
+          * ``project_slug``: the project this decision targets
+          * ``event_id``: stable id of the source event
+          * ``reason``: short human-readable explanation
+          * ``recommended_action``: the action from the source event (when known)
+          * ``decided_at``: ISO8601 UTC timestamp of the decision
+
+    The function NEVER raises — every failure is captured as
+    ``action_taken="error"`` in the returned decision.
+    """
+    pm = pm or _phase_manager()
+    actions = action_map or DEFAULT_ACTION_TO_TIER
+
+    # ----- 1. Parse + validate ---------------------------------------------
+    event_type, payload = _extract_payload(event)
+    eid = _event_id(event)
+
+    errors, warnings = validate_payload(event_type, payload)
+    if event_type not in KNOWN_EVENT_TYPES or errors:
+        for w in warnings:
+            sys.stderr.write(f"warn: steering payload warning: {w}\n")
+        for e in errors:
+            sys.stderr.write(f"warn: steering payload error: {e}\n")
+        decision = _new_decision(
+            action_taken=ACTION_ERROR,
+            previous_tier=None,
+            new_tier=None,
+            project_slug=str(payload.get("project_slug", "<unknown>")),
+            event_id=eid,
+            reason=f"invalid payload: {errors[:3]}" if errors else "unknown event_type",
+        )
+        if not dry_run:
+            _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+        return decision
+
+    # event_type is escalated|advised|applied; we only mutate on escalated.
+    # The bus filter already restricts to escalated, but a programmatic caller
+    # could pass advised/applied — handle gracefully as no-op.
+    if event_type != "wicked.steer.escalated":
+        decision = _new_decision(
+            action_taken=ACTION_NO_OP,
+            previous_tier=None,
+            new_tier=None,
+            project_slug=str(payload.get("project_slug", "<unknown>")),
+            event_id=eid,
+            reason=f"event_type {event_type!r} is informational; subscriber only acts on escalated",
+            recommended_action=str(payload.get("recommended_action", "")),
+        )
+        if not dry_run:
+            _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+        return decision
+
+    project_slug = str(payload["project_slug"])
+    recommended_action = str(payload.get("recommended_action", ""))
+
+    # ----- 2. Idempotency --------------------------------------------------
+    idem_key = (project_slug, eid)
+    if seen_event_ids is not None and idem_key in seen_event_ids:
+        decision = _new_decision(
+            action_taken=ACTION_NO_OP,
+            previous_tier=None,
+            new_tier=None,
+            project_slug=project_slug,
+            event_id=eid,
+            reason="duplicate event in this session (in-memory idempotency)",
+            recommended_action=recommended_action,
+        )
+        # Don't re-emit audit on duplicates — that would create an infinite
+        # echo if a downstream subscriber reflects applied events back.
+        return decision
+
+    # ----- 3. Resolve project ---------------------------------------------
+    try:
+        state = pm.load_project_state(project_slug)
+    except Exception as exc:  # pragma: no cover — defensive only
+        sys.stderr.write(f"warn: load_project_state({project_slug!r}) raised {exc!r}\n")
+        state = None
+
+    if state is None:
+        decision = _new_decision(
+            action_taken=ACTION_ERROR,
+            previous_tier=None,
+            new_tier=None,
+            project_slug=project_slug,
+            event_id=eid,
+            reason=f"project {project_slug!r} not found",
+            recommended_action=recommended_action,
+        )
+        if not dry_run:
+            _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+        return decision
+
+    # ----- 4. Compute decision --------------------------------------------
+    extras = getattr(state, "extras", None) or {}
+    previous_tier = (extras.get("rigor_tier") or "standard").lower()
+    target_tier = actions.get(recommended_action)
+
+    if target_tier is None:
+        # notify-only / regen-test-strategy / require-council-review — no
+        # rigor change, but we still record the decision in history for
+        # require-council-review and regen-test-strategy.
+        update: Dict[str, Any] = {}
+        decision_reason = f"action {recommended_action!r} does not change rigor tier"
+
+        if recommended_action == "regen-test-strategy":
+            decision_reason = (
+                "regen-test-strategy queued — recorded in rigor_escalation_history"
+            )
+        elif recommended_action == "require-council-review":
+            decision_reason = (
+                "require-council-review recorded — next gate dispatch should run "
+                "as council mode"
+            )
+            update["pending_council_upgrade"] = True
+
+        decision = _new_decision(
+            action_taken=ACTION_NO_OP,
+            previous_tier=previous_tier,
+            new_tier=previous_tier,
+            project_slug=project_slug,
+            event_id=eid,
+            reason=decision_reason,
+            recommended_action=recommended_action,
+        )
+
+        # For non-tier-changing actions we still want history + (optional)
+        # pending_council_upgrade flag persisted, except for notify-only.
+        if recommended_action != "notify-only" and not dry_run:
+            _persist_history_only(pm, state, decision, payload, extra_extras=update)
+
+        if not dry_run:
+            _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+        if seen_event_ids is not None:
+            seen_event_ids.add(idem_key)
+        return decision
+
+    # target_tier is "minimal" | "standard" | "full". Apply the
+    # never-de-escalate rule: only mutate when the new tier is STRICTLY
+    # higher than the current tier.
+    prev_rank = _TIER_RANK.get(previous_tier, 2)  # default to standard
+    new_rank = _TIER_RANK.get(target_tier, prev_rank)
+
+    if new_rank <= prev_rank:
+        decision = _new_decision(
+            action_taken=ACTION_REDUNDANT,
+            previous_tier=previous_tier,
+            new_tier=previous_tier,  # unchanged
+            project_slug=project_slug,
+            event_id=eid,
+            reason=(
+                f"never-de-escalate: project already at tier {previous_tier!r}; "
+                f"recommended {target_tier!r} would not increase rigor"
+            ),
+            recommended_action=recommended_action,
+        )
+        # Still record for false-positive metrics & audit trail.
+        if not dry_run:
+            _persist_history_only(pm, state, decision, payload)
+            _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+        if seen_event_ids is not None:
+            seen_event_ids.add(idem_key)
+        return decision
+
+    # Tier increase — escalate.
+    decision = _new_decision(
+        action_taken=ACTION_ESCALATED,
+        previous_tier=previous_tier,
+        new_tier=target_tier,
+        project_slug=project_slug,
+        event_id=eid,
+        reason=f"rigor tier raised from {previous_tier!r} to {target_tier!r}",
+        recommended_action=recommended_action,
+    )
+
+    if not dry_run:
+        try:
+            _persist_tier_change(pm, state, decision, payload)
+        except Exception as exc:
+            sys.stderr.write(
+                f"warn: failed to persist rigor_tier change for {project_slug!r}: {exc!r}\n"
+            )
+            decision = _new_decision(
+                action_taken=ACTION_ERROR,
+                previous_tier=previous_tier,
+                new_tier=None,
+                project_slug=project_slug,
+                event_id=eid,
+                reason=f"persist failed: {exc!r}",
+                recommended_action=recommended_action,
+            )
+        _emit_applied_event(decision, payload, bus_cmd=bus_cmd)
+
+    if seen_event_ids is not None:
+        seen_event_ids.add(idem_key)
+    return decision
+
+
+def _build_history_entry(
+    decision: Dict[str, Any], payload: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Build one append-only history entry. Schema is intentionally flat."""
+    return {
+        "decided_at": decision["decided_at"],
+        "event_id": decision["event_id"],
+        "action_taken": decision["action_taken"],
+        "previous_tier": decision["previous_tier"],
+        "new_tier": decision["new_tier"],
+        "recommended_action": decision["recommended_action"],
+        "detector": payload.get("detector"),
+        "signal": payload.get("signal"),
+        "reason": decision["reason"],
+    }
+
+
+def _persist_history_only(
+    pm: Any,
+    state: Any,
+    decision: Dict[str, Any],
+    payload: Dict[str, Any],
+    *,
+    extra_extras: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Append a history entry without touching ``rigor_tier``.
+
+    Used for ``redundant``, ``no-op`` (regen + council), and audit-only
+    branches. Idempotent: appending the same entry twice is harmless because
+    the in-session idempotency check already gated us, and the (event_id,
+    decided_at) pair is unique per call.
+    """
+    extras = dict(getattr(state, "extras", None) or {})
+    history: List[Dict[str, Any]] = list(extras.get("rigor_escalation_history") or [])
+    history.append(_build_history_entry(decision, payload))
+    update: Dict[str, Any] = {"rigor_escalation_history": history}
+    if extra_extras:
+        update.update(extra_extras)
+    pm.update_project(state, update)
+
+
+def _persist_tier_change(
+    pm: Any,
+    state: Any,
+    decision: Dict[str, Any],
+    payload: Dict[str, Any],
+) -> None:
+    """Persist a rigor_tier change + history append in a single update_project call."""
+    extras = dict(getattr(state, "extras", None) or {})
+    history: List[Dict[str, Any]] = list(extras.get("rigor_escalation_history") or [])
+    history.append(_build_history_entry(decision, payload))
+    pm.update_project(
+        state,
+        {
+            "rigor_tier": decision["new_tier"],
+            "rigor_escalation_history": history,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI subscriber loop
+# ---------------------------------------------------------------------------
+
+def _build_subscribe_cmd(bus_cmd: List[str], cursor: Optional[str]) -> List[str]:
+    """Build the ``wicked-bus subscribe`` argv. Mirrors steering_tail.py."""
+    cmd = list(bus_cmd) + [
+        "subscribe",
+        "--plugin", SUBSCRIBER_PLUGIN,
+        "--filter", BUS_FILTER,
+    ]
+    if cursor:
+        cmd += ["--cursor-id", cursor]
+    return cmd
+
+
+def _stream_loop(
+    bus_cmd: List[str],
+    *,
+    cursor: Optional[str],
+    dry_run: bool,
+    seen_event_ids: Set[Tuple[str, str]],
+) -> int:
+    """Stream events from wicked-bus and dispatch each to apply_steering_event.
+
+    Returns the subscribe child's returncode (or 0 on clean SIGINT).
+    """
+    cmd = _build_subscribe_cmd(bus_cmd, cursor)
+
+    def _on_sigint(_signum, _frame):  # noqa: ARG001 — signal API
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _on_sigint)
+
+    try:
+        # Stream stderr straight through so the user sees subscribe errors live.
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=sys.stderr,
+            text=True,
+        )
+    except FileNotFoundError:
+        sys.stderr.write(
+            f"error: failed to launch wicked-bus subscribe: {' '.join(cmd)!r}\n"
+        )
+        return 1
+
+    try:
+        assert proc.stdout is not None  # type: ignore[unreachable]
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                sys.stderr.write(f"warn: skipping non-JSON line: {line!r}\n")
+                continue
+            if not isinstance(event, dict):
+                continue
+            decision = apply_steering_event(
+                event,
+                dry_run=dry_run,
+                seen_event_ids=seen_event_ids,
+                bus_cmd=bus_cmd,
+            )
+            sys.stdout.write(
+                json.dumps(decision, default=str, separators=(",", ":")) + "\n"
+            )
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        return 0
+    finally:
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass  # intentional: last-resort cleanup; caller observes exit via returncode
+
+    return proc.returncode if proc.returncode is not None else 0
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="rigor_escalator",
+        description=(
+            "Subscribe to wicked.steer.escalated events and mutate the active "
+            "crew project's rigor_tier. Emits wicked.steer.applied for every "
+            "decision. SIGINT (Ctrl-C) for clean exit."
+        ),
+    )
+    parser.add_argument(
+        "--from-cursor",
+        default=None,
+        help=(
+            "Resume from a known cursor id. Optional — without this the bus "
+            "registers a fresh subscription and tails from latest."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Validate and log decisions but do NOT mutate project state and "
+            "do NOT emit wicked.steer.applied audit events."
+        ),
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    bus_cmd = _resolve_bus_command()
+    if bus_cmd is None:
+        sys.stderr.write(
+            "error: wicked-bus is not installed. "
+            "Install via 'npm install -g wicked-bus' or ensure 'npx' is on PATH.\n"
+        )
+        return 1
+
+    seen: Set[Tuple[str, str]] = set()
+    sys.stderr.write(
+        f"rigor-escalator: subscribed to {BUS_FILTER!r} "
+        f"(dry_run={args.dry_run}, cursor={args.from_cursor or '<latest>'})\n"
+    )
+    return _stream_loop(
+        bus_cmd,
+        cursor=args.from_cursor,
+        dry_run=args.dry_run,
+        seen_event_ids=seen,
+    )
+
+
+__all__ = [
+    "SUBSCRIBER_PLUGIN",
+    "BUS_FILTER",
+    "APPLIED_EVENT_TYPE",
+    "APPLIED_EVENT_DOMAIN",
+    "APPLIED_EVENT_SUBDOMAIN",
+    "DEFAULT_ACTION_TO_TIER",
+    "ACTION_ESCALATED",
+    "ACTION_REDUNDANT",
+    "ACTION_NO_OP",
+    "ACTION_ERROR",
+    "apply_steering_event",
+    "main",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry
+    sys.exit(main())

--- a/scripts/crew/steering_event_schema.py
+++ b/scripts/crew/steering_event_schema.py
@@ -2,10 +2,15 @@
 """
 crew/steering_event_schema.py — Schema validator for the wicked.steer.* event family.
 
-The steering detector registry (epic) emits two event types on the bus:
+The steering detector registry (epic) emits three event types on the bus:
 
   * ``wicked.steer.escalated`` — a detector recommends a rigor change
   * ``wicked.steer.advised``   — a detector observed something but is informational only
+  * ``wicked.steer.applied``   — a behavior subscriber acted (or chose not to act) on
+    an escalated/advised signal. Emitted by ``crew:rigor-escalator`` for every
+    decision branch (escalated, redundant, no-op, error). Same payload shape as
+    the other two — adds an ``action_taken`` field via the catch-all evidence
+    dict so the tail subscriber and audit log don't need a separate validator.
 
 Both share the same payload shape. This module is the single source of truth for
 that shape so that emitters, the reference tail subscriber, and any future
@@ -49,6 +54,7 @@ from typing import Any, List, Tuple
 KNOWN_EVENT_TYPES: frozenset = frozenset({
     "wicked.steer.escalated",
     "wicked.steer.advised",
+    "wicked.steer.applied",
 })
 
 #: Detectors planned for v1 of the registry. New detectors require a PR that

--- a/tests/crew/test_rigor_escalator.py
+++ b/tests/crew/test_rigor_escalator.py
@@ -1,0 +1,734 @@
+"""Tests for ``scripts/crew/rigor_escalator.py``.
+
+PR-3 of the steering detector epic (#679). Covers:
+
+  * Action -> tier mutation: force-full-rigor on minimal/standard projects
+    raises tier to full.
+  * Never-de-escalate: force-full-rigor on a full project returns redundant.
+  * regen-test-strategy: tier unchanged, history appended.
+  * require-council-review: tier unchanged, pending_council_upgrade flag set.
+  * notify-only: pure no-op, no persistence side-effects.
+  * Idempotency: same (project, event_id) processed twice → second is no-op.
+  * Invalid payload: returns error decision, audit emit attempted.
+  * Unknown project: error decision, no mutation, audit emitted.
+  * Dry-run: no project mutation, no audit emit.
+  * Audit event emitted on every decision branch (escalated/redundant/no-op/error)
+    — verified by counting ``_emit_applied_event`` mock calls.
+  * escalation_history is append-only (multi-event projects).
+  * Custom action_map override.
+  * Bus subscribe-failure handling (resolve returns None).
+  * Bare-payload tolerance (test convenience for non-bus callers).
+  * advised event_type → no-op (subscriber only acts on escalated).
+
+Pure stdlib + unittest. No live wicked-bus, no live phase_manager — both are
+swapped in via ``mock.patch`` against the rigor_escalator module's references.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from crew import rigor_escalator as escalator  # noqa: E402
+
+
+_FIXED_NOW = datetime(2026, 4, 27, 10, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class FakeProjectState:
+    """Minimal stand-in for ``crew.phase_manager.ProjectState``."""
+
+    def __init__(self, name: str, extras: Optional[Dict[str, Any]] = None):
+        self.name = name
+        self.extras = dict(extras or {})
+
+
+class FakePhaseManager:
+    """In-memory stand-in for the phase_manager module.
+
+    Records every ``update_project`` call so tests can assert on the persisted
+    state without exercising DomainStore.
+    """
+
+    def __init__(self):
+        self.projects: Dict[str, FakeProjectState] = {}
+        self.update_calls: List[tuple] = []
+
+    def add_project(self, slug: str, *, rigor_tier: Optional[str] = None) -> FakeProjectState:
+        extras: Dict[str, Any] = {}
+        if rigor_tier is not None:
+            extras["rigor_tier"] = rigor_tier
+        state = FakeProjectState(slug, extras=extras)
+        self.projects[slug] = state
+        return state
+
+    def load_project_state(self, slug: str) -> Optional[FakeProjectState]:
+        return self.projects.get(slug)
+
+    def update_project(self, state: FakeProjectState, data: Dict[str, Any]):
+        # Mirror real update_project: merges into extras (or top-level for
+        # rigor_tier — phase_manager stores it under extras, so do the same).
+        for key, value in data.items():
+            state.extras[key] = value
+        self.update_calls.append((state.name, dict(data)))
+        return state, list(data.keys())
+
+
+def _make_payload(
+    project_slug: str,
+    *,
+    recommended_action: str = "force-full-rigor",
+    detector: str = "sensitive-path",
+    signal_text: str = "auth path touched",
+    timestamp: str = "2026-04-27T10:00:00Z",
+    session_id: str = "sess-001",
+    evidence: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a schema-valid steering payload for tests."""
+    return {
+        "detector": detector,
+        "signal": signal_text,
+        "threshold": {"glob": "**/auth/**"},
+        "recommended_action": recommended_action,
+        "evidence": dict(evidence or {"file": "src/auth/login.py"}),
+        "session_id": session_id,
+        "project_slug": project_slug,
+        "timestamp": timestamp,
+    }
+
+
+def _make_event(
+    project_slug: str,
+    *,
+    event_id: str = "evt-1",
+    event_type: str = "wicked.steer.escalated",
+    **payload_kwargs,
+) -> Dict[str, Any]:
+    """Wrap a payload in a bus-style envelope."""
+    return {
+        "id": event_id,
+        "event_type": event_type,
+        "domain": "wicked-garden",
+        "subdomain": "crew.detector.sensitive-path",
+        "payload": _make_payload(project_slug, **payload_kwargs),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Action -> tier mapping
+# ---------------------------------------------------------------------------
+
+class ForceFullRigor(unittest.TestCase):
+
+    def test_minimal_project_is_escalated_to_full(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo"), pm=pm,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(decision["previous_tier"], "minimal")
+        self.assertEqual(decision["new_tier"], "full")
+        # Project state mutated.
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "full")
+        # update_project was called once with both rigor_tier and history.
+        self.assertEqual(len(pm.update_calls), 1)
+        _, data = pm.update_calls[0]
+        self.assertEqual(data["rigor_tier"], "full")
+        self.assertIn("rigor_escalation_history", data)
+        # Audit event emitted exactly once.
+        self.assertEqual(emit.call_count, 1)
+
+    def test_standard_project_is_escalated_to_full(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="standard")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(_make_event("demo"), pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(decision["previous_tier"], "standard")
+        self.assertEqual(decision["new_tier"], "full")
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "full")
+
+    def test_default_tier_when_unset_is_standard(self):
+        # Project has no rigor_tier in extras — escalator treats it as
+        # 'standard' and bumps to full.
+        pm = FakePhaseManager()
+        pm.add_project("demo")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(_make_event("demo"), pm=pm)
+
+        self.assertEqual(decision["previous_tier"], "standard")
+        self.assertEqual(decision["new_tier"], "full")
+
+
+class NeverDeEscalate(unittest.TestCase):
+
+    def test_full_project_force_full_is_redundant(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="full")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(_make_event("demo"), pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_REDUNDANT)
+        self.assertEqual(decision["previous_tier"], "full")
+        self.assertEqual(decision["new_tier"], "full", "must not de-escalate")
+        # Tier did NOT change, but history WAS appended for false-positive metrics.
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "full")
+        self.assertEqual(len(pm.update_calls), 1)
+        _, data = pm.update_calls[0]
+        self.assertNotIn("rigor_tier", data, "redundant must not write rigor_tier")
+        self.assertIn("rigor_escalation_history", data)
+        # Audit event still emitted.
+        self.assertEqual(emit.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Non-tier actions
+# ---------------------------------------------------------------------------
+
+class RegenTestStrategy(unittest.TestCase):
+
+    def test_keeps_tier_records_history(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="standard")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo", recommended_action="regen-test-strategy"),
+                pm=pm,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(decision["previous_tier"], "standard")
+        self.assertEqual(decision["new_tier"], "standard")
+        # update_project was called for history (no rigor_tier change).
+        self.assertEqual(len(pm.update_calls), 1)
+        _, data = pm.update_calls[0]
+        self.assertNotIn("rigor_tier", data)
+        self.assertIn("rigor_escalation_history", data)
+        # History entry has the right action.
+        history = data["rigor_escalation_history"]
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]["recommended_action"], "regen-test-strategy")
+        self.assertEqual(emit.call_count, 1)
+
+
+class RequireCouncilReview(unittest.TestCase):
+
+    def test_keeps_tier_sets_pending_council_upgrade(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="standard")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo", recommended_action="require-council-review"),
+                pm=pm,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "standard")
+        # Pending council flag persisted for the next gate dispatch to consume.
+        self.assertTrue(pm.projects["demo"].extras.get("pending_council_upgrade"))
+        # History also recorded.
+        self.assertIn("rigor_escalation_history", pm.projects["demo"].extras)
+        self.assertEqual(emit.call_count, 1)
+
+
+class NotifyOnly(unittest.TestCase):
+
+    def test_no_state_mutation(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="standard")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo", recommended_action="notify-only"),
+                pm=pm,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_NO_OP)
+        # notify-only: no update_project call AT ALL.
+        self.assertEqual(pm.update_calls, [])
+        # But audit event still emitted.
+        self.assertEqual(emit.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+class IdempotencyInSession(unittest.TestCase):
+
+    def test_second_call_with_same_event_id_is_noop(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        seen: set = set()
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            d1 = escalator.apply_steering_event(
+                _make_event("demo", event_id="evt-99"),
+                pm=pm, seen_event_ids=seen,
+            )
+            d2 = escalator.apply_steering_event(
+                _make_event("demo", event_id="evt-99"),
+                pm=pm, seen_event_ids=seen,
+            )
+
+        self.assertEqual(d1["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(d2["action_taken"], escalator.ACTION_NO_OP)
+        self.assertIn("idempotency", d2["reason"].lower())
+        # Only one mutation — second call short-circuited.
+        self.assertEqual(len(pm.update_calls), 1)
+        # Only one audit emit — duplicates do not re-emit (avoids feedback loop).
+        self.assertEqual(emit.call_count, 1)
+
+    def test_different_events_for_same_project_both_processed(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        seen: set = set()
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            d1 = escalator.apply_steering_event(
+                _make_event("demo", event_id="evt-1"),
+                pm=pm, seen_event_ids=seen,
+            )
+            d2 = escalator.apply_steering_event(
+                _make_event("demo", event_id="evt-2"),
+                pm=pm, seen_event_ids=seen,
+            )
+
+        # First escalates minimal -> full; second is redundant (already full).
+        self.assertEqual(d1["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(d2["action_taken"], escalator.ACTION_REDUNDANT)
+
+
+# ---------------------------------------------------------------------------
+# Invalid payloads + missing projects
+# ---------------------------------------------------------------------------
+
+class InvalidPayload(unittest.TestCase):
+
+    def test_missing_required_field_returns_error(self):
+        bad = {
+            "id": "evt-1",
+            "event_type": "wicked.steer.escalated",
+            "payload": {
+                # missing detector, threshold, etc.
+                "project_slug": "demo",
+                "session_id": "sess-001",
+                "recommended_action": "force-full-rigor",
+                "timestamp": "2026-04-27T10:00:00Z",
+            },
+        }
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(bad, pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ERROR)
+        self.assertEqual(pm.update_calls, [], "errors must not mutate state")
+        # Even errors emit an audit so the ledger sees the bad event.
+        self.assertEqual(emit.call_count, 1)
+
+    def test_unknown_event_type_returns_error(self):
+        bad = {
+            "id": "evt-1",
+            "event_type": "wicked.steer.unknown",
+            "payload": _make_payload("demo"),
+        }
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(bad, pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ERROR)
+
+
+class UnknownProject(unittest.TestCase):
+
+    def test_missing_project_returns_error_decision(self):
+        pm = FakePhaseManager()  # No projects added.
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(_make_event("ghost"), pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ERROR)
+        self.assertIn("not found", decision["reason"].lower())
+        self.assertEqual(pm.update_calls, [])
+        # Audit still emitted — required by the per-branch contract.
+        self.assertEqual(emit.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Audit emit on every branch (single concentrated test for the contract)
+# ---------------------------------------------------------------------------
+
+class AuditEmitContract(unittest.TestCase):
+
+    def test_every_branch_emits_audit(self):
+        """Every decision branch must emit a wicked.steer.applied audit event."""
+        pm = FakePhaseManager()
+        pm.add_project("demo-a", rigor_tier="minimal")  # → escalated
+        pm.add_project("demo-b", rigor_tier="full")      # → redundant
+        pm.add_project("demo-c", rigor_tier="standard")  # → no-op (notify-only)
+        # demo-ghost intentionally missing → error
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            d_esc = escalator.apply_steering_event(
+                _make_event("demo-a", event_id="e1"), pm=pm,
+            )
+            d_red = escalator.apply_steering_event(
+                _make_event("demo-b", event_id="e2"), pm=pm,
+            )
+            d_nop = escalator.apply_steering_event(
+                _make_event(
+                    "demo-c", event_id="e3", recommended_action="notify-only",
+                ),
+                pm=pm,
+            )
+            d_err = escalator.apply_steering_event(
+                _make_event("demo-ghost", event_id="e4"), pm=pm,
+            )
+
+        self.assertEqual(d_esc["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(d_red["action_taken"], escalator.ACTION_REDUNDANT)
+        self.assertEqual(d_nop["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(d_err["action_taken"], escalator.ACTION_ERROR)
+        # 4 distinct branches → 4 audit emits.
+        self.assertEqual(
+            emit.call_count, 4,
+            f"expected 4 audit emits across 4 branches, got {emit.call_count}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# History append-only behavior
+# ---------------------------------------------------------------------------
+
+class EscalationHistoryAppendOnly(unittest.TestCase):
+
+    def test_history_grows_across_events(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        seen: set = set()
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            escalator.apply_steering_event(
+                _make_event("demo", event_id="e1"), pm=pm, seen_event_ids=seen,
+            )
+            escalator.apply_steering_event(
+                _make_event(
+                    "demo", event_id="e2", recommended_action="regen-test-strategy",
+                ),
+                pm=pm, seen_event_ids=seen,
+            )
+            escalator.apply_steering_event(
+                _make_event(
+                    "demo", event_id="e3", recommended_action="require-council-review",
+                ),
+                pm=pm, seen_event_ids=seen,
+            )
+
+        history = pm.projects["demo"].extras["rigor_escalation_history"]
+        # 3 distinct events → 3 history entries.
+        self.assertEqual(len(history), 3)
+        self.assertEqual(
+            [h["event_id"] for h in history],
+            ["e1", "e2", "e3"],
+        )
+        # First entry is the tier change; rest are no-op records.
+        self.assertEqual(history[0]["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(history[0]["new_tier"], "full")
+        # Events 2 and 3 happen AFTER tier is full, so they're redundant for
+        # tier-changing actions but no-op for non-tier actions. regen-test-strategy
+        # is a non-tier-action -> no-op (not redundant).
+        self.assertEqual(history[1]["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(history[2]["action_taken"], escalator.ACTION_NO_OP)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+class DryRunMode(unittest.TestCase):
+
+    def test_no_mutation_no_emit(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo"), pm=pm, dry_run=True,
+            )
+
+        # Decision is computed correctly...
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(decision["new_tier"], "full")
+        # ...but state is untouched and no audit event fired.
+        self.assertEqual(pm.update_calls, [])
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "minimal")
+        emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Custom action_map override
+# ---------------------------------------------------------------------------
+
+class CustomActionMapOverride(unittest.TestCase):
+
+    def test_override_force_full_to_standard_only(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        custom = {"force-full-rigor": "standard"}
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(
+                _make_event("demo"), pm=pm, action_map=custom,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+        self.assertEqual(decision["new_tier"], "standard")
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "standard")
+
+    def test_override_makes_action_a_no_op(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        # Map force-full-rigor to None — should become a no-op.
+        custom = {"force-full-rigor": None}
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(
+                _make_event("demo"), pm=pm, action_map=custom,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "minimal")
+
+
+# ---------------------------------------------------------------------------
+# Bus subscribe failure path (CLI surface)
+# ---------------------------------------------------------------------------
+
+class BusSubscribeFailure(unittest.TestCase):
+
+    def test_main_exits_1_when_bus_unreachable(self):
+        with mock.patch.object(escalator, "_resolve_bus_command", return_value=None):
+            rc = escalator.main([])
+        self.assertEqual(rc, 1)
+
+    def test_main_dry_run_still_exits_1_when_bus_unreachable(self):
+        # We require the bus for CLI mode even in --dry-run — there's nothing
+        # to subscribe to without it.
+        with mock.patch.object(escalator, "_resolve_bus_command", return_value=None):
+            rc = escalator.main(["--dry-run"])
+        self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# advised events are not acted on
+# ---------------------------------------------------------------------------
+
+class AdvisedEventNoOp(unittest.TestCase):
+
+    def test_advised_event_returns_noop_no_mutation(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True) as emit:
+            decision = escalator.apply_steering_event(
+                _make_event("demo", event_type="wicked.steer.advised"),
+                pm=pm,
+            )
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_NO_OP)
+        self.assertEqual(pm.update_calls, [])
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "minimal")
+        # Audit still emitted so the trail records that we saw it.
+        self.assertEqual(emit.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Bare-payload tolerance (test convenience for non-bus callers)
+# ---------------------------------------------------------------------------
+
+class BarePayloadTolerance(unittest.TestCase):
+
+    def test_bare_payload_treated_as_escalated(self):
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+        bare = _make_payload("demo")
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(bare, pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+
+
+# ---------------------------------------------------------------------------
+# Bus wire-format compatibility — wicked-bus subscribe ships payload as a
+# JSON-encoded STRING (not a nested object). Verify we parse it correctly.
+# ---------------------------------------------------------------------------
+
+class BusEnvelopeWireFormat(unittest.TestCase):
+
+    def test_payload_as_json_string_is_parsed(self):
+        """wicked-bus subscribe delivers payload as a JSON-encoded string."""
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        wire_envelope = {
+            "event_id": 12345,
+            "event_type": "wicked.steer.escalated",
+            "domain": "wicked-garden",
+            "subdomain": "crew.detector.sensitive-path",
+            "payload": json.dumps(_make_payload("demo")),
+            "idempotency_key": "uuid-abc-123",
+        }
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(wire_envelope, pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ESCALATED)
+        # Idempotency key should be the bus's uuid (preferred over event_id).
+        self.assertEqual(decision["event_id"], "uuid-abc-123")
+
+    def test_malformed_payload_string_returns_error(self):
+        """A non-JSON payload string is treated as an empty payload (schema rejects)."""
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        broken = {
+            "event_id": 99,
+            "event_type": "wicked.steer.escalated",
+            "payload": "not-valid-json{{{",
+        }
+
+        with mock.patch.object(escalator, "_emit_applied_event", return_value=True):
+            decision = escalator.apply_steering_event(broken, pm=pm)
+
+        self.assertEqual(decision["action_taken"], escalator.ACTION_ERROR)
+        # No mutation despite the malformed wire payload.
+        self.assertEqual(pm.update_calls, [])
+        self.assertEqual(pm.projects["demo"].extras["rigor_tier"], "minimal")
+
+
+# ---------------------------------------------------------------------------
+# Clean-shutdown signal handling (smoke — verify SIGINT handler is wired)
+# ---------------------------------------------------------------------------
+
+class SigintHandling(unittest.TestCase):
+
+    def test_stream_loop_keyboard_interrupt_returns_zero(self):
+        """A SIGINT mid-stream returns 0, not a stack trace."""
+
+        # Build a fake Popen whose stdout iterator raises KeyboardInterrupt
+        # on the first read — emulating user pressing Ctrl-C immediately.
+        class _FakePopen:
+            stdout = None
+            returncode = 0
+
+            def __init__(self, *_a, **_kw):
+                self.stdout = self
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise KeyboardInterrupt
+
+            def poll(self):
+                return 0
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+        with mock.patch.object(escalator.subprocess, "Popen", _FakePopen):
+            rc = escalator._stream_loop(
+                ["wicked-bus"], cursor=None, dry_run=True, seen_event_ids=set(),
+            )
+
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# Audit payload shape — make sure what we emit will pass the schema validator
+# ---------------------------------------------------------------------------
+
+class AuditPayloadShape(unittest.TestCase):
+
+    def test_emit_applied_event_payload_passes_schema(self):
+        """The audit emit must build a payload that passes validate_payload.
+
+        Mocks the subprocess so we can inspect the argv.
+        """
+        from crew.steering_event_schema import validate_payload
+
+        pm = FakePhaseManager()
+        pm.add_project("demo", rigor_tier="minimal")
+
+        # Capture the subprocess invocation of `wicked-bus emit` by patching
+        # subprocess.run and asserting on the JSON payload arg.
+        captured: Dict[str, Any] = {}
+
+        class _OkProc:
+            returncode = 0
+            stderr = ""
+
+        def _capture(cmd, *_a, **_kw):
+            # Find --payload arg
+            try:
+                idx = cmd.index("--payload")
+                captured["payload"] = json.loads(cmd[idx + 1])
+                captured["type"] = cmd[cmd.index("--type") + 1]
+            except (ValueError, KeyError, json.JSONDecodeError):
+                pass
+            return _OkProc()
+
+        with mock.patch.object(
+            escalator, "_resolve_bus_command", return_value=["wicked-bus"],
+        ), mock.patch.object(
+            escalator.subprocess, "run", side_effect=_capture,
+        ):
+            escalator.apply_steering_event(_make_event("demo"), pm=pm)
+
+        self.assertIn("payload", captured, "subprocess emit was not called with --payload")
+        self.assertEqual(captured["type"], "wicked.steer.applied")
+        errors, warnings = validate_payload("wicked.steer.applied", captured["payload"])
+        self.assertEqual(
+            errors, [],
+            f"audit payload failed schema: {errors} payload={captured['payload']}",
+        )
+        # action_taken stuffed under evidence as documented.
+        self.assertEqual(captured["payload"]["evidence"]["action_taken"], escalator.ACTION_ESCALATED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_steering_event_schema.py
+++ b/tests/crew/test_steering_event_schema.py
@@ -274,9 +274,15 @@ class AllowlistContents(unittest.TestCase):
         )
 
     def test_known_event_types_v1_set(self):
+        # PR-3 (#679) added wicked.steer.applied — emitted by the rigor-escalator
+        # subscriber for every decision branch (escalated/redundant/no-op/error).
         self.assertEqual(
             KNOWN_EVENT_TYPES,
-            frozenset({"wicked.steer.escalated", "wicked.steer.advised"}),
+            frozenset({
+                "wicked.steer.escalated",
+                "wicked.steer.advised",
+                "wicked.steer.applied",
+            }),
         )
 
     def test_known_actions_v1_set(self):


### PR DESCRIPTION
## Summary

PR-3 of the steering detector epic (#679). Ships the **first behavior subscriber** for `wicked.steer.escalated` — the moment the steering loop closes:

- **PR-1** (#681) — wicked.steer.* event family + tail subscriber + schema validator
- **PR-2** (#682) — sensitive-path detector emits `wicked.steer.escalated`
- **PR-3 (this PR)** — `crew:rigor-escalator` subscriber receives the event and mutates the active project's `rigor_tier`, then emits `wicked.steer.applied` for audit

After this PR, a session that touches `src/auth/login.py` will:

1. Have the sensitive-path detector emit `wicked.steer.escalated@wicked-garden`
2. Have wicked-bus deliver the event to the rigor-escalator subscriber
3. Have the subscriber bump the active project's `rigor_tier` to `full`
4. Have the next gate dispatch read the new tier from `gate-policy.json` and run more reviewers

End-to-end, no human in the loop.

## What's in this PR

- **`scripts/crew/rigor_escalator.py`** (~700 lines including docstrings) — pure-stdlib subscriber + CLI
- **`tests/crew/test_rigor_escalator.py`** — 25 unit tests
- **`scenarios/crew/rigor-escalator-end-to-end.md`** — integration scenario
- **`scripts/crew/steering_event_schema.py`** — adds `wicked.steer.applied` to `KNOWN_EVENT_TYPES`
- **`tests/crew/test_steering_event_schema.py`** — updated assertion for the new event type
- **`CHANGELOG.md`** — Unreleased / Added entry

## Action -> tier mapping

| recommended_action       | effect on project state                                              |
|--------------------------|----------------------------------------------------------------------|
| `force-full-rigor`       | set `rigor_tier = "full"` (unless already full)                      |
| `regen-test-strategy`    | keep tier; record in `rigor_escalation_history`                      |
| `require-council-review` | keep tier; set `pending_council_upgrade` flag for next gate dispatch |
| `notify-only`            | pure no-op; log only                                                 |

## Hard guardrails

- **Never de-escalate** — already-`full` projects stay `full`. A second `force-full-rigor` returns `redundant`, records the event for false-positive metrics, does NOT lower the tier.
- **In-session idempotency** — `(project_slug, event_id)` deduped via process-local set. Cross-session dedup is the bus's job (cursor-poll).
- **Audit on every branch** — every decision (escalated/redundant/no-op/error) emits a follow-up `wicked.steer.applied` event.
- **Fail-open** — phase_manager errors, schema errors, missing projects, and bus emit failures all log to stderr and continue.

## Wire-format note

wicked-bus delivers events with `payload` as a **JSON-encoded string**, not a nested object. `_extract_payload` handles both the wire format and in-process test envelopes uniformly. Discovered + fixed during the manual end-to-end run.

## End-to-end manual verification

```text
$ python3 scripts/crew/rigor_escalator.py
rigor-escalator: subscribed to 'wicked.steer.escalated@wicked-garden' (dry_run=False, cursor=<latest>)

# in another terminal:
$ python3 scripts/crew/detectors/sensitive_path.py \
    --paths src/auth/login.py --session-id e2e-real --project-slug e2e-rigor-test

# subscriber stdout:
{"action_taken":"escalated","previous_tier":"standard","new_tier":"full",
 "project_slug":"e2e-rigor-test",
 "event_id":"16173075-3f1d-4eac-9e2f-af3e244191cd",
 "reason":"rigor tier raised from 'standard' to 'full'",
 "recommended_action":"force-full-rigor",
 "decided_at":"2026-04-27T05:55:06Z"}

# project state after:
rigor_tier: full
history_len: 1
first_entry: {
  "decided_at": "2026-04-27T05:55:06Z",
  "event_id": "16173075-3f1d-4eac-9e2f-af3e244191cd",
  "action_taken": "escalated",
  "previous_tier": "standard",
  "new_tier": "full",
  "recommended_action": "force-full-rigor",
  "detector": "sensitive-path",
  "signal": "sensitive auth path touched: src/auth/login.py",
  "reason": "rigor tier raised from 'standard' to 'full'"
}

# separate audit listener also confirmed wicked.steer.applied landed on the bus:
{"event_id":45105,"event_type":"wicked.steer.applied",
 "domain":"wicked-garden","subdomain":"crew.rigor-escalator",
 "payload":"{...action_taken:redundant, subscriber:wicked-garden:crew:rigor-escalator,...}"}
```

## Test plan

- [x] Unit tests for action -> tier mapping (force-full on minimal/standard/full)
- [x] Never-de-escalate guard returns redundant
- [x] regen-test-strategy / require-council-review / notify-only branches
- [x] In-session idempotency by `(project_slug, event_id)`
- [x] Invalid payload + unknown project return error decisions
- [x] Audit emit on every decision branch (4 branches verified)
- [x] Append-only `escalation_history` across multi-event projects
- [x] Custom `action_map` override
- [x] Bus subscribe-failure handling (CLI exits 1 cleanly)
- [x] SIGINT handler returns 0
- [x] Audit payload schema-validates against PR-1 schema
- [x] Bus wire-format compatibility (JSON-string payload + idempotency_key)
- [x] Bare-payload tolerance for programmatic callers
- [x] End-to-end manual: detector -> bus -> subscriber -> project mutated -> audit emitted

## Out of scope (future PRs)

- Wiring the subscriber into a SessionStart hook so it runs automatically. CLI invocation is the v1 surface.
- Cross-session idempotency ledger (the bus's cursor-poll already handles this).

## Related

- Epic: #679
- PR-1: #681
- PR-2: #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)