### PR TITLE
chore(skills): PR 8 — final 4 template extractions (rollout/design/listen/propose-process)

### DIFF
--- a/skills/delivery/design/SKILL.md
+++ b/skills/delivery/design/SKILL.md
@@ -107,45 +107,9 @@ trackEvent('purchase_completed', {
 
 ## Output Format
 
-```markdown
-## Experiment Design: {Name}
+The skill emits a markdown experiment design with sections: Hypothesis, Metrics (Primary / Secondary / Guardrail), Variants, Sample Size, Statistical Parameters, Instrumentation, Success Criteria, Risks & Mitigations.
 
-### Hypothesis
-{Clear, testable hypothesis}
-
-### Metrics
-- **Primary**: {metric} - {how measured}
-- **Secondary**: {list}
-- **Guardrail**: {list}
-
-### Variants
-- **Control**: {current experience}
-- **Treatment**: {new experience}
-
-### Sample Size
-- Per variant: {n} users
-- Total: {total} users
-- Duration: {days} at {%} traffic
-
-### Statistical Parameters
-- Significance: 0.05
-- Confidence: 95%
-- Power: 80%
-- MDE: {minimum detectable effect}%
-
-### Instrumentation
-**Feature Flag**: {name}
-**Analytics Events**:
-- experiment_viewed
-- {primary_metric_event}
-- {secondary_metric_events}
-
-### Success Criteria
-{What constitutes success}
-
-### Risks & Mitigations
-{Potential issues and how to handle}
-```
+Full template with substitutable placeholders: [`refs/output-template.md`](refs/output-template.md).
 
 ## Capability Discovery
 

--- a/skills/delivery/design/refs/output-template.md
+++ b/skills/delivery/design/refs/output-template.md
@@ -1,6 +1,6 @@
 # Experiment Design Output Template
 
-Markdown template for the experiment design returned by `/wicked-garden:delivery:experiment`. Substitute the placeholders with values from the hypothesis, metrics, sample-size, and instrumentation steps.
+Markdown template for the experiment design output emitted by the `delivery:design` skill. Substitute the placeholders with values from the hypothesis, metrics, sample-size, and instrumentation steps.
 
 ```markdown
 ## Experiment Design: {Name}

--- a/skills/delivery/design/refs/output-template.md
+++ b/skills/delivery/design/refs/output-template.md
@@ -1,0 +1,43 @@
+# Experiment Design Output Template
+
+Markdown template for the experiment design returned by `/wicked-garden:delivery:experiment`. Substitute the placeholders with values from the hypothesis, metrics, sample-size, and instrumentation steps.
+
+```markdown
+## Experiment Design: {Name}
+
+### Hypothesis
+{Clear, testable hypothesis}
+
+### Metrics
+- **Primary**: {metric} - {how measured}
+- **Secondary**: {list}
+- **Guardrail**: {list}
+
+### Variants
+- **Control**: {current experience}
+- **Treatment**: {new experience}
+
+### Sample Size
+- Per variant: {n} users
+- Total: {total} users
+- Duration: {days} at {%} traffic
+
+### Statistical Parameters
+- Significance: 0.05
+- Confidence: 95%
+- Power: 80%
+- MDE: {minimum detectable effect}%
+
+### Instrumentation
+**Feature Flag**: {name}
+**Analytics Events**:
+- experiment_viewed
+- {primary_metric_event}
+- {secondary_metric_events}
+
+### Success Criteria
+{What constitutes success}
+
+### Risks & Mitigations
+{Potential issues and how to handle}
+```

--- a/skills/delivery/rollout/SKILL.md
+++ b/skills/delivery/rollout/SKILL.md
@@ -107,52 +107,9 @@ For each stage:
 
 ## Output Format
 
-```markdown
-## Rollout Plan: {Feature Name}
+The skill emits a markdown rollout plan with sections: Risk Assessment, Strategy, Rollout Stages (table), Monitoring, Rollback Plan, Communication, Stage Gate Checklist, Next Steps.
 
-### Risk Assessment
-- **Overall Risk**: {LOW | MEDIUM | HIGH}
-- **User Impact**: {%} of users
-- **Revenue Impact**: {LOW | MEDIUM | HIGH}
-- **Reversibility**: {HIGH | MEDIUM | LOW}
-
-### Strategy: {Progressive | Canary | Big Bang}
-**Duration**: {weeks}
-**Feature Flag**: {flag_name}
-
-### Rollout Stages
-
-| Stage | Traffic | Duration | Success Criteria | Auto Rollback |
-|-------|---------|----------|------------------|---------------|
-| 1 | 1% | 24h | Error < 0.1% | Error > 0.5% |
-| 2 | 10% | 3d | Conversion >= baseline | Conv < 95% |
-
-### Monitoring
-**Dashboard**: {url}
-**Key Metrics**: {list}
-**Alerts**: WARNING ({conditions}), CRITICAL ({conditions})
-
-### Rollback Plan
-**Automatic**: {triggers}
-**Manual**: {criteria}
-**Procedure**: 1. Set flag to 0%, 2. Verify, 3. Monitor, 4. Notify
-
-### Communication
-**Pre-Launch**: {stakeholder checklist}
-**During**: {update frequency}
-**Post-Launch**: {summary and learnings}
-
-### Stage Gate Checklist
-- [ ] Feature flag configured
-- [ ] Monitoring live
-- [ ] Alerts tested
-- [ ] On-call rotation set
-- [ ] Rollback tested
-
-### Next Steps
-1. {Action 1}
-2. {Action 2}
-```
+Full template with substitutable placeholders: [`refs/output-template.md`](refs/output-template.md).
 
 ## Capability Discovery
 

--- a/skills/delivery/rollout/refs/output-template.md
+++ b/skills/delivery/rollout/refs/output-template.md
@@ -1,0 +1,50 @@
+# Rollout Plan Output Template
+
+Markdown template for the rollout plan returned by `/wicked-garden:delivery:rollout`. Substitute the placeholders with values from the risk assessment, strategy, and capability-discovery results.
+
+```markdown
+## Rollout Plan: {Feature Name}
+
+### Risk Assessment
+- **Overall Risk**: {LOW | MEDIUM | HIGH}
+- **User Impact**: {%} of users
+- **Revenue Impact**: {LOW | MEDIUM | HIGH}
+- **Reversibility**: {HIGH | MEDIUM | LOW}
+
+### Strategy: {Progressive | Canary | Big Bang}
+**Duration**: {weeks}
+**Feature Flag**: {flag_name}
+
+### Rollout Stages
+
+| Stage | Traffic | Duration | Success Criteria | Auto Rollback |
+|-------|---------|----------|------------------|---------------|
+| 1 | 1% | 24h | Error < 0.1% | Error > 0.5% |
+| 2 | 10% | 3d | Conversion >= baseline | Conv < 95% |
+
+### Monitoring
+**Dashboard**: {url}
+**Key Metrics**: {list}
+**Alerts**: WARNING ({conditions}), CRITICAL ({conditions})
+
+### Rollback Plan
+**Automatic**: {triggers}
+**Manual**: {criteria}
+**Procedure**: 1. Set flag to 0%, 2. Verify, 3. Monitor, 4. Notify
+
+### Communication
+**Pre-Launch**: {stakeholder checklist}
+**During**: {update frequency}
+**Post-Launch**: {summary and learnings}
+
+### Stage Gate Checklist
+- [ ] Feature flag configured
+- [ ] Monitoring live
+- [ ] Alerts tested
+- [ ] On-call rotation set
+- [ ] Rollback tested
+
+### Next Steps
+1. {Action 1}
+2. {Action 2}
+```

--- a/skills/product/listen/SKILL.md
+++ b/skills/product/listen/SKILL.md
@@ -22,37 +22,17 @@ Aggregate customer feedback from multiple channels with automatic source discove
 
 ## Capability Discovery
 
-The skill automatically discovers available feedback capabilities:
+The skill automatically discovers available feedback capabilities and routes to whichever are present:
 
-### support-tickets capability
-```bash
-# Discovers CLI tools, APIs, and exports that provide ticket data
-# Examples: ticket system CLIs, support platform exports, help desk APIs
-```
+| Capability | Discovers | Examples |
+|------------|-----------|----------|
+| `support-tickets` | CLI tools, APIs, exports providing ticket data | Ticket system CLIs, support platform exports, help desk APIs |
+| `customer-feedback` | Feedback platforms, voting systems, feature request tools | Feedback exports, product board files, customer labels in issue trackers |
+| `surveys` | Survey response exports (CSV, JSON) | Survey platform exports, NPS data files, form responses |
+| `conversations` | Chat and messaging data sources | Chat exports, messaging platform data |
+| `issue-tracking` | Bug/issue trackers with customer-reported items | Issue tracker CLIs with customer labels or tags |
 
-### customer-feedback capability
-```bash
-# Discovers feedback platforms, voting systems, feature request tools
-# Examples: feedback exports, product board files, customer labels in issue trackers
-```
-
-### surveys capability
-```bash
-# Discovers survey response exports (CSV, JSON)
-# Examples: survey platform exports, NPS data files, form responses
-```
-
-### conversations capability
-```bash
-# Discovers chat and messaging data sources
-# Examples: chat exports, messaging platform data
-```
-
-### issue-tracking capability
-```bash
-# Discovers bug/issue tracking systems with customer-reported items
-# Examples: issue tracker CLIs with customer labels or tags
-```
+See [channels.md](refs/channels.md) for detailed capability integration patterns.
 
 ## Usage
 

--- a/skills/product/listen/SKILL.md
+++ b/skills/product/listen/SKILL.md
@@ -32,8 +32,6 @@ The skill automatically discovers available feedback capabilities and routes to 
 | `conversations` | Chat and messaging data sources | Chat exports, messaging platform data |
 | `issue-tracking` | Bug/issue trackers with customer-reported items | Issue tracker CLIs with customer labels or tags |
 
-See [channels.md](refs/channels.md) for detailed capability integration patterns.
-
 ## Usage
 
 ```bash

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -112,33 +112,7 @@ Task(
    file regardless, and the shim (Steps 3 / 4 below) decides whether to render
    `process-plan.md` based on the caller's `output` value.
 
-   Concrete example for the `crew:start` Step 5 call (description elided):
-
-```
-Task(
-  subagent_type="wicked-garden:crew:process-facilitator",
-  prompt="""
-    Run the propose-process rubric. Documented inputs (one field per line):
-
-    description: Add MFA to the existing login flow.
-    priors: none
-    constraints: none
-    mode: propose
-    current_chain: none
-    auto_proceed: none
-    project_dir: /Users/alex/.something-wicked/wicked-garden/projects/2026-04-26-1430/wicked-crew/projects/auth_rewrite
-    project_slug: auth_rewrite
-    bookend: none
-    phase: none
-
-    For any field whose value is `none`, treat it as absent (use the input's
-    documented default).
-
-    Write the resulting JSON to {project_dir}/process-plan.draft.json before
-    returning. Do NOT issue TaskCreate calls — the caller emits the chain.
-  """
-)
-```
+   See [`refs/dispatch-example.md`](refs/dispatch-example.md) for a fully-substituted concrete example matching the `crew:start` Step 5 call.
 
 2. After the agent returns, read `${project_dir}/process-plan.draft.json` from disk.
 

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -112,7 +112,7 @@ Task(
    file regardless, and the shim (Steps 3 / 4 below) decides whether to render
    `process-plan.md` based on the caller's `output` value.
 
-   See [`refs/dispatch-example.md`](refs/dispatch-example.md) for a fully-substituted concrete example matching the `crew:start` Step 5 call.
+   See [`refs/dispatch-example.md`](refs/dispatch-example.md) for a concrete example with documented inputs filled in for the `crew:start` Step 5 call.
 
 2. After the agent returns, read `${project_dir}/process-plan.draft.json` from disk.
 

--- a/skills/propose-process/refs/dispatch-example.md
+++ b/skills/propose-process/refs/dispatch-example.md
@@ -1,6 +1,8 @@
 # Concrete Dispatch Example
 
-Fully-substituted Task() dispatch example for the `crew:start` Step 5 call. The abstract template (with `{token}` placeholders) lives in SKILL.md; this is the concrete illustration with real values.
+Concrete Task() dispatch example for the `crew:start` Step 5 call. The abstract template (with all `{token}` placeholders) lives in SKILL.md; this version has the *top-level documented inputs* substituted with realistic values so callers can see the expected shape.
+
+Note: `{project_dir}` inside the prompt body **stays as a literal placeholder** — that's the path the agent itself writes the draft JSON to, and it should match the value passed in the `project_dir:` field above. The shim reads from that same path after the agent returns.
 
 ```
 Task(
@@ -14,7 +16,7 @@ Task(
     mode: propose
     current_chain: none
     auto_proceed: none
-    project_dir: /Users/alex/.something-wicked/wicked-garden/projects/2026-04-26-1430/wicked-crew/projects/auth_rewrite
+    project_dir: ~/.something-wicked/wicked-garden/projects/2026-04-26-1430/wicked-crew/projects/auth_rewrite
     project_slug: auth_rewrite
     bookend: none
     phase: none
@@ -29,6 +31,6 @@ Task(
 ```
 
 Notes for adaptation:
-- Substitute `description`, `project_dir`, and `project_slug` with the caller's actual values.
+- Substitute `description`, `project_dir`, and `project_slug` with the caller's actual values. The `~/.something-wicked/...` path above is illustrative; the shim resolves the real absolute path via `resolve_path.py`.
 - Pass `none` (not empty string, not omitted) for any documented input the caller did not provide — the agent treats `none` as the input's documented default.
 - Do not forward `output` to the agent — the shim decides whether to render `process-plan.md` after reading the draft back from disk.

--- a/skills/propose-process/refs/dispatch-example.md
+++ b/skills/propose-process/refs/dispatch-example.md
@@ -1,0 +1,34 @@
+# Concrete Dispatch Example
+
+Fully-substituted Task() dispatch example for the `crew:start` Step 5 call. The abstract template (with `{token}` placeholders) lives in SKILL.md; this is the concrete illustration with real values.
+
+```
+Task(
+  subagent_type="wicked-garden:crew:process-facilitator",
+  prompt="""
+    Run the propose-process rubric. Documented inputs (one field per line):
+
+    description: Add MFA to the existing login flow.
+    priors: none
+    constraints: none
+    mode: propose
+    current_chain: none
+    auto_proceed: none
+    project_dir: /Users/alex/.something-wicked/wicked-garden/projects/2026-04-26-1430/wicked-crew/projects/auth_rewrite
+    project_slug: auth_rewrite
+    bookend: none
+    phase: none
+
+    For any field whose value is `none`, treat it as absent (use the input's
+    documented default).
+
+    Write the resulting JSON to {project_dir}/process-plan.draft.json before
+    returning. Do NOT issue TaskCreate calls — the caller emits the chain.
+  """
+)
+```
+
+Notes for adaptation:
+- Substitute `description`, `project_dir`, and `project_slug` with the caller's actual values.
+- Pass `none` (not empty string, not omitted) for any documented input the caller did not provide — the agent treats `none` as the input's documented default.
+- Do not forward `output` to the agent — the shim decides whether to render `process-plan.md` after reading the draft back from disk.


### PR DESCRIPTION
## Summary

Final batch from the original audit's template-extraction list. Same shape as PR 3b/3c — heavy templates / repetitive sibling-section prose moves to refs/, SKILL.md keeps the explanatory frame.

## Changes (4 SKILL.md + 3 new refs/ files)

| File | Before | After | Refs change |
|------|--------|-------|-------------|
| `skills/delivery/rollout/SKILL.md` | 187 | 143 (**-44**) | NEW `refs/output-template.md` (50 lines) |
| `skills/delivery/design/SKILL.md` | 178 | 141 (**-37**) | NEW `refs/output-template.md` (43 lines) |
| `skills/product/listen/SKILL.md` | 196 | 175 (**-21**) | 5 sibling sub-sections → 5-row table (no new refs/ — table is strictly better here) |
| `skills/propose-process/SKILL.md` | 162 | 136 (**-26**) | NEW `refs/dispatch-example.md` (34 lines) for concrete crew:start example; abstract template kept inline |

**Net: -128 lines across 4 SKILL.md entry points; 3 new refs/ files.**

## Council guidance applied

- propose-process: kept the abstract Task() template inline (load-bearing contract); moved only the concrete crew:start substitution to refs/. Two artifacts were not duplicates — they were spec-vs-illustration.
- listen: chose **table compression** over refs/ extraction since the 5 sub-sections are short comment-only bash blocks with identical shape. refs/ would over-engineer 33 lines of structured prose.
- All new SKILL.md prose explicitly references the new refs/ files (no orphan refs/).

## Hard guardrails (PR #695 anti-patterns NOT repeated)

- ✅ No `disable-model-invocation`, `context: fork`, `portability`, `status`, `user-invocable`, `allowed-tools` keys touched
- ✅ All SKILL.md files comfortably under 200-line cap (143 / 141 / 175 / 136)
- ✅ No description trims (all 4 of these were already trimmed in PR 2a/2b)

## Test plan

- [x] `scripts/ci/validate.py` PASS (0 errors, 0 warnings)
- [x] All new refs/ files referenced from their SKILL.md (no orphans)
- [x] Diff guardrail grep clean

## Sweep status

- ✅ PR 1-3c (#697-702) merged
- ✅ PR 7 follow-up (#703) merged
- 🔄 PR 8 — this PR (final extractions)
- ⏳ PR 9 — Pygments dependabot bump (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)