### PR TITLE
fix: audit phases.json for prose-described test phases (#623)

### DIFF
--- a/daemon/test_dispatch.py
+++ b/daemon/test_dispatch.py
@@ -192,6 +192,22 @@ def detect_test_phases(phases_list: list[dict[str, Any]]) -> list[str]:
     The probe is intentionally conservative — missing fields are treated as empty
     rather than raising, so a partial phase record from the DB does not crash
     detection.
+
+    Known limitation (issue #623, audited 2026-04-27)
+    -------------------------------------------------
+    The detector does NOT scan free-text ``description`` / ``summary`` fields.
+    A hypothetical phase like ``{name: quality-assurance,
+    description: "Run tests and verify"}`` with no QE specialist and no test
+    activities would silently skip dispatch.
+
+    Audit on 2026-04-27 against `.claude-plugin/phases.json` confirmed every
+    phase whose prose mentions testing (``test-strategy``, ``test``) already
+    carries a structured signal (name keyword + qe specialist), so the detector
+    matches every test-engaging phase today. The regression guard at
+    ``tests/daemon/test_test_dispatch.py::TestPhasesJsonProseGuard`` asserts
+    this invariant against the live catalog so any future prose-only phase
+    addition fails CI rather than silently skipping dispatch. Re-audit when
+    phases.json gains new entries.
     """
     detected: list[str] = []
     for phase_row in phases_list:

--- a/tests/daemon/test_test_dispatch.py
+++ b/tests/daemon/test_test_dispatch.py
@@ -812,3 +812,67 @@ class TestAvailabilityProbeNodeWithoutWickedTesting:
             "Node-present-but-wicked-testing-absent must degrade gracefully, not error."
         )
         conn.close()
+
+
+# ===========================================================================
+# Issue #623 — phases.json prose vs structured-detector regression guard
+# ===========================================================================
+
+# Words that suggest a phase engages testing when they appear in the prose
+# `description`/`summary` fields. Used by the regression guard below.
+_PROSE_TEST_KEYWORDS: frozenset[str] = frozenset({
+    "test", "verify", "validation", "verification", "qe",
+})
+
+
+class TestPhasesJsonProseGuard:
+    """Regression guard for issue #623.
+
+    `detect_test_phases` matches by name keyword, qe specialist, or test-keyword
+    activity — it does NOT scan free-text `description`/`summary` fields. If a
+    future phases.json entry describes testing only in prose (no structured
+    signal) it would silently skip dispatch. This test fails CI in that case so
+    the author either adds a structured signal or extends the detector.
+    """
+
+    @staticmethod
+    def _load_catalog() -> dict:
+        """Load .claude-plugin/phases.json from repo root."""
+        catalog_path = _REPO_ROOT / ".claude-plugin" / "phases.json"
+        with catalog_path.open() as fh:
+            return json.load(fh)
+
+    def test_every_prose_test_phase_has_structured_signal(self):
+        """For each phase in phases.json: if its description mentions testing,
+        the structured detector must also match it.
+        """
+        catalog = self._load_catalog()
+        phases = catalog["phases"]
+
+        # Build phase rows the way detect_test_phases expects
+        phase_rows = []
+        for name, phase in phases.items():
+            row = dict(phase)
+            row["phase"] = name
+            phase_rows.append(row)
+
+        detected = set(td.detect_test_phases(phase_rows))
+
+        prose_only_misses: list[str] = []
+        for name, phase in phases.items():
+            prose = (
+                (phase.get("description") or "") + " " + (phase.get("summary") or "")
+            ).lower()
+            mentions_test = any(kw in prose for kw in _PROSE_TEST_KEYWORDS)
+            if mentions_test and name not in detected:
+                prose_only_misses.append(name)
+
+        assert prose_only_misses == [], (
+            "Issue #623: the following phases in .claude-plugin/phases.json "
+            "describe testing in prose but lack a structured signal "
+            "(name keyword in {test-strategy,test,qe} / specialists contains 'qe' "
+            f"/ test-keyword activity), so detect_test_phases skips them: "
+            f"{prose_only_misses}. Either add a structured signal to the phase "
+            "(preferred — keeps the detector cheap) or extend "
+            "daemon/test_dispatch.detect_test_phases to scan description/summary."
+        )

--- a/tests/daemon/test_test_dispatch.py
+++ b/tests/daemon/test_test_dispatch.py
@@ -818,11 +818,20 @@ class TestAvailabilityProbeNodeWithoutWickedTesting:
 # Issue #623 — phases.json prose vs structured-detector regression guard
 # ===========================================================================
 
+import re
+
 # Words that suggest a phase engages testing when they appear in the prose
 # `description`/`summary` fields. Used by the regression guard below.
+# Matched as whole words via `\b` boundaries so "test" doesn't false-positive
+# on "contest" / "latest" and "qe" doesn't false-positive on "queen".
 _PROSE_TEST_KEYWORDS: frozenset[str] = frozenset({
     "test", "verify", "validation", "verification", "qe",
 })
+
+_PROSE_TEST_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(kw) for kw in _PROSE_TEST_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
 
 
 class TestPhasesJsonProseGuard:
@@ -863,7 +872,7 @@ class TestPhasesJsonProseGuard:
             prose = (
                 (phase.get("description") or "") + " " + (phase.get("summary") or "")
             ).lower()
-            mentions_test = any(kw in prose for kw in _PROSE_TEST_KEYWORDS)
+            mentions_test = bool(_PROSE_TEST_PATTERN.search(prose))
             if mentions_test and name not in detected:
                 prose_only_misses.append(name)
 


### PR DESCRIPTION
## Summary

Issue #623: `daemon/test_dispatch.py::detect_test_phases` matches phases by name keyword (`test-strategy`/`test`/`qe`), `specialists` containing `qe`, or test-keyword `activities` — it does NOT scan free-text `description`/`summary`. A hypothetical phase like `{name: quality-assurance, description: "Run tests and verify"}` with no QE specialist or test activities would silently skip dispatch.

**Audit (2026-04-27) against `.claude-plugin/phases.json` — outcome (a): no mismatches.**

| Phase           | Prose mentions test? | Structured signal? | Detector matches? |
|-----------------|:--------------------:|:------------------:|:-----------------:|
| ideate          | no                   | no                 | no (correct)      |
| clarify         | no                   | qe specialist      | yes               |
| design          | no                   | qe specialist      | yes               |
| test-strategy   | yes                  | name + qe          | yes               |
| challenge       | no                   | no                 | no (correct)      |
| build           | no                   | no                 | no (correct)      |
| test            | yes                  | name + qe          | yes               |
| review          | no                   | qe specialist      | yes               |
| operate         | no                   | qe specialist      | yes               |

Every phase that describes testing in prose already carries a structured signal. Current detector matches all test-engaging phases. **No code/config change needed beyond documenting the audit + locking the invariant in CI.**

## Changes

- **`daemon/test_dispatch.py`** — `detect_test_phases` docstring expanded with a Known Limitation section: documents the prose-blindness, the 2026-04-27 audit timestamp, and a pointer to the regression guard.
- **`tests/daemon/test_test_dispatch.py`** — new `TestPhasesJsonProseGuard::test_every_prose_test_phase_has_structured_signal`: loads the live `.claude-plugin/phases.json`, walks every phase, and asserts that any phase whose prose mentions `test`/`verify`/`validation`/`verification`/`qe` is also matched by the structured detector. Fails CI if a future phases.json entry slips into prose-only territory — forces the author to either add a structured signal (preferred — keeps the detector cheap) or extend `detect_test_phases`.

## Test plan

- [x] Run new regression guard against current `phases.json` — passes (0 mismatches)
- [x] Existing `TestDetectTestPhases` + `TestBuildDispatchPlan` — 16/16 still pass
- [x] Verify guard would catch a synthetic prose-only phase (`quality-assurance` with no qe specialist) — confirmed it would fire
- [x] All 17 covered tests pass: `pytest tests/daemon/test_test_dispatch.py::TestPhasesJsonProseGuard tests/daemon/test_test_dispatch.py::TestDetectTestPhases tests/daemon/test_test_dispatch.py::TestBuildDispatchPlan -v`

Closes #623.

Generated with [Claude Code](https://claude.com/claude-code)