### PR TITLE
feat: improve 5 lowest-scoring skills + add Tessl skill review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/agentic/context-engineering/SKILL.md
+++ b/skills/agentic/context-engineering/SKILL.md
@@ -1,179 +1,126 @@
 ---
 name: context-engineering
-description: |
-  Context window management, token optimization, and memory patterns for efficient multi-agent systems.
-  Use when: "context window", "token optimization", "agent memory", "reduce token usage", "context engineering"
-portability: portable
+description: "Optimize context window usage, compress conversation history, manage token budgets, and design efficient memory systems for multi-agent workflows. Use when: reducing token consumption, implementing sliding-window context, compressing agent state, designing cross-session memory, or budgeting tokens across agent turns. Not for general prompt engineering or agent orchestration."
 ---
 
 # Context Engineering
 
-Techniques for managing context windows, optimizing token usage, and designing efficient memory systems for agentic applications.
+Concrete techniques for managing context windows and token budgets in agentic systems.
 
-## Context Window Fundamentals
+## Quick Start — Compress a Long Conversation
 
-**Context Window:** Maximum tokens an LLM can process in a single request (input + output).
+When conversation history exceeds a token budget, compress older turns:
 
-**Common Limits:**
-- Claude Opus 4.6: 200K tokens
-- Claude Sonnet 4.5: 200K tokens
-- GPT-4 Turbo: 128K tokens
-- GPT-4: 8K-32K tokens
-
-**Token Efficiency Matters:**
-- Cost: Charged per token (input + output)
-- Latency: More tokens = slower response
-- Quality: Irrelevant context can confuse model
+```python
+def compress_history(messages, max_tokens=4000):
+    """Keep recent messages verbatim, summarize older ones."""
+    recent = messages[-5:]  # last 5 turns stay intact
+    older = messages[:-5]
+    if not older:
+        return recent
+    summary = summarize(older)  # LLM call to compress
+    return [{"role": "system", "content": f"Prior context: {summary}"}] + recent
+```
 
 ## State Management Patterns
 
 ### Shared State
 All agents access common state store.
-
-**Use when:** Agents need synchronized view of world.
-**Pros:** Consistency, simple coordination
-**Cons:** Contention, single point of failure
+**Use when:** Agents need synchronized view. **Trade-off:** Contention risk.
 
 ### Isolated State
-Each agent maintains its own private state.
-
-**Use when:** Agents operate independently, no coordination needed.
-**Pros:** No contention, parallel execution
-**Cons:** Inconsistency possible, harder to coordinate
+Each agent maintains private state.
+**Use when:** Agents operate independently. **Trade-off:** Inconsistency possible.
 
 ### Checkpointed State
-Periodically save state snapshots for recovery.
-
-**Use when:** Long-running processes, need recovery from failures.
-**Pros:** Fault tolerance, replayability
-**Cons:** Storage overhead, consistency complexity
+Periodic snapshots for recovery.
+**Use when:** Long-running processes. **Trade-off:** Storage overhead.
 
 See `refs/compression-techniques.md` for implementation details.
 
 ## Token Optimization Techniques
 
-### 1. Aggressive Summarization
-Compress old context into summaries to reduce token usage.
+### 1. Structured Compression
+Replace prose with compact formats:
+
+```python
+# Before (42 tokens):
+# "The user's name is John Smith, they work at Acme Corp as a senior engineer"
+# After (12 tokens):
+context = {"name": "John Smith", "company": "Acme Corp", "role": "senior engineer"}
+```
 
 ### 2. Selective Context Loading
-Only load relevant context based on the current task.
+Load only what the current task needs:
 
-### 3. Structured Compression
-Use JSON/structured formats instead of prose to reduce tokens.
+```python
+def load_context(task_type, all_context):
+    """Load relevant context slices based on task type."""
+    relevance_map = {
+        "debugging": ["error_logs", "recent_changes", "stack_trace"],
+        "implementation": ["requirements", "architecture", "api_specs"],
+        "review": ["diff", "test_results", "standards"],
+    }
+    keys = relevance_map.get(task_type, list(all_context.keys())[:3])
+    return {k: all_context[k] for k in keys if k in all_context}
+```
 
-**Example:**
-- Before: "The user's name is John Smith..." (verbose)
-- After: `{"name": "John Smith", ...}` (compact)
+### 3. Reference Instead of Embed
+Point to files rather than inlining full content.
 
 ### 4. Lazy Loading
-Load details only when explicitly needed.
+Defer detail loading until explicitly needed — load summaries first.
 
-### 5. Reference Instead of Embedding
-Reference external documents instead of embedding full text.
-
-See `refs/selective-loading.md` and `refs/caching-and-optimization.md` for code examples and detailed strategies.
+See `refs/selective-loading.md` and `refs/caching-and-optimization.md` for detailed strategies.
 
 ## Memory Patterns
 
-### Short-Term (Working) Memory
-Recent conversation, current task state.
-
-**Scope:** Current session/task
-**Size:** 1K-10K tokens
-**Retention:** Minutes to hours
-
-### Long-Term Memory
-Persistent knowledge, learned facts.
-
-**Scope:** Cross-session, permanent
-**Size:** Unbounded (stored externally via vector DB)
-**Retention:** Days to forever
-
-### Episodic Memory
-Specific past events/experiences.
-
-**Scope:** Historical episodes
-**Size:** Summaries stored
-**Retention:** Varies by importance
+| Pattern | Scope | Size | Retention | Implementation |
+|---------|-------|------|-----------|----------------|
+| Working | Current task | 1K-10K tokens | Session | In-context messages |
+| Long-term | Cross-session | Unbounded | Permanent | Vector DB / FTS5 |
+| Episodic | Historical | Summaries | Varies | Compressed snapshots |
 
 See `refs/compression-techniques.md` for implementation patterns.
 
-## Prompt Engineering for Agents
+## Context Budget Workflow
 
-### Role Definition
-Be specific about agent's role and boundaries.
+1. **Set budget** — Define max tokens per agent and per session
+2. **Measure** — Track input/output tokens per call
+3. **Compress** — When approaching limit, summarize older context
+4. **Validate** — Confirm critical information survived compression
+5. **Report** — Log token usage for cost attribution
 
-**Example:**
+```python
+class TokenBudget:
+    def __init__(self, limit=8000):
+        self.limit = limit
+        self.used = 0
+
+    def can_add(self, tokens):
+        return self.used + tokens <= self.limit
+
+    def add(self, tokens):
+        if not self.can_add(tokens):
+            raise TokenBudgetExceeded(f"{self.used + tokens} > {self.limit}")
+        self.used += tokens
 ```
-You are a Python code reviewer specializing in security.
-Your job is to identify security vulnerabilities.
-You do NOT review style or performance.
-```
-
-### Task Specification
-Clear, actionable instructions with explicit format.
-
-**Bad:** "Review this code."
-**Good:** "Review for security: 1) SQL injection 2) Input validation 3) Secrets. Output: JSON with vulnerabilities."
-
-### Format Control
-Specify exact output format to reduce tokens.
-
-### Few-Shot Examples
-Show examples for complex tasks.
-
-See `refs/selective-loading.md` for detailed prompting patterns.
-
-## Context Loading Strategies
-
-### Anticipatory Loading
-Load context before it's needed (if predictable).
-**Pros:** Faster response time
-**Cons:** May load unnecessary data
-
-### Just-in-Time (JIT) Loading
-Load context only when explicitly needed.
-**Pros:** Minimal token usage
-**Cons:** Latency on each request
-
-### Hybrid Approach
-Combine both: Always load core context + JIT load task-specific context.
-
-## Cost Modeling
-
-### Token Cost Calculation
-Track input and output tokens separately. Rates vary by model (typically $0.003-0.075 per 1K tokens).
-
-### Budget Enforcement
-Set hard token limits per agent/session to prevent runaway costs.
-
-### Multi-Agent Cost Attribution
-Track costs per agent to identify expensive components.
 
 See `refs/cost-calculation-budget.md` and `refs/cost-optimization-reporting.md` for detailed cost strategies.
 
-## Context Window Strategies by Agent Pattern
+## Context Strategies by Agent Pattern
 
-**Sequential Pattern:** Pass only output of previous agent, not entire chain.
-
-**Hierarchical Pattern:** Parent gets summaries from children, children get only relevant task context.
-
-**Collaborative Pattern:** Shared context (compressed), each agent adds only delta.
-
-**Autonomous Pattern:** Minimal shared context, isolated context per agent.
-
-## Quick Wins
-
-1. **Compress old messages:** Summarize history > 20 messages
-2. **Use structured outputs:** JSON instead of prose
-3. **Lazy load details:** Only when needed
-4. **Set token budgets:** Hard limits per agent/session
-5. **Monitor token usage:** Track and optimize high-cost agents
+| Pattern | Strategy | Key rule |
+|---------|----------|----------|
+| Sequential | Pass only previous agent's output, not entire chain | Avoid token accumulation |
+| Hierarchical | Parent gets summaries; children get task-specific context | Minimize parent bloat |
+| Collaborative | Shared compressed context; each agent adds delta only | Control growth rate |
+| Autonomous | Minimal shared context; isolated per agent | Maximize independence |
 
 ## References
 
-- `refs/compression-techniques.md` - Conversation summarization, deduplication, entity compression
-- `refs/selective-loading.md` - Relevance filtering, time decay, token-budgeted retrieval
-- `refs/caching-and-optimization.md` - Prompt caching, semantic caching, batching, cost-aware model selection
-- `refs/cost-calculation-budget.md` - Token pricing, cost calculation, budget management
-- `refs/cost-optimization-reporting.md` - Cost estimation, optimization strategies, reporting
+- `refs/compression-techniques.md` — Conversation summarization, deduplication, entity compression
+- `refs/selective-loading.md` — Relevance filtering, time decay, token-budgeted retrieval
+- `refs/caching-and-optimization.md` — Prompt caching, semantic caching, batching, cost-aware model selection
+- `refs/cost-calculation-budget.md` — Token pricing, cost calculation, budget management
+- `refs/cost-optimization-reporting.md` — Cost estimation, optimization strategies, reporting

--- a/skills/facilitator-score/SKILL.md
+++ b/skills/facilitator-score/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: facilitator-score
-description: |
-  Score 9 risk factors for a new project via structured yes/no questionnaire.
-  Use *before* propose-process to skip the manual rubric tax. Returns a factors
-  block (same shape as propose-process output-schema.md) for direct injection
-  into Step 3. NOT for: re-evaluation of an in-flight project (use
-  propose-process re-evaluate mode), one-off complexity guesses (use deliberate),
-  or any use that requires overriding all 9 factors by hand (just use
-  propose-process directly).
-portability: portable
-allowed-tools:
-  - wicked-garden:ground
+description: "Score 9 risk factors (reversibility, blast radius, compliance, etc.) for a new project via structured yes/no questionnaire. Returns a factors block for direct injection into propose-process Step 3. Use when: pre-scoring project risk before propose-process, generating deterministic factor readings from Q&A, or skipping manual rubric justification. NOT for re-evaluation of in-flight projects (use propose-process re-evaluate mode) or one-off complexity guesses (use deliberate)."
+allowed-tools: "wicked-garden:ground"
 ---
 
 # wicked-garden:facilitator-score — Questionnaire Scorer
@@ -47,7 +38,6 @@ A `factors` block matching `skills/propose-process/refs/output-schema.md`:
 `reading` (backward-compat): HIGH = least risky, LOW = most risky. This direction is counter-intuitive
 for downstream display. Prefer `risk_level` when showing results to users: `low_risk` / `medium_risk` /
 `high_risk` maps directly to standard risk language.
-```
 
 ## Procedure
 

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: persona
-description: |
-  On-demand persona invocation system for applying named perspectives to any task.
-  Use when: "invoke persona", "act as", "apply perspective", "use a persona",
-  "persona:as", "define persona", "list personas", "custom persona",
-  "review as <role>", "from the perspective of", "--persona flag"
-disable-model-invocation: true
+description: "Invoke named personas to apply specialist perspectives to any task. Supports built-in specialists (engineering, platform, product, qe, data, delivery, jam, agentic) and custom persona creation. Use when: invoking a persona, acting as a role, applying a perspective, defining or listing personas, reviewing code through a specific lens, or using the --persona flag on commands."
 ---
 
 # Persona System

--- a/skills/product/mockup/SKILL.md
+++ b/skills/product/mockup/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: mockup
-description: |
-  Use when you need a quick ASCII wireframe or HTML mockup in-chat without Figma overhead.
-  NOT for production design work — use the figma plugin for that.
-portability: portable
+description: "Generate ASCII wireframes, HTML/CSS mockups, and component specs for UI layout exploration and developer handoff. Use when: sketching a layout, quick UI design, wireframing a page, prototyping a component, creating a mockup without Figma, or producing a developer handoff spec. Not for production design work — use Figma for that."
 ---
 
 # Mockup Skill
 
-Generate wireframes and mockup designs in multiple fidelity levels — from quick
-ASCII sketches to HTML/CSS previews ready for developer handoff.
+Generate wireframes and mockups at multiple fidelity levels — from quick ASCII sketches to
+HTML/CSS previews ready for developer handoff.
+
+## Quick Start
+
+```
+# Quick ideation
+"Sketch a login page layout in ASCII"
+
+# Stakeholder review
+"Create an HTML mockup of the dashboard with sidebar navigation"
+
+# Dev handoff
+"Write a component spec for the pricing card"
+```
 
 ## Output Format Selection
 
@@ -22,7 +32,7 @@ ASCII sketches to HTML/CSS previews ready for developer handoff.
 
 ## ASCII Wireframes
 
-Fast, text-based layout sketches. Use for early ideation and flow discussion.
+Fast, text-based layout sketches for early ideation:
 
 ```
 ┌─────────────────────────────────────────┐
@@ -30,145 +40,65 @@ Fast, text-based layout sketches. Use for early ideation and flow discussion.
 │─────────────────────────────────────────│
 │                                         │
 │  ┌──────────────┐  ┌──────────────┐    │
-│  │              │  │              │    │
 │  │   [Image]    │  │   [Image]    │    │
-│  │              │  │              │    │
 │  │  Card Title  │  │  Card Title  │    │
-│  │  Description │  │  Description │    │
 │  │  [Button]    │  │  [Button]    │    │
 │  └──────────────┘  └──────────────┘    │
 │                                         │
 │  ─────── Section Heading ───────────   │
-│                                         │
 │  ████████████████████ [CTA Button]     │
 └─────────────────────────────────────────┘
 ```
 
-### ASCII Symbol Guide
-
-```
-┌─┬─┐  Box borders
-│ │ │  Vertical dividers
-└─┴─┘  Box bottoms
-[...]   Button or interactive element
-{...}   Input field
-████   Image placeholder
-~~~~   Text content placeholder
-────   Horizontal rule / divider
-```
+Conventions: `[...]` = interactive element, `{...}` = input field, `████` = image placeholder.
 
 ## HTML/CSS Preview
 
-For higher-fidelity mockups, generate minimal HTML with inline or embedded CSS:
+For higher-fidelity mockups, generate minimal HTML with embedded CSS using design tokens:
 
 ```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Mockup: {component name}</title>
 <style>
-  /* Design tokens */
   :root {
     --color-primary: #3b82f6;
     --color-surface: #f9fafb;
     --space-4: 1rem;
-    --space-6: 1.5rem;
-    --text-sm: 0.875rem;
-    --text-base: 1rem;
-    --text-lg: 1.125rem;
     --radius: 0.5rem;
   }
-  /* Component styles */
-  .card {
-    background: var(--color-surface);
-    border-radius: var(--radius);
-    padding: var(--space-6);
-  }
 </style>
-</head>
-<body>
-  <!-- mockup content -->
-</body>
-</html>
 ```
 
-## Component Specs (Markdown)
-
-For developer handoff without visual preview:
-
-```markdown
-## Component: {Name}
-
-### Anatomy
-- **Container**: {background, border, border-radius, padding}
-- **Header**: {font-size, font-weight, color}
-- **Body**: {font-size, line-height, color}
-- **Action**: {button variant, size}
-
-### States
-| State | Visual Change |
-|-------|--------------|
-| Default | {description} |
-| Hover | {description} |
-| Active | {description} |
-| Disabled | {opacity: 0.5, cursor: not-allowed} |
-
-### Spacing
-- Internal padding: {token}
-- Gap between elements: {token}
-- External margin: {token or "handled by parent"}
-
-### Responsive Behavior
-- Mobile (<768px): {layout change}
-- Tablet (768–1024px): {layout change}
-- Desktop (>1024px): {base layout}
-
-### Accessibility Notes
-- Role: {semantic element or ARIA role}
-- Focus: {keyboard interaction}
-- Labels: {aria-label or visible label}
-```
+Match the project's existing design tokens if available (check `styles/tokens.css` or equivalent).
 
 ## Wireframe from Description
 
-When given a description, generate a wireframe in this sequence:
+When given a description, follow this sequence:
 
-1. **Identify layout pattern**: Single column, two-column, grid, sidebar+main
-2. **List components**: Header, nav, cards, forms, tables, modals
-3. **Arrange hierarchy**: Most important content first (F-pattern or Z-pattern)
-4. **Add interactions**: Buttons, links, inputs, toggles
-5. **Annotate**: Notes on behavior, states, responsive changes
-
-## Integration with Frontend Design
-
-When handing off to developers:
-
-```markdown
-## Handoff Notes for {component}
-
-**Design tokens to use**: See `styles/tokens.css`
-**Closest existing component**: {component name in codebase}
-**New patterns required**: {list any novel patterns}
-**Assets needed**: {icons, images, fonts}
-**Animation**: {transition type, duration}
-```
+1. **Identify layout pattern** — single column, two-column, grid, sidebar+main
+2. **List components** — header, nav, cards, forms, tables, modals
+3. **Arrange hierarchy** — most important content first (F-pattern or Z-pattern)
+4. **Add interactions** — buttons, links, inputs, toggles
+5. **Annotate** — notes on behavior, states, responsive changes
 
 ## Output Checklist
 
-Before delivering a mockup:
+Before delivering any mockup, verify:
 
 - [ ] All states shown (default, hover, error, empty, loading)
 - [ ] Mobile and desktop layouts included
 - [ ] Spacing annotated with token names (not pixel values)
 - [ ] Interactive elements clearly marked
-- [ ] Accessibility notes included
+- [ ] Accessibility notes included (roles, focus, labels)
 - [ ] Open questions flagged for stakeholder input
+
+## Reference
+
+For detailed templates and handoff formats:
+- [Component Specs](refs/component-specs.md) — full component spec template, state tables, responsive behavior
+- [Handoff Notes](refs/handoff-notes.md) — developer handoff template, asset checklist, animation specs
 
 ## Integration
 
-- **ux-review skill**: Pair mockups with the UX flow they support
-- **screenshot skill**: Compare mockup against built implementation
-- **visual-review skill**: Mockups set the standard for visual review
-- **engineering/frontend-design skill**: Coordinate component implementation
+- **ux-review skill** — pair mockups with the UX flow they support
+- **screenshot skill** — compare mockup against built implementation
+- **visual-review skill** — mockups set the standard for visual review
+- **engineering/frontend skill** — coordinate component implementation

--- a/skills/product/mockup/refs/component-specs.md
+++ b/skills/product/mockup/refs/component-specs.md
@@ -1,0 +1,74 @@
+# Component Spec Template
+
+Use this template when producing developer handoff documentation for individual components.
+
+## Template
+
+```markdown
+## Component: {Name}
+
+### Anatomy
+- **Container**: {background, border, border-radius, padding}
+- **Header**: {font-size, font-weight, color}
+- **Body**: {font-size, line-height, color}
+- **Action**: {button variant, size}
+
+### States
+| State | Visual Change |
+|-------|--------------|
+| Default | {description} |
+| Hover | {description} |
+| Active | {description} |
+| Disabled | {opacity: 0.5, cursor: not-allowed} |
+
+### Spacing
+- Internal padding: {token}
+- Gap between elements: {token}
+- External margin: {token or "handled by parent"}
+
+### Responsive Behavior
+- Mobile (<768px): {layout change}
+- Tablet (768–1024px): {layout change}
+- Desktop (>1024px): {base layout}
+
+### Accessibility Notes
+- Role: {semantic element or ARIA role}
+- Focus: {keyboard interaction}
+- Labels: {aria-label or visible label}
+```
+
+## Example: Pricing Card
+
+```markdown
+## Component: PricingCard
+
+### Anatomy
+- **Container**: bg-surface, border-1 border-gray-200, rounded-lg, p-6
+- **Header**: text-lg font-semibold text-gray-900
+- **Price**: text-3xl font-bold text-primary
+- **Features**: text-sm text-gray-600, list-disc
+- **Action**: Button variant=primary size=lg full-width
+
+### States
+| State | Visual Change |
+|-------|--------------|
+| Default | Border gray-200, shadow-sm |
+| Hover | Shadow-md, border-primary/30 |
+| Featured | Border-primary, shadow-lg, "Popular" badge |
+| Disabled | opacity-50, button disabled |
+
+### Spacing
+- Internal padding: space-6
+- Gap between sections: space-4
+- External margin: handled by grid parent
+
+### Responsive Behavior
+- Mobile (<768px): full width, stacked vertically
+- Tablet (768–1024px): 2-column grid
+- Desktop (>1024px): 3-column grid, featured card slightly larger
+
+### Accessibility Notes
+- Role: article with aria-label="{plan name} pricing plan"
+- Focus: Tab to CTA button, Enter to select
+- Labels: Price announced as "{amount} per {period}"
+```

--- a/skills/product/mockup/refs/handoff-notes.md
+++ b/skills/product/mockup/refs/handoff-notes.md
@@ -1,0 +1,62 @@
+# Developer Handoff Notes
+
+Use this template when handing off mockups to developers for implementation.
+
+## Handoff Template
+
+```markdown
+## Handoff Notes for {component}
+
+**Design tokens to use**: See `styles/tokens.css`
+**Closest existing component**: {component name in codebase}
+**New patterns required**: {list any novel patterns}
+**Assets needed**: {icons, images, fonts}
+**Animation**: {transition type, duration}
+```
+
+## Full HTML/CSS Preview Template
+
+When generating high-fidelity mockups, use this structure:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup: {component name}</title>
+<style>
+  :root {
+    --color-primary: #3b82f6;
+    --color-surface: #f9fafb;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --text-sm: 0.875rem;
+    --text-base: 1rem;
+    --text-lg: 1.125rem;
+    --radius: 0.5rem;
+  }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: var(--space-6); }
+  .card {
+    background: var(--color-surface);
+    border-radius: var(--radius);
+    padding: var(--space-6);
+  }
+</style>
+</head>
+<body>
+  <!-- mockup content here -->
+</body>
+</html>
+```
+
+## ASCII Symbol Reference
+
+| Symbol | Meaning |
+|--------|---------|
+| `┌─┬─┐ │ └─┴─┘` | Box borders and dividers |
+| `[...]` | Button or interactive element |
+| `{...}` | Input field |
+| `████` | Image placeholder |
+| `~~~~` | Text content placeholder |
+| `────` | Horizontal rule / divider |

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: workflow
-description: |
-  Reference for how the wicked-crew workflow engine operates — phase catalog, gate enforcement,
-  rigor tiers, and facilitator rubric. Use when understanding or troubleshooting crew phase
-  mechanics (gate config, CONDITIONAL resolution, phase dependencies).
-  NOT for starting a project (use crew:start) or proposing a process plan (use propose-process).
-context: fork
-
-**Plain:** wicked-crew v6 — propose-process rubric picks phases and rigor tier;
-gates are hard enforcement; two interaction modes (normal / yolo).
+description: "Reference for wicked-crew v6 workflow engine — phase catalog, gate enforcement, rigor tiers, and facilitator rubric. Use when: troubleshooting crew phase mechanics, understanding gate config, resolving CONDITIONAL verdicts, checking phase dependencies, or debugging specialist routing. NOT for starting a project (use crew:start) or proposing a process plan (use propose-process)."
 ---
 
 # Workflow Skill (v6)


### PR DESCRIPTION
Hey @mikeparcewski 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| workflow | 10% | 94% | +84% |
| facilitator-score | 17% | 99% | +82% |
| persona | 17% | 80% | +63% |
| context-engineering | 55% | 89% | +34% |
| mockup | 55% | 88% | +33% |

This PR covers your 5 lowest-scoring skill(s) in the repo (out of 76 total). The five-skill cap keeps the review manageable — the included GitHub Action covers ongoing review for the rest on future PRs.

<details>
<summary>What changed in workflow</summary>

- **Fixed YAML frontmatter** — `**Plain:**` was parsed as a YAML alias `*Plain:**`, causing a parse failure that zeroed out the entire score
- **Description rewritten** as a quoted string with explicit "Use when:" clause listing five concrete scenarios (troubleshooting phase mechanics, understanding gate config, resolving CONDITIONAL verdicts, checking phase dependencies, debugging specialist routing)
- **Removed unknown frontmatter key** `context: fork` to clear the validation warning

</details>

<details>
<summary>What changed in facilitator-score</summary>

- **Fixed `allowed-tools` type** — changed from YAML array to string (`"wicked-garden:ground"`) to pass validation
- **Description rewritten** with concrete action verbs, explicit "Use when:" clause, and natural trigger terms (risk factors, pre-scoring, rubric justification)
- **Removed unknown frontmatter key** `portability: portable`
- **Fixed stray code fence** after the backward-compat note

</details>

<details>
<summary>What changed in persona</summary>

- **Removed XML tag from description** — `<role>` in `"review as <role>"` was flagged as an XML tag, causing a validation failure
- **Description rewritten** in third person with explicit built-in persona names and "Use when:" clause
- **Removed unknown frontmatter key** `disable-model-invocation: true`

</details>

<details>
<summary>What changed in context-engineering</summary>

- **Replaced conceptual padding** with actionable content — removed explanations of what context windows are, model token limits, and basic memory pattern definitions that Claude already knows
- **Added executable code examples** — `compress_history()`, `load_context()`, `TokenBudget` class
- **Added concrete workflow** — 5-step Context Budget Workflow with validation checkpoints
- **Description rewritten** with specific concrete actions and "Not for" exclusion clause
- **Removed unknown frontmatter key** `portability: portable`

</details>

<details>
<summary>What changed in mockup</summary>

- **Description rewritten** in third person with rich trigger terms (sketching, wireframing, prototyping, mockup, developer handoff spec) and explicit "Not for" boundary
- **Trimmed template-heavy content** — removed ASCII Symbol Guide (Claude knows box-drawing), condensed HTML boilerplate, removed verbose component spec template from main file
- **Created refs/ for progressive disclosure** — moved component spec template and handoff notes to `refs/component-specs.md` and `refs/handoff-notes.md` per SKILLS-GUIDELINES.md
- **Added Quick Start section** with concrete usage examples

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
