### PR TITLE
chore(scenarios): PR 10 — Tier 1 cleanup (README shim + delete v5 assertion)

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -21,8 +21,10 @@ Each scenario follows a standard structure with YAML frontmatter, setup steps, n
 
 ## Data Access
 
-All scenarios query plugin data via local storage (DomainStore + SQLite). Scripts are invoked through the `_run.py` wrapper:
+All scenarios query plugin data via local storage (DomainStore + SQLite). Scripts are invoked through the cross-platform `_python.sh` shim and the `_run.py` wrapper:
 
 ```bash
-python3 scripts/_run.py scripts/{domain}/{script}.py {args}
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/{domain}/{script}.py {args}
 ```
+
+The shim resolves `python3`, `python`, or `py -3` based on what's available — bare `python3` is not present on Windows. See `skills/runtime-exec/SKILL.md` for the resolution chain.

--- a/scenarios/crew/07-autonomous-assumptions.md
+++ b/scenarios/crew/07-autonomous-assumptions.md
@@ -88,12 +88,12 @@ When the project completes, the final output should include:
 - **Review**: {list of assumptions}
 ```
 
-### 5. Verify smaht context gathered (if available)
+### 5. Verify smaht context assembly (v6 pull-model)
 
 Expected:
-1. wicked-smaht context_package.py called before phase work
-2. Context package included in subagent Task() dispatches
-3. Graceful degradation if smaht not installed
+1. The `smaht` skill (or its `wicked-brain:search` / `wicked-brain:query` adapters) is invoked at least once during phase work to gather context — the v6 pull-model replaces the deleted v5 push-model orchestrator (`scripts/smaht/v2/orchestrator.py`, removed in #428).
+2. Context retrieved is referenced or summarized in subagent Task() dispatches when relevant.
+3. If `wicked-brain` is not installed (smaht itself is a domain within wicked-garden, not a separate plugin, so it is always present), the brain adapter degrades to empty results and the work continues without raising.
 
 ### 6. Verify orchestrator-only behavior
 

--- a/scenarios/crew/07-autonomous-assumptions.md
+++ b/scenarios/crew/07-autonomous-assumptions.md
@@ -88,12 +88,12 @@ When the project completes, the final output should include:
 - **Review**: {list of assumptions}
 ```
 
-### 5. Verify smaht context assembly (v6 pull-model)
+### 5. Verify context assembly (v6 pull-model)
 
 Expected:
-1. The `smaht` skill (or its `wicked-brain:search` / `wicked-brain:query` adapters) is invoked at least once during phase work to gather context — the v6 pull-model replaces the deleted v5 push-model orchestrator (`scripts/smaht/v2/orchestrator.py`, removed in #428).
+1. Either the `smaht` (`context-assembly`) skill is invoked, or `wicked-brain:search` / `wicked-brain:query` is called directly, at least once during phase work to gather context.
 2. Context retrieved is referenced or summarized in subagent Task() dispatches when relevant.
-3. If `wicked-brain` is not installed (smaht itself is a domain within wicked-garden, not a separate plugin, so it is always present), the brain adapter degrades to empty results and the work continues without raising.
+3. When `wicked-brain` is not installed, the brain-backed lookup degrades to empty results — phase work continues without producing a hard failure that blocks completion.
 
 ### 6. Verify orchestrator-only behavior
 


### PR DESCRIPTION
## Summary

Two scenario fixes flagged in the post-sweep audit. **Real bug** + **propagation risk**, not heuristic noise.

## Changes

### `scenarios/README.md` — propagation risk
The data-access example taught \`python3 scripts/_run.py ...\` directly. CLAUDE.md mandates \`sh \"\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh\" ...\` for cross-platform invocation; bare \`python3\` is not on Windows. Since this is the docs-of-docs file, every new scenario was inheriting the wrong pattern — exactly the same anti-pattern PR 1 fixed in \`runtime-exec/SKILL.md\`.

### `scenarios/crew/07-autonomous-assumptions.md` step 5 — broken assertion

Was:
\`\`\`
1. wicked-smaht context_package.py called before phase work
2. Context package included in subagent Task() dispatches
3. Graceful degradation if smaht not installed
\`\`\`

Two problems:
1. \`scripts/smaht/v2/orchestrator.py\` (which contained the push-model context_package logic) was **deleted in #428** when v6 replaced the v5 push-model with a pull-model. Asserting against a deleted code path produces a false REJECT.
2. \`smaht\` is a **domain inside wicked-garden**, not a separate plugin. The "graceful degradation if smaht not installed" path doesn't exist — same architecture confusion PR 7 fixed in \`observability/SKILL.md\`.

Rewrote to assert against current v6 pull-model: smaht skill invoked via \`wicked-brain:search\` / \`wicked-brain:query\` adapters, brain is the optional external dep that degrades gracefully.

## Out of scope (Tier 2 → separate PR)

41 scenarios still use bare \`python3\` invocations. Same anti-pattern, but mechanical bulk migration. Council recommended splitting per their bug-fix-vs-bulk-sweep distinction.

## Hard guardrails

- ✅ \`scripts/ci/validate.py\` PASS
- ✅ No skill files touched
- ✅ Behavioral structure of scenario unchanged (just step 5 assertion)

## Sweep status

- ✅ PRs 1-9 (skills cleanup arc) merged
- 🔄 PR 10 — this PR (Tier 1 scenario)
- ⏳ PR 11 — Tier 2 (bulk python3 → shim across 41 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)