### PR TITLE
fix: audit factor_questionnaire downstream consumers for risk_level adoption (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- `factor_questionnaire` consumer audit (#627): user-facing render sites now use `risk_level` (`low_risk`/`medium_risk`/`high_risk`) instead of the inverted `reading` field (HIGH=safest backward-compat). Internal-only call sites annotated with the inversion convention. Producer surface unchanged. Affected sites: `skills/propose-process/refs/plan-template.md` (process-plan.md table), `skills/propose-process/refs/output-schema.md` (schema example), `commands/crew/start.md` (user report + brain memory store), `commands/crew/execute.md` (factor diff + injection report), `commands/crew/just-finish.md` (factor diff + injection report), `agents/crew/process-facilitator.md` (Step 3 emit shape), `scripts/crew/validate_plan.py` (now also validates `risk_level` enum + cross-checks against `reading` when present), `scripts/ci/gate4_smoke.py` (annotated as internal-only).
+
+### Deprecation candidates
+- `factors[].reading` (HIGH/MEDIUM/LOW; HIGH=safest) — kept for backward compat in #626; #627 audit migrated all user-facing sites to `risk_level`. Slated for removal in a future major once the inversion convention can no longer surprise downstream contributors. No removal in this release.
+
 ### Added
 - Steering detector event family — `wicked.steer.*` on the bus, reference tail subscriber (`scripts/crew/steering_tail.py`), schema validator (`scripts/crew/steering_event_schema.py`). No detectors yet (PR-1 of epic).
 - First steering detector: `detect_sensitive_path_touch` — emits `wicked.steer.escalated` when sessions touch auth/payments/migration/secrets code (PR-2 of epic #679). Detector + emitter are separated for testability; every emitted payload is re-validated against the PR-1 schema; bus-unreachable is fail-open.

--- a/agents/crew/process-facilitator.md
+++ b/agents/crew/process-facilitator.md
@@ -88,8 +88,13 @@ When opted in, call `wicked-garden:facilitator-score` with description + priors;
 ### 3. Score the 9 factors (one sentence each)
 
 Prose, not numbers — but each factor emits the dict shape
-`{"reading": "LOW|MEDIUM|HIGH", "why": "..."}`, not a flat string (Issue #574).
-See `skills/propose-process/refs/factor-definitions.md` for calibration and
+`{"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."}`,
+not a flat string (Issue #574). `reading` is the backward-compat key
+(HIGH=safest convention — internal-only); `risk_level` is the direction-explicit
+field downstream consumers and `process-plan.md` render off (Issue #627). When
+authoring by hand, fill BOTH and keep them in sync; the questionnaire scorer
+(Step 2.5) emits both automatically. See
+`skills/propose-process/refs/factor-definitions.md` for calibration and
 `skills/propose-process/refs/output-schema.md` for the envelope.
 
 Factors: **reversibility** (undo without customer impact?), **blast_radius** (who/how

--- a/commands/crew/execute.md
+++ b/commands/crew/execute.md
@@ -240,7 +240,7 @@ sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_ru
 
 This returns `{project, project_dir}`. Read `${project_dir}/process-plan.json` for the canonical plan written by `wicked-garden:propose-process`. Pull the following fields (schema: `skills/propose-process/refs/output-schema.md`):
 
-- **factors** — 9 factor readings (reversibility, blast_radius, compliance_scope, user_facing_impact, novelty, scope_effort, state_complexity, operational_risk, coordination_cost), each `{reading: LOW|MEDIUM|HIGH, why: "..."}`. These replace `signals_detected`.
+- **factors** — 9 factor entries (reversibility, blast_radius, compliance_scope, user_facing_impact, novelty, scope_effort, state_complexity, operational_risk, coordination_cost), each `{reading: LOW|MEDIUM|HIGH, risk_level: low_risk|medium_risk|high_risk, why: "..."}`. `reading` is backward-compat (HIGH=safest convention; do NOT display verbatim to users — see #627); `risk_level` is the user-facing field. Use `reading` for internal threshold checks; use `risk_level` for any user-facing text. These replace `signals_detected`.
 - **specialists** — list of `{name, why}` the facilitator picked. Replaces `specialists_recommended`.
 - **phases** — ordered list of `{name, why, primary: [specialist names]}`. Replaces the old `phase_plan`.
 - **rigor_tier** — `minimal | standard | full` (gate enforcement level).
@@ -276,8 +276,12 @@ When a checkpoint phase completes:
    `agents/crew/process-facilitator.md#Re-evaluation mode`.
 3. **Compare factors AND complexity**: Diff new `factors` against project.json
    `factors`, AND compare new `complexity` against `complexity_score`
-4. **If factor readings shift OR complexity increased**:
-   - Update project.json `factors` with new readings
+4. **If factor readings shift OR complexity increased** (compare on the
+   `reading` key — internal canonical; #627):
+   - Update project.json `factors` with new entries — persist BOTH `reading`
+     and `risk_level` from the facilitator output verbatim. Never drop
+     `risk_level` on the way to disk; it is the user-facing field and
+     downstream display code depends on it (#627).
    - Update `complexity_score` if new score is higher
    - Update `specialists` with any new recommendations
    - **Check for phase injection** (see below)

--- a/commands/crew/just-finish.md
+++ b/commands/crew/just-finish.md
@@ -61,7 +61,7 @@ From `project.json`:
 - What's been completed
 
 From `${project_dir}/process-plan.json` (schema: `skills/propose-process/refs/output-schema.md`):
-- **factors**: 9 factor readings (reversibility, blast_radius, compliance_scope, etc.) — replaces `signals_detected`
+- **factors**: 9 factor entries (reversibility, blast_radius, compliance_scope, etc.) — each entry carries both `reading` (HIGH/MEDIUM/LOW; HIGH=safest, backward-compat per #627) and `risk_level` (low_risk/medium_risk/high_risk; user-facing). Use `reading` for internal threshold/diff logic; use `risk_level` for any text shown to the user. Replaces `signals_detected`
 - **complexity**: 0-7 integer
 - **rigor_tier**: `minimal | standard | full`
 - **specialists**: facilitator-picked roster — replaces `specialists_recommended`
@@ -251,11 +251,15 @@ When a checkpoint phase completes:
      }
    )
    ```
-3. Compare new factor readings against project.json `factors`
+3. Compare new factor `reading` values against project.json `factors[].reading`
+   (internal diff — `reading` is the canonical comparison key; #627)
 4. If factor readings shift or complexity increases:
-   - Update project.json (factors, complexity, specialists)
+   - Update project.json (factors, complexity, specialists) — persist BOTH
+     `reading` and `risk_level` from the facilitator output verbatim; never
+     drop `risk_level` on the way to disk (#627)
    - Check if phases NOT in `phase_plan` should be injected (see execute.md Section 4.5 for injection rules)
-   - Report injections to user (even in yolo mode, injections are informational)
+   - When reporting injections to the user (even in yolo mode), surface
+     `risk_level` (low_risk / medium_risk / high_risk), not raw `reading`
 5. Maximum 2 injections per checkpoint
 
 **Skip if**: project.json has `"phase_plan_mode": "static"`.

--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -232,7 +232,7 @@ Skill(
   skill="wicked-brain:memory",
   args={"action": "store", "type": "decision",
         "title": "crew:start facilitator plan for {slug}",
-        "content": "<summary from JSON + factor readings + rigor_tier + specialist list>",
+        "content": "<summary from JSON + per-factor risk_level (low/medium/high_risk — see #627; do NOT paste raw `reading` HIGH/MED/LOW into human-readable text) + rigor_tier + specialist list>",
         "tags": ["crew", "facilitator", "process-plan", "{slug}"],
         "importance": 6}
 )
@@ -271,9 +271,13 @@ Summarize the facilitator's decision in a short markdown report:
 **Rigor**: {standard | minimal | full} — {rigor_why}
 **Complexity**: {N}/7 — {complexity_why}
 
-### Factors (facilitator reading)
-- Reversibility: {LOW/MED/HIGH} — {why}
-- Blast radius: {LOW/MED/HIGH} — {why}
+### Factors (facilitator risk reading)
+Render each factor using its `risk_level` field (`low_risk` / `medium_risk` /
+`high_risk`) — NOT the backward-compat `reading` field, which is inverted
+(HIGH = safest). See #627.
+
+- Reversibility: {low_risk / medium_risk / high_risk} — {why}
+- Blast radius: {low_risk / medium_risk / high_risk} — {why}
 - ... (rest of 9 factors)
 
 ### Specialists

--- a/scripts/ci/gate4_smoke.py
+++ b/scripts/ci/gate4_smoke.py
@@ -201,6 +201,10 @@ def _test_types_union(plan: dict) -> set[str]:
 
 
 def _factor_reading(plan: dict, factor: str) -> str:
+    # NB(#627): scenario YAMLs declare expectations as LOW/MEDIUM/HIGH (the
+    # backward-compat `reading` convention; HIGH=safest). Internal-only CI
+    # comparison — never surfaced to users in this form. User-facing output
+    # should prefer the `risk_level` field (`low_risk`/`medium_risk`/`high_risk`).
     f = (plan.get("factors") or {}).get(factor) or {}
     return str(f.get("reading") or "").upper()
 

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -37,7 +37,23 @@ _CLOSE_MATCHES_N = 3
 _CLOSE_MATCHES_CUTOFF = 0.6
 
 VALID_RIGOR_TIERS = {"minimal", "standard", "full"}
+# NB(#627): `reading` uses the inverted HIGH=safest convention (kept for
+# backward compat). Internal-only — never display to users without translation.
+# `risk_level` (below) is the direction-explicit, user-facing field.
 VALID_FACTOR_READINGS = {"LOW", "MEDIUM", "HIGH"}
+# NB(#627): `risk_level` is the direction-explicit, user-facing field emitted
+# by `factor_questionnaire.score_all()`. Validation here defends against silent
+# producer regression that would drop the field and force consumers back onto
+# the inversion-prone `reading` value.
+VALID_FACTOR_RISK_LEVELS = {"low_risk", "medium_risk", "high_risk"}
+# Mapping mirrors `_RISK_INVERSION` in `scripts/crew/factor_questionnaire.py`.
+# Keep the two in sync — drift here means the validator stops catching producer
+# regression. Tests cover the round-trip in tests/crew/test_validate_plan.py.
+_EXPECTED_RISK_LEVEL_FOR_READING = {
+    "HIGH": "low_risk",
+    "MEDIUM": "medium_risk",
+    "LOW": "high_risk",
+}
 VALID_EVENT_TYPES = {
     "task", "coding-task", "gate-finding",
     "phase-transition", "procedure-trigger", "subtask",
@@ -138,6 +154,24 @@ def _check_factors(plan: dict, violations: list) -> None:
             violations.append(
                 f"factors.{key}.reading — '{reading}' is not one of {sorted(VALID_FACTOR_READINGS)}"
             )
+        # #627: `risk_level` is the user-facing translation of `reading`.
+        # Allow it to be absent on legacy plans (back-compat with pre-#626
+        # facilitator output) but reject any drift when it IS present.
+        if "risk_level" in value:
+            risk_level = value.get("risk_level")
+            if risk_level not in VALID_FACTOR_RISK_LEVELS:
+                violations.append(
+                    f"factors.{key}.risk_level — '{risk_level}' is not one of "
+                    f"{sorted(VALID_FACTOR_RISK_LEVELS)}"
+                )
+            elif reading in _EXPECTED_RISK_LEVEL_FOR_READING:
+                expected = _EXPECTED_RISK_LEVEL_FOR_READING[reading]
+                if risk_level != expected:
+                    violations.append(
+                        f"factors.{key} — risk_level '{risk_level}' does not "
+                        f"match reading '{reading}' (expected '{expected}'; "
+                        f"see scripts/crew/factor_questionnaire.py::_RISK_INVERSION)"
+                    )
         why = value.get("why")
         if not why or not str(why).strip():
             violations.append(f"factors.{key}.why — must be a non-empty string")
@@ -427,6 +461,22 @@ _INVALID_FIXTURES = [
     ("bad event_type", lambda p: {
         **p,
         "tasks": [{**p["tasks"][0], "metadata": {**p["tasks"][0]["metadata"], "event_type": "garbage"}}],
+    }),
+    # #627: bad risk_level enum value
+    ("bad factor risk_level enum", lambda p: {
+        **p,
+        "factors": {
+            **p["factors"],
+            "reversibility": {"reading": "LOW", "risk_level": "wat", "why": "idk"},
+        },
+    }),
+    # #627: risk_level mismatched against reading (LOW reading == high_risk)
+    ("factor risk_level inverted vs reading", lambda p: {
+        **p,
+        "factors": {
+            **p["factors"],
+            "reversibility": {"reading": "LOW", "risk_level": "low_risk", "why": "idk"},
+        },
     }),
 ]
 

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -21,16 +21,23 @@ rubric against a scenario's expected-outcome block.
     {"path": "memory/foo.md", "source_type": "memory", "why": "one sentence"}
   ],
   "factors": {
-    "reversibility":      {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "blast_radius":       {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "compliance_scope":   {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "user_facing_impact": {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "novelty":            {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "scope_effort":       {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "state_complexity":   {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "operational_risk":   {"reading": "LOW|MEDIUM|HIGH", "why": "..."},
-    "coordination_cost":  {"reading": "LOW|MEDIUM|HIGH", "why": "..."}
+    "reversibility":      {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "blast_radius":       {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "compliance_scope":   {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "user_facing_impact": {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "novelty":            {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "scope_effort":       {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "state_complexity":   {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "operational_risk":   {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
+    "coordination_cost":  {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."}
   },
+  // NB(#627): each factor entry carries BOTH `reading` (HIGH/MEDIUM/LOW;
+  // HIGH = safest, LOW = riskiest — backward-compat convention) AND
+  // `risk_level` (low_risk/medium_risk/high_risk — direction-explicit,
+  // user-facing). Internal logic (threshold/diff) uses `reading`; any
+  // user-facing display (process-plan.md, brain memory content, status
+  // summaries) MUST use `risk_level` to avoid the inversion footgun.
+  // `reading` is a candidate for deprecation in a future major.
   "specialists": [
     {"name": "requirements-analyst", "why": "one sentence"},
     {

--- a/skills/propose-process/refs/plan-template.md
+++ b/skills/propose-process/refs/plan-template.md
@@ -34,17 +34,21 @@ any risk words heard.>
 
 ## 3. Factor scoring
 
-| Factor              | Reading | One-sentence reasoning                          |
-|---------------------|---------|-------------------------------------------------|
-| Reversibility       | LOW/MED/HIGH | <one sentence>                             |
-| Blast radius        | LOW/MED/HIGH | <one sentence>                             |
-| Compliance scope    | LOW/MED/HIGH | <one sentence>                             |
-| User-facing impact  | LOW/MED/HIGH | <one sentence>                             |
-| Novelty             | LOW/MED/HIGH | <one sentence>                             |
-| Scope effort        | LOW/MED/HIGH | <one sentence>                             |
-| State complexity    | LOW/MED/HIGH | <one sentence>                             |
-| Operational risk    | LOW/MED/HIGH | <one sentence>                             |
-| Coordination cost   | LOW/MED/HIGH | <one sentence>                             |
+> **Direction**: this table renders the user-facing `risk_level` field
+> (`low_risk` / `medium_risk` / `high_risk`) — NOT the backward-compat
+> `reading` field, which is inverted (HIGH = safest). See #627.
+
+| Factor              | Risk level | One-sentence reasoning                       |
+|---------------------|------------|----------------------------------------------|
+| Reversibility       | low_risk / medium_risk / high_risk | <one sentence>         |
+| Blast radius        | low_risk / medium_risk / high_risk | <one sentence>         |
+| Compliance scope    | low_risk / medium_risk / high_risk | <one sentence>         |
+| User-facing impact  | low_risk / medium_risk / high_risk | <one sentence>         |
+| Novelty             | low_risk / medium_risk / high_risk | <one sentence>         |
+| Scope effort        | low_risk / medium_risk / high_risk | <one sentence>         |
+| State complexity    | low_risk / medium_risk / high_risk | <one sentence>         |
+| Operational risk    | low_risk / medium_risk / high_risk | <one sentence>         |
+| Coordination cost   | low_risk / medium_risk / high_risk | <one sentence>         |
 
 ## 4. Specialists selected
 


### PR DESCRIPTION
## Summary

Resolves #627. PR #626 shipped `factor_questionnaire.score_all()` with both `reading` (HIGH/MEDIUM/LOW; HIGH=safest backward-compat) and `risk_level` (low_risk/medium_risk/high_risk; direction-explicit). The council finding was that documentation alone wouldn't prevent downstream consumers from rendering raw `reading` to users — where HIGH reads as "high risk" but actually means "safest." This PR audits every consumer of `score_all()` output and either migrates user-facing sites to `risk_level` or annotates internal-only sites with the inversion convention.

Producer surface is **unchanged**. `score_all()` still emits both fields per #626.

## Sites grepped

Searched: `score_all(`, `factor_questionnaire`, `reading` field accesses, `risk_level` references, `process-plan.md` template/render sites, brain-memory storage paths, factor reading display in user reports.

Paths covered: `scripts/propose-process/`, `scripts/crew/`, `scripts/ci/`, `skills/propose-process/`, `skills/facilitator-score/`, `commands/crew/`, `agents/crew/`, `tests/`, `docs/`.

Total consumer sites identified: **9** (5 user-facing, 3 internal-only annotation, plus producer-side schema doc).

## User-facing sites migrated to risk_level (5)

| File | Change |
|---|---|
| `skills/propose-process/refs/plan-template.md` | process-plan.md factor table now renders `risk_level` (low_risk / medium_risk / high_risk) instead of LOW/MED/HIGH; explicit direction caution. |
| `skills/propose-process/refs/output-schema.md` | schema example now shows BOTH fields with inline #627 NB block telling producers to use `risk_level` for any user-facing surface. |
| `commands/crew/start.md` | Section 11 user-facing factor report now uses `risk_level`; brain memory store directive forbids pasting raw `reading` into human-readable text. |
| `commands/crew/just-finish.md` | factor diff text + injection-report guidance point at `risk_level` for user surfaces while preserving `reading` for internal threshold/diff logic. |
| `commands/crew/execute.md` | same shape as just-finish.md. |

## Internal-only sites annotated (3)

| File | Annotation |
|---|---|
| `scripts/crew/validate_plan.py` | added `risk_level` enum validation + cross-check against `reading` when present (defends against silent producer regression that would drop `risk_level`); two new selftest fixtures cover the invariant; constants annotated with the inversion convention. |
| `scripts/ci/gate4_smoke.py` | `_factor_reading()` annotated as internal-only — scenario YAMLs declare expectations as LOW/MED/HIGH by design and never surface to users. |
| `agents/crew/process-facilitator.md` | Step 3 emit shape now requires BOTH `reading` and `risk_level` with explicit direction guidance + pointer to the questionnaire scorer's automatic emission. |

## Future deprecation candidate

`factors[].reading` (HIGH/MEDIUM/LOW; HIGH=safest) is recorded in CHANGELOG under "Deprecation candidates." Slated for removal in a future major once the inversion convention can no longer surprise downstream contributors. **No removal in this PR** — backward compat preserved per the issue's hard constraint.

## Verification

- `pytest -k "facilitator or factor or propose or validate_plan"` — **152 passed** (no regressions)
- `validate_plan.py --selftest` — **PASS** (covers the new risk_level validation paths)
- `score_all({})` direct call — confirmed producer still emits both fields; no signature change

## Test plan

- [x] All facilitator/factor/propose/validate_plan tests pass
- [x] validate_plan selftest passes (including new #627 fixtures: bad enum + inverted-mapping)
- [x] Producer signature unchanged (verified via direct `score_all()` invocation)
- [x] All edited skills/commands stay within line-count limits
- [ ] (manual, post-merge) Render a sample `process-plan.md` from a fresh facilitator run and confirm the factor table reads `low_risk/medium_risk/high_risk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)