### PR TITLE
chore(skills): PR 7 — HITL catalog gap + observability domain naming

### DIFF
--- a/skills/agentic/agentic-patterns/refs/pattern-catalog.md
+++ b/skills/agentic/agentic-patterns/refs/pattern-catalog.md
@@ -201,6 +201,32 @@ class MonitoringAgent:
 ### Coordination Patterns
 Even autonomous agents may need minimal coordination via shared event bus, shared state store, or rate limiting to stay under global limits.
 
+## Human-in-the-Loop Pattern
+
+### Description
+Agent execution includes explicit gates where a human approves, rejects, or modifies a proposed action before it takes effect. The human is part of the control loop, not just a downstream consumer. Sits naturally on top of any other pattern (sequential, hierarchical, autonomous) — a workflow can have one HITL gate before a high-stakes step or many gates throughout.
+
+### When to Use
+- High-stakes decisions where an unreviewed agent action could cause material harm (sending external email, paying invoices, altering production state)
+- Regulatory or compliance regimes that require a human sign-off in the audit trail
+- Tasks where the agent's confidence is low and human judgment is the cheapest correction
+- Early deployment of a new agent capability — gates are a useful safety scaffold while trust is being built and metered down later
+
+### When NOT to Use
+- Hot-path or latency-sensitive workflows where pause-for-approval defeats the purpose
+- High-volume actions where the human review queue would saturate
+- Decisions that are reversible cheaply — an undo button is often a better trade-off than a gate
+- The human reviewer cannot meaningfully evaluate the proposed action (no context, no UI, no time)
+
+### Variations
+- **Pre-approval gate** — human approves before any side effect happens
+- **Post-execution review** — agent acts, human reviews and rolls back if needed (only when reversal is safe)
+- **Sampled review** — only every Nth action is gated; balances coverage vs throughput
+- **Risk-tiered gating** — low-risk actions auto-proceed, medium-risk get sampled review, high-risk always block on a human
+
+### Common Pitfalls
+Approval fatigue (humans rubber-stamp without reading), implicit bypass paths (the gate only fires on the happy path), no audit trail of who approved what, and gates that block without timeout (a missing reviewer halts the whole pipeline).
+
 ## ReAct Pattern
 
 ### Description

--- a/skills/agentic/agentic-patterns/refs/pattern-catalog.md
+++ b/skills/agentic/agentic-patterns/refs/pattern-catalog.md
@@ -204,7 +204,7 @@ Even autonomous agents may need minimal coordination via shared event bus, share
 ## Human-in-the-Loop Pattern
 
 ### Description
-Agent execution includes explicit gates where a human approves, rejects, or modifies a proposed action before it takes effect. The human is part of the control loop, not just a downstream consumer. Sits naturally on top of any other pattern (sequential, hierarchical, autonomous) — a workflow can have one HITL gate before a high-stakes step or many gates throughout.
+Agent execution includes explicit gates where a human approves, rejects, or modifies a proposed action before it takes effect. The human is part of the control loop, not just a downstream consumer. Human-in-the-Loop (HITL) sits naturally on top of any other pattern in this catalog — a workflow can have one HITL gate before a high-stakes step or many gates throughout.
 
 ### When to Use
 - High-stakes decisions where an unreviewed agent action could cause material harm (sending external email, paying invoices, altering production state)

--- a/skills/platform/observability/SKILL.md
+++ b/skills/platform/observability/SKILL.md
@@ -121,6 +121,6 @@ Detection uses `command -v` — no external dependencies.
 
 ## Integration
 
-- **wicked-smaht**: Context assembly uses trace data to detect degraded adapters
-- **wicked-crew**: Health probes run during execution gates
+- **smaht** (domain): Context assembly uses trace data to detect degraded adapters
+- **crew** (domain): Health probes run during execution gates
 - **DomainStore**: Traces stored via DomainStore (local JSON), with SqliteStore for search


### PR DESCRIPTION
## Summary

Two small follow-ups flagged after the 6-PR salvage sweep (#697-702) landed. Tiny scope on purpose.

## Changes (2 files)

### `skills/agentic/agentic-patterns/refs/pattern-catalog.md` (+26 lines)

The PR 3a SKILL.md table (#700) lists 8 core patterns including **Human-in-the-Loop**, with a footer pointer that says \"see refs/pattern-catalog.md for full descriptions and implementation notes per pattern.\" The catalog had entries for the other 7 but **no HITL section** — dead-end cross-reference.

Added an HITL entry shaped like Plan-Execute and Reflection (Description / When to Use / When NOT to Use / Variations / Common Pitfalls — no code example). Council explicitly called out: don't add a code example here while Plan-Execute and Reflection lack one — that would create a new asymmetry.

### `skills/platform/observability/SKILL.md` (-2/+2 lines)

Lines 124-125 used \`**wicked-smaht**\` and \`**wicked-crew**\` to label items in the Integration section. Per CLAUDE.md, smaht and crew are **domains within wicked-garden**, not separate sibling plugins. The actual sibling plugins are wicked-brain, wicked-bus, and wicked-testing. The \`wicked-\` prefix here was misleading. Renamed to \`smaht (domain)\` and \`crew (domain)\`.

## Out of scope (by council guidance)

- \`workflow/SKILL.md\` v5/v6 historical references — intentional anchors documenting the workflow-engine version (independent of plugin v8.6.0).
- \`smaht/SKILL.md\` opener — the pull-model distinction lives there and was preserved verbatim by PR 2b.
- Plan-Execute and Reflection patterns lack code examples (the other 5 have them) — pre-existing asymmetry, not introduced by the sweep, deferred.

## Hard guardrails

- ✅ No frontmatter keys touched on either file
- ✅ \`scripts/ci/validate.py\` PASS (0 errors, 0 warnings)
- ✅ All files under 200-line cap (catalog 325 is a refs/ file, no cap; SKILL.md unchanged at 126)
- ✅ No PR #695 anti-patterns

## Test plan

- [x] validate.py PASS
- [x] grep confirmed no other files cross-reference pattern-catalog.md by name (only the SKILL.md table)
- [x] CLAUDE.md confirmed smaht/crew as domains, not plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)