### PR TITLE
fix: phase_manager approve syncs native gate-finding task to completed (#653)

### DIFF
--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3207,14 +3207,25 @@ def _sync_gate_finding_task(
     Scans the current session's task store for a task whose metadata
     matches ``event_type=gate-finding`` AND ``phase=phase`` AND whose
     ``chain_id`` starts with the project name prefix.  When found, updates
-    the task file to ``status=completed`` and stamps the verdict + score
-    from ``gate_result`` into metadata.
+    the task file to ``status=completed`` and stamps verdict, score,
+    min_score, and (for CONDITIONAL verdicts) conditions_manifest_path
+    into metadata so the resulting completed-state task satisfies the
+    ``gate-finding.required_at_completion`` schema in
+    ``scripts/_event_schema.py`` (Issue #570).
 
     This closes the dual-record divergence (#653): the DomainStore phase
     record and the native task chain both reflect the gate outcome.
 
-    Fail-open on every error path — a task-store update failure must
-    never block phase advancement.
+    Multiple-match handling: when more than one gate-finding task matches
+    the lookup (e.g. re-eval / repeat-gate scenarios), the helper updates
+    the task with the most-recent ``st_mtime``. The other matches stay
+    untouched — they belong to a previous gate run and rewriting them
+    would corrupt prior history.
+
+    Fail-open on every error path — a task-store update failure (write
+    permission, missing dir, malformed JSON) must never block phase
+    advancement. Errors are logged to stderr at WARNING; the helper
+    returns silently.
 
     When ``gate_result`` is None (e.g. ``--override-gate`` path, non-gated
     phases) the function returns immediately without touching any task file.
@@ -3248,6 +3259,7 @@ def _sync_gate_finding_task(
 
     verdict: Optional[str] = None
     score: Optional[float] = None
+    min_score: Optional[float] = None
     if gate_result and isinstance(gate_result, dict):
         verdict = gate_result.get("verdict") or gate_result.get("result")
         raw_score = gate_result.get("score")
@@ -3256,6 +3268,28 @@ def _sync_gate_finding_task(
                 score = float(raw_score)
             except (TypeError, ValueError):
                 score = None
+        raw_min_score = gate_result.get("min_score")
+        if raw_min_score is not None:
+            try:
+                min_score = float(raw_min_score)
+            except (TypeError, ValueError):
+                min_score = None
+
+    # CONDITIONAL verdict requires conditions_manifest_path in completed
+    # metadata (scripts/_event_schema.py#L191-192). The path is deterministic
+    # — phase_manager writes it to {project_dir}/phases/{phase}/conditions-manifest.json
+    # in its CONDITIONAL handling path. We resolve the same location here so
+    # the completed task carries the schema-required field.
+    conditions_manifest_path: Optional[str] = None
+    if verdict == "CONDITIONAL":
+        try:
+            manifest_path = (
+                get_project_dir(project_name) / "phases" / phase
+                / "conditions-manifest.json"
+            )
+            conditions_manifest_path = str(manifest_path)
+        except Exception:
+            conditions_manifest_path = None
 
     session_id = os.environ.get("CLAUDE_SESSION_ID", "")
     if not session_id:
@@ -3269,6 +3303,12 @@ def _sync_gate_finding_task(
 
     _MAX_TASKS_SCAN: int = 200  # R5: bounded scan — never iterate unbounded task dirs
 
+    # Phase 1: collect all matching pending/in-progress gate-finding tasks.
+    # We sort by st_mtime descending and update only the most-recent one to
+    # handle re-eval / repeat-gate scenarios correctly (multiple gate runs
+    # for the same phase produce multiple tasks; the freshest is the one
+    # whose verdict is being recorded right now).
+    matches: List[Tuple[float, Path, dict]] = []
     try:
         scanned = 0
         for entry in tasks_dir.iterdir():
@@ -3297,31 +3337,70 @@ def _sync_gate_finding_task(
             if not isinstance(chain_id, str) or not chain_id.startswith(expected_chain_prefix):
                 continue
 
-            # Found a matching gate-finding task — stamp it completed.
-            data["status"] = "completed"
-            if verdict:
-                meta["verdict"] = verdict
-            if score is not None:
-                meta["score"] = score
-            data["metadata"] = meta
             try:
-                entry.write_text(
-                    json.dumps(data, indent=2, sort_keys=True),
-                    encoding="utf-8",
-                )
-                logger.debug(
-                    "[approve] synced gate-finding task %s → completed "
-                    "(phase=%s, verdict=%s, score=%s)",
-                    entry.stem, phase, verdict, score,
-                )
-            except Exception as exc:
-                logger.debug(
-                    "[approve] gate-finding task sync write failed: %s", exc
-                )
-            # At most one gate-finding task per phase — stop after first match.
-            return
+                mtime = entry.stat().st_mtime
+            except OSError:
+                mtime = 0.0
+            matches.append((mtime, entry, data))
     except Exception as exc:
+        # Scan error — log and bail. Approve flow continues.
+        print(
+            f"[approve] _sync_gate_finding_task scan error: {exc}",
+            file=sys.stderr,
+        )
         logger.debug("[approve] _sync_gate_finding_task scan error: %s", exc)
+        return
+
+    if not matches:
+        logger.debug(
+            "[approve] no native gate-finding task to sync for phase=%s "
+            "(project=%s) — chain may not have been emitted",
+            phase, project_name,
+        )
+        return
+
+    # Take the most-recent match by st_mtime (descending). Ties broken
+    # deterministically by file path so behaviour is reproducible.
+    matches.sort(key=lambda triple: (triple[0], str(triple[1])), reverse=True)
+    _mtime, entry, data = matches[0]
+    meta = data.get("metadata") or {}
+
+    # Stamp the verdict, score, min_score, and (CONDITIONAL only)
+    # conditions_manifest_path so the completed task satisfies the
+    # gate-finding.required_at_completion schema (#570).
+    data["status"] = "completed"
+    if verdict:
+        meta["verdict"] = verdict
+    if score is not None:
+        meta["score"] = score
+    if min_score is not None:
+        meta["min_score"] = min_score
+    if conditions_manifest_path is not None:
+        meta["conditions_manifest_path"] = conditions_manifest_path
+    data["metadata"] = meta
+
+    try:
+        entry.write_text(
+            json.dumps(data, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        logger.debug(
+            "[approve] synced gate-finding task %s → completed "
+            "(phase=%s, verdict=%s, score=%s, min_score=%s, "
+            "conditions_manifest_path=%s)",
+            entry.stem, phase, verdict, score, min_score,
+            conditions_manifest_path,
+        )
+    except Exception as exc:
+        # Write failure — log to stderr (visible to operators) and continue.
+        # Approve flow MUST NOT fail just because a task-store write broke.
+        print(
+            f"[approve] gate-finding task sync write failed: {exc}",
+            file=sys.stderr,
+        )
+        logger.debug(
+            "[approve] gate-finding task sync write failed: %s", exc
+        )
 
 
 def _run_build_phase_guard(project_dir: Path) -> List[str]:

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -1141,6 +1141,250 @@ class TestSyncGateFindingTask(unittest.TestCase):
         with patch.dict(os.environ, env, clear=True):
             pm._sync_gate_finding_task(state, "clarify", gate_result)  # no exception
 
+    def test_sync_picks_most_recently_modified_when_multiple_match(self):
+        """Multiple matching tasks → only the most-recent (mtime) is updated.
+
+        Re-eval / repeat-gate scenarios produce more than one gate-finding
+        task per phase. The freshest one corresponds to the gate run whose
+        verdict is being recorded right now; older matches belong to
+        previous runs and must remain in their stored state.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-multi"
+            tasks_dir.mkdir(parents=True)
+
+            shared_meta = {
+                "event_type": "gate-finding",
+                "phase": "design",
+                "chain_id": "multi-proj.design.code-quality",
+                "source_agent": "gate-adjudicator",
+            }
+
+            old_task = {
+                "id": "task-old",
+                "subject": "Gate: design (old)",
+                "status": "in_progress",
+                "metadata": dict(shared_meta),
+            }
+            old_path = tasks_dir / "task-old.json"
+            old_path.write_text(json.dumps(old_task, indent=2))
+            old_sha = hashlib.sha256(old_path.read_bytes()).hexdigest()
+            # Force the older task's mtime to be earlier than the new one.
+            os.utime(old_path, (1_700_000_000.0, 1_700_000_000.0))
+
+            new_task = {
+                "id": "task-new",
+                "subject": "Gate: design (new)",
+                "status": "in_progress",
+                "metadata": dict(shared_meta),
+            }
+            new_path = tasks_dir / "task-new.json"
+            new_path.write_text(json.dumps(new_task, indent=2))
+            os.utime(new_path, (1_900_000_000.0, 1_900_000_000.0))
+
+            state = _make_state(name="multi-proj")
+            gate_result = {"verdict": "APPROVE", "score": 0.81}
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-multi", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "design", gate_result)
+
+            # Newest match is updated.
+            updated = json.loads(new_path.read_text())
+            self.assertEqual(updated["status"], "completed")
+            self.assertEqual(updated["metadata"]["verdict"], "APPROVE")
+            # Older match remains byte-identical.
+            self.assertEqual(
+                hashlib.sha256(old_path.read_bytes()).hexdigest(),
+                old_sha,
+                "older gate-finding task was rewritten — only the most-recent "
+                "(mtime) match should be touched on re-eval scenarios",
+            )
+
+    def test_sync_conditional_writes_conditions_manifest_path(self):
+        """CONDITIONAL verdict stamps conditions_manifest_path into metadata.
+
+        The gate-finding schema in scripts/_event_schema.py requires
+        conditions_manifest_path on completed CONDITIONAL tasks (#570).
+        Without it, the resulting task file fails the PreToolUse validator.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-cond"
+            gate_task = {
+                "id": "task-gate-cond",
+                "subject": "Gate: clarify",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "clarify",
+                    "chain_id": "cond-proj.clarify.requirements",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-cond", gate_task)
+
+            state = _make_state(name="cond-proj")
+            gate_result = {
+                "verdict": "CONDITIONAL",
+                "result": "CONDITIONAL",
+                "score": 0.65,
+                "min_score": 0.6,
+            }
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-cond", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "clarify", gate_result)
+
+            updated = json.loads(task_file.read_text())
+            self.assertEqual(updated["status"], "completed")
+            self.assertEqual(updated["metadata"]["verdict"], "CONDITIONAL")
+            self.assertAlmostEqual(updated["metadata"]["score"], 0.65)
+            self.assertAlmostEqual(updated["metadata"]["min_score"], 0.6)
+            # The schema-required path field must be present and end with the
+            # canonical conditions-manifest filename.
+            cmp = updated["metadata"].get("conditions_manifest_path")
+            self.assertIsNotNone(
+                cmp,
+                "CONDITIONAL verdict must stamp conditions_manifest_path "
+                "or the completed task fails the gate-finding schema (#570)",
+            )
+            self.assertTrue(cmp.endswith("conditions-manifest.json"))
+            self.assertIn("clarify", cmp)
+
+    def test_sync_reject_marks_task_completed_with_reject_verdict(self):
+        """REJECT verdict still marks task completed with REJECT in metadata.
+
+        REJECT blocks phase advancement at the approve_phase level, but if
+        approve_phase reaches _sync_gate_finding_task with a REJECT result
+        (e.g. via override-gate-after-reject paths or test fixtures), the
+        gate-finding task must reflect the verdict honestly rather than be
+        left dangling pending.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-reject"
+            gate_task = {
+                "id": "task-gate-rej",
+                "subject": "Gate: build",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "build",
+                    "chain_id": "rej-proj.build.code-quality",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-rej", gate_task)
+
+            state = _make_state(name="rej-proj")
+            gate_result = {
+                "verdict": "REJECT",
+                "result": "REJECT",
+                "score": 0.35,
+                "min_score": 0.7,
+            }
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-reject", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "build", gate_result)
+
+            updated = json.loads(task_file.read_text())
+            self.assertEqual(updated["status"], "completed")
+            self.assertEqual(updated["metadata"]["verdict"], "REJECT")
+            self.assertAlmostEqual(updated["metadata"]["score"], 0.35)
+            self.assertAlmostEqual(updated["metadata"]["min_score"], 0.7)
+            # REJECT must NOT carry conditions_manifest_path (only CONDITIONAL does).
+            self.assertNotIn(
+                "conditions_manifest_path", updated["metadata"],
+                "REJECT verdict should not carry conditions_manifest_path",
+            )
+
+    def test_sync_fail_open_when_task_file_write_fails(self):
+        """A task-file write failure logs to stderr and does not raise.
+
+        Approve flow MUST NOT fail because a downstream task-store write
+        broke (permission, ENOSPC, etc.). Operators still see the failure
+        on stderr.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-write-fail"
+            gate_task = {
+                "id": "task-write-fail",
+                "subject": "Gate: design",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "design",
+                    "chain_id": "writefail-proj.design.review",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            self._write_task(tasks_dir, "task-write-fail", gate_task)
+
+            state = _make_state(name="writefail-proj")
+            gate_result = {"verdict": "APPROVE", "score": 0.9}
+
+            # Patch Path.write_text to raise OSError on the gate-finding
+            # task file, simulating a permission / ENOSPC failure.
+            real_write_text = Path.write_text
+
+            def boom_write_text(self, *args, **kwargs):
+                if self.name == "task-write-fail.json":
+                    raise OSError("simulated write failure")
+                return real_write_text(self, *args, **kwargs)
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-write-fail", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                with patch.object(Path, "write_text", boom_write_text):
+                    # MUST NOT raise — fail-open contract.
+                    pm._sync_gate_finding_task(state, "design", gate_result)
+
+    def test_sync_writes_min_score_for_schema_compliance(self):
+        """min_score from gate-result lands in completed task metadata.
+
+        scripts/_event_schema.py declares min_score in
+        gate-finding.required_at_completion. Without it the completed
+        task fails the PreToolUse validator (#570).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-min"
+            gate_task = {
+                "id": "task-gate-min",
+                "subject": "Gate: review",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "review",
+                    "chain_id": "min-proj.review.evidence",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-min", gate_task)
+
+            state = _make_state(name="min-proj")
+            gate_result = {
+                "verdict": "APPROVE",
+                "score": 0.92,
+                "min_score": 0.8,
+            }
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-min", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "review", gate_result)
+
+            updated = json.loads(task_file.read_text())
+            self.assertEqual(updated["status"], "completed")
+            self.assertAlmostEqual(updated["metadata"]["min_score"], 0.8)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Issue #653 was largely resolved by PR #657, which added `_sync_gate_finding_task()` so that `approve_phase` updates the matching native task to `status=completed` after the gate-result lands. Three gaps remained that this PR closes:

1. **Schema compliance for CONDITIONAL verdicts.** Per `scripts/_event_schema.py` lines 191-192, completed `gate-finding` tasks with `verdict=CONDITIONAL` require `metadata.conditions_manifest_path` (#570). The previous sync set `status=completed` without that field, producing a task that violates the schema and would fail the PreToolUse validator. The helper now resolves the deterministic manifest path (`{project_dir}/phases/{phase}/conditions-manifest.json`) and stamps it on CONDITIONAL.

2. **`min_score` propagation.** `gate-finding.required_at_completion` also demands `min_score`. The helper now reads it from `gate_result` and writes it through alongside `score` and `verdict`.

3. **Multi-match handling for re-eval / repeat-gate scenarios.** The previous impl took the first `iterdir()` match — filesystem ordering, non-deterministic — and could update a stale gate-finding task from a prior gate run. The helper now collects all matches, sorts by `st_mtime` descending (file-path tiebreaker for reproducibility), and updates only the most-recent one. Older matches stay byte-identical.

## Lookup strategy (unchanged)

`metadata.event_type == "gate-finding"` AND `metadata.phase == phase` AND `metadata.chain_id` starts with `"{project}.{phase}"` AND `status != "completed"`. Now followed by an mtime-descending sort to pick the freshest match in re-eval scenarios.

## Fail-open behavior (preserved)

- Missing `CLAUDE_SESSION_ID` → silent no-op
- Tasks dir absent → silent no-op
- Scan error → log to stderr, return silently
- Write failure (permission / ENOSPC) → log to stderr, return silently

Approve flow never aborts because of a downstream task-store failure.

## Tests

`tests/crew/test_phase_manager.py::TestSyncGateFindingTask` — 5 baseline + 5 new = 10 cases:

- `test_sync_marks_gate_finding_task_completed` (baseline)
- `test_sync_skips_already_completed_tasks` (baseline)
- `test_sync_no_op_when_no_matching_task` (baseline)
- `test_sync_gate_result_none_does_not_close_pending_task` (baseline)
- `test_sync_fail_open_no_session_id` (baseline)
- `test_sync_picks_most_recently_modified_when_multiple_match` (NEW — mtime ordering)
- `test_sync_conditional_writes_conditions_manifest_path` (NEW — #570 schema)
- `test_sync_reject_marks_task_completed_with_reject_verdict` (NEW)
- `test_sync_fail_open_when_task_file_write_fails` (NEW — write failure)
- `test_sync_writes_min_score_for_schema_compliance` (NEW — #570 schema)

## Test plan

- [ ] `pytest tests/crew/test_phase_manager.py::TestSyncGateFindingTask` — 10 pass
- [ ] `pytest tests/crew/test_phase_manager.py` — 40 pass (no regression)
- [ ] `pytest tests/crew/` — 1146 pass (full crew suite)
- [ ] Schema check: `validate_metadata(meta, status='completed')` returns `None` for APPROVE / CONDITIONAL / REJECT shapes produced by `_sync_gate_finding_task` (verified inline)

## Hard constraints honored

- Stdlib only
- Fail-open: approve_phase never raises because of task-store sync
- gate-result.json schema and on-disk approve flow unchanged
- Sync side-effect is additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)