### PR TITLE
chore(skills): PR 3c/6 — extract worktrees recipes + mockup templates (FINAL)

### DIFF
--- a/skills/product/mockup/SKILL.md
+++ b/skills/product/mockup/SKILL.md
@@ -67,7 +67,7 @@ Full template: `refs/templates.md` § HTML/CSS Preview.
 
 For developer handoff without visual preview, use the spec template. Sections: Anatomy, States table, Spacing tokens, Responsive Behavior, Accessibility Notes.
 
-Full template: `refs/templates.md` § Component Spec.
+Full template: `refs/templates.md` § Component Spec (Markdown).
 
 ## Wireframe from Description
 

--- a/skills/product/mockup/SKILL.md
+++ b/skills/product/mockup/SKILL.md
@@ -59,77 +59,15 @@ Fast, text-based layout sketches. Use for early ideation and flow discussion.
 
 ## HTML/CSS Preview
 
-For higher-fidelity mockups, generate minimal HTML with inline or embedded CSS:
+For higher-fidelity mockups, generate minimal HTML with embedded CSS using design tokens. Match the project's existing tokens if available (check `styles/tokens.css` or equivalent).
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Mockup: {component name}</title>
-<style>
-  /* Design tokens */
-  :root {
-    --color-primary: #3b82f6;
-    --color-surface: #f9fafb;
-    --space-4: 1rem;
-    --space-6: 1.5rem;
-    --text-sm: 0.875rem;
-    --text-base: 1rem;
-    --text-lg: 1.125rem;
-    --radius: 0.5rem;
-  }
-  /* Component styles */
-  .card {
-    background: var(--color-surface);
-    border-radius: var(--radius);
-    padding: var(--space-6);
-  }
-</style>
-</head>
-<body>
-  <!-- mockup content -->
-</body>
-</html>
-```
+Full template: `refs/templates.md` § HTML/CSS Preview.
 
 ## Component Specs (Markdown)
 
-For developer handoff without visual preview:
+For developer handoff without visual preview, use the spec template. Sections: Anatomy, States table, Spacing tokens, Responsive Behavior, Accessibility Notes.
 
-```markdown
-## Component: {Name}
-
-### Anatomy
-- **Container**: {background, border, border-radius, padding}
-- **Header**: {font-size, font-weight, color}
-- **Body**: {font-size, line-height, color}
-- **Action**: {button variant, size}
-
-### States
-| State | Visual Change |
-|-------|--------------|
-| Default | {description} |
-| Hover | {description} |
-| Active | {description} |
-| Disabled | {opacity: 0.5, cursor: not-allowed} |
-
-### Spacing
-- Internal padding: {token}
-- Gap between elements: {token}
-- External margin: {token or "handled by parent"}
-
-### Responsive Behavior
-- Mobile (<768px): {layout change}
-- Tablet (768–1024px): {layout change}
-- Desktop (>1024px): {base layout}
-
-### Accessibility Notes
-- Role: {semantic element or ARIA role}
-- Focus: {keyboard interaction}
-- Labels: {aria-label or visible label}
-```
+Full template: `refs/templates.md` § Component Spec.
 
 ## Wireframe from Description
 
@@ -143,17 +81,9 @@ When given a description, generate a wireframe in this sequence:
 
 ## Integration with Frontend Design
 
-When handing off to developers:
+When handing off to developers, attach handoff notes covering: design tokens to use, closest existing component, new patterns required, assets needed, animation specs.
 
-```markdown
-## Handoff Notes for {component}
-
-**Design tokens to use**: See `styles/tokens.css`
-**Closest existing component**: {component name in codebase}
-**New patterns required**: {list any novel patterns}
-**Assets needed**: {icons, images, fonts}
-**Animation**: {transition type, duration}
-```
+Template: `refs/templates.md` § Handoff Notes.
 
 ## Output Checklist
 

--- a/skills/product/mockup/refs/templates.md
+++ b/skills/product/mockup/refs/templates.md
@@ -1,6 +1,6 @@
 # Mockup Templates
 
-Copy-paste templates for the three mockup output formats. The SKILL.md selection table tells you when to use each.
+Copy-paste templates for three common mockup deliverables: HTML/CSS preview, component spec, and handoff notes. See the SKILL.md selection table for when to use each output format.
 
 ## HTML/CSS Preview
 

--- a/skills/product/mockup/refs/templates.md
+++ b/skills/product/mockup/refs/templates.md
@@ -1,0 +1,91 @@
+# Mockup Templates
+
+Copy-paste templates for the three mockup output formats. The SKILL.md selection table tells you when to use each.
+
+## HTML/CSS Preview
+
+Minimal HTML with embedded CSS using design tokens. Match the project's existing tokens if available (check `styles/tokens.css` or equivalent).
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup: {component name}</title>
+<style>
+  /* Design tokens */
+  :root {
+    --color-primary: #3b82f6;
+    --color-surface: #f9fafb;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --text-sm: 0.875rem;
+    --text-base: 1rem;
+    --text-lg: 1.125rem;
+    --radius: 0.5rem;
+  }
+  /* Component styles */
+  .card {
+    background: var(--color-surface);
+    border-radius: var(--radius);
+    padding: var(--space-6);
+  }
+</style>
+</head>
+<body>
+  <!-- mockup content -->
+</body>
+</html>
+```
+
+## Component Spec (Markdown)
+
+For developer handoff without visual preview:
+
+```markdown
+## Component: {Name}
+
+### Anatomy
+- **Container**: {background, border, border-radius, padding}
+- **Header**: {font-size, font-weight, color}
+- **Body**: {font-size, line-height, color}
+- **Action**: {button variant, size}
+
+### States
+| State | Visual Change |
+|-------|--------------|
+| Default | {description} |
+| Hover | {description} |
+| Active | {description} |
+| Disabled | {opacity: 0.5, cursor: not-allowed} |
+
+### Spacing
+- Internal padding: {token}
+- Gap between elements: {token}
+- External margin: {token or "handled by parent"}
+
+### Responsive Behavior
+- Mobile (<768px): {layout change}
+- Tablet (768–1024px): {layout change}
+- Desktop (>1024px): {base layout}
+
+### Accessibility Notes
+- Role: {semantic element or ARIA role}
+- Focus: {keyboard interaction}
+- Labels: {aria-label or visible label}
+```
+
+## Handoff Notes
+
+When handing off a mockup to developers:
+
+```markdown
+## Handoff Notes for {component}
+
+**Design tokens to use**: See `styles/tokens.css`
+**Closest existing component**: {component name in codebase}
+**New patterns required**: {list any novel patterns}
+**Assets needed**: {icons, images, fonts}
+**Animation**: {transition type, duration}
+```

--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -25,142 +25,43 @@ and a quiet source of three repeating bugs.
 
 ### 1. Subagent dangling commits
 
-A subagent dispatched into an isolated worktree commits inside that
-worktree. The commit lands in the object database but the branch ref
-lives only inside the worktree. When the worktree is removed (auto or
-manual), the commit becomes **dangling** — reachable only via
-`git fsck --no-reflogs --lost-found` until `git gc` collects it
-(default 2-week grace via `gc.pruneExpire`).
+Subagent dispatched into an isolated worktree commits inside that worktree. Branch ref lives only in the worktree; when the worktree is removed, the commit is **dangling** — reachable only via `git fsck --no-reflogs --lost-found` until `git gc` collects it (14-day default via `gc.pruneExpire`). The subagent's "Commit SHA: abc1234" report becomes a lie. Code may also be sitting in the main worktree as unstaged changes.
 
-The subagent reports "Commit SHA: abc1234" in its summary. The main
-agent treats that as shipped. Reality: the commit is not in `main`'s
-ancestry. The fix code may also be sitting in the main worktree as
-**unstaged changes** (because the subagent edited shared files before
-its own commit took place — the harness behavior here is fuzzy).
-
-**Trust-but-verify rule** — every time a subagent reports a commit:
-
-```bash
-# Use origin/main (not HEAD) so a checked-out feature branch doesn't
-# false-positive. Run `git fetch origin main` first if origin/main is stale.
-git merge-base --is-ancestor <sha> origin/main && echo "in main" || echo "DANGLING"
-```
-
-If DANGLING, the fix didn't land. Either re-commit the working-tree
-changes yourself, or `git cherry-pick <sha>` to bring the dangling
-commit forward.
+**Trust-but-verify rule** — every time a subagent reports a commit, run the ancestry check from `refs/recipes.md` §1.
 
 ### 2. Orphan branches with unique work, no worktree on disk
 
-The CLAUDE.md hygiene contract that ships with most projects covers
-the "delete worktree + branch when content is in main" case. It does
-NOT cover this:
+Worktree dir is gone (auto-cleaned, deleted weeks ago); branch (local or `origin/crew/<name>`) still points at commits NOT in main; `git worktree list` says nothing about it. Bulk-deleting branches because "no worktree = no work" silently loses everything between fork-point and tip.
 
-- Worktree dir is gone (deleted weeks ago, auto-cleaned, etc.)
-- Branch (local or `origin/crew/<name>`) still points at commits
-  that are NOT in main
-- `git worktree list` and `git worktree prune` say nothing about it
-- The work is invisible to worktree commands
-
-If you bulk-delete branches because "no worktree means no work", you
-silently lose anything between fork-point and tip. Detection:
-
-```bash
-# Local branches with unique commits not in main
-git for-each-ref refs/heads/ --format='%(refname:short)' \
-  | xargs -I{} sh -c 'unique=$(git rev-list --count origin/main..{} 2>/dev/null); [ "${unique:-0}" -gt 0 ] && echo "{}: $unique unique"'
-
-# Remote crew/* branches with unique commits not in main
-git for-each-ref refs/remotes/origin/crew/ --format='%(refname:short)' \
-  | xargs -I{} sh -c 'unique=$(git rev-list --count origin/main..{} 2>/dev/null); [ "${unique:-0}" -gt 0 ] && echo "{}: $unique unique"'
-```
-
-Each such branch needs an explicit salvage decision (see Salvage flow
-below). Do NOT bulk-delete on the assumption that "no worktree = no work".
+Detection commands in `refs/recipes.md` §2. Each branch needs an explicit salvage decision (see Salvage flow below).
 
 ### 3. Dangling commits, no branch ref at all
 
-The commit object exists but no branch points at it. Reachable only
-via `git fsck --no-reflogs --lost-found` until `git gc` runs. **Time
-sensitive** — once gc runs (default grace: 14 days via
-`gc.pruneExpire`), the commit object is unreachable forever.
+Commit object exists but no branch points at it. **Time sensitive** — once `git gc` runs (default grace 14 days), the object is unreachable forever. List + preserve commands in `refs/recipes.md` §3.
 
-```bash
-# List dangling commits
-git fsck --no-reflogs --lost-found 2>&1 | grep "dangling commit"
-
-# Inspect one (shows its tree + parent + message)
-git show <sha> --stat | head -20
-
-# Preserve one before gc takes it
-git branch salvage-<topic> <sha>
-git push origin salvage-<topic>
-```
-
-**Decision must be prompt** — there is no third state. Either preserve
-or accept the loss.
+**Decision must be prompt** — there is no third state. Either preserve or accept the loss.
 
 ## Authoritative signal for "is this work safe to delete"
 
-Branch + remote ref state, **not** on-disk worktree presence.
-Worktree-dir absence is the LEAST reliable indicator of merge state.
-
-The full safety check before deleting any worktree-or-branch:
-
-```bash
-# 1. Verify content is in main (MUST be empty before proceeding)
-git log origin/main..<branch-name> --oneline
-
-# 2. Then delete (only if step 1 was empty)
-git worktree unlock <path> 2>/dev/null   # in case it's locked
-git worktree remove --force <path>
-git branch -D <branch-name>
-```
+Branch + remote ref state, **not** on-disk worktree presence. Worktree-dir absence is the LEAST reliable indicator of merge state. Safe-delete recipe in `refs/recipes.md` §4.
 
 ## Salvage flow (when you find unique work)
 
 For each candidate branch:
 
-1. **Locate** — `.claude/worktrees/agent-*` and project-specific dirs (e.g.
-   `~/.command_iq/worktrees/crew-*`). Run `git worktree list`.
+1. **Locate** — `.claude/worktrees/agent-*` and project-specific dirs (e.g. `~/.command_iq/worktrees/crew-*`). Run `git worktree list`.
 2. **Identify** — branch name + HEAD SHA.
-3. **Compare against main** — use ancestry-based checks, NOT tree-identity:
-   - `git log origin/main..<branch> --oneline` empty → every branch commit is reachable from main (truly merged, even if main has advanced)
-   - `git cherry -v origin/main <branch>` shows patch equivalence — `-` rows mean the patch is already in main (covers squash + cherry-pick landings); `+` rows mean unique work. More reliable than subject-grepping `git log origin/main | grep -i <subject>` (squashed commits often change subject text).
-   - `git rev-list --count origin/main..<branch>` returns the count of unique-by-ancestry commits. Use as supporting context.
-4. **Classify** as one of:
-   - **ALREADY_MERGED** — `git log origin/main..<branch>` is empty AND `git cherry -v` shows zero `+` rows. Safe to delete. (Tree-identity diff between branch tips is NOT a valid signal — main may have advanced past a fully-merged branch.)
-   - **SALVAGEABLE** — `git cherry -v` shows `+` rows. Orphaned but valuable. Note what's there. Either cherry-pick or extract patterns manually.
-   - **DEAD** — abandoned with no useful changes. Delete with note.
-5. **For ALREADY_MERGED**: delete using the safety check above.
-   **For SALVAGEABLE**: do not delete; produce an extract plan; only delete after extraction lands on main.
-   **For DEAD**: delete branch + log the deletion (subject + date).
+3. **Classify** using ancestry-based checks (NOT tree-identity diffs — main may have advanced past a fully-merged branch). Verdict table and signals in `refs/recipes.md` §5.
+4. **Act** per verdict:
+   - **ALREADY_MERGED** → delete using the safety recipe.
+   - **SALVAGEABLE** → do not delete; extract plan first; delete only after extraction lands on main.
+   - **DEAD** → delete branch + log the deletion (subject + date).
 
-Manual file-by-file extraction beats `git cherry-pick` when the candidate
-branch has 70k+ LOC of regenerated noise (lockfiles, brain index json,
-snapshot files) plus a few hundred LOC of real work. Cherry-pick drags
-everything; manual extraction keeps only the substantive change set.
+Manual file-by-file extraction often beats `git cherry-pick` on noisy branches — see `refs/recipes.md` §7.
 
 ## When the subagent reports a commit but the work is partly unstaged
 
-This combination — dangling commit SHA + unstaged changes in main worktree —
-shows up when the subagent edited shared files (which the main worktree
-sees as unstaged) before making its commit (which lands in the worktree's
-branch). Both halves of the work need attention:
-
-```bash
-# Check if the working tree has uncommitted changes from the subagent
-git status -s
-
-# If yes, and they look like the fix the subagent claimed:
-git diff --stat                                    # confirm scope is right
-# Run project-specific verification — typecheck / build / unit tests as appropriate
-# (e.g. `npx tsc --noEmit`, `cargo check`, `pytest`, `go test ./...`, etc.)
-git add <files> && git commit -m "..."
-```
-
-You're effectively re-landing the subagent's work as your own commit
-because the subagent's worktree commit is unreachable.
+Dangling commit SHA + unstaged changes in main worktree shows up when the subagent edited shared files (main worktree sees as unstaged) before its own commit (lands in worktree branch). Both halves need attention. Re-landing recipe in `refs/recipes.md` §6.
 
 ## Trust-but-verify checklist for subagent reports
 

--- a/skills/worktrees/refs/recipes.md
+++ b/skills/worktrees/refs/recipes.md
@@ -1,0 +1,92 @@
+# Worktree Recipes
+
+Detection, salvage, and verification commands for the three worktree failure modes.
+
+## 1. Verify a subagent commit landed in main
+
+Use `origin/main` (not `HEAD`) so a checked-out feature branch doesn't false-positive. Run `git fetch origin main` first if origin is stale.
+
+```bash
+git merge-base --is-ancestor <sha> origin/main && echo "in main" || echo "DANGLING"
+```
+
+If DANGLING: re-commit working-tree changes yourself, or `git cherry-pick <sha>` to bring the dangling commit forward.
+
+## 2. Find orphan branches with unique work (no worktree on disk)
+
+```bash
+# Local branches with unique commits not in main
+git for-each-ref refs/heads/ --format='%(refname:short)' \
+  | xargs -I{} sh -c 'unique=$(git rev-list --count origin/main..{} 2>/dev/null); [ "${unique:-0}" -gt 0 ] && echo "{}: $unique unique"'
+
+# Remote crew/* branches with unique commits not in main
+git for-each-ref refs/remotes/origin/crew/ --format='%(refname:short)' \
+  | xargs -I{} sh -c 'unique=$(git rev-list --count origin/main..{} 2>/dev/null); [ "${unique:-0}" -gt 0 ] && echo "{}: $unique unique"'
+```
+
+Each such branch needs an explicit salvage decision — do NOT bulk-delete on the assumption that "no worktree = no work".
+
+## 3. Find and preserve dangling commits before gc
+
+`git gc` runs after default 14-day grace (`gc.pruneExpire`); after that, dangling commit objects are unreachable forever.
+
+```bash
+# List dangling commits
+git fsck --no-reflogs --lost-found 2>&1 | grep "dangling commit"
+
+# Inspect one (shows tree + parent + message)
+git show <sha> --stat | head -20
+
+# Preserve one before gc takes it
+git branch salvage-<topic> <sha>
+git push origin salvage-<topic>
+```
+
+## 4. Safe delete of worktree + branch
+
+Only delete after step 1 returns empty.
+
+```bash
+# 1. Verify content is in main (MUST be empty before proceeding)
+git log origin/main..<branch-name> --oneline
+
+# 2. Then delete (only if step 1 was empty)
+git worktree unlock <path> 2>/dev/null   # in case it's locked
+git worktree remove --force <path>
+git branch -D <branch-name>
+```
+
+## 5. Salvage classification (per candidate branch)
+
+Use ancestry-based checks, NOT tree-identity diffs. Main may have advanced past a fully-merged branch; tree-identity will lie about it.
+
+| Verdict | Signal | Action |
+|---------|--------|--------|
+| **ALREADY_MERGED** | `git log origin/main..<branch>` empty AND `git cherry -v` shows zero `+` rows | Safe to delete using §4 |
+| **SALVAGEABLE** | `git cherry -v origin/main <branch>` shows `+` rows | Do not delete; produce extract plan; delete only after extraction lands on main |
+| **DEAD** | Abandoned with no useful changes | Delete branch + log the deletion (subject + date) |
+
+`git cherry -v` is more reliable than subject-grepping — it shows patch equivalence even when squash + cherry-pick changed the commit message text.
+
+`git rev-list --count origin/main..<branch>` returns the count of unique-by-ancestry commits — supporting context, not a verdict on its own.
+
+## 6. Re-land work after a dangling commit + unstaged changes
+
+This combination shows up when a subagent edited shared files (which the main worktree sees as unstaged) before making its commit (which lands in the worktree's branch). Both halves need attention:
+
+```bash
+# Check if the working tree has uncommitted changes from the subagent
+git status -s
+
+# If yes, and they look like the fix the subagent claimed:
+git diff --stat                                    # confirm scope is right
+# Run project-specific verification — typecheck / build / unit tests as appropriate
+# (e.g. `npx tsc --noEmit`, `cargo check`, `pytest`, `go test ./...`, etc.)
+git add <files> && git commit -m "..."
+```
+
+You're effectively re-landing the subagent's work as your own commit because the subagent's worktree commit is unreachable.
+
+## 7. Manual extraction beats cherry-pick on noisy branches
+
+When a candidate branch has 70k+ LOC of regenerated noise (lockfiles, brain-index json, snapshot files) plus a few hundred LOC of real work, `git cherry-pick` drags everything. Manual file-by-file extraction keeps only the substantive change set.


### PR DESCRIPTION
## Summary

**Final PR in the 6-PR salvage sweep.** Two skills with heavy procedural / template content get the bulk moved to new refs/ files for progressive disclosure.

## Changes

### `skills/worktrees/SKILL.md` (183 → 84 lines, **-99**) + new `refs/recipes.md` (92 lines)

Extracted 7 sections of bash recipes:
1. Subagent commit ancestry verification
2. Orphan-branch detection commands
3. Dangling commit list / preserve recipes
4. Safe delete recipe
5. Salvage classification verdict table + ancestry-vs-tree-identity signals
6. Re-land recipe (dangling commit + unstaged combo)
7. Manual extraction guidance for noisy branches

SKILL.md retains: failure-mode **summaries**, salvage decision **flow**, trust-but-verify checklist. Operational bash details sit one Read away.

### `skills/product/mockup/SKILL.md` (174 → 104 lines, **-70**) + new `refs/templates.md` (91 lines)

Extracted 3 templates:
1. HTML/CSS Preview boilerplate (~32 lines)
2. Component Spec markdown template (~32 lines)
3. Handoff Notes template (~9 lines)

SKILL.md retains: format-selection table, ASCII wireframe + symbol guide, wireframe-from-description procedure, output checklist, integration cross-references.

## Hard guardrails (PR #695 anti-patterns NOT repeated)

- ✅ No \`disable-model-invocation:\` removed
- ✅ No \`context: fork\` removed
- ✅ \`portability: portable\` kept on mockup
- ✅ \`status: stable\` kept on worktrees
- ✅ No \`allowed-tools:\` array→string conversion
- ✅ New refs/ files added under correct skill directories

## Test plan

- [x] \`scripts/ci/validate.py\` PASS
- [x] Both SKILL.md files comfortably under 200-line cap (84 / 104)
- [x] All refs/ pointers reference sections that actually exist
- [x] Frontmatter-key guardrail grep clean

## Sweep status — COMPLETE after this PR

- ✅ PR 1/6 stale-facts (#697 merged)
- ✅ PR 2a/6 description hygiene half 1 (#698 merged)
- ✅ PR 2b/6 description hygiene half 2 (#699 merged)
- ✅ PR 3a/6 agentic table compression (#700 merged)
- ✅ PR 3b/6 CI YAML trim (#701 merged)
- 🔄 PR 3c/6 — this PR

## Net result across all 6 PRs

- ~32 SKILL.md files touched
- ~600 lines net removed from SKILL.md entry points
- 2 new refs/ files added (worktrees/refs/recipes.md, mockup/refs/templates.md)
- Zero PR #695 anti-patterns introduced
- Council reviewed every PR pre-merge; bot review feedback addressed in fixup commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)