### PR TITLE
chore(scenarios): PR 11 — bulk migrate 40 scenarios from bare python3 to _python.sh shim

### DIFF
--- a/scenarios/crew/01-memory-storage.md
+++ b/scenarios/crew/01-memory-storage.md
@@ -33,8 +33,8 @@ EOF
 
 ```bash
 echo '{"subject": "build: implement auth service", "task_id": "t1", "status": "completed", "project_id": "test-proj"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('MEMSTORE' if 'wicked-brain:memory' in msg else 'MISSING'); print('PROCEDURAL' if 'type=procedural' in msg else 'NO_TYPE'); print('NO_ESCALATION' if '[ESCALATION]' not in msg else 'ESCALATION_FOUND')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('MEMSTORE' if 'wicked-brain:memory' in msg else 'MISSING'); print('PROCEDURAL' if 'type=procedural' in msg else 'NO_TYPE'); print('NO_ESCALATION' if '[ESCALATION]' not in msg else 'ESCALATION_FOUND')"
 ```
 
 **Expected**:
@@ -48,8 +48,8 @@ NO_ESCALATION
 
 ```bash
 echo '{"subject": "fix: resolve race condition in queue processor", "task_id": "t2", "status": "completed", "project_id": "test-proj"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('DECISION' if 'type=decision' in msg else 'WRONG_TYPE')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('DECISION' if 'type=decision' in msg else 'WRONG_TYPE')"
 ```
 
 **Expected**: `DECISION`
@@ -58,8 +58,8 @@ echo '{"subject": "fix: resolve race condition in queue processor", "task_id": "
 
 ```bash
 echo '{"subject": "Phase: design - authentication architecture", "task_id": "t3", "status": "completed", "project_id": "test-proj"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('EPISODIC' if 'type=episodic' in msg else 'WRONG_TYPE')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('EPISODIC' if 'type=episodic' in msg else 'WRONG_TYPE')"
 ```
 
 **Expected**: `EPISODIC`
@@ -72,8 +72,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"subject": "build: fourth task without storing memory", "task_id": "t4", "status": "completed", "project_id": "test-proj"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('ESCALATION' if msg.startswith('[ESCALATION]') else 'NO_ESCALATION')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('ESCALATION' if msg.startswith('[ESCALATION]') else 'NO_ESCALATION')"
 ```
 
 **Expected**: `ESCALATION`
@@ -87,8 +87,8 @@ EOF
 
 for subject in "test: write unit tests for queue" "review: security audit of auth" "document: API reference v2" "configure: set up CI pipeline" "analyze: performance bottlenecks"; do
   result=$(echo "{\"subject\": \"${subject}\", \"task_id\": \"tx\", \"status\": \"completed\", \"project_id\": \"test-proj\"}" \
-    | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
-    | python3 -c "import sys,json; d=json.load(sys.stdin); print('OK' if 'wicked-brain:memory' in d.get('systemMessage','') else 'MISSING')")
+    | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py" \
+    | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); print('OK' if 'wicked-brain:memory' in d.get('systemMessage','') else 'MISSING')")
   echo "${subject}: ${result}"
 done
 ```
@@ -103,9 +103,9 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 output=$(echo '{"subject": "build: standalone work", "task_id": "t9", "status": "completed"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/task_completed.py")
 
-echo "${output}" | python3 -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('SOFT_NUDGE' if msg and '[ESCALATION]' not in msg and 'wicked-brain:memory' in msg else 'NO_NUDGE')"
+echo "${output}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); msg=d.get('systemMessage',''); print('SOFT_NUDGE' if msg and '[ESCALATION]' not in msg and 'wicked-brain:memory' in msg else 'NO_NUDGE')"
 ```
 
 **Expected**: `SOFT_NUDGE`

--- a/scenarios/crew/02-onboarding.md
+++ b/scenarios/crew/02-onboarding.md
@@ -34,8 +34,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "show me the current task list", "session_id": "sess-1"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('SETUP_DIRECTIVE' if 'wicked-garden:setup' in ctx else 'NO_DIRECTIVE')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('SETUP_DIRECTIVE' if 'wicked-garden:setup' in ctx else 'NO_DIRECTIVE')"
 ```
 
 **Expected**: `SETUP_DIRECTIVE`
@@ -85,8 +85,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "show me current tasks", "session_id": "sess-3"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('NO_DIRECTIVE' if 'wicked-garden:setup' not in ctx and 'search:index' not in ctx else 'DIRECTIVE_FOUND')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('NO_DIRECTIVE' if 'wicked-garden:setup' not in ctx and 'search:index' not in ctx else 'DIRECTIVE_FOUND')"
 ```
 
 **Expected**: `NO_DIRECTIVE`
@@ -99,7 +99,7 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "/wicked-garden:setup", "session_id": "sess-4"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null
 echo "Exit code: $?"
 ```
 
@@ -113,8 +113,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "what tasks are pending?", "session_id": "sess-5"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('CLEAN' if 'setup' not in ctx.lower() else 'UNEXPECTED_DIRECTIVE')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('CLEAN' if 'setup' not in ctx.lower() else 'UNEXPECTED_DIRECTIVE')"
 ```
 
 **Expected**: `CLEAN`
@@ -127,7 +127,7 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 result=$(echo '{"prompt": "what is next?", "session_id": "sess-6"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null; echo $?)
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null; echo $?)
 
 echo "Exit code: ${result}"
 ```

--- a/scenarios/crew/03-crew-detection.md
+++ b/scenarios/crew/03-crew-detection.md
@@ -39,8 +39,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "Help me plan and architect a complete migration of our monolith to microservices — first design the service boundaries, then implement the first service with full testing and after that build the full data migration pipeline with rollback support", "session_id": "sess-1"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
 
 **Expected**: `HINT_FOUND`
@@ -58,8 +58,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "I need to design and implement a new authentication system with OAuth2 providers, database schema migrations, and changes to three API services", "session_id": "sess-2"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
 
 **Expected**: `NO_HINT`
@@ -80,8 +80,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "Help me plan and architect a complete migration of our monolith to microservices — first design the service boundaries, then implement the first service with full testing and after that build the full data migration pipeline with rollback support", "session_id": "sess-3"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
 
 **Expected**: `NO_HINT` (suppressed by crew_hint_shown=True — once per session, no re-fire)
@@ -99,8 +99,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "fix a typo in README", "session_id": "sess-4"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('HINT_FOUND' if 'crew:start' in ctx else 'NO_HINT')"
 ```
 
 **Expected**: `NO_HINT`
@@ -113,9 +113,9 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "I need to design and implement a complete OAuth2 migration with database changes and API versioning strategy across multiple services", "session_id": "sess-5"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null > /dev/null
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null > /dev/null
 
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, os, glob
 session_files = glob.glob('${TMPDIR}/wicked-garden-session-*.json')
 if session_files:
@@ -139,8 +139,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 output=$(echo '{"prompt": "Help me plan and architect a complete migration of our monolith to microservices — first design the service boundaries, then implement the first service with full testing and after that build the full data migration pipeline with rollback support", "session_id": "sess-6"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print(ctx.count('crew:start'))")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print(ctx.count('crew:start'))")
 
 echo "Hint count in output: ${output}"
 [ "${output}" -eq 0 ] && echo "NO_SPAM_OK" || echo "SPAM_DETECTED"

--- a/scenarios/crew/04-jam-triggers.md
+++ b/scenarios/crew/04-jam-triggers.md
@@ -34,8 +34,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "What are the tradeoffs between using Redis vs Postgres for session storage? Compare the alternatives.", "session_id": "sess-1"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('JAM_FOUND' if 'jam:' in ctx else 'NO_JAM')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('JAM_FOUND' if 'jam:' in ctx else 'NO_JAM')"
 ```
 
 **Expected**: `JAM_FOUND`
@@ -48,8 +48,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "Should we use a monorepo or separate repos? Explore the options.", "session_id": "sess-2"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); has_quick='jam:quick' in ctx; has_brainstorm='jam:brainstorm' in ctx; print('NAMED' if has_quick or has_brainstorm else 'UNNAMED')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); has_quick='jam:quick' in ctx; has_brainstorm='jam:brainstorm' in ctx; print('NAMED' if has_quick or has_brainstorm else 'UNNAMED')"
 ```
 
 **Expected**: `NAMED`
@@ -62,8 +62,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "/wicked-garden:jam:quick thinking through tradeoffs for session storage options", "session_id": "sess-3"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); count=ctx.count('jam:'); print('DUPLICATE' if count > 1 else 'OK')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); count=ctx.count('jam:'); print('DUPLICATE' if count > 1 else 'OK')"
 ```
 
 **Expected**: `OK` (no duplicate suggestion appended)
@@ -76,8 +76,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "Should we use option A or B? Compare the alternatives and tradeoffs.", "session_id": "sess-4"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('JAM_FOUND' if '[Suggestion]' in ctx and 'jam:' in ctx else 'NO_JAM')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); print('JAM_FOUND' if '[Suggestion]' in ctx and 'jam:' in ctx else 'NO_JAM')"
 ```
 
 **Expected**: `NO_JAM`
@@ -90,9 +90,9 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "What are the tradeoffs between GraphQL and REST for our API?", "session_id": "sess-5"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null > /dev/null
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null > /dev/null
 
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, glob
 files = glob.glob('${TMPDIR}/wicked-garden-session-*.json')
 if files:
@@ -118,8 +118,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "What are the tradeoffs between these design options? Compare alternatives.", "session_id": "sess-6"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); has_jam='[Suggestion]' in ctx and 'jam:' in ctx; has_onboarding='setup' in ctx.lower(); print(f'jam={has_jam} onboarding={has_onboarding}')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); has_jam='[Suggestion]' in ctx and 'jam:' in ctx; has_onboarding='setup' in ctx.lower(); print(f'jam={has_jam} onboarding={has_onboarding}')"
 ```
 
 **Expected**: `jam=False onboarding=True`
@@ -142,8 +142,8 @@ cat > "${TMPDIR}/wicked-garden-session-test.json" <<'EOF'
 EOF
 
 echo '{"prompt": "I need to design and implement a migration strategy — but should we use a strangler fig pattern or big bang? Help me think through the tradeoffs and alternatives across the system architecture", "session_id": "sess-7"}' \
-  | python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); is_synthesis='path=synthesis' in ctx or 'synthesize' in ctx.lower(); has_jam='[Suggestion]' in ctx and 'jam:' in ctx; print(f'synthesis={is_synthesis} jam={has_jam}')"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" 2>/dev/null \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); ctx=d.get('additionalContext',''); is_synthesis='path=synthesis' in ctx or 'synthesize' in ctx.lower(); has_jam='[Suggestion]' in ctx and 'jam:' in ctx; print(f'synthesis={is_synthesis} jam={has_jam}')"
 ```
 
 **Expected**: `synthesis=True jam=False` (synthesis path returns early; jam hint never appended)

--- a/scenarios/crew/05-multi-project-management.md
+++ b/scenarios/crew/05-multi-project-management.md
@@ -241,7 +241,7 @@ Exercise the `project_registry.py` CLI directly to verify formal project isolati
 
 ```bash
 # Create a project via the registry API
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
   --name "registry-test" --workspace "multi-project-test" --json
 ```
 
@@ -249,15 +249,15 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
 
 ```bash
 # Set it as the active project for the workspace
-PROJECT_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
+PROJECT_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
   --name "registry-test-2" --workspace "multi-project-test" --json \
-  | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['id'])")
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" set-active \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" set-active \
   --id "${PROJECT_ID}" --json
 
 # Verify active project
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" get-active \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" get-active \
   --workspace "multi-project-test" --json
 ```
 
@@ -265,14 +265,14 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" get-active \
 
 ```bash
 # Get project filter for cross-domain isolation
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json
 ```
 
 **Expected**: `{"project_id": "<PROJECT_ID>"}` — non-empty filter when project is active
 
 ```bash
 # Switch between projects
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
   --workspace "multi-project-test" --json
 ```
 

--- a/scenarios/crew/05-qe-gate.md
+++ b/scenarios/crew/05-qe-gate.md
@@ -86,7 +86,7 @@ seed_preconditions() {
 
   # 1. Re-eval addendum — must post-date phase.started_at. We write "now"
   #    in ISO-8601 which is always >= the phase start recorded on entry.
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib, datetime
 p = pathlib.Path('${phase_dir}/reeval-log.jsonl')
 now = datetime.datetime.now(datetime.timezone.utc).isoformat()
@@ -101,7 +101,7 @@ p.write_text(json.dumps({
   # 2. Required deliverables for design phase (architecture.md, min_bytes=200).
   #    For other phases this is a no-op; extend as needed.
   if [ "${phase}" = "design" ]; then
-    python3 -c "
+    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import pathlib
 p = pathlib.Path('${phase_dir}/architecture.md')
 # 300+ bytes of plausible architecture content to clear the 200-byte floor
@@ -111,7 +111,7 @@ p.write_text('# Architecture\n\n' + ('Design notes for gate-enforcement-test. ' 
 }
 
 reset_phase() {
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 p = pathlib.Path('${PROJECT_DIR}/project.json')
 d = json.loads(p.read_text())
@@ -132,7 +132,7 @@ p.write_text(json.dumps(d, indent=2))
 ```bash
 seed_preconditions design
 mock_gate design NONE
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 
@@ -144,7 +144,7 @@ echo "Exit: $?"
 - project.json current_phase still "design" (not advanced)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 d = json.loads(pathlib.Path('${PROJECT_DIR}/project.json').read_text())
 print('PHASE_HELD' if d['current_phase'] == 'design' else 'PHASE_ADVANCED_UNEXPECTEDLY')
@@ -159,7 +159,7 @@ print('PHASE_HELD' if d['current_phase'] == 'design' else 'PHASE_ADVANCED_UNEXPE
 reset_phase
 mock_gate design REJECT "test coverage below threshold"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 
@@ -169,7 +169,7 @@ echo "Exit: $?"
 - project.json current_phase still "design"
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 d = json.loads(pathlib.Path('${PROJECT_DIR}/project.json').read_text())
 print('PHASE_HELD' if d['current_phase'] == 'design' else 'PHASE_ADVANCED_UNEXPECTEDLY')
@@ -184,7 +184,7 @@ print('PHASE_HELD' if d['current_phase'] == 'design' else 'PHASE_ADVANCED_UNEXPE
 reset_phase
 mock_gate design PASS
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 
@@ -193,7 +193,7 @@ echo "Exit: $?"
 - project current_phase advances to "build"
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 d = json.loads(pathlib.Path('${PROJECT_DIR}/project.json').read_text())
 print('ADVANCED' if d['current_phase'] == 'build' else 'NOT_ADVANCED')
@@ -208,7 +208,7 @@ print('ADVANCED' if d['current_phase'] == 'build' else 'NOT_ADVANCED')
 reset_phase
 mock_gate design REJECT "known issue tracked in JIRA-456"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design \
   --override-gate --reason "known issue tracked in JIRA-456, not blocking release" \
   2>&1
 echo "Exit: $?"
@@ -229,7 +229,7 @@ grep -A5 "Gate Override" "${PROJECT_DIR}/phases/design/status.md" 2>/dev/null ||
 reset_phase
 mock_gate design NONE
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design \
   --override-gate --reason "fast-pass waived for hotfix" \
   2>&1
 echo "Exit: $?"
@@ -243,7 +243,7 @@ grep "Gate Override" "${PROJECT_DIR}/phases/design/status.md" 2>/dev/null && ech
 
 ```bash
 # Advance project back to ideate phase (gate_required=false)
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 p = pathlib.Path('${PROJECT_DIR}/project.json')
 d = json.loads(p.read_text())
@@ -257,7 +257,7 @@ mkdir -p "${PROJECT_DIR}/phases/ideate"
 # ideate is gate_required=false, but the re-eval addendum check (AC-8) still
 # runs for every phase. Seed the addendum + the brainstorm-summary.md
 # deliverable so the only thing we're exercising is the "no gate" path.
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib, datetime
 phase_dir = pathlib.Path('${PROJECT_DIR}/phases/ideate')
 phase_dir.mkdir(parents=True, exist_ok=True)
@@ -273,7 +273,7 @@ now = datetime.datetime.now(datetime.timezone.utc).isoformat()
 # No gate-result.json present for ideate
 rm -f "${PROJECT_DIR}/phases/ideate/gate-result.json"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase ideate 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase ideate 2>&1
 echo "Exit: $?"
 ```
 
@@ -285,7 +285,7 @@ echo "Exit: $?"
 reset_phase
 echo 'not valid json{' > "${PROJECT_DIR}/phases/design/gate-result.json"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 
@@ -303,7 +303,7 @@ reset_phase
 rm -f "${PROJECT_DIR}/phases/design/reeval-log.jsonl"
 mock_gate design NONE
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 
@@ -321,7 +321,7 @@ reset_phase
 rm -f "${PROJECT_DIR}/phases/design/architecture.md"
 mock_gate design NONE
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" "${TEST_PROJECT}" approve --phase design 2>&1
 echo "Exit: $?"
 ```
 

--- a/scenarios/crew/07-autonomous-assumptions.md
+++ b/scenarios/crew/07-autonomous-assumptions.md
@@ -49,7 +49,7 @@ Expected:
 Assumptions are stored in `project.json` by the just-finish orchestrator. Read them directly from the project file (assumptions bypass the status summary):
 
 ```bash
-Run: python3 -c "
+Run: sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 from _paths import get_local_path

--- a/scenarios/crew/artifact-state-machine.md
+++ b/scenarios/crew/artifact-state-machine.md
@@ -18,7 +18,7 @@ and enforcing CLOSED as a terminal state.
 
 ```bash
 # Verify artifact_state.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --help > /dev/null 2>&1 \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --help > /dev/null 2>&1 \
   && echo "artifact_state.py available" || echo "NOT FOUND"
 ```
 
@@ -27,9 +27,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --help > /dev/nul
 ### 1. Register artifact
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name arch.md --type design --project test-asm --phase design \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('STATE:', d.get('state', 'N/A'))
@@ -45,36 +45,36 @@ print('ARTIFACT_ID:', aid)
 
 ```bash
 # Capture artifact ID from registration
-ART_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+ART_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name lifecycle.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
 echo "Artifact: ${ART_ID}"
 
 # DRAFT -> IN_REVIEW
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to IN_REVIEW --by reviewer \
-  | python3 -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
 
 # IN_REVIEW -> APPROVED
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to APPROVED --by gate-pass \
-  | python3 -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
 
 # APPROVED -> IMPLEMENTED
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to IMPLEMENTED --by build-phase \
-  | python3 -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
 
 # IMPLEMENTED -> VERIFIED
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to VERIFIED --by test-phase \
-  | python3 -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
 
 # VERIFIED -> CLOSED
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to CLOSED --by delivery \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print('STATE:', d.get('state')); print('HISTORY_LEN:', len(d.get('state_history', [])))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); print('STATE:', d.get('state')); print('HISTORY_LEN:', len(d.get('state_history', [])))"
 ```
 
 **Expected**: States progress DRAFT -> IN_REVIEW -> APPROVED -> IMPLEMENTED -> VERIFIED -> CLOSED. `HISTORY_LEN:` >= 5.
@@ -83,11 +83,11 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition
 
 ```bash
 # Register a fresh artifact in DRAFT, try to skip to APPROVED
-SKIP_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+SKIP_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name skip-test.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${SKIP_ID}" --to APPROVED --by shortcut 2>&1
 echo "Exit: $?"
 ```
@@ -98,16 +98,16 @@ echo "Exit: $?"
 
 ```bash
 # Register artifact, move to IN_REVIEW, then revert to DRAFT (simulating gate reject)
-GATE_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+GATE_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name gate-test.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${GATE_ID}" --to IN_REVIEW --by reviewer > /dev/null
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${GATE_ID}" --to DRAFT --by gate-reject \
-  | python3 -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print('STATE:', json.load(sys.stdin).get('state'))"
 ```
 
 **Expected**: `STATE: DRAFT` -- IN_REVIEW can revert to DRAFT.
@@ -116,30 +116,30 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition
 
 ```bash
 # Register 3 artifacts in design phase, approve 2
-BULK1=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+BULK1=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name bulk-1.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
-BULK2=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+BULK2=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name bulk-2.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
-BULK3=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
+BULK3=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json register \
   --name bulk-3.md --type design --project test-asm --phase design \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
 # Approve bulk-1 and bulk-2 (DRAFT -> IN_REVIEW -> APPROVED)
 for AID in "${BULK1}" "${BULK2}"; do
-  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
     --id "${AID}" --to IN_REVIEW --by reviewer > /dev/null
-  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
     --id "${AID}" --to APPROVED --by gate > /dev/null
 done
 
 # bulk-3 stays in DRAFT
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json bulk-check \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json bulk-check \
   --project test-asm --phase design --required-state APPROVED \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 # CLI returns {pass: bool, total: int, passing: int, failing: [ids]}
@@ -156,9 +156,9 @@ print('PASSING:', d.get('passing', 0))
 ### 6. List with filters
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json list \
   --project test-asm --state APPROVED \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 # CLI returns a JSON array of artifact records directly
 items = json.load(sys.stdin)
@@ -176,7 +176,7 @@ print('COUNT:', len(items))
 
 ```bash
 # Use the lifecycle artifact from step 2 (already CLOSED)
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/artifact_state.py" --json transition \
   --id "${ART_ID}" --to DRAFT --by reopen 2>&1
 echo "Exit: $?"
 ```

--- a/scenarios/crew/challenge-gate-enforcement.md
+++ b/scenarios/crew/challenge-gate-enforcement.md
@@ -52,7 +52,7 @@ export CLAUDE_PROJECT_NAME="wg-scenario-challenge-gate"
 # directory. Crew stores projects as a sibling pair:
 #   wicked-crew/projects/{id}.json   — DomainStore record (list() reads this)
 #   wicked-crew/projects/{id}/       — phase artifacts (challenge-artifacts.md)
-export PROJECTS_ROOT=$(python3 -c "
+export PROJECTS_ROOT=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -71,7 +71,7 @@ mkdir -p "${PROJECT_DIR}"
 # DomainStore record + phase directory. The record sits at
 # projects/{id}.json so `DomainStore('wicked-crew').list('projects')`
 # picks it up; phase content goes under projects/{id}/phases/...
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -112,7 +112,7 @@ hook's JSON output so each step can assert on `permissionDecision` and
 ```bash
 write_guard() {
   local file_path="$1"
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json, os
 sys.path.insert(0, '${PLUGIN_ROOT}/hooks/scripts')
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
@@ -140,7 +140,7 @@ must be permitted.
 ```bash
 mkdir -p "${PROJECT_DIR}/phases/design"
 
-python3 <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
 import os, textwrap, pathlib
 project_dir = pathlib.Path(os.environ['PROJECT_DIR'])
 body = textwrap.dedent("""\
@@ -197,7 +197,7 @@ PYEOF
 
 result=$(write_guard "src/payments/processor.py")
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 decision = d.get('hookSpecificOutput', {}).get('permissionDecision', 'allow')
@@ -223,7 +223,7 @@ rm -f "${PROJECT_DIR}/phases/design/challenge-artifacts.md"
 
 result=$(write_guard "src/payments/processor.py")
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 out = d.get('hookSpecificOutput', {})
@@ -251,7 +251,7 @@ but has all three challenges resolved under a single theme. The
 convergence-collapse detector must fire and the gate must deny.
 
 ```bash
-python3 <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
 import os, textwrap, pathlib
 project_dir = pathlib.Path(os.environ['PROJECT_DIR'])
 body = textwrap.dedent("""\
@@ -300,7 +300,7 @@ PYEOF
 
 result=$(write_guard "src/payments/processor.py")
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 out = d.get('hookSpecificOutput', {})
@@ -323,7 +323,7 @@ be allowed — no hook-server restart, no cache bust, no state outside
 the filesystem.
 
 ```bash
-python3 <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
 import os, textwrap, pathlib
 project_dir = pathlib.Path(os.environ['PROJECT_DIR'])
 body = textwrap.dedent("""\
@@ -377,7 +377,7 @@ PYEOF
 
 result=$(write_guard "src/payments/processor.py")
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 decision = d.get('hookSpecificOutput', {}).get('permissionDecision', 'allow')
@@ -400,7 +400,7 @@ escape hatch works exactly as advertised.
 
 ```bash
 # Restore the collapsed-theme artifact that failed in Step 3
-python3 <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
 import os, textwrap, pathlib
 project_dir = pathlib.Path(os.environ['PROJECT_DIR'])
 body = textwrap.dedent("""\
@@ -450,7 +450,7 @@ PYEOF
 # Confirm it blocks without the bypass (baseline — the bypass MUST actually change behavior)
 unset WG_CHALLENGE_GATE
 result=$(write_guard "src/payments/processor.py")
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 decision = d.get('hookSpecificOutput', {}).get('permissionDecision', 'allow')
@@ -462,7 +462,7 @@ print('baseline: deny (as expected — bypass not set)')
 export WG_CHALLENGE_GATE=off
 result=$(write_guard "src/payments/processor.py")
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.loads(sys.stdin.read())
 decision = d.get('hookSpecificOutput', {}).get('permissionDecision', 'allow')

--- a/scenarios/crew/cross-module-integration.md
+++ b/scenarios/crew/cross-module-integration.md
@@ -34,7 +34,7 @@ JAM="${CLAUDE_PLUGIN_ROOT}/scripts/jam"
 ### 1. Create project via project_registry
 
 ```bash
-python3 "${CREW}/project_registry.py" create --name "$PROJECT" --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/project_registry.py" create --name "$PROJECT" --json
 ```
 
 **Expected**: Returns JSON with the project record including `id`, `name` matching the project name, `status` = "active". Capture the project ID for subsequent steps.
@@ -42,15 +42,15 @@ python3 "${CREW}/project_registry.py" create --name "$PROJECT" --json
 ### 2. Register entities in knowledge graph
 
 ```bash
-REQ=$(python3 "${SMAHT}/knowledge_graph.py" create-entity --type requirement --name "Users must authenticate via OAuth2" --phase clarify --project "$PROJECT")
-DESIGN=$(python3 "${SMAHT}/knowledge_graph.py" create-entity --type design_artifact --name "OAuth2 flow architecture" --phase design --project "$PROJECT")
-TASK=$(python3 "${SMAHT}/knowledge_graph.py" create-entity --type task --name "Implement OAuth2 middleware" --phase build --project "$PROJECT")
-TEST=$(python3 "${SMAHT}/knowledge_graph.py" create-entity --type test_scenario --name "OAuth2 token validation" --phase test --project "$PROJECT")
+REQ=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${SMAHT}/knowledge_graph.py" create-entity --type requirement --name "Users must authenticate via OAuth2" --phase clarify --project "$PROJECT")
+DESIGN=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${SMAHT}/knowledge_graph.py" create-entity --type design_artifact --name "OAuth2 flow architecture" --phase design --project "$PROJECT")
+TASK=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${SMAHT}/knowledge_graph.py" create-entity --type task --name "Implement OAuth2 middleware" --phase build --project "$PROJECT")
+TEST=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${SMAHT}/knowledge_graph.py" create-entity --type test_scenario --name "OAuth2 token validation" --phase test --project "$PROJECT")
 
-echo "$REQ" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('REQ: %s' % d['entity_id'])"
-echo "$DESIGN" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('DESIGN: %s' % d['entity_id'])"
-echo "$TASK" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('TASK: %s' % d['entity_id'])"
-echo "$TEST" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('TEST: %s' % d['entity_id'])"
+echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('REQ: %s' % d['entity_id'])"
+echo "$DESIGN" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('DESIGN: %s' % d['entity_id'])"
+echo "$TASK" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('TASK: %s' % d['entity_id'])"
+echo "$TEST" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); assert d['state']=='DRAFT'; print('TEST: %s' % d['entity_id'])"
 ```
 
 **Expected**: Four entities created with state=DRAFT. Each prints its entity_id.
@@ -58,22 +58,22 @@ echo "$TEST" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['st
 ### 3. Create traceability links between artifacts
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-DESIGN_ID=$(echo "$DESIGN" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-TASK_ID=$(echo "$TASK" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-TEST_ID=$(echo "$TEST" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+DESIGN_ID=$(echo "$DESIGN" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+TASK_ID=$(echo "$TASK" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+TEST_ID=$(echo "$TEST" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
 
-python3 "${CREW}/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/traceability.py" create \
   --source-id "$REQ_ID" --source-type requirement \
   --target-id "$DESIGN_ID" --target-type design \
   --link-type TRACES_TO --project "$PROJECT" --created-by clarify
 
-python3 "${CREW}/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/traceability.py" create \
   --source-id "$DESIGN_ID" --source-type design \
   --target-id "$TASK_ID" --target-type task \
   --link-type IMPLEMENTED_BY --project "$PROJECT" --created-by design
 
-python3 "${CREW}/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/traceability.py" create \
   --source-id "$REQ_ID" --source-type requirement \
   --target-id "$TEST_ID" --target-type test_scenario \
   --link-type TESTED_BY --project "$PROJECT" --created-by clarify
@@ -84,12 +84,12 @@ python3 "${CREW}/traceability.py" create \
 ### 4. Register and transition artifact via artifact_state
 
 ```bash
-ART=$(python3 "${CREW}/artifact_state.py" register --name "OAuth2 architecture doc" --type design --project "$PROJECT" --phase design --json)
-ART_ID=$(echo "$ART" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+ART=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/artifact_state.py" register --name "OAuth2 architecture doc" --type design --project "$PROJECT" --phase design --json)
+ART_ID=$(echo "$ART" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['id'])")
 echo "Registered artifact: $ART_ID"
 
-python3 "${CREW}/artifact_state.py" transition --id "$ART_ID" --to IN_REVIEW --by "design-phase" --json
-python3 "${CREW}/artifact_state.py" transition --id "$ART_ID" --to APPROVED --by "gate-check" --json | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/artifact_state.py" transition --id "$ART_ID" --to IN_REVIEW --by "design-phase" --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/artifact_state.py" transition --id "$ART_ID" --to APPROVED --by "gate-check" --json | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 art = json.load(sys.stdin)
 assert art['state'] == 'APPROVED', 'Expected APPROVED, got %s' % art['state']
@@ -103,8 +103,8 @@ print('PASS: Artifact transitioned to APPROVED with 2 history entries')
 ### 5. Run impact analysis from requirement
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CREW}/impact_analyzer.py" analyze --source-id "$REQ_ID" --project "$PROJECT" --depth 3 | tee "${TMPDIR:-/tmp}/impact.json" | python3 -c "
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/impact_analyzer.py" analyze --source-id "$REQ_ID" --project "$PROJECT" --depth 3 | tee "${TMPDIR:-/tmp}/impact.json" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 report = json.load(sys.stdin)
 assert 'impact' in report, 'Missing impact key'
@@ -123,7 +123,7 @@ Note: The search lifecycle scoring script was removed. This step now tests the s
 domain adapter fan-out, which is the current mechanism for scoring/prioritising items.
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/smaht')
@@ -145,7 +145,7 @@ print('PASS: DomainAdapter fan-out succeeded (%d impact items queued)' % len(ite
 ### 7. Run verification protocol
 
 ```bash
-python3 "${CREW}/verification_protocol.py" run --project "$PROJECT" --phases-dir "${TMPDIR:-/tmp}/phases-$$" | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/verification_protocol.py" run --project "$PROJECT" --phases-dir "${TMPDIR:-/tmp}/phases-$$" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 report = json.load(sys.stdin)
 check_names = [c['name'] for c in report.get('checks', [])]
@@ -171,7 +171,7 @@ cat > "${TMPDIR:-/tmp}/mini-proposals.json" <<'EOF'
 ]
 EOF
 
-python3 "${JAM}/consensus.py" synthesize --proposals "${TMPDIR:-/tmp}/mini-proposals.json" --question "Auth approach" | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${JAM}/consensus.py" synthesize --proposals "${TMPDIR:-/tmp}/mini-proposals.json" --question "Auth approach" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 result = json.load(sys.stdin)
 assert 'decision' in result, 'Missing decision'
@@ -187,7 +187,7 @@ print('Decision: %s' % result['decision'][:80])
 ### 9. Traceability coverage report
 
 ```bash
-python3 "${CREW}/traceability.py" coverage --project "$PROJECT" | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/traceability.py" coverage --project "$PROJECT" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 report = json.load(sys.stdin)
 assert 'total_requirements' in report, 'Missing total_requirements'
@@ -217,10 +217,10 @@ if report['covered']:
 ## Cleanup
 
 ```bash
-python3 "${CREW}/traceability.py" delete --project "$PROJECT" 2>/dev/null
-PROJECT_ID=$(python3 "${CREW}/project_registry.py" find --name "$PROJECT" --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null)
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/traceability.py" delete --project "$PROJECT" 2>/dev/null
+PROJECT_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/project_registry.py" find --name "$PROJECT" --json 2>/dev/null | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null)
 if [ -n "$PROJECT_ID" ]; then
-  python3 "${CREW}/project_registry.py" archive --id "$PROJECT_ID" --json 2>/dev/null
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CREW}/project_registry.py" archive --id "$PROJECT_ID" --json 2>/dev/null
 fi
 rm -f "${TMPDIR:-/tmp}/impact.json" "${TMPDIR:-/tmp}/impact_items.json" "${TMPDIR:-/tmp}/mini-proposals.json"
 rm -rf "${TMPDIR:-/tmp}/phases-$$"

--- a/scenarios/crew/gate-enforcement-adversarial.md
+++ b/scenarios/crew/gate-enforcement-adversarial.md
@@ -36,7 +36,7 @@ export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
 
 # Resolve the project directory using the same path logic as the hook.
 # get_local_path is project-scoped so it must be resolved at runtime.
-export PROJECT_DIR=$(python3 -c "
+export PROJECT_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -49,7 +49,7 @@ rm -rf "${PROJECT_DIR}"
 mkdir -p "${PROJECT_DIR}"
 
 # project.json — complexity 7, full 6-phase plan
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib, sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -86,7 +86,7 @@ bypassing the hook dispatch machinery while exercising the exact same logic.
 ```bash
 preflight() {
   local phase="$1"
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, os
 sys.path.insert(0, '${PLUGIN_ROOT}/hooks/scripts')
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
@@ -109,7 +109,7 @@ The phase has no directory at all — it has produced zero output.
 # No phases/ directory yet — every phase directory is absent
 result=$(preflight clarify)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'
@@ -136,7 +136,7 @@ mkdir -p "${PROJECT_DIR}/phases/clarify"
 
 result=$(preflight clarify)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'
@@ -162,7 +162,7 @@ rm -rf "${PROJECT_DIR}/phases/clarify"
 
 result=$(preflight design)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'
@@ -188,7 +188,7 @@ minimum coverage gate must block approval.
 
 ```bash
 # Build out all preceding phases with minimal valid deliverables
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, pathlib
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -236,7 +236,7 @@ print('phase directories written')
 
 result=$(preflight test)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'
@@ -259,7 +259,7 @@ Fix coverage to 20/20 (100%). No `specialist-engagement.json` exists. Complexity
 
 ```bash
 # Fix test-results.md to 20/20 executed
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, pathlib
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -277,7 +277,7 @@ ls "${PROJECT_DIR}/phases/test/" 2>&1 | grep specialist || echo "(no specialist-
 
 result=$(preflight test)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'
@@ -297,7 +297,7 @@ Create `specialist-engagement.json` with the required `qe` specialist. All other
 checks already pass. The preflight must return `ok: true`.
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys, pathlib
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -309,7 +309,7 @@ print('specialist-engagement.json written')
 
 result=$(preflight test)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert d['ok'], f'Expected ok=True but got: {d}'
@@ -327,7 +327,7 @@ phase (`test-strategy`) must be blocked with a specific unresolved-conditions me
 
 ```bash
 # Write an unresolved conditions manifest for the design phase
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys, pathlib
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -352,7 +352,7 @@ print('conditions-manifest.json written with 1 unresolved condition')
 
 result=$(preflight test-strategy)
 echo "${result}"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 d = json.load(sys.stdin)
 assert not d['ok'], 'Expected block but got ok=True'

--- a/scenarios/crew/impact-analysis.md
+++ b/scenarios/crew/impact-analysis.md
@@ -18,26 +18,26 @@ and producing valid JSON under all conditions.
 
 ```bash
 # Clean slate
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-impact 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-impact 2>/dev/null || true
 
 # Create a chain: req-1 -> design-1 -> task-1 -> test-1
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id req-1 --source-type requirement \
   --target-id design-1 --target-type design \
   --link-type TRACES_TO --project test-impact --created-by setup
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id design-1 --source-type design \
   --target-id task-1 --target-type code \
   --link-type IMPLEMENTED_BY --project test-impact --created-by setup
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id task-1 --source-type code \
   --target-id test-1 --target-type test \
   --link-type TESTED_BY --project test-impact --created-by setup
 
 # Verify impact_analyzer.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" --help > /dev/null 2>&1 \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" --help > /dev/null 2>&1 \
   && echo "impact_analyzer.py available" || echo "NOT FOUND"
 ```
 
@@ -46,9 +46,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" --help > /dev/nu
 ### 1. Analyze from requirement
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id req-1 --project test-impact \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 items = d.get('impacts', d.get('affected', d.get('direct', [])))
@@ -72,9 +72,9 @@ print('VALID_JSON: True')
 ### 2. Risk classification
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id req-1 --project test-impact \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 risk = d.get('risk_summary', d.get('risk', {}))
@@ -89,9 +89,9 @@ print('NOT_NONE:', level != 'none')
 ### 3. Phases affected
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id req-1 --project test-impact \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 phases = d.get('phases_affected', d.get('phases', []))
@@ -105,9 +105,9 @@ print('MULTI_PHASE:', len(phases) > 1 if isinstance(phases, list) else False)
 ### 4. Shallow analysis
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id req-1 --project test-impact --depth 1 \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 # With depth=1, should only see direct impacts (design-1), not transitive
@@ -129,9 +129,9 @@ print('TRANSITIVE_COUNT:', len(trans_ids))
 ### 5. No impacts
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id nonexistent --project test-impact \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 items = d.get('impacts', d.get('affected', d.get('direct', [])))
@@ -150,9 +150,9 @@ print('VALID_JSON: True')
 
 ```bash
 # Run analysis against a project with no knowledge graph data
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/impact_analyzer.py" analyze \
   --source-id req-1 --project nonexistent-project \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -177,5 +177,5 @@ echo "Exit: $?"
 ## Cleanup
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-impact 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-impact 2>/dev/null || true
 ```

--- a/scenarios/crew/local-mode.md
+++ b/scenarios/crew/local-mode.md
@@ -43,7 +43,7 @@ echo "Sandbox ready: $WG_TMP"
   - The file contains the correct payload fields
 
 ```bash
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import sys, os, json
 from pathlib import Path
 
@@ -92,7 +92,7 @@ PYEOF
 **Then**: The record is returned correctly — local JSON is the durable store
 
 ```bash
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import sys, os, json
 from pathlib import Path
 
@@ -144,7 +144,7 @@ PYEOF
   - `list` after `delete` excludes the record
 
 ```bash
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import sys, os
 from pathlib import Path
 
@@ -196,7 +196,7 @@ PYEOF
 **Then**: The JSON output's `additionalContext` contains the string `"Storage:"` and `"local"`
 
 ```bash
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import sys, os, json, subprocess
 from pathlib import Path
 
@@ -243,7 +243,7 @@ PYEOF
 **Then**: Only the record containing "authentication" is returned
 
 ```bash
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import sys, os
 from pathlib import Path
 

--- a/scenarios/crew/orchestrator-no-inline-work.md
+++ b/scenarios/crew/orchestrator-no-inline-work.md
@@ -76,8 +76,8 @@ Assert: PASS: parallel dispatch referenced
 
 ```bash
 Run: echo '{"tool_name": "Write", "tool_input": {"file_path": "/tmp/test_output.py", "content": "print(hello)"}}' | \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre_tool.py" | \
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre_tool.py" | \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 data = json.load(sys.stdin)
 # Hook should allow (fail open) — never deny writes
@@ -93,8 +93,8 @@ Assert: PASS: pre_tool allows writes (fail open)
 
 ```bash
 Run: echo '{"tool_name": "Write", "tool_input": {"file_path": "/home/user/.something-wicked/wicked-garden/projects/test-slug/wicked-crew/projects/test/status.md", "content": "status: ok"}}' | \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre_tool.py" | \
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre_tool.py" | \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 data = json.load(sys.stdin)
 decision = data.get('hookSpecificOutput', {}).get('permissionDecision', '')

--- a/scenarios/crew/phase-boundary-reeval.md
+++ b/scenarios/crew/phase-boundary-reeval.md
@@ -30,7 +30,7 @@ codes, stderr output) — no LLM response is asserted.
 export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
 export TEST_PROJECT="phase-reeval-test"
 
-export PROJECT_DIR=$(python3 -c "
+export PROJECT_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
 from _paths import get_local_path
@@ -41,7 +41,7 @@ rm -rf "${PROJECT_DIR}"
 mkdir -p "${PROJECT_DIR}/phases/design"
 
 # Minimal project.json
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 d = {
     'id': '${TEST_PROJECT}',
@@ -125,7 +125,7 @@ Approve is invoked without `--skip-reeval`.
 rm -f "${PROJECT_DIR}/phases/design/reeval-log.jsonl"
 
 # Record design start timestamp in project state
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, pathlib
 p = pathlib.Path('${PROJECT_DIR}/project.json')
 d = json.loads(p.read_text())
@@ -386,7 +386,7 @@ echo "Teardown complete"
 
 ```bash
 # Run all case scripts directly (Python)
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import subprocess, sys
 cases = [
     'structured-current-chain',

--- a/scenarios/crew/phase-executor-deliverable-contract.md
+++ b/scenarios/crew/phase-executor-deliverable-contract.md
@@ -73,7 +73,7 @@ Assert: PASS: halt reason present
 as a distinct reason from `executor-empty-deliverables`.
 
 ```bash
-Run: python3 -c "
+Run: sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import pathlib, sys
 text = pathlib.Path('${CLAUDE_PLUGIN_ROOT}/agents/crew/phase-executor.md').read_text()
 assert 'executor-missing-deliverable' in text, 'executor-missing-deliverable reason not found'
@@ -92,7 +92,7 @@ make a silent empty-manifest exit impossible — the verification must run befor
 any ok return.
 
 ```bash
-Run: python3 -c "
+Run: sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import pathlib, sys, re
 text = pathlib.Path('${CLAUDE_PLUGIN_ROOT}/agents/crew/phase-executor.md').read_text()
 

--- a/scenarios/crew/project-registry.md
+++ b/scenarios/crew/project-registry.md
@@ -17,7 +17,7 @@ and unarchiving, finding by name, and producing correct filter output.
 
 ```bash
 # Verify project_registry.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" --help > /dev/null 2>&1 \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" --help > /dev/null 2>&1 \
   && echo "project_registry.py available" || echo "NOT FOUND"
 ```
 
@@ -26,9 +26,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" --help > /dev/n
 ### 1. Create project
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
   --name test-proj-1 --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('HAS_ID:', bool(d.get('id')))
@@ -45,9 +45,9 @@ print('PROJ1_ID:', proj_id)
 ### 2. Create second project
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" create \
   --name test-proj-2 --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('NAME:', d.get('name', 'N/A'))
@@ -60,9 +60,9 @@ print('PROJ2_ID:', d.get('id', ''))
 ### 3. List projects
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
   --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 projects = d.get('projects', d if isinstance(d, list) else [])
@@ -79,17 +79,17 @@ print('BOTH_PRESENT:', 'test-proj-1' in names and 'test-proj-2' in names)
 
 ```bash
 # Get proj-1 ID
-PROJ1_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
+PROJ1_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
   --name test-proj-1 --workspace test-ws --json \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id', d.get('projects',[{}])[0].get('id','') if isinstance(d.get('projects'),list) else ''))")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); print(d.get('id', d.get('projects',[{}])[0].get('id','') if isinstance(d.get('projects'),list) else ''))")
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" set-active \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" set-active \
   --id "${PROJ1_ID}" 2>&1
 echo "Exit: $?"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" get-active \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" get-active \
   --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('ACTIVE_NAME:', d.get('name', 'N/A'))
@@ -101,13 +101,13 @@ print('ACTIVE_NAME:', d.get('name', 'N/A'))
 ### 5. Switch project
 
 ```bash
-PROJ2_ID=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
+PROJ2_ID=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
   --name test-proj-2 --workspace test-ws --json \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id', d.get('projects',[{}])[0].get('id','') if isinstance(d.get('projects'),list) else ''))")
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); print(d.get('id', d.get('projects',[{}])[0].get('id','') if isinstance(d.get('projects'),list) else ''))")
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" switch \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" switch \
   --id "${PROJ2_ID}" --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('SWITCHED_TO:', d.get('name', 'N/A'))
@@ -119,8 +119,8 @@ print('SWITCHED_TO:', d.get('name', 'N/A'))
 ### 6. Get project filter
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json \
-  | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 has_project = bool(d.get('project_id'))
@@ -133,13 +133,13 @@ print('HAS_PROJECT_ID:', has_project)
 ### 7. Archive
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive \
   --id "${PROJ1_ID}" 2>&1
 echo "Exit: $?"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
   --workspace test-ws --active --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 projects = d.get('projects', d if isinstance(d, list) else [])
@@ -154,13 +154,13 @@ print('PROJ2_VISIBLE:', 'test-proj-2' in names)
 ### 8. Unarchive
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive \
   --id "${PROJ1_ID}" 2>&1
 echo "Exit: $?"
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" list \
   --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 projects = d.get('projects', d if isinstance(d, list) else [])
@@ -174,9 +174,9 @@ print('BOTH_BACK:', 'test-proj-1' in names and 'test-proj-2' in names)
 ### 9. Find by name
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" find \
   --name test-proj-1 --workspace test-ws --json \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 name = d.get('name', d.get('projects', [{}])[0].get('name', '') if isinstance(d.get('projects'), list) else '')
@@ -190,11 +190,11 @@ print('FOUND:', name == 'test-proj-1')
 
 ```bash
 # Archive both projects
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive --id "${PROJ1_ID}" 2>/dev/null
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive --id "${PROJ2_ID}" 2>/dev/null
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive --id "${PROJ1_ID}" 2>/dev/null
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" archive --id "${PROJ2_ID}" 2>/dev/null
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json \
-  | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" filter --json \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('EMPTY_FILTER:', d == {} or not d.get('project_id'))
@@ -219,6 +219,6 @@ print('EMPTY_FILTER:', d == {} or not d.get('project_id'))
 
 ```bash
 # Unarchive to enable deletion if needed
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive --id "${PROJ1_ID}" 2>/dev/null || true
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive --id "${PROJ2_ID}" 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive --id "${PROJ1_ID}" 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/project_registry.py" unarchive --id "${PROJ2_ID}" 2>/dev/null || true
 ```

--- a/scenarios/crew/task-evidence-complete-block.md
+++ b/scenarios/crew/task-evidence-complete-block.md
@@ -16,8 +16,8 @@ This scenario validates that `scripts/crew/evidence.py` correctly validates task
 No special setup needed. Uses `evidence.py` directly.
 
 ```bash
-python3 -c "from scripts.crew.evidence import validate_evidence; print('evidence.py importable')" 2>/dev/null || \
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/evidence.py" --help > /dev/null 2>&1 && echo "evidence.py available"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "from scripts.crew.evidence import validate_evidence; print('evidence.py importable')" 2>/dev/null || \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/evidence.py" --help > /dev/null 2>&1 && echo "evidence.py available"
 ```
 
 ## Steps
@@ -25,7 +25,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/evidence.py" --help > /dev/null 2>&1
 ### 1. Low complexity (score 1-2): requires code_diff + test_results
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -57,7 +57,7 @@ Expected: `PASS: Low complexity evidence accepted`
 ### 2. Low complexity: missing evidence fields blocked
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -84,7 +84,7 @@ Expected: `PASS: Missing evidence detected for complexity 2`
 ### 3. Medium complexity (score 3-4): requires code_diff + test_results + verification
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -116,7 +116,7 @@ Expected: `PASS: Verification required for complexity 4`
 ### 4. Medium complexity: full evidence passes
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -148,7 +148,7 @@ Expected: `PASS: Full medium complexity evidence accepted`
 ### 5. High complexity (score 5+): requires performance + assumptions
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -181,7 +181,7 @@ Expected: `PASS: Performance metrics required for complexity 6`
 ### 6. High complexity: complete evidence passes
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import validate_evidence
@@ -216,7 +216,7 @@ Expected: `PASS: High complexity evidence accepted`
 ### 7. EVIDENCE_SCHEMA is exported and inspectable
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from evidence import EVIDENCE_SCHEMA

--- a/scenarios/crew/tdd-enforcement-red-green-refactor.md
+++ b/scenarios/crew/tdd-enforcement-red-green-refactor.md
@@ -20,7 +20,7 @@ This scenario validates that:
 
 ```bash
 # Verify traceability_generator.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" --help > /dev/null 2>&1 && echo "traceability_generator.py available"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" --help > /dev/null 2>&1 && echo "traceability_generator.py available"
 
 # Verify evidence-taxonomy.md exists
 test -f "${CLAUDE_PLUGIN_ROOT}/skills/qe/qe-strategy/refs/evidence-taxonomy.md" && echo "evidence-taxonomy.md exists"
@@ -69,7 +69,7 @@ cat > /tmp/tdd-test-scenario/phases/test-strategy/test-strategy.md << 'STRATEGY'
 | AC-003 | Session expires after 30 minutes | tests/auth/test_session.py |
 STRATEGY
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" \
   --phases-dir /tmp/tdd-test-scenario/phases \
   --output /tmp/tdd-test-scenario/phases/build/traceability-matrix.md \
   --dry-run 2>&1 | head -20 && echo "PASS: traceability_generator.py ran without error"
@@ -91,11 +91,11 @@ cat > /tmp/tdd-test-scenario/phases/test-strategy/test-strategy.md << 'STRATEGY'
 | AC-002 | Password reset works | tests/auth/test_reset.py |
 STRATEGY
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" \
   --phases-dir /tmp/tdd-test-scenario/phases \
   --output /tmp/tdd-test-scenario/phases/build/traceability-matrix.md
 
-cat /tmp/tdd-test-scenario/phases/build/traceability-matrix.md | python3 -c "
+cat /tmp/tdd-test-scenario/phases/build/traceability-matrix.md | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 content = sys.stdin.read()
 print('Content preview:', content[:500])
@@ -111,7 +111,7 @@ Expected: `PASS: All required columns present in traceability matrix`
 ### 6. evidence-taxonomy.md exists with required table
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os
 path = os.environ.get('CLAUDE_PLUGIN_ROOT', '${CLAUDE_PLUGIN_ROOT}') + '/skills/qe/qe-strategy/refs/evidence-taxonomy.md'
 with open(path) as f:
@@ -136,7 +136,7 @@ Expected: `PASS: When required column present`
 ### 8. traceability_generator.py --help shows expected options
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" --help
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability_generator.py" --help
 ```
 
 Expected: Help output showing `--phases-dir`, `--output`, `--project` options

--- a/scenarios/crew/traceability-links.md
+++ b/scenarios/crew/traceability-links.md
@@ -17,11 +17,11 @@ reports, filtering by link type, rejecting invalid link types, and bulk deletion
 
 ```bash
 # Verify traceability.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" --help > /dev/null 2>&1 \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" --help > /dev/null 2>&1 \
   && echo "traceability.py available" || echo "NOT FOUND"
 
 # Clean slate — delete any leftover links from prior runs
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace 2>/dev/null || true
 ```
 
 ## Steps
@@ -30,32 +30,32 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project te
 
 ```bash
 # req-1 TRACES_TO design-1
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id req-1 --source-type requirement \
   --target-id design-1 --target-type design \
   --link-type TRACES_TO --project test-trace --created-by clarify-phase
 
 # design-1 IMPLEMENTED_BY task-1
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id design-1 --source-type design \
   --target-id task-1 --target-type code \
   --link-type IMPLEMENTED_BY --project test-trace --created-by build-phase
 
 # req-1 TESTED_BY test-1
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id req-1 --source-type requirement \
   --target-id test-1 --target-type test \
   --link-type TESTED_BY --project test-trace --created-by test-phase
 
 # test-1 VERIFIES req-1
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id test-1 --source-type test \
   --target-id req-1 --target-type requirement \
   --link-type VERIFIES --project test-trace --created-by test-phase
 
 # Validate link count
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list --project test-trace \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print('LINK_COUNT:', len(d.get('links', d if isinstance(d, list) else [])))"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list --project test-trace \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); print('LINK_COUNT:', len(d.get('links', d if isinstance(d, list) else [])))"
 ```
 
 **Expected**: 4 links created, each returns JSON with source_id, target_id, link_type. `LINK_COUNT: 4`.
@@ -63,9 +63,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list --project test
 ### 2. Forward trace from requirement
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" forward \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" forward \
   --source-id req-1 --project test-trace \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 ids = [n.get('id', n.get('target_id', '')) for n in d.get('trace', d.get('nodes', []))]
@@ -80,9 +80,9 @@ print('HAS_DESIGN:', has_design)
 ### 3. Reverse trace from test
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" reverse \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" reverse \
   --target-id test-1 --project test-trace \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 ids = [n.get('id', n.get('source_id', '')) for n in d.get('trace', d.get('nodes', []))]
@@ -96,9 +96,9 @@ print('WALKS_TO_REQ:', has_req)
 ### 4. Coverage report — full coverage
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" coverage \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" coverage \
   --project test-trace \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('TOTAL_REQS:', d.get('total_requirements', 'N/A'))
@@ -114,14 +114,14 @@ print('REQ1_COVERED:', 'req-1' in covered)
 
 ```bash
 # Create a second requirement with no test link
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id req-2 --source-type requirement \
   --target-id design-2 --target-type design \
   --link-type TRACES_TO --project test-trace --created-by clarify-phase
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" coverage \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" coverage \
   --project test-trace \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 pct = d.get('coverage_pct', 100)
@@ -136,9 +136,9 @@ print('HAS_GAP_REQ2:', 'req-2' in gaps)
 ### 6. List with filters
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list \
   --project test-trace --link-type TRACES_TO \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 links = d.get('links', d if isinstance(d, list) else [])
@@ -153,7 +153,7 @@ print('COUNT:', len(links))
 ### 7. Invalid link type rejected
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" create \
   --source-id req-1 --source-type requirement \
   --target-id bogus --target-type design \
   --link-type INVALID --project test-trace --created-by test 2>&1
@@ -165,16 +165,16 @@ echo "Exit: $?"
 ### 8. Delete by project
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace \
-  | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('DELETED:', d.get('deleted', d.get('count', 0)))
 "
 
 # Confirm empty
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list --project test-trace \
-  | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" list --project test-trace \
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 links = d.get('links', d if isinstance(d, list) else [])
@@ -198,5 +198,5 @@ print('EMPTY:', len(links) == 0)
 ## Cleanup
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace 2>/dev/null || true
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/traceability.py" delete --project test-trace 2>/dev/null || true
 ```

--- a/scenarios/crew/v7-0-alias-deprecation.md
+++ b/scenarios/crew/v7-0-alias-deprecation.md
@@ -95,7 +95,7 @@ grep -F '[DEPRECATED] /wicked-garden:qe:report is removed in v7.1 — use /wicke
 ### Step 9: No shim body exceeds 25 lines (thin shim check) (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 shims = ['qe.md','qe-plan.md','scenarios.md','automate.md','run.md','acceptance.md','qe-review.md','report.md']
@@ -135,7 +135,7 @@ print('PASS: all shims are thin (<= 30 lines)')
 ### Step 10: Each shim delegates to correct wicked-testing:* target (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 expected = {
@@ -184,7 +184,7 @@ print('PASS: all shims reference correct delegation targets')
 ### Step 11: All shims check wicked_testing_missing before emitting deprecation (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 shims = ['qe.md','qe-plan.md','scenarios.md','automate.md','run.md','acceptance.md','qe-review.md','report.md']
@@ -242,7 +242,7 @@ grep -F 'Deprecated — removed in v7.1' \
 ### Step 13: help.md names all 8 aliases in the deprecated section (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 path = os.path.join(root, 'commands', 'help.md')
@@ -281,7 +281,7 @@ print('PASS')
 ### Step 14: help.md names all 4 wicked-testing replacement targets (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 path = os.path.join(root, 'commands', 'help.md')
@@ -314,7 +314,7 @@ print('PASS')
 ### Step 15: Non-shim QE commands do not contain DEPRECATED marker (bash)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 preserved = ['check.md', 'list.md', 'setup.md', 'help.md']

--- a/scenarios/crew/v7-1-deletions-regression.md
+++ b/scenarios/crew/v7-1-deletions-regression.md
@@ -22,7 +22,7 @@ or structural grep audits — no side-effects on the repo.
 ## Step 1: 4 deleted directories are absent (GA-01..GA-04)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 absent = ['agents/qe', 'skills/qe', 'skills/acceptance-testing', 'commands/qe']
@@ -47,7 +47,7 @@ print('PASS (GA-01..GA-04): all 4 directories absent')
 ## Step 2: Zero wicked-garden:qe: refs in dispatch-path code (GA-05, GA-07..GA-09)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys, pathlib
 root = pathlib.Path(os.environ.get('CLAUDE_PLUGIN_ROOT', '.'))
 targets = [
@@ -87,7 +87,7 @@ print('PASS (GA-05, GA-07..GA-09): dispatch-path files clean')
 ## Step 3: cli_discovery.py deleted (GA-10)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 path = os.path.join(os.environ.get('CLAUDE_PLUGIN_ROOT', '.'), 'scripts', 'qe', 'cli_discovery.py')
 if os.path.exists(path):
@@ -106,7 +106,7 @@ print('PASS (GA-10): cli_discovery.py absent')
 ## Step 4: CHANGELOG has [7.1.0] entry with all 4 deleted dirs (CA-01, CA-02)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 path = os.path.join(root, 'CHANGELOG.md')
@@ -143,7 +143,7 @@ print('PASS (CA-01..CA-04): CHANGELOG checks passed')
 ## Step 5: plugin.json version is 7.1.0 and v7.0.0 git tag exists (CA-05, CA-06)
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import os, sys, json, subprocess
 root = os.environ.get('CLAUDE_PLUGIN_ROOT', '.')
 plugin_path = os.path.join(root, '.claude-plugin', 'plugin.json')

--- a/scenarios/crew/verification-protocol.md
+++ b/scenarios/crew/verification-protocol.md
@@ -46,7 +46,7 @@ def login(user, pw):
 PYEOF
 
 # Verify verification_protocol.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" --help > /dev/null 2>&1 \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" --help > /dev/null 2>&1 \
   && echo "verification_protocol.py available" || echo "NOT FOUND"
 ```
 
@@ -55,10 +55,10 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" --help > /
 ### 1. Debug artifacts check (FAIL)
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --check debug_artifacts --files "${VP_TMPDIR}/code.py" \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 checks = d.get('checks', [d]) if not d.get('status') else [d]
@@ -83,10 +83,10 @@ def login(user, pw):
     return authenticate(user, pw)
 PYEOF
 
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --check debug_artifacts --files "${VP_TMPDIR}/code_clean.py" \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 checks = d.get('checks', [d]) if not d.get('status') else [d]
@@ -102,10 +102,10 @@ for c in checks:
 ### 3. Acceptance criteria check
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --check acceptance_criteria \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 checks = d.get('checks', [d]) if not d.get('status') else [d]
@@ -123,10 +123,10 @@ for c in checks:
 ### 4. Test suite check (SKIP)
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --check test_suite \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 checks = d.get('checks', [d]) if not d.get('status') else [d]
@@ -142,10 +142,10 @@ for c in checks:
 ### 5. Full protocol run
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --files "${VP_TMPDIR}/code.py" \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 checks = d.get('checks', [])
@@ -165,10 +165,10 @@ print('SUMMARY_EXISTS:', bool(summary))
 
 ```bash
 # With debug artifacts present (code.py has TODO + print), expect FAIL verdict
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --files "${VP_TMPDIR}/code.py" \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 verdict = d.get('verdict', d.get('summary', {}).get('verdict', 'N/A'))
@@ -176,10 +176,10 @@ print('VERDICT_WITH_ISSUES:', verdict)
 "
 
 # With clean code, check for improved verdict
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verification_protocol.py" run \
   --project test-vp --phases-dir "${VP_TMPDIR}/phases" \
   --files "${VP_TMPDIR}/code_clean.py" \
-  | python3 -c "
+  | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 verdict = d.get('verdict', d.get('summary', {}).get('verdict', 'N/A'))

--- a/scenarios/crew/worktree-parallel-build-clean-merge.md
+++ b/scenarios/crew/worktree-parallel-build-clean-merge.md
@@ -22,10 +22,10 @@ This scenario validates that:
 git worktree list > /dev/null 2>&1 && echo "worktrees supported"
 
 # Verify worktree_manager.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/worktree_manager.py" --help > /dev/null 2>&1 && echo "worktree_manager.py available"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/worktree_manager.py" --help > /dev/null 2>&1 && echo "worktree_manager.py available"
 
 # Verify build_dependency_analyzer.py is available
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/build_dependency_analyzer.py" --help > /dev/null 2>&1 && echo "build_dependency_analyzer.py available"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/build_dependency_analyzer.py" --help > /dev/null 2>&1 && echo "build_dependency_analyzer.py available"
 ```
 
 ## Steps
@@ -33,7 +33,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/build_dependency_analyzer.py" --help
 ### 1. worktree_manager.py check_capability returns bool
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from worktree_manager import check_capability
@@ -49,7 +49,7 @@ Expected: `PASS: check_capability() returns bool`
 ### 2. build_dependency_analyzer.py batches independent tasks as parallel
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from build_dependency_analyzer import analyze_dependencies
@@ -76,7 +76,7 @@ Expected: `PASS: Independent tasks batched as parallel`
 ### 3. build_dependency_analyzer.py separates conflicting tasks
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from build_dependency_analyzer import analyze_dependencies
@@ -103,7 +103,7 @@ Expected: `PASS: Conflicting tasks separated into different batches`
 ### 4. build_dependency_analyzer.py respects max_parallelism
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from build_dependency_analyzer import analyze_dependencies
@@ -127,7 +127,7 @@ Expected: `PASS: max_parallelism=2 respected`
 ### 5. worktree_manager.py list_active_worktrees returns list
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/crew')
 from worktree_manager import list_active_worktrees
@@ -168,8 +168,8 @@ Expected: `PASS: Conflict escalation guardrail referenced`
 
 ```bash
 echo '[{"id":"1","subject":"Build: proj - task1","description":"Implement auth.py"},{"id":"2","subject":"Build: proj - task2","description":"Implement profile.py"}]' | \
-  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/crew/build_dependency_analyzer.py" --stdin | \
-  python3 -c "
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/build_dependency_analyzer.py" --stdin | \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 data = json.load(sys.stdin)
 assert isinstance(data, list), f'Expected list, got {type(data)}'

--- a/scenarios/data/06-large-file-sql-analysis.md
+++ b/scenarios/data/06-large-file-sql-analysis.md
@@ -17,7 +17,7 @@ Create a larger dataset that simulates real-world file sizes. This example uses 
 
 ```bash
 # Create a 10,000 row transaction log
-python3 << 'EOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" << 'EOF'
 import csv
 import random
 from datetime import datetime, timedelta

--- a/scenarios/jam/04-integration-with-wicked-mem.md
+++ b/scenarios/jam/04-integration-with-wicked-mem.md
@@ -19,7 +19,7 @@ Requires wicked-jam plugin installed and wicked-brain plugin installed and runni
 
 ```bash
 # Verify wicked-brain is running
-curl -s http://localhost:${WICKED_BRAIN_PORT:-4242}/health | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('ok'), 'Brain not running'"
+curl -s http://localhost:${WICKED_BRAIN_PORT:-4242}/health | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; d=json.load(sys.stdin); assert d.get('ok'), 'Brain not running'"
 
 # Create test project directory
 mkdir -p ~/test-wicked-jam/database-migration
@@ -167,12 +167,12 @@ cat > /tmp/test-proposals.json <<'EOF'
 EOF
 
 # Synthesize consensus
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
   --proposals /tmp/test-proposals.json \
   --question "Which database for time-series data?" > /tmp/consensus-result.json
 
 # Verify structured output
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 r = json.load(open('/tmp/consensus-result.json'))
 assert 'decision' in r, 'Missing decision'
@@ -190,7 +190,7 @@ print(f'Dissenting views: {len(r[\"dissenting_views\"])}')
 ### 10. Verify format_for_memory Returns Brain-Compatible Dict
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/jam')

--- a/scenarios/jam/council-consensus.md
+++ b/scenarios/jam/council-consensus.md
@@ -39,7 +39,7 @@ EOF
 ### 1. Score consensus from proposals
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" score --proposals "${TMPDIR:-/tmp}/proposals.json" | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" score --proposals "${TMPDIR:-/tmp}/proposals.json" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 result = json.load(sys.stdin)
 assert 'consensus_points' in result, 'Missing consensus_points'
@@ -57,10 +57,10 @@ print('Consensus points: %d, Divergent points: %d' % (len(result['consensus_poin
 ### 2. Full synthesis with proposals and reviews
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
   --proposals "${TMPDIR:-/tmp}/proposals.json" \
   --reviews "${TMPDIR:-/tmp}/reviews.json" \
-  --question "How should we handle API authentication?" | tee "${TMPDIR:-/tmp}/result.json" | python3 -c "
+  --question "How should we handle API authentication?" | tee "${TMPDIR:-/tmp}/result.json" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 result = json.load(sys.stdin)
 assert 'decision' in result, 'Missing decision'
@@ -80,7 +80,7 @@ print('Decision: %s' % result['decision'][:100])
 ### 3. Dissent extraction from synthesis
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 result = json.load(open('${TMPDIR:-/tmp}/result.json'))
 dissents = result.get('dissenting_views', [])
@@ -98,7 +98,7 @@ print('PASS: Found %d dissenting views with strengths: %s' % (len(dissents), str
 ### 4. Confidence is in valid range
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 result = json.load(open('${TMPDIR:-/tmp}/result.json'))
 conf = result['confidence']
@@ -112,7 +112,7 @@ print('PASS: Confidence %.3f is in valid range [0.0, 1.0]' % conf)
 ### 5. Format for display
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" format --result "${TMPDIR:-/tmp}/result.json" | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" format --result "${TMPDIR:-/tmp}/result.json" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 output = sys.stdin.read()
 assert '## Council Consensus' in output, 'Missing header'
@@ -127,7 +127,7 @@ print('PASS: Display format has expected markdown headers')
 ### 6. Format for display with dissent section
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" format --result "${TMPDIR:-/tmp}/result.json" --show-dissent | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" format --result "${TMPDIR:-/tmp}/result.json" --show-dissent | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys
 output = sys.stdin.read()
 assert '### Dissenting Views' in output, 'Missing Dissenting Views section when --show-dissent used'
@@ -140,7 +140,7 @@ print('PASS: --show-dissent flag includes Dissenting Views section')
 ### 7. Format for memory produces correct structure
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
 sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts/jam')
@@ -165,9 +165,9 @@ print('Dissent count: %d, Strong: %d' % (md['dissent_count'], md['strong_dissent
 ### 8. Synthesis works without reviews (optional cross-reviews)
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/consensus.py" synthesize \
   --proposals "${TMPDIR:-/tmp}/proposals.json" \
-  --question "test without reviews" | python3 -c "
+  --question "test without reviews" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 result = json.load(sys.stdin)
 assert 'decision' in result, 'Missing decision'

--- a/scenarios/jam/persona-transcript-session-retrieval.md
+++ b/scenarios/jam/persona-transcript-session-retrieval.md
@@ -15,7 +15,7 @@ This scenario verifies that wicked-jam records and exposes individual persona co
 
 ```bash
 # Confirm jam.py is accessible
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" --help
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" --help
 ```
 
 ## Steps
@@ -74,12 +74,12 @@ Verify the output:
 
 ```bash
 # First get the session ID from list-sessions
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" list-sessions --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" list-sessions --json
 
 # Then retrieve transcript for that specific session
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --session-id <SESSION_ID>
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" persona "Cost Optimizer" --session-id <SESSION_ID>
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" thinking --session-id <SESSION_ID>
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --session-id <SESSION_ID>
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" persona "Cost Optimizer" --session-id <SESSION_ID>
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" thinking --session-id <SESSION_ID>
 ```
 
 Expected: All three subcommands accept `--session-id` and retrieve data from the specified session, not just the latest.
@@ -87,8 +87,8 @@ Expected: All three subcommands accept `--session-id` and retrieve data from the
 ### 6. Test JSON Output
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --json
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" thinking --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" thinking --json
 ```
 
 Expected: Valid JSON output with `entries` array and `session_id` at the top level. Suitable for programmatic use by other scripts.
@@ -113,8 +113,8 @@ Verify:
 ### 8. Test Error Handling
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --session-id nonexistent-id-xyz
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" persona "Nobody Real"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" transcript --session-id nonexistent-id-xyz
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/jam/jam.py" persona "Nobody Real"
 ```
 
 Expected: Graceful output like "No transcript found for session: nonexistent-id-xyz" and "No contributions found for persona: Nobody Real". Exit code 0 (not a crash).

--- a/scenarios/qe/03-acceptance-testing-pipeline.md
+++ b/scenarios/qe/03-acceptance-testing-pipeline.md
@@ -66,7 +66,7 @@ cd ~/test-wicked-qe/acceptance-test
 ### 1. Test addition
 
 ```bash
-python3 -c "from src.calc import add; print(f'result={add(3, 4)}')"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "from src.calc import add; print(f'result={add(3, 4)}')"
 ```
 
 **Expected**: Output shows result=7
@@ -74,7 +74,7 @@ python3 -c "from src.calc import add; print(f'result={add(3, 4)}')"
 ### 2. Test subtraction
 
 ```bash
-python3 -c "from src.calc import subtract; print(f'result={subtract(10, 3)}')"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "from src.calc import subtract; print(f'result={subtract(10, 3)}')"
 ```
 
 **Expected**: Output shows result=7
@@ -82,7 +82,7 @@ python3 -c "from src.calc import subtract; print(f'result={subtract(10, 3)}')"
 ### 3. Test multiplication
 
 ```bash
-python3 -c "from src.calc import multiply; print(f'result={multiply(3, 4)}')"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "from src.calc import multiply; print(f'result={multiply(3, 4)}')"
 ```
 
 **Expected**: Output shows result=12
@@ -90,7 +90,7 @@ python3 -c "from src.calc import multiply; print(f'result={multiply(3, 4)}')"
 ### 4. Test division by zero
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 from src.calc import divide
 try:
     divide(10, 0)

--- a/scenarios/qe/api-health-check.md
+++ b/scenarios/qe/api-health-check.md
@@ -33,7 +33,7 @@ curl -sfL --max-time 10 "${API_URL}/get" -o /dev/null -w '%{http_code}'
 ### Step 2: JSON response validation (curl)
 
 ```bash
-curl -sfL --max-time 10 "${API_URL}/get" -H "Accept: application/json" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'url' in d, 'Missing url field'; print('OK: JSON valid with url field')"
+curl -sfL --max-time 10 "${API_URL}/get" -H "Accept: application/json" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys,json; d=json.load(sys.stdin); assert 'url' in d, 'Missing url field'; print('OK: JSON valid with url field')"
 ```
 
 **Expect**: Exit code 0, JSON parsed successfully with expected field

--- a/scenarios/qe/browser-page-audit.md
+++ b/scenarios/qe/browser-page-audit.md
@@ -11,7 +11,7 @@ timeout: 60
 
 # Browser Page Audit
 
-Verifies that a web page loads successfully, renders expected content, and responds to basic interactions using browser CLI tools. Uses a local HTML fixture served via `python3 -m http.server` so assertions are deterministic and never break due to external content changes.
+Verifies that a web page loads successfully, renders expected content, and responds to basic interactions using browser CLI tools. Uses a local HTML fixture served via `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -m http.server` so assertions are deterministic and never break due to external content changes.
 
 ## Setup
 
@@ -33,11 +33,11 @@ cat > "${TMPDIR:-/tmp}/wicked-scenario-pw/index.html" << 'HTML_EOF'
 HTML_EOF
 
 # Pick a free port (fall back to 8765 if python one-liner fails)
-SCEN_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null || echo 8765)
+SCEN_PORT=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null || echo 8765)
 echo "$SCEN_PORT" > "${TMPDIR:-/tmp}/wicked-scenario-pw/port"
 
 # Start a local server in the background
-python3 -m http.server "$SCEN_PORT" --directory "${TMPDIR:-/tmp}/wicked-scenario-pw" &
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -m http.server "$SCEN_PORT" --directory "${TMPDIR:-/tmp}/wicked-scenario-pw" &
 SERVER_PID=$!
 echo "$SERVER_PID" > "${TMPDIR:-/tmp}/wicked-scenario-pw/server.pid"
 

--- a/scenarios/qe/qe-lifecycle-expansion.md
+++ b/scenarios/qe/qe-lifecycle-expansion.md
@@ -32,7 +32,7 @@ The facilitator reads `agents/**/*.md` frontmatter directly. Validate the QE
 lifecycle agent files exist and their body mentions quality/testing cues.
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import re
 from pathlib import Path
 plugin_root = Path('${CLAUDE_PLUGIN_ROOT}')
@@ -130,7 +130,7 @@ done
 #### 2. Validate YAML frontmatter has required fields
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import re
 from pathlib import Path
 
@@ -187,7 +187,7 @@ No external setup required.
 #### 1. Verify specialist.json QE entry
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 from pathlib import Path
 
@@ -227,7 +227,7 @@ PASS: persona registered — Production Quality Engineer
 #### 2. Verify phases.json has qe in clarify and design
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 from pathlib import Path
 

--- a/scenarios/qe/security-sast-scan.md
+++ b/scenarios/qe/security-sast-scan.md
@@ -40,7 +40,7 @@ if ! command -v semgrep &>/dev/null; then
   echo "SKIP: semgrep not installed. Run /wicked-testing:execution to install."
   exit 0
 fi
-semgrep scan --config p/security-audit --json --quiet "${SCAN_TARGET}" 2>&1 | python3 -c "
+semgrep scan --config p/security-audit --json --quiet "${SCAN_TARGET}" 2>&1 | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 data = json.load(sys.stdin)
 findings = data.get('results', [])

--- a/scenarios/smaht/01-fresh-install.md
+++ b/scenarios/smaht/01-fresh-install.md
@@ -36,7 +36,7 @@ echo "$PLUGIN_DIR" > "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir"
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir")
 PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 [ -f "$PLUGIN_JSON" ] || { echo "FAIL: plugin.json not found at $PLUGIN_JSON"; exit 1; }
-python3 -c "import json; d=json.load(open('$PLUGIN_JSON')); print(f\"Plugin: {d['name']} v{d['version']}\"); assert d.get('name'), 'missing name'; assert d.get('version'), 'missing version'"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json; d=json.load(open('$PLUGIN_JSON')); print(f\"Plugin: {d['name']} v{d['version']}\"); assert d.get('name'), 'missing name'; assert d.get('version'), 'missing version'"
 echo "PASS: plugin.json is valid"
 ```
 
@@ -48,7 +48,7 @@ echo "PASS: plugin.json is valid"
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir")
 HOOKS_JSON="$PLUGIN_DIR/hooks/hooks.json"
 [ -f "$HOOKS_JSON" ] || { echo "FAIL: hooks.json not found"; exit 1; }
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 hooks = json.load(open('$HOOKS_JSON'))
 hooks_data = hooks.get('hooks', {})
@@ -69,7 +69,7 @@ echo "PASS: SessionStart hook configured in hooks.json"
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir")
 BOOTSTRAP="$PLUGIN_DIR/hooks/scripts/bootstrap.py"
 [ -f "$BOOTSTRAP" ] || { echo "FAIL: bootstrap.py not found"; exit 1; }
-echo '{"session_id": "test-fresh-install"}' | python3 "$BOOTSTRAP" 2>/dev/null
+echo '{"session_id": "test-fresh-install"}' | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "$BOOTSTRAP" 2>/dev/null
 EXIT_CODE=$?
 [ $EXIT_CODE -eq 0 ] || { echo "FAIL: bootstrap.py exited with $EXIT_CODE"; exit 1; }
 echo "PASS: SessionStart hook script runs without errors"
@@ -123,7 +123,7 @@ echo "PASS: key domains have command files"
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wicked-scenario-plugin-dir")
 SPEC_JSON="$PLUGIN_DIR/.claude-plugin/specialist.json"
 [ -f "$SPEC_JSON" ] || { echo "FAIL: specialist.json not found"; exit 1; }
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 d = json.load(open('$SPEC_JSON'))
 specs = d.get('specialists', [])

--- a/scenarios/smaht/04-mcp-server-integration.md
+++ b/scenarios/smaht/04-mcp-server-integration.md
@@ -34,7 +34,7 @@ if [ ! -f "${HOME}/.claude/mcp.json" ]; then
 fi
 
 # Check context7 MCP configuration exists
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 cfg = json.load(open('${HOME}/.claude/mcp.json'))
 c7 = cfg.get('context7', {})
@@ -66,7 +66,7 @@ if [ ! -f "${HOME}/.claude/mcp.json" ]; then
   echo "SKIP: ~/.claude/mcp.json not found — MCP not configured"
   exit 0
 fi
-cat ~/.claude/mcp.json | python3 -c "import json,sys; cfg = json.load(sys.stdin); c7 = cfg.get('context7', {}); print('type:', c7.get('type')); print('command:', c7.get('command')); print('args:', c7.get('args'))"
+cat ~/.claude/mcp.json | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; cfg = json.load(sys.stdin); c7 = cfg.get('context7', {}); print('type:', c7.get('type')); print('command:', c7.get('command')); print('args:', c7.get('args'))"
 ```
 
 Expected:
@@ -139,7 +139,7 @@ if [ ! -f "${HOME}/.claude/mcp.json" ]; then
   exit 0
 fi
 # Temporarily corrupt context7 config to test fallback behavior
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 with open('$HOME/.claude/mcp.json') as f:
     cfg = json.load(f)
@@ -177,7 +177,7 @@ if [ ! -f "${HOME}/.claude/mcp.json" ]; then
   echo "SKIP: ~/.claude/mcp.json not found — MCP not configured"
   exit 0
 fi
-cat ~/.claude/mcp.json | python3 -c "
+cat ~/.claude/mcp.json | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 cfg = json.load(sys.stdin)
 args = cfg.get('context7', {}).get('args', [])

--- a/scenarios/smaht/guard-fresh-install.md
+++ b/scenarios/smaht/guard-fresh-install.md
@@ -39,7 +39,7 @@ EOF
 
 CLAUDE_SESSION_ID="ac277-1" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "show me all open tasks", "session_id": "ac277-1"}' \
   2>&1
 echo "Exit code: $?"
@@ -65,12 +65,12 @@ EOF
 
 result=$(CLAUDE_SESSION_ID="ac277-3" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "/wicked-garden:setup", "session_id": "ac277-3"}' \
   2>/dev/null)
 
 echo "Exit code: $?"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('PASS_THROUGH' if d.get('continue') else 'BLOCKED')
@@ -93,12 +93,12 @@ EOF
 
 result=$(CLAUDE_SESSION_ID="ac277-3b" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "/wicked-garden:help", "session_id": "ac277-3b"}' \
   2>/dev/null)
 
 echo "Exit code: $?"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('PASS_THROUGH' if d.get('continue') else 'BLOCKED')
@@ -138,12 +138,12 @@ EOF
 
 result=$(CLAUDE_SESSION_ID="ac277-5" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "show me open tasks", "session_id": "ac277-5"}' \
   2>/dev/null)
 
 echo "Exit code: $?"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 print('PASS_THROUGH' if d.get('continue') else 'BLOCKED')

--- a/scenarios/smaht/guard-needs-onboarding.md
+++ b/scenarios/smaht/guard-needs-onboarding.md
@@ -51,12 +51,12 @@ EOF
 
 result=$(CLAUDE_SESSION_ID="ac277-2" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "what tasks are in progress?", "session_id": "ac277-2"}' \
   2>/dev/null)
 
 echo "Exit code: $?"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 d = json.load(sys.stdin)
 ctx = d.get('hookSpecificOutput', {}).get('additionalContext', '') or d.get('additionalContext', '')
@@ -86,12 +86,12 @@ printf '{broken json!!' > "${TMPDIR}/wicked-garden-session-ac277-6.json"
 
 result=$(CLAUDE_SESSION_ID="ac277-6" \
 HOME="${TEST_HOME}" \
-  python3 "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prompt_submit.py" \
   <<< '{"prompt": "what tasks are in progress?", "session_id": "ac277-6"}' \
   2>/dev/null)
 
 echo "Exit code: $?"
-echo "${result}" | python3 -c "
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 try:
     d = json.load(sys.stdin)

--- a/scenarios/smaht/knowledge-graph.md
+++ b/scenarios/smaht/knowledge-graph.md
@@ -27,16 +27,16 @@ Note: The script uses DomainStore by default for its DB path. We will use the CL
 ### 1. Create entities of four different types
 
 ```bash
-REQ=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type requirement --name "Auth must use OAuth2" --phase clarify --project test-kg)
+REQ=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type requirement --name "Auth must use OAuth2" --phase clarify --project test-kg)
 echo "$REQ"
 
-DESIGN=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type design_artifact --name "OAuth2 flow diagram" --phase design --project test-kg)
+DESIGN=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type design_artifact --name "OAuth2 flow diagram" --phase design --project test-kg)
 echo "$DESIGN"
 
-TASK=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type task --name "Implement OAuth2 middleware" --phase build --project test-kg)
+TASK=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type task --name "Implement OAuth2 middleware" --phase build --project test-kg)
 echo "$TASK"
 
-TEST=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type test_scenario --name "OAuth2 token validation tests" --phase test --project test-kg)
+TEST=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type test_scenario --name "OAuth2 token validation tests" --phase test --project test-kg)
 echo "$TEST"
 ```
 
@@ -45,8 +45,8 @@ echo "$TEST"
 ### 2. Get entity by ID
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" get-entity --id "$REQ_ID"
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" get-entity --id "$REQ_ID"
 ```
 
 **Expected**: Returns the same requirement entity with matching `entity_id`, `name` = "Auth must use OAuth2", `entity_type` = "requirement".
@@ -54,7 +54,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" get-entity --id
 ### 3. List entities with type filter
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" list-entities --type requirement --project test-kg
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" list-entities --type requirement --project test-kg
 ```
 
 **Expected**: Returns a JSON array containing only requirement entities. The "Auth must use OAuth2" entity is present. No design_artifact, task, or test_scenario entities appear.
@@ -62,18 +62,18 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" list-entities -
 ### 4. Create relationships between entities
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-DESIGN_ID=$(echo "$DESIGN" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-TASK_ID=$(echo "$TASK" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-TEST_ID=$(echo "$TEST" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+DESIGN_ID=$(echo "$DESIGN" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+TASK_ID=$(echo "$TASK" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+TEST_ID=$(echo "$TEST" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
 
-REL1=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$REQ_ID" --target "$DESIGN_ID" --type TRACES_TO)
+REL1=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$REQ_ID" --target "$DESIGN_ID" --type TRACES_TO)
 echo "$REL1"
 
-REL2=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$DESIGN_ID" --target "$TASK_ID" --type IMPLEMENTED_BY)
+REL2=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$DESIGN_ID" --target "$TASK_ID" --type IMPLEMENTED_BY)
 echo "$REL2"
 
-REL3=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$REQ_ID" --target "$TEST_ID" --type TESTED_BY)
+REL3=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-rel --source "$REQ_ID" --target "$TEST_ID" --type TESTED_BY)
 echo "$REL3"
 ```
 
@@ -82,8 +82,8 @@ echo "$REL3"
 ### 5. Get related entities (forward direction)
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$REQ_ID" --direction forward
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$REQ_ID" --direction forward
 ```
 
 **Expected**: Returns JSON array with the design_artifact and test_scenario entities (both are forward targets from the requirement). Each result includes `_rel_type` and `_direction` = "forward".
@@ -91,8 +91,8 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$
 ### 6. Get related entities (reverse direction)
 
 ```bash
-TASK_ID=$(echo "$TASK" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$TASK_ID" --direction reverse
+TASK_ID=$(echo "$TASK" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$TASK_ID" --direction reverse
 ```
 
 **Expected**: Returns JSON array containing the design_artifact entity (the only entity with a forward link to the task). Result includes `_direction` = "reverse".
@@ -100,8 +100,8 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" related --id "$
 ### 7. Subgraph traversal from requirement
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" subgraph --id "$REQ_ID" --depth 3
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" subgraph --id "$REQ_ID" --depth 3
 ```
 
 **Expected**: Returns JSON with `entities` and `relationships` arrays. The entities array contains all 4 entities (requirement, design, task, test). The relationships array contains all 3 relationships. Depth 3 ensures the full chain is traversed.
@@ -109,7 +109,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" subgraph --id "
 ### 8. Stats reflect created data
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" stats | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" stats | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 s = json.load(sys.stdin)
 assert s['total_entities'] >= 4, 'Expected at least 4 entities, got %d' % s['total_entities']
@@ -125,7 +125,7 @@ print('PASS: Stats match expected counts')
 ### 9. Invalid entity type is rejected
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type invalid_type --name "Should fail" --project test-kg 2>&1; echo "EXIT: $?"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity --type invalid_type --name "Should fail" --project test-kg 2>&1; echo "EXIT: $?"
 ```
 
 **Expected**: Returns an error message mentioning "Invalid entity_type" and exits with non-zero status.
@@ -133,7 +133,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" create-entity -
 ### 10. List entities with project filter returns scoped results
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" list-entities --project test-kg | python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" list-entities --project test-kg | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 entities = json.load(sys.stdin)
 for e in entities:
@@ -147,8 +147,8 @@ print('PASS: All %d entities scoped to test-kg' % len(entities))
 ### 11. Subgraph with depth 1 returns only immediate neighbors
 
 ```bash
-REQ_ID=$(echo "$REQ" | python3 -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" subgraph --id "$REQ_ID" --depth 1 | python3 -c "
+REQ_ID=$(echo "$REQ" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import json,sys; print(json.load(sys.stdin)['entity_id'])")
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/smaht/knowledge_graph.py" subgraph --id "$REQ_ID" --depth 1 | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json, sys
 sg = json.load(sys.stdin)
 entity_count = len(sg['entities'])

--- a/scenarios/smaht/propose-skills-shape.md
+++ b/scenarios/smaht/propose-skills-shape.md
@@ -49,7 +49,7 @@ PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wg-propose-skills-scenario-dir")
 HELPER="$PLUGIN_DIR/scripts/smaht/propose_skills.py"
 [ -f "$HELPER" ] || { echo "FAIL: helper missing at $HELPER"; exit 1; }
 # Reject any third-party import — the helper must be stdlib-only.
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import ast, sys
 tree = ast.parse(open('$HELPER').read())
 banned = {'requests','httpx','aiohttp','urllib3','numpy','pandas','pydantic'}
@@ -70,7 +70,7 @@ PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wg-propose-skills-scenario-dir")
 HELPER="$PLUGIN_DIR/scripts/smaht/propose_skills.py"
 # Use a project slug that is unlikely to exist (no sessions) so the helper
 # emits an empty report rather than processing real user data.
-OUT_PATH=$(python3 "$HELPER" --project=__nonexistent_test_project__)
+OUT_PATH=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "$HELPER" --project=__nonexistent_test_project__)
 [ -f "$OUT_PATH" ] || { echo "FAIL: report file not created at $OUT_PATH"; exit 1; }
 case "$OUT_PATH" in
   "${TMPDIR:-/tmp}"/wg-propose-skills-*.md|/tmp/wg-propose-skills-*.md|/var/folders/*/wg-propose-skills-*.md)
@@ -95,7 +95,7 @@ echo "PASS: report has the expected header + summary"
 PLUGIN_DIR=$(cat "${TMPDIR:-/tmp}/wg-propose-skills-scenario-dir")
 HELPER="$PLUGIN_DIR/scripts/smaht/propose_skills.py"
 # The helper must not import any networking module — verify by AST scan.
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import ast
 tree = ast.parse(open('$HELPER').read())
 banned = {'socket','http','urllib','urllib3','httpx','requests','aiohttp','smtplib','ftplib','telnetlib'}

--- a/scenarios/smaht/wizard-environment-scan.md
+++ b/scenarios/smaht/wizard-environment-scan.md
@@ -33,7 +33,7 @@ return a JSON object with a `languages` array that includes `"Python"`.
 
 ```bash
 cd "${PROJ_DIR}"
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import json
 from pathlib import Path
 cwd = Path.cwd()
@@ -62,7 +62,7 @@ detected_langs = [l for l, fs in markers.items() if any((cwd / f).exists() for f
 detected_fws = [fw for fw, fs in frameworks.items() if any((cwd / f).exists() for f in fs)]
 result = {'languages': detected_langs, 'frameworks': detected_fws}
 print(json.dumps(result))
-" | python3 -c "
+" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 data = json.load(sys.stdin)
 langs = data.get('languages', [])
@@ -89,7 +89,7 @@ with boolean values for each tool. When `gh` is installed on the test machine, `
 be `true`.
 
 ```bash
-python3 -c "
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import shutil, json
 tools = {
     'gh': shutil.which('gh') is not None,
@@ -100,7 +100,7 @@ tools = {
     'kubectl': shutil.which('kubectl') is not None,
 }
 print(json.dumps(tools))
-" | python3 -c "
+" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
 import sys, json
 data = json.load(sys.stdin)
 all_bool = all(isinstance(v, bool) for v in data.values())
@@ -130,7 +130,7 @@ object, mimicking how `setup.md` uses `DETECTED_LANGS`, `DETECTED_FWS`, and `DET
 
 ```bash
 cd "${PROJ_DIR}"
-python3 - <<'PYEOF'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PYEOF'
 import json, shutil
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

Tier 2 of the post-sweep scenario cleanup. **Mechanical migration** applying CLAUDE.md's cross-platform shim rule across all scenario file invocations.

## Why

Bare \`python3\` is **unavailable on Windows** (where Python is reachable via \`python\` or \`py -3\`). The \`_python.sh\` shim resolves \`python3\` / \`python\` / \`py -3\` in priority order, so scenarios run in any environment. CLAUDE.md mandates the shim for plugin-side script invocation.

PR 1 fixed this anti-pattern in \`runtime-exec/SKILL.md\` (the doc that should be teaching the right pattern). PR 10 fixed it in \`scenarios/README.md\` (docs-of-docs). This PR completes the migration to the actual scenario contents.

## Scope

**40 files** — covers every \`python3\` invocation in \`scenarios/\`. Net diff: 393 lines changed (393 insertions, 393 deletions — pure substitution). Six patterns migrated:

| Before | After |
|--------|-------|
| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/X.py" args\` | \`sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "\${CLAUDE_PLUGIN_ROOT}/scripts/X.py" args\` |
| \`python3 "\${VAR}/X.py" args\` | \`sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "\${VAR}/X.py" args\` |
| \`python3 -c "..."\` | \`sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "..."\` |
| \`python3 - <<'EOF'\` (heredoc stdin) | \`sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'EOF'\` |
| \`python3 -m module\` (e.g. \`http.server\`) | \`sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -m module\` |
| \`\$(python3 ...)\` (command substitution) | \`\$(sh "\${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" ...)\` |

## Preserved (intentional historical references)

- \`scenarios/smaht/06-context7-integration.md\` — describes the deleted v5 \`scripts/smaht/v2/orchestrator.py\` as historical context. These are prose mentions, not invocations.

## Shim semantics verified

\`scripts/_python.sh\` ends with \`exec python3 "\$@"\` (or \`python\` / \`py -3\`) — all argument forms pass through transparently: \`-c\`, \`-m\`, heredoc stdin, command substitution, pipe input.

## Hard guardrails

- ✅ Only \`scenarios/\` touched; no skill, agent, or command files modified
- ✅ \`scripts/ci/validate.py\` PASS (0 errors, 0 warnings)
- ✅ No content semantics changed — pure invocation substitution

## Sweep status — closing

- ✅ PRs 1-9 (skill cleanup arc, #697-705) merged
- ✅ PR 10 #706 (Tier 1 scenario) merged
- 🔄 PR 11 — this PR (Tier 2 scenario, the last of the arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)