### PR TITLE
chore(skills): PR 2a/6 — description hygiene, half 1 (7 files)

### DIFF
--- a/skills/agentic/trust-and-safety/SKILL.md
+++ b/skills/agentic/trust-and-safety/SKILL.md
@@ -2,7 +2,8 @@
 name: trust-and-safety
 description: |
   Trust, safety, and control patterns for production agentic systems with human-in-the-loop gates and guardrails.
-  Use when: "agent safety", "guardrails", "human-in-the-loop", "agent trust", "prompt injection defense"
+  Use when: designing guardrails or human-in-the-loop gates for an agent, or
+  hardening an agentic system against prompt injection.
 portability: portable
 ---
 

--- a/skills/agentic/trust-and-safety/SKILL.md
+++ b/skills/agentic/trust-and-safety/SKILL.md
@@ -2,6 +2,7 @@
 name: trust-and-safety
 description: |
   Trust, safety, and control patterns for production agentic systems with human-in-the-loop gates and guardrails.
+
   Use when: designing guardrails or human-in-the-loop gates for an agent, or
   hardening an agentic system against prompt injection.
 portability: portable

--- a/skills/crew/adaptive/SKILL.md
+++ b/skills/crew/adaptive/SKILL.md
@@ -4,9 +4,8 @@ description: |
   Adaptive engagement patterns for wicked-crew based on context, phase, and user preferences.
   Controls autonomy levels (just-finish, balanced, ask-first) and communication style.
 
-  Use when: "autonomy mode", "crew autonomy", "how much to ask", "just finish it",
-  "ask me before", "adapt to my style", "preference profile", "autonomy level",
-  "just-finish", "ask-first", "balanced autonomy", or setting engagement preferences.
+  Use when: setting or changing autonomy level (just-finish / balanced / ask-first),
+  adjusting communication style, or applying a saved engagement preference profile.
 ---
 
 # Adaptive Engagement Skill

--- a/skills/crew/crew-qe-gate/SKILL.md
+++ b/skills/crew/crew-qe-gate/SKILL.md
@@ -5,9 +5,8 @@ description: |
   Runs gate analysis at crew checkpoints (post-clarify, post-design, post-build) to validate
   readiness before advancing. Quality checkpoint within the wicked-crew workflow.
 
-  Use when: "quality gate", "value gate", "strategy gate", "execution gate",
-  "gate analysis", "quality checkpoint", "phase gate", "crew quality gate",
-  "ready to advance", "should we build this", "does it work", "crew QE checkpoint"
+  Use when: running a value / strategy / execution gate at a crew checkpoint,
+  validating phase-transition readiness, or asking "is this ready to advance".
 ---
 
 # Crew QE Gate Skill

--- a/skills/crew/evidence-validation/SKILL.md
+++ b/skills/crew/evidence-validation/SKILL.md
@@ -5,9 +5,8 @@ description: |
   at the appropriate level for the task's complexity score. Three tiers (low,
   medium, high) map to complexity ranges 1-2, 3-4, 5-7.
 
-  Use when: "validate evidence", "check task completion", "evidence required",
-  "missing evidence", "evidence schema", "task description review",
-  or validating a TaskUpdate description before marking complete.
+  Use when: validating a TaskUpdate description before marking complete, or
+  checking that evidence fields match the task's complexity tier.
 ---
 
 # Evidence Validation Skill

--- a/skills/delivery/reporting/SKILL.md
+++ b/skills/delivery/reporting/SKILL.md
@@ -4,9 +4,8 @@ description: |
   Multi-perspective project delivery reporting with persona-based analysis.
   Generates actionable reports from project data using 6 specialized stakeholder perspectives.
 
-  Use when: "generate report", "delivery report", "project status report",
-  "sprint retrospective", "steering committee report", "stakeholder update",
-  "project health summary"
+  Use when: generating a delivery / status report, preparing a sprint
+  retrospective, or producing a stakeholder update from project data.
 
   Enhanced with:
   - wicked-brain:memory Stores insights across sessions

--- a/skills/engineering/unit-test-quality/SKILL.md
+++ b/skills/engineering/unit-test-quality/SKILL.md
@@ -9,10 +9,8 @@ description: |
   retest, constant verification, sleep-coupled, exception-swallowing), and a
   one-line decision rule per pattern.
 
-  Use when: writing a new unit test, reviewing a test diff, auditing a suite
-  with high coverage but low confidence, "is this test worth keeping",
-  "why didn't our tests catch that bug", before approving a PR that adds tests,
-  pairing a test with a bug fix, "this test feels redundant".
+  Use when: writing or reviewing a unit test, auditing a suite with high
+  coverage but low confidence, or pairing a regression test with a bug fix.
 status: stable
 portability: portable
 ---

--- a/skills/platform/health/SKILL.md
+++ b/skills/platform/health/SKILL.md
@@ -4,7 +4,8 @@ description: |
   System health overview from discovered observability sources. Aggregates errors,
   performance metrics, and SLO status across services. Correlates with deployments
   and code changes. Use for proactive health monitoring and post-deployment validation.
-  Use when: "system health", "health check", "deployment health", "production status", "how is production"
+  Use when: checking aggregated system health, validating a post-deployment
+  state, or correlating production status with recent changes.
 portability: portable
 ---
 

--- a/skills/platform/health/SKILL.md
+++ b/skills/platform/health/SKILL.md
@@ -4,6 +4,7 @@ description: |
   System health overview from discovered observability sources. Aggregates errors,
   performance metrics, and SLO status across services. Correlates with deployments
   and code changes. Use for proactive health monitoring and post-deployment validation.
+
   Use when: checking aggregated system health, validating a post-deployment
   state, or correlating production status with recent changes.
 portability: portable


### PR DESCRIPTION
## Summary

PR 2a of 6 in the salvage sweep after rejecting vendor PR #695. **Pure description-field edits** in 7 SKILL.md files. Trims keyword-stuffed \"Use when:\" clauses to 2-4 specific triggers per skill.

## Files

| File | Before | After |
|------|--------|-------|
| `skills/crew/adaptive` | 11 quoted triggers | 1 sentence with 3 distinctive triggers |
| `skills/crew/crew-qe-gate` | **12 quoted triggers** (worst in repo) | 1 sentence |
| `skills/crew/evidence-validation` | 6 quoted triggers | 1 sentence |
| `skills/delivery/reporting` | 7 quoted triggers | 1 sentence (Enhanced with: kept) |
| `skills/engineering/unit-test-quality` | 8 triggers | 1 sentence |
| `skills/platform/health` | 5 quoted triggers | 1 sentence |
| `skills/agentic/trust-and-safety` | 5 quoted phrases | 1 sentence |

## Council guidance applied

- Preserved \`Use when:\` / \`Enhanced with:\` block structure intact (routing logic, not fluff).
- Carved out \`agentic/agentic-patterns\` and \`agentic/context-engineering\` — those go in PR 3a where their templates also get extracted; bundling avoids merge-conflict on the same frontmatter block.

## Hard guardrails (PR #695 anti-patterns NOT repeated)

- ✅ No \`disable-model-invocation:\` removed
- ✅ No \`context: fork\` removed
- ✅ No \`portability: portable\` removed
- ✅ No \`allowed-tools:\` array→string conversion
- ✅ Diff guardrail: only \`description:\` field changed in any file (verified)

## Test plan

- [x] \`scripts/ci/validate.py\` PASS
- [x] All files remain under 200-line cap
- [x] Frontmatter-key guardrail grep — no protected keys touched

## Sweep status

- ✅ PR 1/6 stale-facts (#697, merged)
- 🔄 PR 2a/6 — this PR
- ⏳ PR 2b/6 — description hygiene half 2 (product + root domains)
- ⏳ PR 3a/6 — agentic-patterns + context-engineering extractions
- ⏳ PR 3b/6 — github-actions + gitlab-ci extractions
- ⏳ PR 3c/6 — worktrees + mockup extractions

🤖 Generated with [Claude Code](https://claude.com/claude-code)