### PR TITLE
feat: /wicked-garden:crew:reconcile — diagnostic for native TaskList vs garden chain drift (#579 Option C, interim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+- `factor_questionnaire` consumer audit (#627): user-facing render sites now use `risk_level` (`low_risk`/`medium_risk`/`high_risk`) instead of the inverted `reading` field (HIGH=safest backward-compat). Internal-only call sites annotated with the inversion convention. Producer surface unchanged. Affected sites: `skills/propose-process/refs/plan-template.md` (process-plan.md table), `skills/propose-process/refs/output-schema.md` (schema example), `commands/crew/start.md` (user report + brain memory store), `commands/crew/execute.md` (factor diff + injection report), `commands/crew/just-finish.md` (factor diff + injection report), `agents/crew/process-facilitator.md` (Step 3 emit shape), `scripts/crew/validate_plan.py` (now also validates `risk_level` enum + cross-checks against `reading` when present), `scripts/ci/gate4_smoke.py` (annotated as internal-only).
+
+### Deprecation candidates
+- `factors[].reading` (HIGH/MEDIUM/LOW; HIGH=safest) — kept for backward compat in #626; #627 audit migrated all user-facing sites to `risk_level`. Slated for removal in a future major once the inversion convention can no longer surprise downstream contributors. No removal in this release.
+
 ### Added
 - Steering detector event family — `wicked.steer.*` on the bus, reference tail subscriber (`scripts/crew/steering_tail.py`), schema validator (`scripts/crew/steering_event_schema.py`). No detectors yet (PR-1 of epic).
 - First steering detector: `detect_sensitive_path_touch` — emits `wicked.steer.escalated` when sessions touch auth/payments/migration/secrets code (PR-2 of epic #679). Detector + emitter are separated for testability; every emitted payload is re-validated against the PR-1 schema; bus-unreachable is fail-open.
 - Rigor escalator subscriber: `crew:rigor-escalator` mutates project `rigor_tier` in response to `wicked.steer.escalated` events. Closes the steering loop end-to-end (PR-3 of epic #679). Action -> tier mapping is `force-full-rigor → full`; `regen-test-strategy` and `require-council-review` keep tier and append history; `notify-only` is pure no-op. Enforces never-de-escalate rule, in-session idempotency by `(project_slug, event_id)`, and emits `wicked.steer.applied` audit events on every decision branch (escalated/redundant/no-op/error). Adds `wicked.steer.applied` to `KNOWN_EVENT_TYPES`.
 - Steering detectors v1 starter set complete: blast-radius, council-split, test-failure-spike (escalating) + cross-domain-edits (advisory). 5-detector starter set per epic #679 brainstorm now shipped (PR-4). Shared infrastructure factored into `scripts/crew/detectors/_common.py` (validate-then-emit, threaded bus emit, reachability probe, standard CLI surface). cross-domain-edits intentionally emits `wicked.steer.advised` so rigor-escalator does not mutate rigor on it. test-failure-spike ships with explicit `--exit-codes` CLI input; signal-source wiring is a follow-up TODO since post-tool hooks do not yet capture pytest exit codes.
+- `/wicked-garden:crew:reconcile` diagnostic command — walks native TaskList + garden chain stores and surfaces drift without mutating either. First half of issue #579 (Option C interim diagnostic; Option A projection arrives in a follow-up PR once drift patterns from real usage are visible).
 
 ## [8.4.0] - 2026-04-26
 

--- a/commands/crew/reconcile.md
+++ b/commands/crew/reconcile.md
@@ -1,0 +1,107 @@
+---
+description: Diagnose drift between native TaskList and garden chain (read-only)
+argument-hint: "[--project=<slug> | --all] [--json]"
+---
+
+# /wicked-garden:crew:reconcile
+
+Walks the native TaskList store and the garden chain (process-plan.json + per-phase gate-result.json) and surfaces drift WITHOUT mutating either store.
+
+> **Scope**: Pure diagnostic. Read-only by contract — guaranteed not to write to any task file or project artifact. If the two stores disagree, this command names the disagreements; it does not fix them.
+
+This is the interim Option C from the issue #579 brainstorm (D3). Option A (TaskList as truth, garden chain as projection) is a larger refactor that will follow once drift patterns from real usage are visible.
+
+## Drift types reported
+
+| Type             | Meaning                                                                                                    |
+|------------------|------------------------------------------------------------------------------------------------------------|
+| `missing_native` | A plan task has no matching native task with the expected `chain_id`.                                      |
+| `stale_status`   | A native task and its plan phase disagree on completion (e.g., phase APPROVED but native still pending).   |
+| `orphan_native`  | A native task carries a `chain_id` whose project slug is not present under the projects root.              |
+| `phase_drift`    | A phase's `gate-result.json` is APPROVE/CONDITIONAL but its gate-finding native task is still open. (#653) |
+
+## Arguments
+
+- `--project <slug>` — reconcile a single project by slug
+- `--all` — reconcile every project under the projects root
+- `--json` — emit machine-readable JSON instead of the text report
+
+Exactly one of `--project` or `--all` is required.
+
+## Instructions
+
+### 1. Run reconcile
+
+```bash
+# Single project
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/reconcile.py" \
+  --project "$PROJECT" ${JSON:+--json}
+
+# All projects
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/reconcile.py" \
+  --all ${JSON:+--json}
+```
+
+The script honors `CLAUDE_CONFIG_DIR` for the native task path (per the lesson from PR #678).
+
+### 2. Render the report
+
+Default output is a human-readable text report grouped by project. Each section shows:
+
+- Counts: plan tasks vs native tasks vs phases-with-gate-result
+- Drift summary (by type)
+- Per-entry drift details: type, identifier, one-line reason
+- Errors (when a store is unreachable; we still report what we can)
+
+Example (text mode):
+
+```
+Reconcile report — project: my-project
+======================================
+  Plan tasks (process-plan.json):   12
+  Native tasks (matching chain_id): 11
+  Phases with gate-result.json:     3  (clarify, design, build)
+
+Drift summary:
+  total:          2
+  missing_native: 1
+  stale_status:   1
+  orphan_native:  0
+  phase_drift:    0
+
+Drift entries:
+  [missing_native] t7 — no native task with matching chain_id
+  [stale_status] task-abc123 — phase 'design' verdict is 'APPROVE' but native task still 'in_progress'
+```
+
+If `--json`, the same data is emitted as a single dict (`--project`) or a list of dicts (`--all`).
+
+### 3. What to do with the results
+
+`reconcile` does not mutate either store, so any drift it surfaces is a signal — not an automatic fix. Common next steps:
+
+- **`missing_native`** — a `TaskCreate` was lost or the plan emitted a task without `chain_id`. Re-run the facilitator phase or open an issue with the plan path.
+- **`stale_status`** — usually fixed at the next `/wicked-garden:crew:approve` (PR #653 closes the WRITE side). Long-stale entries are worth investigating.
+- **`orphan_native`** — the project was deleted or renamed; native tasks are dangling. Consider archiving the parent project or migrating chain ids.
+- **`phase_drift`** — the gate completed before #653 landed; one approval cycle should clean it up.
+
+## Examples
+
+```bash
+# Default: text report for one project
+/wicked-garden:crew:reconcile --project=my-feature
+
+# JSON for piping into another tool
+/wicked-garden:crew:reconcile --project=my-feature --json
+
+# Sweep every project
+/wicked-garden:crew:reconcile --all
+```
+
+## Notes
+
+- Stdlib only; no DomainStore writes.
+- Fail-open: if `process-plan.json` is missing or unreadable, the report still lists native tasks the project owns and explains the gap.
+- The drift entries this command surfaces in real usage will inform the design of Option A (the projection refactor).

--- a/scripts/crew/reconcile.py
+++ b/scripts/crew/reconcile.py
@@ -81,19 +81,16 @@ _UNREACHABLE_PREFIX: str = "could not read"
 def _projects_root() -> Path:
     """Return the projects root: ${WG_LOCAL_ROOT}/wicked-crew/projects.
 
-    Mirrors the resolution used by phase_manager.get_project_dir but does NOT
-    create the directory — reconcile is read-only.
+    Read-only: this function does NOT call get_local_path() because that helper
+    internally executes mkdir(parents=True, exist_ok=True), which would violate
+    reconcile's read-only contract. We replicate the path-resolution logic
+    directly without the mkdir side-effect.
     """
-    # Try the canonical helper first; fall back to env / default.
-    try:
-        from _paths import get_local_path  # type: ignore[import-not-found]
-        return get_local_path("wicked-crew", "projects")
-    except Exception:
-        base = (
-            os.environ.get("WG_LOCAL_ROOT")
-            or str(Path.home() / ".something-wicked" / "wicked-garden" / "local")
-        )
-        return Path(base) / "wicked-crew" / "projects"
+    base = (
+        os.environ.get("WG_LOCAL_ROOT")
+        or str(Path.home() / ".something-wicked" / "wicked-garden" / "local")
+    )
+    return Path(base) / "wicked-crew" / "projects"
 
 
 def _project_dir(project_slug: str) -> Path:
@@ -474,6 +471,7 @@ def reconcile_project(
     _all_native_tasks: Optional[List[dict]] = None,
     _all_native_error: Optional[str] = None,
     _known_project_slugs: Optional[set[str]] = None,
+    _skip_orphan_detection: bool = False,
 ) -> dict:
     """Walk the garden chain + native task store for ``project_slug``.
 
@@ -504,10 +502,13 @@ def reconcile_project(
         drift.extend(_detect_stale_status(plan, project_slug, native_for_project, gate_results))
         drift.extend(_detect_phase_drift(plan, project_slug, native_for_project, gate_results))
 
-    # Orphan detection only when we have a registry of known slugs;
-    # reconcile_all passes one in. Single-project mode skips it because we
-    # can't tell "old chain" from "different project" without the registry.
-    if _known_project_slugs is not None:
+    # Orphan detection only when we have a registry of known slugs.
+    # When called from reconcile_all (which sets _skip_orphan_detection=True),
+    # orphan detection runs ONCE outside the per-project loop to avoid
+    # O(projects × tasks) duplicate scans. Single-project mode skips entirely
+    # because we can't tell "old chain" from "different project" without the
+    # registry.
+    if _known_project_slugs is not None and not _skip_orphan_detection:
         drift.extend(_detect_orphan_native(all_native_tasks, _known_project_slugs))
 
     errors: List[str] = []
@@ -558,21 +559,53 @@ def _list_known_project_slugs() -> List[str]:
 def reconcile_all() -> List[dict]:
     """Run reconcile_project for every project in the projects root.
 
-    Shares a single native-task scan across all projects so the cost is
-    O(projects + tasks) rather than O(projects * tasks).
+    Shares a single native-task scan across all projects AND a single orphan
+    detection pass so the cost is truly O(projects + tasks) rather than
+    O(projects × tasks). Orphan results are added to the FIRST project's
+    drift list so they appear once in aggregate output.
     """
     slugs = _list_known_project_slugs()
     all_native_tasks, native_error = _scan_all_native_tasks()
     known_slugs_set = set(slugs)
-    return [
+    results = [
         reconcile_project(
             slug,
             _all_native_tasks=all_native_tasks,
             _all_native_error=native_error,
             _known_project_slugs=known_slugs_set,
+            _skip_orphan_detection=True,  # we run it once below, not per-project
         )
         for slug in slugs
     ]
+
+    # Single orphan detection pass across ALL native tasks vs the known-slugs
+    # registry. Attach to first result (or create a synthetic aggregate result
+    # if there are no projects).
+    orphans = _detect_orphan_native(all_native_tasks, known_slugs_set)
+    if orphans:
+        if results:
+            results[0]["drift"].extend(orphans)
+            results[0]["summary"]["orphan_native_count"] = len(orphans)
+            results[0]["summary"]["total_drift_count"] += len(orphans)
+        else:
+            # No projects but orphans exist — synthesize an aggregate-only result
+            results.append({
+                "project_slug": "<orphans-aggregate>",
+                "garden_chain_tasks": 0,
+                "native_tasks": 0,
+                "phases_with_gate_result": [],
+                "drift": orphans,
+                "summary": {
+                    "total_drift_count": len(orphans),
+                    "missing_native_count": 0,
+                    "stale_status_count": 0,
+                    "orphan_native_count": len(orphans),
+                    "phase_drift_count": 0,
+                },
+                "errors": [],
+            })
+
+    return results
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/crew/reconcile.py
+++ b/scripts/crew/reconcile.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Reconcile diagnostic — surface drift between native TaskList + garden chain.
+
+Walks both stores for one or more projects and reports diffs WITHOUT mutating
+either side. Pure read + report.
+
+Background
+----------
+Issue #579 documented drift between two stores:
+  - Native TaskList: ${CLAUDE_CONFIG_DIR:-~/.claude}/tasks/{session_id}/*.json
+  - Garden chain:    {project_dir}/process-plan.json + phases/{phase}/gate-result.json
+
+The brainstorm decision (D3) selected Option C (read-only diagnostic) as the
+interim shipment. Once drift patterns from real usage are visible, Option A
+(garden chain becomes a projection of the TaskList truth) follows in a later
+PR informed by what this command surfaces.
+
+Drift types detected
+--------------------
+  missing_native — plan task has no matching native task with the expected
+                   chain_id prefix
+  stale_status   — native task and its plan phase disagree on completion
+                   (phase approved/conditional but native still pending or
+                   in_progress; phase rejected but native completed)
+  orphan_native  — native task carries a chain_id whose project_slug does
+                   not exist in any process-plan.json (deleted/renamed
+                   project)
+  phase_drift    — phase has a gate-result.json (APPROVE | CONDITIONAL) but
+                   the corresponding gate-finding native task is still
+                   pending — read-side complement to the WRITE path that
+                   PR #653 just fixed
+
+Hard constraints
+----------------
+  - Stdlib only.
+  - READ ONLY — never write to either store. We assert this in the test
+    suite by snapshotting mtimes around every reconcile call.
+  - Fail-open — if a store is unreachable, report what we can reach plus a
+    clear "could not read X" line.
+  - Honor CLAUDE_CONFIG_DIR for the native task path (lesson from PR #678).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Resolve helpers from parent scripts/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Drift type labels — kept as module-level constants so the test suite and
+# downstream consumers can reference them without string typos.
+DRIFT_MISSING_NATIVE: str = "missing_native"
+DRIFT_STALE_STATUS: str = "stale_status"
+DRIFT_ORPHAN_NATIVE: str = "orphan_native"
+DRIFT_PHASE_GATE: str = "phase_drift"
+
+# Verdicts that imply downstream native tasks should be completed.
+_APPROVE_VERDICTS: frozenset[str] = frozenset({"APPROVE", "CONDITIONAL"})
+_REJECT_VERDICTS: frozenset[str] = frozenset({"REJECT"})
+
+# Native task statuses that indicate work is still open.
+_OPEN_STATUSES: frozenset[str] = frozenset({"pending", "in_progress"})
+_COMPLETED_STATUSES: frozenset[str] = frozenset({"completed"})
+
+# Banner used in error reports when a store cannot be read.
+_UNREACHABLE_PREFIX: str = "could not read"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution (no DomainStore import — keep it pure stdlib + path-based)
+# ---------------------------------------------------------------------------
+
+def _projects_root() -> Path:
+    """Return the projects root: ${WG_LOCAL_ROOT}/wicked-crew/projects.
+
+    Mirrors the resolution used by phase_manager.get_project_dir but does NOT
+    create the directory — reconcile is read-only.
+    """
+    # Try the canonical helper first; fall back to env / default.
+    try:
+        from _paths import get_local_path  # type: ignore[import-not-found]
+        return get_local_path("wicked-crew", "projects")
+    except Exception:
+        base = (
+            os.environ.get("WG_LOCAL_ROOT")
+            or str(Path.home() / ".something-wicked" / "wicked-garden" / "local")
+        )
+        return Path(base) / "wicked-crew" / "projects"
+
+
+def _project_dir(project_slug: str) -> Path:
+    """Return the canonical project dir for ``project_slug``.
+
+    No path-traversal protection is applied here because reconcile is read
+    only — the worst case is an unreadable path, which we already fail-open
+    on. Callers that want stricter validation should use
+    ``phase_manager.get_project_dir``.
+    """
+    return _projects_root() / project_slug
+
+
+def _claude_config_dir() -> Path:
+    """Resolve ${CLAUDE_CONFIG_DIR:-~/.claude} (per PR #678 lesson)."""
+    raw = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(raw) if raw else Path.home() / ".claude"
+
+
+# ---------------------------------------------------------------------------
+# Garden-chain readers (process-plan.json)
+# ---------------------------------------------------------------------------
+
+def _load_process_plan(project_slug: str) -> Tuple[Optional[dict], Optional[str]]:
+    """Read process-plan.json for ``project_slug``.
+
+    Returns ``(plan_dict, error_message)``. On success ``error_message`` is
+    None. On failure ``plan_dict`` is None and ``error_message`` carries a
+    one-line, human-readable diagnostic.
+    """
+    plan_path = _project_dir(project_slug) / "process-plan.json"
+    if not plan_path.is_file():
+        return None, f"{_UNREACHABLE_PREFIX} process-plan.json (not found at {plan_path})"
+    try:
+        text = plan_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"{_UNREACHABLE_PREFIX} process-plan.json: {exc}"
+    try:
+        plan = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, f"{_UNREACHABLE_PREFIX} process-plan.json: invalid JSON ({exc})"
+    if not isinstance(plan, dict):
+        return None, f"{_UNREACHABLE_PREFIX} process-plan.json: top-level not an object"
+    return plan, None
+
+
+def _phase_gate_results(project_slug: str) -> Dict[str, dict]:
+    """Return ``{phase_name: gate-result-dict}`` for every phase with a result.
+
+    Silently skips unreadable / malformed files — those are reported as
+    drift if a native counterpart exists, but they don't crash the report.
+    """
+    out: Dict[str, dict] = {}
+    phases_dir = _project_dir(project_slug) / "phases"
+    if not phases_dir.is_dir():
+        return out
+    try:
+        entries = sorted(phases_dir.iterdir())
+    except OSError:
+        return out
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        gate_file = entry / "gate-result.json"
+        if not gate_file.is_file():
+            continue
+        try:
+            data = json.loads(gate_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            out[entry.name] = data
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Native-task readers (CLAUDE_CONFIG_DIR/tasks/{session_id}/*.json)
+# ---------------------------------------------------------------------------
+
+def _scan_all_native_tasks() -> Tuple[List[dict], Optional[str]]:
+    """Walk every session under ${CLAUDE_CONFIG_DIR}/tasks/ and return all tasks.
+
+    Returns ``(tasks, error_message)``. The error string is set when the
+    tasks root itself is unreachable; per-file read errors are silently
+    skipped to keep the diagnostic resilient (a single malformed task file
+    must not poison the entire report).
+    """
+    config_dir = _claude_config_dir()
+    tasks_root = config_dir / "tasks"
+    if not tasks_root.is_dir():
+        return [], f"{_UNREACHABLE_PREFIX} native tasks (no directory at {tasks_root})"
+
+    out: List[dict] = []
+    try:
+        for task_file in tasks_root.rglob("*.json"):
+            try:
+                data = json.loads(task_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            # Tag with source path so callers can attribute drift entries.
+            data.setdefault("_session_id", task_file.parent.name)
+            data.setdefault("_task_file", str(task_file))
+            out.append(data)
+    except OSError as exc:
+        return out, f"{_UNREACHABLE_PREFIX} native tasks: {exc}"
+    return out, None
+
+
+def _project_slug_from_chain_id(chain_id: str) -> Optional[str]:
+    """Extract the project slug from a metadata.chain_id.
+
+    chain_id format (per CLAUDE.md): ``{slug}(.(root|{phase}))(.{gate})?``
+    The slug is everything before the first dot.
+    """
+    if not isinstance(chain_id, str) or not chain_id:
+        return None
+    return chain_id.split(".", 1)[0] or None
+
+
+def _matches_project_chain(task: dict, project_slug: str) -> bool:
+    """Return True when ``task.metadata.chain_id`` belongs to ``project_slug``."""
+    meta = task.get("metadata") or {}
+    if not isinstance(meta, dict):
+        return False
+    return _project_slug_from_chain_id(meta.get("chain_id") or "") == project_slug
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+def _phase_status_implies_completion(gate_result: dict) -> Optional[bool]:
+    """Return True if phase verdict means downstream tasks should be completed,
+    False if they should be open (rejected), or None when verdict is unknown.
+    """
+    verdict = (gate_result.get("verdict") or "").upper().strip()
+    if verdict in _APPROVE_VERDICTS:
+        return True
+    if verdict in _REJECT_VERDICTS:
+        return False
+    return None
+
+
+def _detect_missing_native(
+    plan: dict,
+    project_slug: str,
+    native_tasks_for_project: List[dict],
+) -> List[dict]:
+    """Plan tasks with no matching native counterpart.
+
+    Match heuristic: a plan task is "matched" when at least one native task
+    in ``native_tasks_for_project`` has the same chain_id as the plan task's
+    metadata.chain_id AND its subject contains the plan task title (case
+    insensitive substring) OR matches the plan id exactly. Subjects vary
+    slightly between writers, so substring is the most stable signal.
+    """
+    plan_tasks = plan.get("tasks") or []
+    if not isinstance(plan_tasks, list):
+        return []
+
+    drift: List[dict] = []
+    for plan_task in plan_tasks:
+        if not isinstance(plan_task, dict):
+            continue
+        plan_id = plan_task.get("id") or "<unknown>"
+        plan_title = (plan_task.get("title") or "").strip()
+        plan_meta = plan_task.get("metadata") or {}
+        expected_chain = plan_meta.get("chain_id") if isinstance(plan_meta, dict) else None
+
+        if not expected_chain:
+            # Plan task lacks chain_id — surface as missing_native because
+            # we cannot verify emission at all.
+            drift.append({
+                "type": DRIFT_MISSING_NATIVE,
+                "plan_task_id": plan_id,
+                "plan_title": plan_title,
+                "expected_chain_id": None,
+                "reason": "plan task has no metadata.chain_id",
+            })
+            continue
+
+        # Find candidates with the same chain_id.
+        candidates = [
+            t for t in native_tasks_for_project
+            if (t.get("metadata") or {}).get("chain_id") == expected_chain
+        ]
+        if not candidates:
+            drift.append({
+                "type": DRIFT_MISSING_NATIVE,
+                "plan_task_id": plan_id,
+                "plan_title": plan_title,
+                "expected_chain_id": expected_chain,
+                "reason": "no native task with matching chain_id",
+            })
+            continue
+
+        # Title heuristic — only flag when none of the candidates look like
+        # this plan task. Several plan tasks may share a chain_id (gate
+        # findings, sub-tasks), so we accept any candidate that contains the
+        # title or whose subject is the plan id.
+        if plan_title:
+            needle = plan_title.lower()
+            title_match = any(
+                needle in (c.get("subject") or "").lower()
+                or (c.get("subject") or "").lower() == plan_id.lower()
+                for c in candidates
+            )
+            if not title_match:
+                drift.append({
+                    "type": DRIFT_MISSING_NATIVE,
+                    "plan_task_id": plan_id,
+                    "plan_title": plan_title,
+                    "expected_chain_id": expected_chain,
+                    "reason": (
+                        f"chain_id present ({len(candidates)} task(s)) "
+                        f"but no subject matches plan title"
+                    ),
+                })
+    return drift
+
+
+def _detect_stale_status(
+    plan: dict,
+    project_slug: str,
+    native_tasks_for_project: List[dict],
+    gate_results: Dict[str, dict],
+) -> List[dict]:
+    """Native task vs plan-phase status mismatches.
+
+    For each native task, look up its phase via metadata.phase. If a
+    gate-result for that phase exists with verdict APPROVE/CONDITIONAL but
+    the native task is still pending/in_progress, flag stale_status. The
+    converse (REJECT but completed) is also flagged.
+    """
+    drift: List[dict] = []
+    for task in native_tasks_for_project:
+        meta = task.get("metadata") or {}
+        if not isinstance(meta, dict):
+            continue
+        phase = meta.get("phase")
+        if not phase or phase not in gate_results:
+            continue
+
+        expects_complete = _phase_status_implies_completion(gate_results[phase])
+        if expects_complete is None:
+            continue
+
+        status = task.get("status") or "unknown"
+        if expects_complete and status in _OPEN_STATUSES:
+            drift.append({
+                "type": DRIFT_STALE_STATUS,
+                "native_task_id": task.get("id"),
+                "native_subject": task.get("subject"),
+                "native_status": status,
+                "phase": phase,
+                "phase_verdict": gate_results[phase].get("verdict"),
+                "expected_status": "completed",
+                "reason": (
+                    f"phase {phase!r} verdict is "
+                    f"{gate_results[phase].get('verdict')!r} "
+                    f"but native task still {status!r}"
+                ),
+            })
+        elif (not expects_complete) and status in _COMPLETED_STATUSES:
+            drift.append({
+                "type": DRIFT_STALE_STATUS,
+                "native_task_id": task.get("id"),
+                "native_subject": task.get("subject"),
+                "native_status": status,
+                "phase": phase,
+                "phase_verdict": gate_results[phase].get("verdict"),
+                "expected_status": "pending or in_progress",
+                "reason": (
+                    f"phase {phase!r} was rejected but native task is "
+                    f"{status!r}"
+                ),
+            })
+    return drift
+
+
+def _detect_phase_drift(
+    plan: dict,
+    project_slug: str,
+    native_tasks_for_project: List[dict],
+    gate_results: Dict[str, dict],
+) -> List[dict]:
+    """Phase has APPROVE/CONDITIONAL gate-result but no completed gate-finding task.
+
+    Read-side complement to PR #653 (which fixed the WRITE path so future
+    approvals do close the matching task). reconcile catches drift that
+    landed BEFORE that fix shipped.
+    """
+    drift: List[dict] = []
+    for phase, gate_result in gate_results.items():
+        if _phase_status_implies_completion(gate_result) is not True:
+            continue
+        # Find any gate-finding task for this phase.
+        gate_findings = [
+            t for t in native_tasks_for_project
+            if isinstance(t.get("metadata"), dict)
+            and t["metadata"].get("phase") == phase
+            and t["metadata"].get("event_type") == "gate-finding"
+        ]
+        if not gate_findings:
+            drift.append({
+                "type": DRIFT_PHASE_GATE,
+                "phase": phase,
+                "phase_verdict": gate_result.get("verdict"),
+                "reason": (
+                    f"phase {phase!r} has verdict "
+                    f"{gate_result.get('verdict')!r} but no gate-finding "
+                    f"task exists in the native store"
+                ),
+            })
+            continue
+        # If any are still open, flag — the gate verdict says we're done.
+        open_findings = [
+            t for t in gate_findings
+            if (t.get("status") or "unknown") in _OPEN_STATUSES
+        ]
+        if open_findings:
+            for t in open_findings:
+                drift.append({
+                    "type": DRIFT_PHASE_GATE,
+                    "phase": phase,
+                    "phase_verdict": gate_result.get("verdict"),
+                    "native_task_id": t.get("id"),
+                    "native_subject": t.get("subject"),
+                    "native_status": t.get("status"),
+                    "reason": (
+                        f"phase {phase!r} verdict is "
+                        f"{gate_result.get('verdict')!r} but gate-finding "
+                        f"task still {t.get('status')!r}"
+                    ),
+                })
+    return drift
+
+
+def _detect_orphan_native(
+    all_native_tasks: List[dict],
+    known_project_slugs: set[str],
+) -> List[dict]:
+    """Native tasks whose chain_id project does NOT exist in the registry."""
+    drift: List[dict] = []
+    for task in all_native_tasks:
+        meta = task.get("metadata") or {}
+        if not isinstance(meta, dict):
+            continue
+        chain_id = meta.get("chain_id")
+        slug = _project_slug_from_chain_id(chain_id) if chain_id else None
+        if slug is None:
+            continue
+        if slug in known_project_slugs:
+            continue
+        drift.append({
+            "type": DRIFT_ORPHAN_NATIVE,
+            "native_task_id": task.get("id"),
+            "native_subject": task.get("subject"),
+            "chain_id": chain_id,
+            "orphan_project_slug": slug,
+            "reason": (
+                f"native task carries chain_id for project {slug!r} "
+                f"which has no process-plan.json"
+            ),
+        })
+    return drift
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def reconcile_project(
+    project_slug: str,
+    *,
+    _all_native_tasks: Optional[List[dict]] = None,
+    _all_native_error: Optional[str] = None,
+    _known_project_slugs: Optional[set[str]] = None,
+) -> dict:
+    """Walk the garden chain + native task store for ``project_slug``.
+
+    Returns the reconcile-result dict (see module docstring for shape).
+    The leading-underscore kwargs let ``reconcile_all`` share a single
+    native-task scan across many projects without re-reading the same
+    files; external callers should leave them unset.
+    """
+    plan, plan_error = _load_process_plan(project_slug)
+
+    if _all_native_tasks is None:
+        all_native_tasks, native_error = _scan_all_native_tasks()
+    else:
+        all_native_tasks = _all_native_tasks
+        native_error = _all_native_error
+
+    native_for_project = [
+        t for t in all_native_tasks if _matches_project_chain(t, project_slug)
+    ]
+
+    gate_results = _phase_gate_results(project_slug)
+
+    drift: List[dict] = []
+    plan_task_count = 0
+    if plan is not None:
+        plan_task_count = len(plan.get("tasks") or [])
+        drift.extend(_detect_missing_native(plan, project_slug, native_for_project))
+        drift.extend(_detect_stale_status(plan, project_slug, native_for_project, gate_results))
+        drift.extend(_detect_phase_drift(plan, project_slug, native_for_project, gate_results))
+
+    # Orphan detection only when we have a registry of known slugs;
+    # reconcile_all passes one in. Single-project mode skips it because we
+    # can't tell "old chain" from "different project" without the registry.
+    if _known_project_slugs is not None:
+        drift.extend(_detect_orphan_native(all_native_tasks, _known_project_slugs))
+
+    errors: List[str] = []
+    if plan_error:
+        errors.append(plan_error)
+    if native_error:
+        errors.append(native_error)
+
+    summary = {
+        "total_drift_count": len(drift),
+        "missing_native_count": sum(1 for d in drift if d["type"] == DRIFT_MISSING_NATIVE),
+        "stale_status_count": sum(1 for d in drift if d["type"] == DRIFT_STALE_STATUS),
+        "orphan_native_count": sum(1 for d in drift if d["type"] == DRIFT_ORPHAN_NATIVE),
+        "phase_drift_count": sum(1 for d in drift if d["type"] == DRIFT_PHASE_GATE),
+    }
+
+    return {
+        "project_slug": project_slug,
+        "garden_chain_tasks": plan_task_count,
+        "native_tasks": len(native_for_project),
+        "phases_with_gate_result": sorted(gate_results.keys()),
+        "drift": drift,
+        "summary": summary,
+        "errors": errors,
+    }
+
+
+def _list_known_project_slugs() -> List[str]:
+    """List every project slug that has a directory under projects_root.
+
+    Slug = directory name. We don't require process-plan.json here — the
+    presence of a project dir is enough to count as "known" so a project
+    that hasn't run propose-process yet doesn't trigger orphan-native
+    flags for tasks that ARE legitimately tied to it.
+    """
+    root = _projects_root()
+    if not root.is_dir():
+        return []
+    try:
+        return sorted(
+            entry.name for entry in root.iterdir()
+            if entry.is_dir() and not entry.name.startswith(".")
+        )
+    except OSError:
+        return []
+
+
+def reconcile_all() -> List[dict]:
+    """Run reconcile_project for every project in the projects root.
+
+    Shares a single native-task scan across all projects so the cost is
+    O(projects + tasks) rather than O(projects * tasks).
+    """
+    slugs = _list_known_project_slugs()
+    all_native_tasks, native_error = _scan_all_native_tasks()
+    known_slugs_set = set(slugs)
+    return [
+        reconcile_project(
+            slug,
+            _all_native_tasks=all_native_tasks,
+            _all_native_error=native_error,
+            _known_project_slugs=known_slugs_set,
+        )
+        for slug in slugs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_text_report(result: dict) -> str:
+    """Render a single reconcile result as a human-readable text report."""
+    lines: List[str] = []
+    slug = result.get("project_slug", "<unknown>")
+    summary = result.get("summary") or {}
+    lines.append(f"Reconcile report — project: {slug}")
+    lines.append("=" * (len(lines[-1])))
+    lines.append(f"  Plan tasks (process-plan.json):   {result.get('garden_chain_tasks', 0)}")
+    lines.append(f"  Native tasks (matching chain_id): {result.get('native_tasks', 0)}")
+    phases = result.get("phases_with_gate_result") or []
+    lines.append(f"  Phases with gate-result.json:     {len(phases)}"
+                 + (f"  ({', '.join(phases)})" if phases else ""))
+    lines.append("")
+    lines.append("Drift summary:")
+    lines.append(f"  total:          {summary.get('total_drift_count', 0)}")
+    lines.append(f"  missing_native: {summary.get('missing_native_count', 0)}")
+    lines.append(f"  stale_status:   {summary.get('stale_status_count', 0)}")
+    lines.append(f"  orphan_native:  {summary.get('orphan_native_count', 0)}")
+    lines.append(f"  phase_drift:    {summary.get('phase_drift_count', 0)}")
+
+    errors = result.get("errors") or []
+    if errors:
+        lines.append("")
+        lines.append("Errors (fail-open — partial report shown):")
+        for err in errors:
+            lines.append(f"  - {err}")
+
+    drift = result.get("drift") or []
+    if drift:
+        lines.append("")
+        lines.append("Drift entries:")
+        for entry in drift:
+            kind = entry.get("type", "?")
+            reason = entry.get("reason", "")
+            ident = (
+                entry.get("plan_task_id")
+                or entry.get("native_task_id")
+                or entry.get("phase")
+                or "?"
+            )
+            lines.append(f"  [{kind}] {ident} — {reason}")
+    else:
+        lines.append("")
+        lines.append("No drift detected.")
+    return "\n".join(lines) + "\n"
+
+
+def render_text_report_all(results: List[dict]) -> str:
+    """Render multiple reconcile results, one section per project."""
+    if not results:
+        return "No projects found under the projects root.\n"
+    chunks: List[str] = []
+    grand_total = 0
+    for r in results:
+        grand_total += int((r.get("summary") or {}).get("total_drift_count", 0))
+        chunks.append(render_text_report(r))
+    chunks.append(
+        f"--- Aggregate ---\nProjects scanned: {len(results)}\n"
+        f"Total drift entries: {grand_total}\n"
+    )
+    return "\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Reconcile native TaskList vs garden chain stores. Pure read-only "
+            "diagnostic — never mutates either store."
+        ),
+    )
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--project", dest="project", help="Reconcile a single project slug.")
+    group.add_argument("--all", action="store_true", help="Reconcile every known project.")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="Emit machine-readable JSON instead of the text report.")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.all:
+        results = reconcile_all()
+        if args.as_json:
+            sys.stdout.write(json.dumps(results, indent=2) + "\n")
+        else:
+            sys.stdout.write(render_text_report_all(results))
+        return 0
+
+    # Single-project mode.
+    result = reconcile_project(args.project)
+    if args.as_json:
+        sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    else:
+        sys.stdout.write(render_text_report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/crew/test_reconcile.py
+++ b/tests/crew/test_reconcile.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/crew/reconcile.py.
+
+Coverage focuses on:
+  - Empty / healthy / mixed-drift projects
+  - Each drift type in isolation
+  - reconcile_all aggregation across multiple projects
+  - JSON output is parseable
+  - Text output contains the drift counts
+  - READ-ONLY contract: no file mtimes change during reconcile
+
+All tests are deterministic, stdlib-only, and use cross-platform tempdirs.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Iterable, List
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+
+import reconcile  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _make_plan_task(
+    *,
+    task_id: str,
+    title: str,
+    phase: str,
+    chain_id: str,
+    blocked_by: List[str] | None = None,
+) -> dict:
+    return {
+        "id": task_id,
+        "title": title,
+        "phase": phase,
+        "blockedBy": blocked_by or [],
+        "metadata": {
+            "chain_id": chain_id,
+            "event_type": "task",
+            "source_agent": "facilitator",
+            "phase": phase,
+            "rigor_tier": "standard",
+        },
+    }
+
+
+def _make_native_task(
+    *,
+    task_id: str,
+    subject: str,
+    status: str,
+    chain_id: str,
+    phase: str,
+    event_type: str = "task",
+) -> dict:
+    return {
+        "id": task_id,
+        "subject": subject,
+        "status": status,
+        "metadata": {
+            "chain_id": chain_id,
+            "event_type": event_type,
+            "source_agent": "implementer",
+            "phase": phase,
+            "rigor_tier": "standard",
+        },
+    }
+
+
+def _build_plan(slug: str, tasks: List[dict]) -> dict:
+    return {
+        "project_slug": slug,
+        "summary": "fixture",
+        "rigor_tier": "standard",
+        "complexity": 2,
+        "factors": {},
+        "specialists": [],
+        "phases": ["build"],
+        "tasks": tasks,
+    }
+
+
+def _snapshot_mtimes(root: Path) -> dict[str, float]:
+    """Capture every file mtime under ``root`` as {relpath: mtime}."""
+    out: dict[str, float] = {}
+    if not root.exists():
+        return out
+    for path in root.rglob("*"):
+        if path.is_file():
+            out[str(path.relative_to(root))] = path.stat().st_mtime_ns
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding — patches projects root + CLAUDE_CONFIG_DIR for every test
+# ---------------------------------------------------------------------------
+
+class _ReconcileFixture(unittest.TestCase):
+    """Base class that patches the two filesystem roots reconcile reads from."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_root = Path(self._tmp.name)
+
+        self.projects_root = self.tmp_root / "wicked-crew" / "projects"
+        self.projects_root.mkdir(parents=True, exist_ok=True)
+
+        self.config_dir = self.tmp_root / "claude-config"
+        self.tasks_root = self.config_dir / "tasks"
+        self.tasks_root.mkdir(parents=True, exist_ok=True)
+
+        # Patch: route _projects_root + _claude_config_dir to the fixture.
+        self._patches = [
+            mock.patch.object(reconcile, "_projects_root", return_value=self.projects_root),
+            mock.patch.object(reconcile, "_claude_config_dir", return_value=self.config_dir),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    # --- Convenience fixture builders -------------------------------------
+
+    def _add_project(self, slug: str) -> Path:
+        proj_dir = self.projects_root / slug
+        proj_dir.mkdir(parents=True, exist_ok=True)
+        return proj_dir
+
+    def _write_plan(self, slug: str, plan: dict) -> Path:
+        proj_dir = self._add_project(slug)
+        path = proj_dir / "process-plan.json"
+        _write_json(path, plan)
+        return path
+
+    def _write_gate_result(self, slug: str, phase: str, verdict: str) -> Path:
+        path = self.projects_root / slug / "phases" / phase / "gate-result.json"
+        _write_json(path, {"verdict": verdict, "min_score": 0.7, "score": 0.85})
+        return path
+
+    def _write_native_task(self, session: str, task: dict) -> Path:
+        path = self.tasks_root / session / f"{task['id']}.json"
+        _write_json(path, task)
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class EmptyProjectTests(_ReconcileFixture):
+    def test_project_with_no_chain_emits_no_error(self) -> None:
+        # Project dir exists but no process-plan.json and no native tasks.
+        self._add_project("empty-proj")
+        result = reconcile.reconcile_project("empty-proj")
+        self.assertEqual(result["project_slug"], "empty-proj")
+        self.assertEqual(result["garden_chain_tasks"], 0)
+        self.assertEqual(result["native_tasks"], 0)
+        self.assertEqual(result["drift"], [])
+        # The missing process-plan.json must surface as an error string,
+        # not an exception.
+        self.assertTrue(any("process-plan.json" in err for err in result["errors"]))
+
+    def test_completely_unknown_project_returns_empty_drift(self) -> None:
+        # Nothing under the projects root at all.
+        result = reconcile.reconcile_project("does-not-exist")
+        self.assertEqual(result["garden_chain_tasks"], 0)
+        self.assertEqual(result["native_tasks"], 0)
+        self.assertEqual(result["drift"], [])
+
+
+class HealthyProjectTests(_ReconcileFixture):
+    def test_healthy_project_has_zero_drift(self) -> None:
+        slug = "healthy"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Implement feature",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Implement feature",
+            status="completed",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        result = reconcile.reconcile_project(slug)
+        self.assertEqual(result["garden_chain_tasks"], 1)
+        self.assertEqual(result["native_tasks"], 1)
+        self.assertEqual(result["drift"], [])
+        self.assertEqual(result["summary"]["total_drift_count"], 0)
+
+
+class MissingNativeTests(_ReconcileFixture):
+    def test_plan_task_without_native_counterpart(self) -> None:
+        slug = "missing-native"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t5",
+                title="Refactor module",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        # No native task written.
+        result = reconcile.reconcile_project(slug)
+        self.assertEqual(result["summary"]["missing_native_count"], 1)
+        entry = result["drift"][0]
+        self.assertEqual(entry["type"], reconcile.DRIFT_MISSING_NATIVE)
+        self.assertEqual(entry["plan_task_id"], "t5")
+        self.assertEqual(entry["expected_chain_id"], f"{slug}.build")
+
+    def test_chain_present_but_title_mismatch_flags_missing(self) -> None:
+        slug = "title-mismatch"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="A very specific feature title",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-x",
+            subject="Something completely different",
+            status="completed",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        result = reconcile.reconcile_project(slug)
+        # Native tasks count is 1 (chain matches the project), but drift is
+        # surfaced because the title heuristic doesn't see a match.
+        self.assertEqual(result["native_tasks"], 1)
+        self.assertEqual(result["summary"]["missing_native_count"], 1)
+
+
+class StaleStatusTests(_ReconcileFixture):
+    def test_native_pending_when_phase_approved(self) -> None:
+        slug = "stale-pending"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Build the thing",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "build", "APPROVE")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Build the thing",
+            status="in_progress",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        result = reconcile.reconcile_project(slug)
+        stale = [d for d in result["drift"] if d["type"] == reconcile.DRIFT_STALE_STATUS]
+        self.assertEqual(len(stale), 1)
+        self.assertEqual(stale[0]["native_status"], "in_progress")
+        self.assertEqual(stale[0]["phase"], "build")
+        self.assertEqual(stale[0]["phase_verdict"], "APPROVE")
+
+    def test_conditional_verdict_also_implies_completion(self) -> None:
+        slug = "conditional"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Build the thing",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "build", "CONDITIONAL")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Build the thing",
+            status="pending",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        result = reconcile.reconcile_project(slug)
+        self.assertEqual(result["summary"]["stale_status_count"], 1)
+
+    def test_completed_when_phase_rejected_is_drift(self) -> None:
+        slug = "rejected-but-done"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Build the thing",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "build", "REJECT")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Build the thing",
+            status="completed",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        result = reconcile.reconcile_project(slug)
+        self.assertEqual(result["summary"]["stale_status_count"], 1)
+
+
+class OrphanNativeTests(_ReconcileFixture):
+    def test_orphan_only_surfaced_via_reconcile_all(self) -> None:
+        # A native task references a project that does not exist on disk.
+        self._write_native_task("session-1", _make_native_task(
+            task_id="orphan-1",
+            subject="Old work",
+            status="completed",
+            chain_id="deleted-project.build",
+            phase="build",
+        ))
+        # And a real project exists (with no native tasks).
+        slug = "real-project"
+        self._write_plan(slug, _build_plan(slug, []))
+
+        results = reconcile.reconcile_all()
+        # Find the result for the real project — orphan drift attaches there
+        # (the only place it can attach in --all mode).
+        flat = [d for r in results for d in r["drift"]]
+        orphans = [d for d in flat if d["type"] == reconcile.DRIFT_ORPHAN_NATIVE]
+        self.assertEqual(len(orphans), 1)
+        self.assertEqual(orphans[0]["orphan_project_slug"], "deleted-project")
+
+    def test_single_project_mode_skips_orphan_detection(self) -> None:
+        # Without the registry, single-project mode cannot tell "orphan"
+        # from "task belonging to a different known project". Make sure we
+        # don't false-positive in that mode.
+        self._write_native_task("session-1", _make_native_task(
+            task_id="other-1",
+            subject="Other project work",
+            status="completed",
+            chain_id="some-other-project.build",
+            phase="build",
+        ))
+        slug = "primary"
+        self._write_plan(slug, _build_plan(slug, []))
+        result = reconcile.reconcile_project(slug)
+        orphans = [d for d in result["drift"] if d["type"] == reconcile.DRIFT_ORPHAN_NATIVE]
+        self.assertEqual(orphans, [])
+
+
+class PhaseDriftTests(_ReconcileFixture):
+    def test_approved_phase_with_no_gate_finding_task_is_drift(self) -> None:
+        slug = "phase-drift-no-task"
+        plan = _build_plan(slug, [])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "design", "APPROVE")
+        # No native gate-finding task at all.
+        result = reconcile.reconcile_project(slug)
+        phase_drift = [d for d in result["drift"] if d["type"] == reconcile.DRIFT_PHASE_GATE]
+        self.assertEqual(len(phase_drift), 1)
+        self.assertEqual(phase_drift[0]["phase"], "design")
+        self.assertEqual(phase_drift[0]["phase_verdict"], "APPROVE")
+
+    def test_approved_phase_with_open_gate_finding_is_drift(self) -> None:
+        slug = "phase-drift-open"
+        plan = _build_plan(slug, [])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "design", "APPROVE")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="gf-1",
+            subject="Gate finding",
+            status="pending",
+            chain_id=f"{slug}.design.gf-1",
+            phase="design",
+            event_type="gate-finding",
+        ))
+        result = reconcile.reconcile_project(slug)
+        phase_drift = [d for d in result["drift"] if d["type"] == reconcile.DRIFT_PHASE_GATE]
+        self.assertEqual(len(phase_drift), 1)
+        self.assertEqual(phase_drift[0]["native_task_id"], "gf-1")
+
+    def test_completed_gate_finding_is_not_drift(self) -> None:
+        slug = "phase-clean"
+        plan = _build_plan(slug, [])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "design", "APPROVE")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="gf-1",
+            subject="Gate finding",
+            status="completed",
+            chain_id=f"{slug}.design.gf-1",
+            phase="design",
+            event_type="gate-finding",
+        ))
+        result = reconcile.reconcile_project(slug)
+        phase_drift = [d for d in result["drift"] if d["type"] == reconcile.DRIFT_PHASE_GATE]
+        self.assertEqual(phase_drift, [])
+
+
+class MixedDriftTests(_ReconcileFixture):
+    def test_project_with_all_three_local_drift_types(self) -> None:
+        slug = "messy"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Build it",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+            _make_plan_task(
+                task_id="t2",
+                title="Document it",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        # gate-result.json says APPROVE
+        self._write_gate_result(slug, "build", "APPROVE")
+        # Native task t1 exists but is still in_progress -> stale_status
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Build it",
+            status="in_progress",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+        # Native task t2 missing -> missing_native
+        # No gate-finding task -> phase_drift
+
+        result = reconcile.reconcile_project(slug)
+        types = sorted({d["type"] for d in result["drift"]})
+        self.assertIn(reconcile.DRIFT_MISSING_NATIVE, types)
+        self.assertIn(reconcile.DRIFT_STALE_STATUS, types)
+        self.assertIn(reconcile.DRIFT_PHASE_GATE, types)
+        self.assertEqual(result["summary"]["total_drift_count"], len(result["drift"]))
+
+
+class ReconcileAllTests(_ReconcileFixture):
+    def test_reconcile_all_walks_multiple_projects(self) -> None:
+        # Three projects, two with simple state, one empty.
+        for slug in ["alpha", "beta", "gamma"]:
+            self._write_plan(slug, _build_plan(slug, []))
+
+        results = reconcile.reconcile_all()
+        slugs = sorted(r["project_slug"] for r in results)
+        self.assertEqual(slugs, ["alpha", "beta", "gamma"])
+
+    def test_reconcile_all_returns_empty_when_no_projects(self) -> None:
+        # Don't call _add_project — projects root exists but is empty.
+        results = reconcile.reconcile_all()
+        self.assertEqual(results, [])
+
+
+class CLIOutputTests(_ReconcileFixture):
+    def test_json_output_is_parseable_for_single_project(self) -> None:
+        slug = "json-test"
+        self._write_plan(slug, _build_plan(slug, []))
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = reconcile.main(["--project", slug, "--json"])
+        self.assertEqual(rc, 0)
+        parsed = json.loads(buf.getvalue())
+        self.assertEqual(parsed["project_slug"], slug)
+        self.assertIn("summary", parsed)
+
+    def test_json_output_is_parseable_for_all(self) -> None:
+        for slug in ["one", "two"]:
+            self._write_plan(slug, _build_plan(slug, []))
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = reconcile.main(["--all", "--json"])
+        self.assertEqual(rc, 0)
+        parsed = json.loads(buf.getvalue())
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 2)
+
+    def test_text_output_contains_drift_counts_and_header(self) -> None:
+        slug = "text-test"
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Missing task",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = reconcile.main(["--project", slug])
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        self.assertIn("Reconcile report", output)
+        self.assertIn("Drift summary", output)
+        self.assertIn("missing_native:", output)
+        self.assertIn("stale_status:", output)
+        self.assertIn("orphan_native:", output)
+        self.assertIn("phase_drift:", output)
+
+
+class ReadOnlyContractTests(_ReconcileFixture):
+    """Snapshot mtimes around every reconcile call — they must NOT change."""
+
+    def _build_busy_state(self, slug: str) -> None:
+        plan = _build_plan(slug, [
+            _make_plan_task(
+                task_id="t1",
+                title="Build it",
+                phase="build",
+                chain_id=f"{slug}.build",
+            ),
+        ])
+        self._write_plan(slug, plan)
+        self._write_gate_result(slug, "build", "APPROVE")
+        self._write_native_task("session-1", _make_native_task(
+            task_id="native-1",
+            subject="Build it",
+            status="in_progress",
+            chain_id=f"{slug}.build",
+            phase="build",
+        ))
+
+    def test_reconcile_project_does_not_mutate_any_file(self) -> None:
+        slug = "ro-project"
+        self._build_busy_state(slug)
+        before = _snapshot_mtimes(self.tmp_root)
+        reconcile.reconcile_project(slug)
+        after = _snapshot_mtimes(self.tmp_root)
+        self.assertEqual(before, after, "reconcile_project mutated a file")
+
+    def test_reconcile_all_does_not_mutate_any_file(self) -> None:
+        for slug in ["ro1", "ro2"]:
+            self._build_busy_state(slug)
+        before = _snapshot_mtimes(self.tmp_root)
+        reconcile.reconcile_all()
+        after = _snapshot_mtimes(self.tmp_root)
+        self.assertEqual(before, after, "reconcile_all mutated a file")
+
+    def test_cli_json_run_does_not_mutate_any_file(self) -> None:
+        slug = "ro-cli"
+        self._build_busy_state(slug)
+        before = _snapshot_mtimes(self.tmp_root)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            reconcile.main(["--project", slug, "--json"])
+        after = _snapshot_mtimes(self.tmp_root)
+        self.assertEqual(before, after, "CLI run mutated a file")
+
+
+class FailOpenTests(_ReconcileFixture):
+    def test_invalid_json_in_process_plan_surfaces_as_error(self) -> None:
+        slug = "broken-plan"
+        proj_dir = self._add_project(slug)
+        (proj_dir / "process-plan.json").write_text("{ not valid json", encoding="utf-8")
+        result = reconcile.reconcile_project(slug)
+        self.assertTrue(any("invalid JSON" in err for err in result["errors"]))
+        # Should still return a complete result dict — no exception.
+        self.assertEqual(result["project_slug"], slug)
+
+    def test_unreachable_native_root_does_not_crash(self) -> None:
+        # Patch _claude_config_dir to a path that does not exist.
+        nonexistent = self.tmp_root / "no-such-dir"
+        with mock.patch.object(reconcile, "_claude_config_dir", return_value=nonexistent):
+            slug = "unreachable"
+            self._write_plan(slug, _build_plan(slug, []))
+            result = reconcile.reconcile_project(slug)
+        self.assertTrue(any("native tasks" in err for err in result["errors"]))
+        self.assertEqual(result["native_tasks"], 0)
+
+
+class HelperTests(unittest.TestCase):
+    def test_project_slug_extraction(self) -> None:
+        self.assertEqual(reconcile._project_slug_from_chain_id("foo.root"), "foo")
+        self.assertEqual(reconcile._project_slug_from_chain_id("foo.build.gate"), "foo")
+        self.assertEqual(reconcile._project_slug_from_chain_id("only-slug"), "only-slug")
+        self.assertIsNone(reconcile._project_slug_from_chain_id(""))
+        self.assertIsNone(reconcile._project_slug_from_chain_id(None))  # type: ignore[arg-type]
+
+    def test_phase_status_implies_completion(self) -> None:
+        self.assertTrue(reconcile._phase_status_implies_completion({"verdict": "APPROVE"}))
+        self.assertTrue(reconcile._phase_status_implies_completion({"verdict": "CONDITIONAL"}))
+        self.assertFalse(reconcile._phase_status_implies_completion({"verdict": "REJECT"}))
+        self.assertIsNone(reconcile._phase_status_implies_completion({"verdict": "MAYBE"}))
+        self.assertIsNone(reconcile._phase_status_implies_completion({}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per the brainstorm decision (D3) on issue #579, ship **Option C first**: a read-only diagnostic that walks both stores (native TaskList + garden chain) and surfaces drift without mutating either side. Option A (TaskList as truth, garden chain as projection) is a larger refactor that follows once drift patterns from real usage are visible.

- New slash command: `/wicked-garden:crew:reconcile [--project=<slug>] [--all] [--json]`
- Backing script `scripts/crew/reconcile.py` (stdlib only) with public API: `reconcile_project`, `reconcile_all`, `render_text_report`
- 26 unit tests in `tests/crew/test_reconcile.py` — all four drift types in isolation, mixed cases, `reconcile_all` aggregation, JSON/text output, fail-open behavior, and an explicit **read-only contract** test that snapshots mtimes around every reconcile call

## Drift types detected

| Type             | Meaning                                                                                                    |
|------------------|------------------------------------------------------------------------------------------------------------|
| `missing_native` | A plan task has no matching native task with the expected `chain_id`.                                      |
| `stale_status`   | Native task and its plan phase disagree on completion (e.g., phase APPROVED but native still pending).      |
| `orphan_native`  | Native task carries a `chain_id` whose project slug is not present under the projects root.                |
| `phase_drift`    | A phase's `gate-result.json` is APPROVE/CONDITIONAL but its gate-finding native task is still open. (#653) |

`phase_drift` is the read-side complement to PR #653 (which fixed the WRITE path so future approvals close the matching task). reconcile catches drift that landed BEFORE that fix.

## Read-only confirmation

- The contract is enforced by `ReadOnlyContractTests` in the test suite — every reconcile entry point is wrapped with mtime snapshots before/after, and the tests fail loudly if any file is touched.
- Manual verification against the local state dir (`~/.something-wicked/wicked-garden/...` and `~/.claude/tasks/...`): 0 mtime changes, 0 new files after `--all --json`.

## Honors lessons learned

- `CLAUDE_CONFIG_DIR` for the native task path (per PR #678).
- Fail-open: if either store is unavailable, the report includes a `could not read X` line and still surfaces what was reachable.
- Stdlib only — no DomainStore writes, no daemon path required.

## Sample output (run against real local state)

```
Reconcile report — project: refactor-finish-cleanup
===================================================
  Plan tasks (process-plan.json):   6
  Native tasks (matching chain_id): 0
  Phases with gate-result.json:     0

Drift summary:
  total:          6
  missing_native: 6
  stale_status:   0
  orphan_native:  0
  phase_drift:    0

Drift entries:
  [missing_native] t1 — no native task with matching chain_id
  [missing_native] t2 — no native task with matching chain_id
  ...
```

## Follow-up — Option A scope

The drift patterns this command surfaces in real usage will inform the design of **Option A** (garden chain becomes a projection of the TaskList truth). That refactor is intentionally deferred until we have evidence on which drift types dominate. Tracked under issue #579 — once enough usage data is collected, a separate PR will land the projection model.

## Test plan

- [x] `pytest tests/crew/test_reconcile.py -v` — 26 / 26 pass
- [x] `pytest tests/crew/ -q` — full crew suite (1167 tests) still green; no regressions
- [x] Manual run: `python3 scripts/crew/reconcile.py --all` against real local state — sensible report, no errors
- [x] Manual run: `python3 scripts/crew/reconcile.py --project=refactor-finish-cleanup` — surfaces 6 missing_native entries (matches reality)
- [x] Read-only verified: 0 mtime changes after `--all --json`
- [ ] Reviewer: confirm `phase_drift` heuristic matches the gate-finding lifecycle from #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)