### PR TITLE
[codex] fix: close #689 polish bundle

### DIFF
--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -232,7 +232,7 @@ Skill(
   skill="wicked-brain:memory",
   args={"action": "store", "type": "decision",
         "title": "crew:start facilitator plan for {slug}",
-        "content": "<summary from JSON + per-factor risk_level (low/medium/high_risk — see #627; do NOT paste raw `reading` HIGH/MED/LOW into human-readable text) + rigor_tier + specialist list>",
+        "content": "<summary from JSON + per-factor risk_level (low_risk/medium_risk/high_risk — see #627; do NOT paste raw `reading` HIGH/MED/LOW into human-readable text) + rigor_tier + specialist list>",
         "tags": ["crew", "facilitator", "process-plan", "{slug}"],
         "importance": 6}
 )

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3252,9 +3252,9 @@ def _sync_gate_finding_task(
     if not project_name:
         return
 
-    # Resolve the chain_id prefix that gate-finding tasks carry for this project.
-    # Pattern: "{project}.{phase}.{gate}" or "{project}.{phase}".
-    # We match any chain_id starting with "{project}.{phase}".
+    # Resolve the chain_id prefix that gate-finding tasks carry for this
+    # project. Valid matches are exactly "{project}.{phase}" or
+    # "{project}.{phase}.{gate}".
     expected_chain_prefix = f"{project_name}.{phase}"
 
     verdict: Optional[str] = None
@@ -3275,6 +3275,16 @@ def _sync_gate_finding_task(
             except (TypeError, ValueError):
                 min_score = None
 
+    if min_score is None:
+        logger.warning(
+            "WARNING: [approve] _sync_gate_finding_task missing valid min_score "
+            "for phase=%s (project=%s) — skipping task sync to avoid writing "
+            "schema-invalid completed metadata",
+            phase,
+            project_name,
+        )
+        return
+
     # CONDITIONAL verdict requires conditions_manifest_path in completed
     # metadata (scripts/_event_schema.py#L191-192). The path is deterministic
     # — phase_manager writes it to {project_dir}/phases/{phase}/conditions-manifest.json
@@ -3288,8 +3298,21 @@ def _sync_gate_finding_task(
                 / "conditions-manifest.json"
             )
             conditions_manifest_path = str(manifest_path)
-        except Exception:
-            conditions_manifest_path = None
+        except Exception as exc:
+            print(
+                "WARNING: [approve] _sync_gate_finding_task could not resolve "
+                f"conditions_manifest_path for project={project_name} "
+                f"phase={phase}: {exc}",
+                file=sys.stderr,
+            )
+            logger.warning(
+                "WARNING: [approve] _sync_gate_finding_task could not resolve "
+                "conditions_manifest_path for project=%s phase=%s: %s",
+                project_name,
+                phase,
+                exc,
+            )
+            return
 
     session_id = os.environ.get("CLAUDE_SESSION_ID", "")
     if not session_id:
@@ -3334,7 +3357,10 @@ def _sync_gate_finding_task(
             if meta.get("phase") != phase:
                 continue
             chain_id = meta.get("chain_id", "")
-            if not isinstance(chain_id, str) or not chain_id.startswith(expected_chain_prefix):
+            if not isinstance(chain_id, str) or (
+                chain_id != expected_chain_prefix
+                and not chain_id.startswith(f"{expected_chain_prefix}.")
+            ):
                 continue
 
             try:
@@ -3345,10 +3371,10 @@ def _sync_gate_finding_task(
     except Exception as exc:
         # Scan error — log and bail. Approve flow continues.
         print(
-            f"[approve] _sync_gate_finding_task scan error: {exc}",
+            f"WARNING: [approve] _sync_gate_finding_task scan error: {exc}",
             file=sys.stderr,
         )
-        logger.debug("[approve] _sync_gate_finding_task scan error: %s", exc)
+        logger.warning("WARNING: [approve] _sync_gate_finding_task scan error: %s", exc)
         return
 
     if not matches:
@@ -3395,11 +3421,11 @@ def _sync_gate_finding_task(
         # Write failure — log to stderr (visible to operators) and continue.
         # Approve flow MUST NOT fail just because a task-store write broke.
         print(
-            f"[approve] gate-finding task sync write failed: {exc}",
+            f"WARNING: [approve] gate-finding task sync write failed: {exc}",
             file=sys.stderr,
         )
-        logger.debug(
-            "[approve] gate-finding task sync write failed: %s", exc
+        logger.warning(
+            "WARNING: [approve] gate-finding task sync write failed: %s", exc
         )
 
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3276,8 +3276,14 @@ def _sync_gate_finding_task(
                 min_score = None
 
     if min_score is None:
-        logger.warning(
+        print(
             "WARNING: [approve] _sync_gate_finding_task missing valid min_score "
+            f"for phase={phase} project={project_name}; skipping task sync to "
+            "avoid writing schema-invalid completed metadata",
+            file=sys.stderr,
+        )
+        logger.warning(
+            "[approve] _sync_gate_finding_task missing valid min_score "
             "for phase=%s (project=%s) — skipping task sync to avoid writing "
             "schema-invalid completed metadata",
             phase,
@@ -3306,7 +3312,7 @@ def _sync_gate_finding_task(
                 file=sys.stderr,
             )
             logger.warning(
-                "WARNING: [approve] _sync_gate_finding_task could not resolve "
+                "[approve] _sync_gate_finding_task could not resolve "
                 "conditions_manifest_path for project=%s phase=%s: %s",
                 project_name,
                 phase,
@@ -3374,7 +3380,7 @@ def _sync_gate_finding_task(
             f"WARNING: [approve] _sync_gate_finding_task scan error: {exc}",
             file=sys.stderr,
         )
-        logger.warning("WARNING: [approve] _sync_gate_finding_task scan error: %s", exc)
+        logger.warning("[approve] _sync_gate_finding_task scan error: %s", exc)
         return
 
     if not matches:
@@ -3425,7 +3431,7 @@ def _sync_gate_finding_task(
             file=sys.stderr,
         )
         logger.warning(
-            "WARNING: [approve] gate-finding task sync write failed: %s", exc
+            "[approve] gate-finding task sync write failed: %s", exc
         )
 
 

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -48,7 +48,8 @@ VALID_FACTOR_READINGS = {"LOW", "MEDIUM", "HIGH"}
 VALID_FACTOR_RISK_LEVELS = {"low_risk", "medium_risk", "high_risk"}
 # Mapping mirrors `_RISK_INVERSION` in `scripts/crew/factor_questionnaire.py`.
 # Keep the two in sync — drift here means the validator stops catching producer
-# regression. Tests cover the round-trip in tests/crew/test_validate_plan.py.
+# regression. Tests cover the round-trip in tests/test_validate_plan_test_strategy_check.py
+# plus the validate_plan selftest fixtures below.
 _EXPECTED_RISK_LEVEL_FOR_READING = {
     "HIGH": "low_risk",
     "MEDIUM": "medium_risk",
@@ -155,10 +156,14 @@ def _check_factors(plan: dict, violations: list) -> None:
                 f"factors.{key}.reading — '{reading}' is not one of {sorted(VALID_FACTOR_READINGS)}"
             )
         # #627: `risk_level` is the user-facing translation of `reading`.
-        # Allow it to be absent on legacy plans (back-compat with pre-#626
-        # facilitator output) but reject any drift when it IS present.
-        if "risk_level" in value:
-            risk_level = value.get("risk_level")
+        # Facilitator output is expected to carry it on every factor; missing
+        # it is now treated as producer regression.
+        risk_level = value.get("risk_level")
+        if "risk_level" not in value:
+            violations.append(
+                f"factors.{key}.risk_level — missing required key 'risk_level'"
+            )
+        else:
             if risk_level not in VALID_FACTOR_RISK_LEVELS:
                 violations.append(
                     f"factors.{key}.risk_level — '{risk_level}' is not one of "
@@ -419,7 +424,7 @@ _VALID_FIXTURE = {
     "rigor_tier": "standard",
     "complexity": 3,
     "factors": {
-        key: {"reading": "LOW", "why": "because reasons"}
+        key: {"reading": "LOW", "risk_level": "high_risk", "why": "because reasons"}
         for key in REQUIRED_FACTOR_KEYS
     },
     "specialists": [{"name": "backend-engineer", "why": "writes the code"}],
@@ -447,7 +452,10 @@ _INVALID_FIXTURES = [
     ("bad rigor_tier", lambda p: {**p, "rigor_tier": "turbo"}),
     ("bad factor reading", lambda p: {
         **p,
-        "factors": {**p["factors"], "reversibility": {"reading": "MAYBE", "why": "idk"}},
+        "factors": {
+            **p["factors"],
+            "reversibility": {"reading": "MAYBE", "risk_level": "high_risk", "why": "idk"},
+        },
     }),
     ("missing task metadata key", lambda p: {
         **p,
@@ -468,6 +476,14 @@ _INVALID_FIXTURES = [
         "factors": {
             **p["factors"],
             "reversibility": {"reading": "LOW", "risk_level": "wat", "why": "idk"},
+        },
+    }),
+    # #689: risk_level is now required on every factor entry.
+    ("missing factor risk_level", lambda p: {
+        **p,
+        "factors": {
+            **p["factors"],
+            "reversibility": {"reading": "LOW", "why": "idk"},
         },
     }),
     # #627: risk_level mismatched against reading (LOW reading == high_risk)

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -31,13 +31,6 @@ rubric against a scenario's expected-outcome block.
     "operational_risk":   {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."},
     "coordination_cost":  {"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."}
   },
-  // NB(#627): each factor entry carries BOTH `reading` (HIGH/MEDIUM/LOW;
-  // HIGH = safest, LOW = riskiest — backward-compat convention) AND
-  // `risk_level` (low_risk/medium_risk/high_risk — direction-explicit,
-  // user-facing). Internal logic (threshold/diff) uses `reading`; any
-  // user-facing display (process-plan.md, brain memory content, status
-  // summaries) MUST use `risk_level` to avoid the inversion footgun.
-  // `reading` is a candidate for deprecation in a future major.
   "specialists": [
     {"name": "requirements-analyst", "why": "one sentence"},
     {
@@ -89,6 +82,13 @@ rubric against a scenario's expected-outcome block.
   ]
 }
 ```
+
+Note: each factor entry carries BOTH `reading` (HIGH/MEDIUM/LOW; HIGH = safest,
+LOW = riskiest, for backward compatibility) AND `risk_level`
+(`low_risk`/`medium_risk`/`high_risk`, direction-explicit and user-facing).
+Internal logic may still use `reading`, but any human-readable output should use
+`risk_level` to avoid the inversion footgun. `reading` remains a candidate for
+future deprecation.
 
 ---
 

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -1079,7 +1079,7 @@ class TestSyncGateFindingTask(unittest.TestCase):
             original_sha = hashlib.sha256(original_bytes).hexdigest()
 
             state = _make_state(name="noop-proj")
-            gate_result = {"verdict": "APPROVE", "score": 0.9}
+            gate_result = {"verdict": "APPROVE", "score": 0.9, "min_score": 0.7}
 
             with patch.dict(
                 os.environ,
@@ -1140,7 +1140,7 @@ class TestSyncGateFindingTask(unittest.TestCase):
     def test_sync_fail_open_no_session_id(self):
         """Missing CLAUDE_SESSION_ID is silently a no-op (fail-open)."""
         state = _make_state(name="failopen-proj")
-        gate_result = {"verdict": "APPROVE", "score": 0.9}
+        gate_result = {"verdict": "APPROVE", "score": 0.9, "min_score": 0.7}
         # Remove CLAUDE_SESSION_ID from env; must not raise.
         env = {k: v for k, v in os.environ.items() if k != "CLAUDE_SESSION_ID"}
         with patch.dict(os.environ, env, clear=True):

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -994,7 +994,12 @@ class TestSyncGateFindingTask(unittest.TestCase):
             task_file = self._write_task(tasks_dir, "task-gate-1", gate_task)
 
             state = _make_state(name="sync-proj")
-            gate_result = {"verdict": "APPROVE", "result": "APPROVE", "score": 0.82}
+            gate_result = {
+                "verdict": "APPROVE",
+                "result": "APPROVE",
+                "score": 0.82,
+                "min_score": 0.7,
+            }
 
             with patch.dict(
                 os.environ,
@@ -1183,7 +1188,7 @@ class TestSyncGateFindingTask(unittest.TestCase):
             os.utime(new_path, (1_900_000_000.0, 1_900_000_000.0))
 
             state = _make_state(name="multi-proj")
-            gate_result = {"verdict": "APPROVE", "score": 0.81}
+            gate_result = {"verdict": "APPROVE", "score": 0.81, "min_score": 0.7}
 
             with patch.dict(
                 os.environ,
@@ -1201,6 +1206,39 @@ class TestSyncGateFindingTask(unittest.TestCase):
                 old_sha,
                 "older gate-finding task was rewritten — only the most-recent "
                 "(mtime) match should be touched on re-eval scenarios",
+            )
+
+    def test_sync_ignores_chain_id_prefix_collisions(self):
+        """A sibling phase prefix must not match the requested phase (#689)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-prefix"
+            colliding_task = {
+                "id": "task-collide",
+                "subject": "Gate: design-review",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "design",
+                    "chain_id": "prefix-proj.design-review.code-quality",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-collide", colliding_task)
+            original_sha = hashlib.sha256(task_file.read_bytes()).hexdigest()
+
+            state = _make_state(name="prefix-proj")
+            gate_result = {"verdict": "APPROVE", "score": 0.81, "min_score": 0.7}
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-prefix", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "design", gate_result)
+
+            self.assertEqual(
+                hashlib.sha256(task_file.read_bytes()).hexdigest(),
+                original_sha,
+                "phase prefix collision rewrote the wrong gate-finding task",
             )
 
     def test_sync_conditional_writes_conditions_manifest_path(self):
@@ -1254,6 +1292,43 @@ class TestSyncGateFindingTask(unittest.TestCase):
             )
             self.assertTrue(cmp.endswith("conditions-manifest.json"))
             self.assertIn("clarify", cmp)
+
+    def test_sync_conditional_skips_completion_when_manifest_path_unavailable(self):
+        """A CONDITIONAL verdict must not complete without manifest path (#689)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-cond-missing"
+            gate_task = {
+                "id": "task-gate-cond-missing",
+                "subject": "Gate: clarify",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "clarify",
+                    "chain_id": "cond-missing-proj.clarify.requirements",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-cond-missing", gate_task)
+            original = json.loads(task_file.read_text())
+
+            state = _make_state(name="cond-missing-proj")
+            gate_result = {
+                "verdict": "CONDITIONAL",
+                "result": "CONDITIONAL",
+                "score": 0.65,
+                "min_score": 0.6,
+            }
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-cond-missing", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                with patch.object(pm, "get_project_dir", side_effect=RuntimeError("boom")):
+                    pm._sync_gate_finding_task(state, "clarify", gate_result)
+
+            after = json.loads(task_file.read_text())
+            self.assertEqual(after, original)
+            self.assertEqual(after["status"], "in_progress")
 
     def test_sync_reject_marks_task_completed_with_reject_verdict(self):
         """REJECT verdict still marks task completed with REJECT in metadata.
@@ -1327,7 +1402,7 @@ class TestSyncGateFindingTask(unittest.TestCase):
             self._write_task(tasks_dir, "task-write-fail", gate_task)
 
             state = _make_state(name="writefail-proj")
-            gate_result = {"verdict": "APPROVE", "score": 0.9}
+            gate_result = {"verdict": "APPROVE", "score": 0.9, "min_score": 0.7}
 
             # Patch Path.write_text to raise OSError on the gate-finding
             # task file, simulating a permission / ENOSPC failure.
@@ -1384,6 +1459,40 @@ class TestSyncGateFindingTask(unittest.TestCase):
             updated = json.loads(task_file.read_text())
             self.assertEqual(updated["status"], "completed")
             self.assertAlmostEqual(updated["metadata"]["min_score"], 0.8)
+
+    def test_sync_skips_completion_when_min_score_missing(self):
+        """Completed gate-finding metadata must not omit min_score (#689)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks" / "sess-min-missing"
+            gate_task = {
+                "id": "task-gate-min-missing",
+                "subject": "Gate: review",
+                "status": "in_progress",
+                "metadata": {
+                    "event_type": "gate-finding",
+                    "phase": "review",
+                    "chain_id": "min-missing-proj.review.evidence",
+                    "source_agent": "gate-adjudicator",
+                },
+            }
+            task_file = self._write_task(tasks_dir, "task-gate-min-missing", gate_task)
+            original = json.loads(task_file.read_text())
+
+            state = _make_state(name="min-missing-proj")
+            gate_result = {
+                "verdict": "APPROVE",
+                "score": 0.92,
+            }
+
+            with patch.dict(
+                os.environ,
+                {"CLAUDE_SESSION_ID": "sess-min-missing", "CLAUDE_CONFIG_DIR": tmpdir},
+            ):
+                pm._sync_gate_finding_task(state, "review", gate_result)
+
+            after = json.loads(task_file.read_text())
+            self.assertEqual(after, original)
+            self.assertEqual(after["status"], "in_progress")
 
 
 if __name__ == "__main__":

--- a/tests/test_event_schema_gate_finding_lifecycle.py
+++ b/tests/test_event_schema_gate_finding_lifecycle.py
@@ -76,6 +76,19 @@ def test_gate_finding_completion_with_approve_fields_passes():
     assert err is None, f"completed APPROVE should validate, got: {err}"
 
 
+def test_gate_finding_completion_without_min_score_fails():
+    """#689: completed gate-finding missing min_score must fail validation."""
+    metadata = {
+        **_SHELL_METADATA,
+        "verdict": "APPROVE",
+        "score": 0.85,
+    }
+    err = validate_metadata(metadata, status="completed")
+    assert err is not None and "min_score" in err, (
+        f"completed metadata missing min_score should fail, got: {err}"
+    )
+
+
 def test_gate_finding_completion_approve_below_min_score_fails():
     """#570: completion still enforces APPROVE score >= min_score ordering."""
     metadata = {

--- a/tests/test_specialist_resolver.py
+++ b/tests/test_specialist_resolver.py
@@ -192,7 +192,11 @@ def _valid_plan_with_specialist(name: str) -> dict:
         "rigor_tier": "standard",
         "complexity": 3,
         "factors": {
-            key: {"reading": "LOW", "why": "because reasons"}
+            key: {
+                "reading": "LOW",
+                "risk_level": "high_risk",
+                "why": "because reasons",
+            }
             for key in (
                 "reversibility",
                 "blast_radius",

--- a/tests/test_validate_plan_test_strategy_check.py
+++ b/tests/test_validate_plan_test_strategy_check.py
@@ -46,7 +46,11 @@ def _base_plan() -> dict:
         "rigor_tier": "standard",
         "complexity": 3,
         "factors": {
-            key: {"reading": "LOW", "why": "fixture baseline"}
+            key: {
+                "reading": "LOW",
+                "risk_level": "high_risk",
+                "why": "fixture baseline",
+            }
             for key in validate_plan.REQUIRED_FACTOR_KEYS
         },
         "specialists": [
@@ -165,6 +169,39 @@ def test_warning_names_every_offending_task_id():
     [warn] = validate_plan.warnings(plan)
     assert "t1" in warn["message"]
     assert "t2" in warn["message"]
+
+
+def test_validate_rejects_missing_factor_risk_level():
+    """Issue #689: missing factor risk_level is producer regression."""
+    plan = _base_plan()
+    del plan["factors"]["reversibility"]["risk_level"]
+    violations = validate_plan.validate(plan)
+    assert any(
+        "factors.reversibility.risk_level" in v and "missing required key" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_rejects_bad_factor_risk_level_enum():
+    """Issue #689: invalid risk_level enum is rejected."""
+    plan = _base_plan()
+    plan["factors"]["reversibility"]["risk_level"] = "wat"
+    violations = validate_plan.validate(plan)
+    assert any(
+        "factors.reversibility.risk_level" in v and "not one of" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_rejects_inverted_factor_risk_level():
+    """Issue #689: risk_level must agree with reading."""
+    plan = _base_plan()
+    plan["factors"]["reversibility"]["risk_level"] = "low_risk"
+    violations = validate_plan.validate(plan)
+    assert any(
+        "factors.reversibility" in v and "does not match reading" in v
+        for v in violations
+    ), violations
 
 
 def test_existing_specialist_check_still_passes():


### PR DESCRIPTION
## Summary

- tighten gate-finding task sync so phase prefix collisions do not rewrite the wrong native task
- refuse to complete gate-finding tasks when min_score is missing or a CONDITIONAL manifest path cannot be resolved
- require factor risk_level in validate_plan and align selftest fixtures/docs with the current schema
- add regression coverage for phase_manager sync, event-schema validation, and validate_plan risk_level enforcement

## Root Cause

PRs #687 and #688 fixed the main paths but left follow-up gaps: loose chain_id prefix matching, fail-open completion paths that could stamp schema-invalid task metadata, and validator/docs drift around risk_level.

## Validation

- pytest -q tests/crew/test_phase_manager.py -k "sync_"
- pytest -q tests/test_event_schema_gate_finding_lifecycle.py tests/test_validate_plan_test_strategy_check.py tests/test_specialist_resolver.py
- python3 scripts/crew/validate_plan.py --selftest

Closes #689
