### PR TITLE
feat(delivery): PR 18 — SPC drift detection (closes #719)

### DIFF
--- a/commands/delivery/process-health.md
+++ b/commands/delivery/process-health.md
@@ -1,16 +1,17 @@
 ---
-description: Surface process memory — kaizen status, unresolved action items, aging alerts
-argument-hint: "[--project name] [--format text|json|both]"
+description: Surface process memory — kaizen status, unresolved action items, aging alerts, and SPC drift
+argument-hint: "[--project name] [--format text|json|both] [--spc]"
 ---
 
 # /wicked-garden:delivery:process-health
 
-Render the persistent process memory for a crew project — kaizen backlog status, unresolved retrospective action items, and aging alerts for items unresolved across two or more sessions. Backs issue #447.
+Render the persistent process memory for a crew project — kaizen backlog status, unresolved retrospective action items, aging alerts, and (with `--spc`) statistical-process-control drift findings on the gate-quality timeline. Backs issues #447 and #719.
 
 ## Arguments
 
 - `--project` (optional): Project name. Defaults to the active crew project.
 - `--format` (optional): `text` (default), `json`, or `both` (json to stderr + text to stdout).
+- `--spc` (optional): Include the SPC drift section — current chart state, recent persisted flags (`delivery:spc:flag`), per-(phase, tier) classifications, and warmup status. See `docs/spc.md` for chart-reading guidance.
 
 ## Instructions
 
@@ -27,7 +28,7 @@ If neither resolves to a name, abort with an informative message — this comman
 ### 2. Render the report
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/delivery/process_health.py --project "{project}" --format text
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/delivery/process_health.py --project "{project}" --format text [--spc]
 ```
 
 Forward the output verbatim. The report contains:
@@ -55,6 +56,9 @@ Based on the report, point the user at the right next move:
 
 # Named project, JSON format
 /wicked-garden:delivery:process-health --project my-feature --format json
+
+# Include SPC drift section (issue #719)
+/wicked-garden:delivery:process-health --project my-feature --spc
 ```
 
 ## Related
@@ -62,3 +66,5 @@ Based on the report, point the user at the right next move:
 - `/wicked-garden:crew:retro` writes retro findings into the process memory.
 - `/wicked-garden:delivery:setup` configures thresholds this command surfaces.
 - Uncertainty gate is evaluated via `scripts/delivery/process_memory.py uncertainty-gate` when a specialist proposes adding a new process gate.
+- `docs/spc.md` — chart-reading guide for the `--spc` section (issue #719).
+- `scripts/delivery/drift.py flag <project>` — persist SPC flags to the DomainStore (`delivery:spc:flag`).

--- a/docs/spc.md
+++ b/docs/spc.md
@@ -1,0 +1,128 @@
+# SPC Drift Detection — Chart-Reading Guide
+
+This document explains the Statistical Process Control (SPC) drift detection that wicked-garden runs over the gate-quality timeline. It is written for engineers and tech leads, not statisticians.
+
+## What problem this solves
+
+Quality regressions rarely arrive as a single catastrophic session. They creep in across a week or two of small drops, each one inside the normal range. By the time the latest score is obviously bad, the regression has been compounding for many sessions. SPC catches that drift early using a small set of well-studied rules from manufacturing quality control (Western Electric, 1956).
+
+## Where to look
+
+```
+/wicked-garden:delivery:process-health --project <name> --spc
+```
+
+The `--spc` section reports:
+
+- **Sample count** vs. the warmup threshold (currently 8). No flags fire below warmup.
+- **Classifications** for the headline `gate_pass_rate` and any per-`(phase, tier)` `min_score` series with enough history.
+- **Recent flags** persisted to the `delivery:spc:flag` source in the DomainStore — newest first, with rule, severity, sample window, and the value that tripped it.
+
+You can also drive the underlying script directly:
+
+```
+sh scripts/_python.sh scripts/delivery/drift.py classify <project> [metric]
+sh scripts/_python.sh scripts/delivery/drift.py flag <project> [metric]    # persists flags
+sh scripts/_python.sh scripts/delivery/drift.py list-flags <project>
+```
+
+## EWMA in plain English
+
+EWMA stands for **Exponentially Weighted Moving Average**. It is a smoothed line through your raw data that gives the most recent points more weight than older ones (alpha = 0.3 — the most recent point counts ~30% toward the smoothed value, and the rest fades over the previous samples).
+
+Why use it instead of a plain average? A plain average treats a sudden cliff and a gradual slide the same way. EWMA reacts faster to change, which is exactly what you want for drift detection. We report the **slope** of the EWMA series — a meaningfully negative slope is advisory context that the trend is downward.
+
+## The four Western Electric rules
+
+All four rules look at the timeline relative to a baseline `(mean, stddev)` computed from the four sessions immediately before the latest one.
+
+### Rule (a) — 1 point outside 3σ (`1_outside_3sigma`)
+
+> The most recent point is more than three standard deviations below the baseline mean.
+
+**What it catches:** a single session that is unambiguously broken. A point this far out is approximately a 1-in-700 event under normal variation — almost always a real signal.
+
+**Severity:** `critical`.
+
+### Rule (b) — 2 of 3 outside 2σ on the same side (`2_of_3_zone_b`)
+
+> Of the most recent three points, at least two are more than two standard deviations below the baseline mean.
+
+**What it catches:** the process is starting to live in the bad-tail of normal variation. One outlier is noise; two of the last three is signal.
+
+**Severity:** `warn`.
+
+### Rule (c) — 4 of 5 outside 1σ on the same side (`4_of_5_zone_c`)
+
+> Of the most recent five points, at least four are more than one standard deviation below the baseline mean.
+
+**What it catches:** sustained mediocrity. The points haven't crossed any dramatic line individually, but four-of-five sitting on the bad side of the first sigma band means the process has drifted closer to its lower control limit.
+
+**Severity:** `warn`.
+
+### Rule (d) — 8 in a row on one side of the mean (`8_consecutive_one_side`)
+
+> The most recent eight points are all below the baseline mean.
+
+**What it catches:** a subtle but persistent bias. None of the points have to be unusual on their own — eight consecutive coin flips landing the same way is roughly a 1-in-256 event, so eight points all on one side of the mean strongly suggests the underlying process has shifted, not that you got unlucky.
+
+**Severity:** `critical`.
+
+### Bonus rule — 6 consecutive monotonically decreasing (`trending_down`)
+
+This one is from the broader SPC literature, not the original Western Electric set, but it shipped with the v1 detector for issue #459 and remains. It catches a strict downward staircase — useful when degradation is gradual but unmistakable.
+
+## How to read a flag
+
+A flag record looks like:
+
+```json
+{
+  "id": "...",
+  "metric": "gate_pass_rate",
+  "rule": "4_of_5_zone_c",
+  "severity": "warn",
+  "sample_window": {"start": 0.91, "end": 0.62, "n": 12},
+  "current_value": 0.62,
+  "baseline_mean": 0.85,
+  "baseline_stddev": 0.06,
+  "drop_pct": 0.27,
+  "reasons": ["WE 4-of-5: 4+ of last 5 points beyond 1σ below baseline", "..."],
+  "recorded_at": "2026-04-29T12:34:56Z"
+}
+```
+
+Reading order:
+
+1. **`metric` + `rule`** — what dropped, and which rule caught it.
+2. **`baseline_mean` vs. `current_value`** — how far the latest reading is from the recent norm.
+3. **`drop_pct`** — the same comparison as a percentage, easier for non-statistical readers.
+4. **`severity`** — `critical` warrants immediate triage; `warn` warrants attention by end of week.
+5. **`reasons`** — the human-readable trail of every check that fired.
+6. **`sample_window.n`** — sanity check that you have enough history to trust the call.
+
+## Warmup gate
+
+No SPC flag fires until the project has at least 8 sessions of telemetry. This prevents:
+
+- Freshly-onboarded projects from spamming flags during their first noisy week.
+- A trivial 5-session baseline producing wildly different `mean ± stddev` figures from one session to the next.
+
+The `--spc` report shows `Warmup: PENDING` when below the threshold and `Warmup: satisfied` once you cross it.
+
+## Silencing noise
+
+If a metric you don't care about is producing flags, you have a few levers:
+
+- **Don't query it.** Only `gate_pass_rate` is auto-classified by `process-health --spc`. Per-(phase, tier) `min_score` series only appear when the project has accumulated at least 5 sessions of that exact slot.
+- **Re-baseline.** Flags persist in the DomainStore. Once you've addressed the underlying regression, archive old flag records — they continue to show up in `list-flags` until soft-deleted.
+- **Tune thresholds at the call site.** `drift.classify(records, metric, drop_pct_threshold=0.20, special_cause_sigma=4.0)` accepts overrides. The defaults match the issue acceptance criteria; tune them for your team's tolerance.
+- **Investigate before silencing.** A flag that "always fires" usually means the metric is genuinely unstable, not that the rule is wrong. Look at the underlying timeline (`scripts/delivery/telemetry.py show <project>`) before you tune the alarm down.
+
+## Related
+
+- `scripts/delivery/drift.py` — the classifier implementation.
+- `scripts/delivery/telemetry.py` — the per-session capture that feeds the timeline.
+- `commands/delivery/process-health.md` — the `--spc` surface.
+- `scenarios/delivery/07-spc-drift-detected.md`, `scenarios/delivery/08-spc-stable-no-flag.md` — positive and negative scenarios.
+- Issue #719 — original specification.

--- a/scenarios/delivery/07-spc-drift-detected.md
+++ b/scenarios/delivery/07-spc-drift-detected.md
@@ -1,0 +1,93 @@
+---
+name: spc-drift-detected
+title: SPC Drift Flag Fires on Declining Gate Quality
+description: Synthetic timeline with declining gate_pass_rate triggers a delivery:spc:flag via drift.py
+type: workflow
+difficulty: intermediate
+estimated_minutes: 5
+execution: manual
+---
+
+# SPC Drift Flag Fires on Declining Gate Quality
+
+This scenario validates issue #719: Statistical Process Control drift detection. A timeline of 10 sessions with monotonically degrading `gate_pass_rate` should trip at least one Western Electric rule (`trending_down`, `4_of_5_zone_c`, or `8_consecutive_one_side`) and produce a persisted `delivery:spc:flag` record in the DomainStore.
+
+## Setup
+
+Inject 10 synthetic timeline records into a sandboxed DomainStore root, then ask `drift.py` to classify the headline `gate_pass_rate` metric and persist any fired flags. Sandboxing keeps the scenario from polluting real telemetry.
+
+```bash
+set -euo pipefail
+# Sandbox by redirecting CLAUDE_CWD — _paths.py derives the project-scoped
+# storage root from cwd, so a unique tmpdir → a fresh isolated DomainStore
+# slot the scenario can write to and rm afterwards.
+WG_SANDBOX="${TMPDIR:-/tmp}/wg-spc-drift-$$"
+mkdir -p "$WG_SANDBOX"
+export CLAUDE_CWD="$WG_SANDBOX"
+PROJECT="spc-drift-demo"
+
+# Step 1: write 10 declining sessions to the project's timeline.jsonl, then
+# Step 2: invoke drift.py classify + flag, then
+# Step 3: list any persisted SPC flags.
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, os, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from delivery.telemetry import _timeline_path
+path = _timeline_path('${PROJECT}')
+path.parent.mkdir(parents=True, exist_ok=True)
+declining = [0.95, 0.93, 0.92, 0.90, 0.88, 0.78, 0.70, 0.65, 0.60, 0.55]
+with open(path, 'w', encoding='utf-8') as fh:
+    for i, v in enumerate(declining):
+        rec = {
+            'version': '1',
+            'session_id': f's{i:02d}',
+            'project': '${PROJECT}',
+            'recorded_at': f'2026-04-{i+1:02d}T00:00:00Z',
+            'sample_window': {'tasks_observed': 1},
+            'metrics': {'gate_pass_rate': v},
+        }
+        fh.write(json.dumps(rec) + '\n')
+print('TIMELINE_WRITTEN', path)
+"
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" flag "$PROJECT" gate_pass_rate
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" list-flags "$PROJECT"
+
+# Cleanup the sandboxed storage slot + tmp cwd.
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import shutil, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from _paths import get_project_root
+shutil.rmtree(get_project_root(), ignore_errors=True)
+"
+rm -rf "$WG_SANDBOX"
+```
+
+## Expected Output
+
+The classify+flag invocation should return JSON with:
+
+- `classification.drift = true`
+- `classification.insufficient_warmup = false` (10 samples > 8 warmup gate)
+- `classification.we_rules` includes at least one of: `trending_down`, `4_of_5_zone_c`, `8_consecutive_one_side`
+- `flags_written` is a non-empty list — each entry includes `metric: "gate_pass_rate"`, a `rule`, `severity` (`warn` or `critical`), `sample_window`, `current_value`, and `baseline_mean`
+
+The list-flags invocation should echo the same flag(s) back via DomainStore.
+
+## Success Criteria
+
+- [ ] `classification.drift` is `true`
+- [ ] At least one Western Electric rule fires
+- [ ] `flags_written` contains >= 1 record with `rule` set to one of the WE rules
+- [ ] `list-flags` returns the same flag(s)
+- [ ] No errors raised by `drift.py` or telemetry
+
+## Value Demonstrated
+
+Process degradation that creeps in over weeks (not a single bad session) is exactly what Western Electric rules catch. Without SPC, a team only notices when the latest run is catastrophically bad — by which point the regression has been compounding for many sessions. The `delivery:spc:flag` record gives an audit trail of *when* drift was first detected and *which* rule caught it, enabling earlier intervention.
+
+## Related
+
+- `docs/spc.md` — chart-reading guide.
+- `/wicked-garden:delivery:process-health --spc` — surfaces flags in the process-health report.

--- a/scenarios/delivery/08-spc-stable-no-flag.md
+++ b/scenarios/delivery/08-spc-stable-no-flag.md
@@ -1,0 +1,115 @@
+---
+name: spc-stable-no-flag
+title: SPC Stays Quiet on Stable Process + Warmup Gate
+description: Stable timeline produces zero SPC flags; pre-warmup timeline produces zero flags even with noise
+type: workflow
+difficulty: intermediate
+estimated_minutes: 5
+execution: manual
+---
+
+# SPC Stays Quiet on Stable Process + Warmup Gate
+
+This scenario validates the *negative* side of issue #719: SPC must NOT fire on a healthy process, and must NOT fire before the 8-sample warmup gate is satisfied. False positives erode trust; the warmup gate prevents a freshly-onboarded project from spamming flags during its first noisy week.
+
+## Setup
+
+Two checks share one sandboxed DomainStore root:
+
+1. 20 stable sessions (`gate_pass_rate ≈ 0.90` ± noise) → expect zero flags.
+2. 7 noisy sessions (below the 8-sample warmup threshold) → expect zero flags even though the values dip aggressively at the end.
+
+```bash
+set -euo pipefail
+# Sandbox by redirecting CLAUDE_CWD — _paths.py derives the project-scoped
+# storage root from cwd, so a unique tmpdir → a fresh isolated DomainStore
+# slot the scenario can write to and rm afterwards.
+WG_SANDBOX="${TMPDIR:-/tmp}/wg-spc-stable-$$"
+mkdir -p "$WG_SANDBOX"
+export CLAUDE_CWD="$WG_SANDBOX"
+STABLE="spc-stable-demo"
+WARMUP="spc-warmup-demo"
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from delivery.telemetry import _timeline_path
+
+def write_timeline(project, values):
+    path = _timeline_path(project)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as fh:
+        for i, v in enumerate(values):
+            rec = {
+                'version': '1',
+                'session_id': f's{i:02d}',
+                'project': project,
+                'recorded_at': f'2026-04-{i+1:02d}T00:00:00Z',
+                'sample_window': {'tasks_observed': 1},
+                'metrics': {'gate_pass_rate': v},
+            }
+            fh.write(json.dumps(rec) + '\n')
+    print('WROTE', project, len(values))
+
+# 20 stable sessions — small natural noise, no trend.
+stable = [0.90, 0.91, 0.89, 0.90, 0.92, 0.88, 0.91, 0.90, 0.89, 0.91,
+          0.90, 0.92, 0.88, 0.91, 0.89, 0.90, 0.92, 0.91, 0.89, 0.90]
+write_timeline('${STABLE}', stable)
+
+# 7 sessions with steep decline — must still produce zero flags
+# because the warmup gate (n>=8) blocks emission.
+warmup = [0.95, 0.92, 0.85, 0.70, 0.55, 0.40, 0.30]
+write_timeline('${WARMUP}', warmup)
+"
+
+echo '--- Check 1: stable process, expect no flags ---'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" flag "$STABLE" gate_pass_rate
+
+echo '--- Check 2: pre-warmup noisy process, expect no flags ---'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" flag "$WARMUP" gate_pass_rate
+
+echo '--- list-flags must be empty for both ---'
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" list-flags "$STABLE"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/delivery/drift.py" list-flags "$WARMUP"
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import shutil, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from _paths import get_project_root
+shutil.rmtree(get_project_root(), ignore_errors=True)
+"
+rm -rf "$WG_SANDBOX"
+```
+
+## Expected Output
+
+For the stable project:
+
+- `classification.drift = false`
+- `classification.we_rules` is empty
+- `classification.zone` is `common-cause`
+- `flags_written` is empty
+- `list-flags` returns empty
+
+For the warmup project:
+
+- `classification.insufficient_warmup = true`
+- `classification.drift = false` even though the latest value (0.30) is far below baseline mean
+- `flags_written` is empty
+- `list-flags` returns empty
+
+## Success Criteria
+
+- [ ] Stable project: `drift = false`, `flags_written = []`, `list-flags = []`
+- [ ] Warmup project: `insufficient_warmup = true`, `drift = false`, `flags_written = []`
+- [ ] Neither project produces a `delivery:spc:flag` record
+- [ ] No errors raised by `drift.py` or telemetry
+
+## Value Demonstrated
+
+Two failure modes for any monitoring system are (a) crying wolf on noise and (b) firing on incomplete data. Healthy variation in `gate_pass_rate` should not look like a regression, and a project with five sessions of telemetry doesn't have enough history to call *anything* drift. The 8-sample warmup gate combined with the Western Electric rules' minimum-window requirements (3, 5, 6, or 8 points depending on rule) makes SPC quiet by default — flags only appear when a real signal emerges.
+
+## Related
+
+- `docs/spc.md` — chart-reading guide and silencing tips.
+- `scenarios/delivery/07-spc-drift-detected.md` — the positive counterpart.

--- a/scripts/delivery/drift.py
+++ b/scripts/delivery/drift.py
@@ -192,21 +192,26 @@ def _we_4_of_5_zone_c(
     mean: float,
     stddev: float,
     *,
+    side: str = "below",
     zone_c_sigma: float = DEFAULT_ZONE_C_SIGMA,
 ) -> bool:
-    """WE rule (#719): 4 of the last 5 points beyond 1σ below the baseline mean.
+    """WE rule (#719): 4 of the last 5 points beyond 1σ on one side of the baseline.
 
-    Same shape as ``_we_2_of_3_zone_b`` — only the bad (below-baseline) side
-    fires for higher-is-better metrics. Requires non-zero baseline stddev and
-    at least ``WE_4OF5_WINDOW`` observations.
+    ``side`` mirrors ``_we_8_consecutive_one_side``: "below" (default — the
+    bad side for higher-is-better metrics) or "above". Requires non-zero
+    baseline stddev and at least ``WE_4OF5_WINDOW`` observations.
     """
     if stddev <= 0:
         return False
     if len(series) < WE_4OF5_WINDOW:
         return False
     recent = series[-WE_4OF5_WINDOW:]
-    threshold = mean - zone_c_sigma * stddev
-    breaches = sum(1 for x in recent if x < threshold)
+    if side == "above":
+        threshold = mean + zone_c_sigma * stddev
+        breaches = sum(1 for x in recent if x > threshold)
+    else:
+        threshold = mean - zone_c_sigma * stddev
+        breaches = sum(1 for x in recent if x < threshold)
     return breaches >= WE_4OF5_COUNT
 
 
@@ -330,6 +335,10 @@ def classify(
     result["ewma_slope"] = round(slope, 6)
 
     # Zone classification (zone-A sigma test).
+    # Surface structured fields so _classify_rule doesn't have to substring-match
+    # the human-readable reasons text (Copilot review on PR #730).
+    result["outside_special_cause_sigma"] = z >= special_cause_sigma
+    result["special_cause_sigma_threshold"] = special_cause_sigma
     if z >= special_cause_sigma:
         zone = "special-cause"
         result["reasons"].append(f"outside {special_cause_sigma:.0f}σ (z={z:.2f})")
@@ -514,14 +523,12 @@ def _classify_rule(classification: Dict[str, Any]) -> List[str]:
     forcing the priority decision here.
     """
     rules = list(classification.get("we_rules") or [])
-    # Synthesize a rule id for the zone-A z-score breach so it gets a flag too.
-    if classification.get("zone") == "special-cause":
-        # Reasons array contains "outside 3σ" only on a sigma breach.
-        for reason in classification.get("reasons") or []:
-            if "outside" in reason and "σ" in reason and "3" in reason:
-                if "1_outside_3sigma" not in rules:
-                    rules.append("1_outside_3sigma")
-                break
+    # Synthesize a rule id for the zone-A z-score breach using the structured
+    # field set by classify() — substring-matching the reasons text was brittle
+    # against tuned ``special_cause_sigma`` (e.g. "z=4.2" matches "3" by accident).
+    if classification.get("outside_special_cause_sigma"):
+        if "1_outside_3sigma" not in rules:
+            rules.append("1_outside_3sigma")
     drop = classification.get("drop_pct") or 0.0
     if drop >= DEFAULT_DROP_PCT_THRESHOLD and not rules:
         rules.append("drop_pct_threshold")

--- a/scripts/delivery/drift.py
+++ b/scripts/delivery/drift.py
@@ -16,10 +16,14 @@ Algorithms
 3. 3σ Western Electric zone-A rule (baseline mean ± 3 * baseline_stddev).
    Points outside 3σ are tagged ``special-cause``. Points outside 2σ are
    reported as ``warn`` (zone B). Everything else is ``common-cause`` noise.
-4. Western Electric runs rules (issue #459) beyond zone A:
+4. Western Electric runs rules (issues #459, #719) beyond zone A:
    - ``2_of_3_zone_b``: 2 of the last 3 points are beyond 2σ on the bad side
      (below-baseline). Fires ``special-cause`` even when the latest point is
      inside zone A.
+   - ``4_of_5_zone_c``: 4 of the last 5 points beyond 1σ on the bad side
+     (issue #719). Catches sustained drift one zone closer to the mean.
+   - ``8_consecutive_one_side``: 8 consecutive points all on the bad side of
+     the mean (issue #719). Catches subtle but persistent bias.
    - ``trending_down``: 6 consecutive points each lower than the one before
      (monotonic degradation). Fires ``special-cause``.
    - ``trending_up``: symmetric monotonic climb. Reported but never flips
@@ -76,12 +80,20 @@ DEFAULT_EWMA_ALPHA = 0.3
 DEFAULT_DROP_PCT_THRESHOLD = 0.15  # issue acceptance: 15% below 4-session baseline
 DEFAULT_SPECIAL_CAUSE_SIGMA = 3.0  # Western Electric zone A
 DEFAULT_WARN_SIGMA = 2.0           # zone B
-MIN_SESSIONS_FOR_DRIFT = 5         # issue acceptance: >=5 sessions
+DEFAULT_ZONE_C_SIGMA = 1.0         # zone C (issue #719)
+MIN_SESSIONS_FOR_DRIFT = 5         # issue #459 acceptance
+# Issue #719 acceptance: at least 8 samples before *any* WE rule may fire.
+WARMUP_MIN_SAMPLES = 8
 
-# Western Electric runs-rule thresholds (issue #459).
+# Western Electric runs-rule thresholds (issues #459, #719).
 # 2-of-3: "2 of the most recent 3 points beyond 2σ on the same side."
 WE_2OF3_WINDOW = 3
 WE_2OF3_COUNT = 2
+# 4-of-5: "4 of the most recent 5 points beyond 1σ on the same side."
+WE_4OF5_WINDOW = 5
+WE_4OF5_COUNT = 4
+# Run-of-8: "8 consecutive points on the same side of the centerline."
+WE_RUN_OF_8_WINDOW = 8
 # Trending: 6 consecutive monotonically increasing / decreasing points.
 WE_TRENDING_WINDOW = 6
 
@@ -173,6 +185,51 @@ def _we_2_of_3_zone_b(
     threshold = mean - warn_sigma * stddev
     breaches = sum(1 for x in recent if x < threshold)
     return breaches >= WE_2OF3_COUNT
+
+
+def _we_4_of_5_zone_c(
+    series: List[float],
+    mean: float,
+    stddev: float,
+    *,
+    zone_c_sigma: float = DEFAULT_ZONE_C_SIGMA,
+) -> bool:
+    """WE rule (#719): 4 of the last 5 points beyond 1σ below the baseline mean.
+
+    Same shape as ``_we_2_of_3_zone_b`` — only the bad (below-baseline) side
+    fires for higher-is-better metrics. Requires non-zero baseline stddev and
+    at least ``WE_4OF5_WINDOW`` observations.
+    """
+    if stddev <= 0:
+        return False
+    if len(series) < WE_4OF5_WINDOW:
+        return False
+    recent = series[-WE_4OF5_WINDOW:]
+    threshold = mean - zone_c_sigma * stddev
+    breaches = sum(1 for x in recent if x < threshold)
+    return breaches >= WE_4OF5_COUNT
+
+
+def _we_8_consecutive_one_side(
+    series: List[float],
+    mean: float,
+    *,
+    side: str = "below",
+) -> bool:
+    """WE rule (#719): 8 consecutive points on one side of the centerline.
+
+    ``side="below"`` is the bad side for higher-is-better metrics.
+    Equality with the mean does not count — SPC theory requires strict
+    one-sided runs to indicate a process shift.
+    """
+    if len(series) < WE_RUN_OF_8_WINDOW:
+        return False
+    window = series[-WE_RUN_OF_8_WINDOW:]
+    if side == "below":
+        return all(x < mean for x in window)
+    if side == "above":
+        return all(x > mean for x in window)
+    return False
 
 
 def _we_trending(series: List[float], direction: str = "down") -> bool:
@@ -282,41 +339,72 @@ def classify(
     else:
         zone = "common-cause"
 
-    # Western Electric runs rules (issue #459) — operate on the full observed
-    # series using the baseline mean/stddev as the reference frame. These fire
-    # independently of the single-point z-score.
+    # Western Electric runs rules (issues #459, #719) — operate on the full
+    # observed series using the baseline mean/stddev as the reference frame.
+    # Issue #719 acceptance: at least WARMUP_MIN_SAMPLES observations before
+    # *any* WE rule may fire, regardless of which rule is configured. Below
+    # warmup we still classify zone-A from the latest z-score, but suppress
+    # WE flags entirely. ``insufficient_warmup`` lets callers tell "below
+    # warmup" apart from "warm but quiet".
     we_rules: List[str] = []
-    if _we_2_of_3_zone_b(series, mu, sigma, warn_sigma=warn_sigma):
-        we_rules.append("2_of_3_zone_b")
+    insufficient_warmup = session_count < WARMUP_MIN_SAMPLES
+    result["insufficient_warmup"] = insufficient_warmup
+    result["warmup_min_samples"] = WARMUP_MIN_SAMPLES
+
+    if not insufficient_warmup:
+        if _we_2_of_3_zone_b(series, mu, sigma, warn_sigma=warn_sigma):
+            we_rules.append("2_of_3_zone_b")
+            result["reasons"].append(
+                f"WE 2-of-3: 2+ of last {WE_2OF3_WINDOW} points beyond "
+                f"{warn_sigma:.0f}σ below baseline"
+            )
+        if _we_4_of_5_zone_c(series, mu, sigma):
+            we_rules.append("4_of_5_zone_c")
+            result["reasons"].append(
+                f"WE 4-of-5: 4+ of last {WE_4OF5_WINDOW} points beyond "
+                f"{DEFAULT_ZONE_C_SIGMA:.0f}σ below baseline"
+            )
+        if _we_8_consecutive_one_side(series, mu, side="below"):
+            we_rules.append("8_consecutive_one_side")
+            result["reasons"].append(
+                f"WE run-of-8: {WE_RUN_OF_8_WINDOW} consecutive points below baseline mean"
+            )
+        if _we_trending(series, direction="down"):
+            we_rules.append("trending_down")
+            result["reasons"].append(
+                f"WE trending-down: {WE_TRENDING_WINDOW} consecutive decreasing points"
+            )
+        if _we_trending(series, direction="up"):
+            we_rules.append("trending_up")
+            result["reasons"].append(
+                f"WE trending-up: {WE_TRENDING_WINDOW} consecutive increasing points"
+            )
+    else:
         result["reasons"].append(
-            f"WE 2-of-3: 2+ of last {WE_2OF3_WINDOW} points beyond "
-            f"{warn_sigma:.0f}σ below baseline"
-        )
-    if _we_trending(series, direction="down"):
-        we_rules.append("trending_down")
-        result["reasons"].append(
-            f"WE trending-down: {WE_TRENDING_WINDOW} consecutive decreasing points"
-        )
-    if _we_trending(series, direction="up"):
-        we_rules.append("trending_up")
-        result["reasons"].append(
-            f"WE trending-up: {WE_TRENDING_WINDOW} consecutive increasing points"
+            f"warmup gate: need {WARMUP_MIN_SAMPLES} samples for WE rules, "
+            f"have {session_count}"
         )
     result["we_rules"] = we_rules
 
     # Any "bad-side" WE runs rule escalates zone to special-cause.
     # trending_up is informational only (higher-is-better metrics).
-    if "2_of_3_zone_b" in we_rules or "trending_down" in we_rules:
+    bad_side_rules = {"2_of_3_zone_b", "4_of_5_zone_c", "8_consecutive_one_side", "trending_down"}
+    if any(r in bad_side_rules for r in we_rules):
         zone = "special-cause"
 
     # Drift alarm: >=15% drop below baseline OR special-cause zone.
+    # Issue #719 acceptance: gate all flags behind WARMUP_MIN_SAMPLES so we
+    # don't fire on a freshly-onboarded project's first noisy week. The
+    # existing ``min_sessions`` (default 5) is the *classification* floor; the
+    # warmup gate is the *flag* floor.
     drift = False
     if drop_pct >= drop_pct_threshold:
-        drift = True
         result["reasons"].append(
             f"drop_pct {drop_pct * 100:.1f}% >= {drop_pct_threshold * 100:.0f}%"
         )
-    if zone == "special-cause":
+        if not insufficient_warmup:
+            drift = True
+    if zone == "special-cause" and not insufficient_warmup:
         drift = True
 
     # Trending degradation: EWMA slope meaningfully negative.
@@ -410,6 +498,118 @@ def emit_drift_event(
 
 
 # ---------------------------------------------------------------------------
+# SPC flag emission via DomainStore (issue #719)
+# ---------------------------------------------------------------------------
+
+# Critical = zone-A (3σ) breach or 8-in-a-row run; warn = lesser WE rules
+# or simple drop_pct trigger. Severity drives downstream alert routing.
+_CRITICAL_RULES = {"1_outside_3sigma", "8_consecutive_one_side"}
+
+
+def _classify_rule(classification: Dict[str, Any]) -> List[str]:
+    """Return all rule identifiers that fired for this classification.
+
+    A single classification can fire multiple rules — emit one flag per rule
+    so downstream consumers can deduplicate by (metric, rule) instead of
+    forcing the priority decision here.
+    """
+    rules = list(classification.get("we_rules") or [])
+    # Synthesize a rule id for the zone-A z-score breach so it gets a flag too.
+    if classification.get("zone") == "special-cause":
+        # Reasons array contains "outside 3σ" only on a sigma breach.
+        for reason in classification.get("reasons") or []:
+            if "outside" in reason and "σ" in reason and "3" in reason:
+                if "1_outside_3sigma" not in rules:
+                    rules.append("1_outside_3sigma")
+                break
+    drop = classification.get("drop_pct") or 0.0
+    if drop >= DEFAULT_DROP_PCT_THRESHOLD and not rules:
+        rules.append("drop_pct_threshold")
+    # Strip informational-only rules from emission set.
+    return [r for r in rules if r != "trending_up"]
+
+
+def emit_spc_flag(
+    project: str,
+    classification: Dict[str, Any],
+    *,
+    metric: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Persist one ``delivery:spc:flag`` record per fired rule.
+
+    Returns the list of payloads written (empty when nothing fired or warmup
+    blocks emission). Never raises — DomainStore failures are logged to stderr.
+    """
+    if classification.get("insufficient_warmup"):
+        return []
+    if not classification.get("drift"):
+        return []
+    rules = _classify_rule(classification)
+    if not rules:
+        return []
+
+    metric_name = metric or classification.get("metric") or "unknown"
+    base = classification.get("baseline") or {}
+    samples = base.get("samples") or []
+    sample_window = {
+        "start": samples[0] if samples else None,
+        "end": classification.get("latest"),
+        "n": classification.get("session_count"),
+    }
+    written: List[Dict[str, Any]] = []
+    try:
+        from _domain_store import DomainStore  # type: ignore
+        ds = DomainStore("delivery", hook_mode=True)
+    except Exception as exc:  # pragma: no cover — DomainStore is plugin core
+        print(f"[wicked-garden] spc flag store error: {exc}", file=sys.stderr)
+        return []
+
+    for rule in rules:
+        payload = {
+            "project": project,
+            "metric": metric_name,
+            "rule": rule,
+            "severity": "critical" if rule in _CRITICAL_RULES else "warn",
+            "sample_window": sample_window,
+            "current_value": classification.get("latest"),
+            "baseline_mean": base.get("mean"),
+            "baseline_stddev": base.get("stddev"),
+            "drop_pct": classification.get("drop_pct"),
+            "reasons": classification.get("reasons"),
+            "recorded_at": _utc_iso_now(),
+        }
+        try:
+            rec = ds.create("spc", payload)
+            if rec is not None:
+                written.append(rec)
+        except Exception as exc:  # pragma: no cover
+            print(f"[wicked-garden] spc flag write error: {exc}", file=sys.stderr)
+    return written
+
+
+def _utc_iso_now() -> str:
+    """Local helper — drift.py is otherwise time-free, so import datetime here."""
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def list_recent_flags(
+    project: str,
+    *,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """Return recent SPC flags for a project, newest first. Fail-open."""
+    try:
+        from _domain_store import DomainStore  # type: ignore
+        ds = DomainStore("delivery", hook_mode=True)
+        flags = ds.list("spc", project=project) or []
+    except Exception:
+        return []
+    flags.sort(key=lambda r: r.get("recorded_at") or "", reverse=True)
+    return flags[:limit] if limit and limit > 0 else flags
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -462,13 +662,55 @@ def _cli_emit(args: List[str]) -> int:
     return 0
 
 
+def _cli_flag(args: List[str]) -> int:
+    """Classify and persist any SPC flags via DomainStore. Used by /delivery:health."""
+    if not args:
+        print(json.dumps({"ok": False, "reason": "project required"}))
+        return 0
+    project = args[0]
+    metric = args[1] if len(args) > 1 else "gate_pass_rate"
+    try:
+        from delivery.telemetry import read_timeline  # type: ignore
+    except Exception:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from telemetry import read_timeline  # type: ignore
+    cls = classify(read_timeline(project), metric)
+    flags = emit_spc_flag(project, cls, metric=metric)
+    print(json.dumps({
+        "ok": True,
+        "project": project,
+        "metric": metric,
+        "classification": cls,
+        "flags_written": flags,
+    }))
+    return 0
+
+
+def _cli_list_flags(args: List[str]) -> int:
+    if not args:
+        print(json.dumps({"ok": False, "reason": "project required"}))
+        return 0
+    project = args[0]
+    limit = 20
+    if len(args) > 1:
+        try:
+            limit = int(args[1])
+        except ValueError:
+            limit = 20
+    flags = list_recent_flags(project, limit=limit)
+    print(json.dumps({"ok": True, "project": project, "flags": flags}))
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     argv = list(argv if argv is not None else sys.argv[1:])
     if not argv or argv[0] in ("-h", "--help", "help"):
         print(
             "Usage:\n"
             "  drift.py classify <project> [metric]\n"
-            "  drift.py emit <project> [metric]\n",
+            "  drift.py emit <project> [metric]\n"
+            "  drift.py flag <project> [metric]\n"
+            "  drift.py list-flags <project> [limit]\n",
             file=sys.stderr,
         )
         return 0
@@ -478,6 +720,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         return _cli_classify(rest)
     if cmd == "emit":
         return _cli_emit(rest)
+    if cmd == "flag":
+        return _cli_flag(rest)
+    if cmd == "list-flags":
+        return _cli_list_flags(rest)
     print(json.dumps({"ok": False, "reason": f"unknown command: {cmd}"}))
     return 0
 

--- a/scripts/delivery/process_health.py
+++ b/scripts/delivery/process_health.py
@@ -159,10 +159,19 @@ def _spc_section(project: str) -> dict:
                     drift_mod.classify(synth, f"{slot_key}.min_score")
                 )
     flags = drift_mod.list_recent_flags(project, limit=10)
+    # PR #730 review: warmup gate inside drift.classify() counts numeric samples
+    # (skipping records with None for the metric). Mirror that here so the
+    # report doesn't show "satisfied" while the headline classification still
+    # reports insufficient_warmup=true. headline_metric_samples is the most
+    # honest count to surface — derived from the headline classification's
+    # session_count (which already skipped None).
+    headline_classification = classifications[0] if classifications else {}
+    metric_sample_count = headline_classification.get("session_count", len(timeline))
     return {
-        "sample_count": len(timeline),
+        "sample_count": metric_sample_count,
+        "timeline_length": len(timeline),
         "warmup_min_samples": drift_mod.WARMUP_MIN_SAMPLES,
-        "warmup_satisfied": len(timeline) >= drift_mod.WARMUP_MIN_SAMPLES,
+        "warmup_satisfied": metric_sample_count >= drift_mod.WARMUP_MIN_SAMPLES,
         "classifications": classifications,
         "recent_flags": flags,
     }

--- a/scripts/delivery/process_health.py
+++ b/scripts/delivery/process_health.py
@@ -20,6 +20,8 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_SCRIPTS_ROOT))
 
 from delivery import process_memory as pm
+from delivery import drift as drift_mod
+from delivery import telemetry as tm
 
 
 def _rollup(memory: dict) -> dict:
@@ -127,6 +129,85 @@ def render_report(project: str, memory: dict, rollup: dict) -> str:
     return "\n".join(lines)
 
 
+def _spc_section(project: str) -> dict:
+    """Build the SPC drift summary for a project (issue #719).
+
+    Classifies the gate_pass_rate timeline + per-gate min_score series,
+    surfaces the warmup status, and lists recent persisted flags. Always
+    returns a dict — empty fields when telemetry hasn't accumulated yet.
+    """
+    timeline = tm.read_timeline(project)
+    classifications: list[dict] = []
+    # Always classify the headline metric.
+    headline = drift_mod.classify(timeline, "gate_pass_rate")
+    classifications.append(headline)
+    # Per-(phase, tier) min_score series — one classification per gate slot
+    # observed in the most recent record. We synthesize a synthetic series by
+    # pulling each slot's min_score from each timeline record.
+    if timeline:
+        latest_slots = (timeline[-1].get("metrics") or {}).get("gate_breakdown") or {}
+        for slot_key in sorted(latest_slots.keys()):
+            synth: list[dict] = []
+            for rec in timeline:
+                gb = (rec.get("metrics") or {}).get("gate_breakdown") or {}
+                slot = gb.get(slot_key) or {}
+                min_score = slot.get("min_score")
+                if isinstance(min_score, (int, float)):
+                    synth.append({"metrics": {f"{slot_key}.min_score": float(min_score)}})
+            if len(synth) >= 5:
+                classifications.append(
+                    drift_mod.classify(synth, f"{slot_key}.min_score")
+                )
+    flags = drift_mod.list_recent_flags(project, limit=10)
+    return {
+        "sample_count": len(timeline),
+        "warmup_min_samples": drift_mod.WARMUP_MIN_SAMPLES,
+        "warmup_satisfied": len(timeline) >= drift_mod.WARMUP_MIN_SAMPLES,
+        "classifications": classifications,
+        "recent_flags": flags,
+    }
+
+
+def render_spc(spc: dict) -> str:
+    """Format the SPC section as a markdown block."""
+    lines = ["## SPC Drift", ""]
+    lines.append(
+        f"- Samples: **{spc['sample_count']}** "
+        f"(warmup threshold: {spc['warmup_min_samples']})"
+    )
+    lines.append(
+        f"- Warmup: **{'satisfied' if spc['warmup_satisfied'] else 'PENDING'}**"
+    )
+    lines.append("")
+    lines.append("### Classifications")
+    lines.append("")
+    for cls in spc["classifications"]:
+        zone = cls.get("zone", "unknown")
+        metric = cls.get("metric", "?")
+        n = cls.get("session_count", 0)
+        rules = ", ".join(cls.get("we_rules") or []) or "—"
+        lines.append(
+            f"- `{metric}` n={n} zone=**{zone}** drift={cls.get('drift', False)} "
+            f"rules=[{rules}]"
+        )
+    lines.append("")
+    flags = spc.get("recent_flags") or []
+    if flags:
+        lines.append("### Recent flags")
+        lines.append("")
+        lines.append("| Recorded | Metric | Rule | Severity |")
+        lines.append("|----------|--------|------|----------|")
+        for f in flags:
+            lines.append(
+                f"| {f.get('recorded_at', '—')} | {f.get('metric', '—')} "
+                f"| {f.get('rule', '—')} | {f.get('severity', '—')} |"
+            )
+    else:
+        lines.append("_No SPC flags persisted yet._")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Render process-health summary for a crew project."
@@ -138,23 +219,33 @@ def main(argv: list[str] | None = None) -> int:
         choices=("text", "json", "both"),
         help="Output format. 'both' prints JSON to stderr and text to stdout.",
     )
+    parser.add_argument(
+        "--spc",
+        action="store_true",
+        help="Include SPC drift section (issue #719). Default off for back-compat.",
+    )
     args = parser.parse_args(argv)
 
     memory = pm.load_memory(args.project)
     rollup = _rollup(memory)
     context = pm.facilitator_context(args.project)
+    spc = _spc_section(args.project) if args.spc else None
     # Merge rollup into context for JSON consumers.
     payload = {
         "project": args.project,
         "context": context,
         "rollup": rollup,
     }
+    if spc is not None:
+        payload["spc"] = spc
 
     if args.format == "json":
         print(json.dumps(payload, indent=2))
         return 0
 
     report = render_report(args.project, memory, rollup)
+    if spc is not None:
+        report += "\n" + render_spc(spc)
     if args.format == "both":
         sys.stderr.write(json.dumps(payload, indent=2) + "\n")
     sys.stdout.write(report)

--- a/scripts/delivery/telemetry.py
+++ b/scripts/delivery/telemetry.py
@@ -74,6 +74,7 @@ if str(_SCRIPTS_ROOT) not in sys.path:
 SCHEMA_VERSION = "1"
 # Per-session capture worst-case budget. We bail out rather than block session-end.
 _CAPTURE_BUDGET_SECONDS = 0.5
+_MAX_SCENARIO_SCAN = 500  # PR #730: bound DomainStore iteration in scenario extractor
 # Max tasks to scan in one capture. Covers any realistic session.
 _MAX_TASKS_SCAN = 500
 # Minimum total verdicts before gate_pass_rate is considered meaningful.
@@ -276,18 +277,25 @@ def _extract_metrics_from_tasks(
     }
 
 
-def _extract_convergence_metrics(project: Optional[str]) -> Dict[str, Any]:
+def _extract_convergence_metrics(
+    project: Optional[str],
+    deadline: Optional[float] = None,
+) -> Dict[str, Any]:
     """Read crew convergence stalls for the active project.
 
     Returns counts of stalled artifacts (sessions_in_state >= threshold) and
     the count of recorded transitions in the most recent log scan. Fail-open:
-    any failure → all-zero metrics.
+    any failure → all-zero metrics. Honors capture deadline (PR #730 review):
+    if budget already exhausted on entry, returns zeros without doing any work.
     """
     out = {"convergence_stalls": 0, "convergence_artifacts": 0}
     if not project or project == "_global":
         return out
+    if deadline is not None and time.monotonic() > deadline:
+        return out  # over budget — skip rather than block the hook
     try:
-        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+        # `_SCRIPTS_ROOT` is already on sys.path at module-load (lines 63-65).
+        # No per-call insert needed — flagged in gemini's PR #730 review.
         from crew import convergence  # type: ignore
         # convergence APIs take a project *directory*, not the slug. Resolve
         # via the same helper its CLI uses so we honor _paths.
@@ -301,25 +309,53 @@ def _extract_convergence_metrics(project: Optional[str]) -> Dict[str, Any]:
     return out
 
 
-def _extract_scenario_metrics(project: Optional[str]) -> Dict[str, Any]:
-    """Read scenario verdict counts for the active project.
+def _extract_scenario_metrics(
+    project: Optional[str],
+    deadline: Optional[float] = None,
+    since_iso: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Read PER-SESSION scenario verdict counts for the active project.
 
-    Looks for a wicked-testing DomainStore source; if absent, returns zeros.
-    Acceptance criterion (#719) is "capture if available" — we never hard-fail
-    when wicked-testing isn't installed.
+    Counts only verdicts whose recorded timestamp is later than ``since_iso``
+    (the previous session's recorded_at). This produces session-delta counts
+    suitable for ratio drift detection — Copilot flagged the prior cumulative
+    behavior in PR #730 as semantically wrong (lifetime cumulative counts can
+    only grow, so per-session ratios cannot drift).
+
+    Honors ``deadline``: if budget exhausted on entry, returns zeros. Caps the
+    iteration at _MAX_SCENARIO_SCAN to bound the worst-case scan even when no
+    deadline is provided.
+
+    Falls back to all-zero output when wicked-testing is not installed.
     """
     out = {"scenario_pass": 0, "scenario_partial": 0, "scenario_fail": 0}
     if not project or project == "_global":
         return out
+    if deadline is not None and time.monotonic() > deadline:
+        return out
     try:
         from _domain_store import DomainStore  # type: ignore
         ds = DomainStore("wicked-testing", hook_mode=True)
+        scanned = 0
         for source in ("verdicts", "runs", "scenarios"):
+            if deadline is not None and time.monotonic() > deadline:
+                break
             try:
                 rows = ds.list(source, project=project) or []
             except Exception:
                 rows = []
             for row in rows:
+                scanned += 1
+                if scanned > _MAX_SCENARIO_SCAN:
+                    break
+                # Only count verdicts after the previous session's capture.
+                # Records older than `since_iso` (or all rows on the first ever
+                # capture, where since_iso is None) are excluded so each
+                # session emits its own delta, not the running total.
+                if since_iso:
+                    rec_ts = str(row.get("recorded_at") or row.get("created_at") or "")
+                    if rec_ts and rec_ts <= since_iso:
+                        continue
                 v = str(row.get("verdict") or row.get("result") or "").upper()
                 if v == "PASS":
                     out["scenario_pass"] += 1
@@ -327,7 +363,7 @@ def _extract_scenario_metrics(project: Optional[str]) -> Dict[str, Any]:
                     out["scenario_partial"] += 1
                 elif v in ("FAIL", "ERROR"):
                     out["scenario_fail"] += 1
-            if any(out.values()):
+            if any(out.values()) and scanned <= _MAX_SCENARIO_SCAN:
                 break  # first source that yielded data wins
     except Exception:
         pass
@@ -416,8 +452,19 @@ def capture_session(
         metrics["complexity_delta"] = extras["complexity_delta"]
         # Issue #719: convergence + scenario rollups join the per-session metric
         # bag. Fail-open on both — empty zeros are better than dropped records.
-        metrics.update(_extract_convergence_metrics(raw_project))
-        metrics.update(_extract_scenario_metrics(raw_project))
+        # PR #730 review: pass `deadline` so these helpers respect the same
+        # _CAPTURE_BUDGET_SECONDS guardrail the task scanner honors.
+        # Scenario extractor also gets the previous session's recorded_at as
+        # `since_iso` so it counts session deltas, not lifetime cumulative.
+        prev_recorded_at: Optional[str] = None
+        try:
+            prior = read_timeline(resolved_project, limit=1)
+            if prior:
+                prev_recorded_at = prior[-1].get("recorded_at")
+        except Exception:
+            pass
+        metrics.update(_extract_convergence_metrics(raw_project, deadline=deadline))
+        metrics.update(_extract_scenario_metrics(raw_project, deadline=deadline, since_iso=prev_recorded_at))
 
         # Build sample window from the first/last task timestamps observed.
         first_ts: Optional[str] = None

--- a/scripts/delivery/telemetry.py
+++ b/scripts/delivery/telemetry.py
@@ -178,6 +178,11 @@ def _extract_metrics_from_tasks(
     phase_started: Dict[str, float] = {}
     cycle_time_by_phase: Dict[str, float] = {}
 
+    # Per-(phase, tier) verdict + score breakdown — issue #719 ACs need
+    # `{phase}.{tier}.min_score` and verdict ratios per gate. Stored as a
+    # nested dict keyed by ``f"{phase}.{tier}"`` for stable JSON addressing.
+    gate_breakdown: Dict[str, Dict[str, Any]] = {}
+
     for t in tasks:
         if not isinstance(t, dict):
             continue
@@ -203,6 +208,32 @@ def _extract_metrics_from_tasks(
             if isinstance(score, (int, float)):
                 scores.append(float(score))
 
+            # Per phase × tier rollup. Tier defaults to "standard" when the
+            # gate-finding event doesn't carry an explicit rigor tag — most
+            # phase events do, but legacy fallbacks may not.
+            phase_name = meta.get("phase") or "unknown"
+            tier = (meta.get("rigor_tier") or meta.get("tier") or "standard")
+            key = f"{phase_name}.{tier}"
+            slot = gate_breakdown.setdefault(key, {
+                "phase": phase_name,
+                "tier": tier,
+                "approve": 0,
+                "conditional": 0,
+                "reject": 0,
+                "scores": [],
+                "min_score": None,
+            })
+            if verdict == "APPROVE":
+                slot["approve"] += 1
+            elif verdict == "CONDITIONAL":
+                slot["conditional"] += 1
+            elif verdict == "REJECT":
+                slot["reject"] += 1
+            if isinstance(score, (int, float)):
+                slot["scores"].append(float(score))
+                cur_min = slot["min_score"]
+                slot["min_score"] = float(score) if cur_min is None else min(cur_min, float(score))
+
         elif et == "phase-transition":
             phase = meta.get("phase") or meta.get("from_phase")
             ts_end = _parse_iso(t.get("updated_at") or t.get("created_at"))
@@ -212,6 +243,14 @@ def _extract_metrics_from_tasks(
                     cycle_time_by_phase[phase] = round(ts_end - start, 3)
                 # Any transition on the phase resets its start anchor.
                 phase_started[phase] = ts_end
+
+    # Finalize per-gate avg scores (kept alongside min for SPC of mean lines).
+    for slot in gate_breakdown.values():
+        scores_list = slot.pop("scores", [])
+        slot["avg_score"] = round(sum(scores_list) / len(scores_list), 4) if scores_list else None
+        total = slot["approve"] + slot["conditional"] + slot["reject"]
+        slot["total"] = total
+        slot["reject_rate"] = round(slot["reject"] / total, 4) if total else None
 
     total_verdicts = approve + conditional + reject
     if total_verdicts >= _MIN_VERDICTS_FOR_RATE:
@@ -232,7 +271,67 @@ def _extract_metrics_from_tasks(
         "task_count": task_count,
         "task_completed": task_completed,
         "cycle_time_by_phase": cycle_time_by_phase,
+        # Issue #719: nested per-(phase, tier) rollups for SPC drift.
+        "gate_breakdown": gate_breakdown,
     }
+
+
+def _extract_convergence_metrics(project: Optional[str]) -> Dict[str, Any]:
+    """Read crew convergence stalls for the active project.
+
+    Returns counts of stalled artifacts (sessions_in_state >= threshold) and
+    the count of recorded transitions in the most recent log scan. Fail-open:
+    any failure → all-zero metrics.
+    """
+    out = {"convergence_stalls": 0, "convergence_artifacts": 0}
+    if not project or project == "_global":
+        return out
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+        from crew import convergence  # type: ignore
+        # convergence APIs take a project *directory*, not the slug. Resolve
+        # via the same helper its CLI uses so we honor _paths.
+        project_dir = convergence._resolve_project_dir(project)
+        stalls = convergence.detect_stalls(project_dir) or []
+        status = convergence.project_status(project_dir) or {}
+        out["convergence_stalls"] = len(stalls)
+        out["convergence_artifacts"] = int(status.get("total") or 0)
+    except Exception:
+        pass
+    return out
+
+
+def _extract_scenario_metrics(project: Optional[str]) -> Dict[str, Any]:
+    """Read scenario verdict counts for the active project.
+
+    Looks for a wicked-testing DomainStore source; if absent, returns zeros.
+    Acceptance criterion (#719) is "capture if available" — we never hard-fail
+    when wicked-testing isn't installed.
+    """
+    out = {"scenario_pass": 0, "scenario_partial": 0, "scenario_fail": 0}
+    if not project or project == "_global":
+        return out
+    try:
+        from _domain_store import DomainStore  # type: ignore
+        ds = DomainStore("wicked-testing", hook_mode=True)
+        for source in ("verdicts", "runs", "scenarios"):
+            try:
+                rows = ds.list(source, project=project) or []
+            except Exception:
+                rows = []
+            for row in rows:
+                v = str(row.get("verdict") or row.get("result") or "").upper()
+                if v == "PASS":
+                    out["scenario_pass"] += 1
+                elif v in ("PARTIAL", "WARN"):
+                    out["scenario_partial"] += 1
+                elif v in ("FAIL", "ERROR"):
+                    out["scenario_fail"] += 1
+            if any(out.values()):
+                break  # first source that yielded data wins
+    except Exception:
+        pass
+    return out
 
 
 def _extract_session_extras() -> Dict[str, Any]:
@@ -315,6 +414,10 @@ def capture_session(
         metrics = _extract_metrics_from_tasks(tasks)
         metrics["skip_reeval_count"] = extras["skip_reeval_count"]
         metrics["complexity_delta"] = extras["complexity_delta"]
+        # Issue #719: convergence + scenario rollups join the per-session metric
+        # bag. Fail-open on both — empty zeros are better than dropped records.
+        metrics.update(_extract_convergence_metrics(raw_project))
+        metrics.update(_extract_scenario_metrics(raw_project))
 
         # Build sample window from the first/last task timestamps observed.
         first_ts: Optional[str] = None


### PR DESCRIPTION
## Summary

Closes #719. Extends existing \`drift.py\` with the missing 2 Western Electric rules, 8-sample warmup gate, DomainStore-backed flag emission, and surfaces results via \`/wicked-garden:delivery:process-health --spc\`. Avoids parallel \`spc.py\` system — extends what's already there.

## Why this approach

\`scripts/delivery/drift.py\` already implemented EWMA + 2 of 4 Western Electric runs rules (1>3σ, 2/3>2σ, trending_down/up). Building a parallel \`spc.py\` would have duplicated baseline/EWMA/storage logic. Extending hits the same AC with ~half the code surface.

## Changes

| File | Change |
|------|--------|
| \`scripts/delivery/drift.py\` | +2 WE rules (4-of-5-zone-c, 8-consecutive), warmup gate, \`emit_spc_flag()\` + \`list_recent_flags()\`, CLI \`flag\`/\`list-flags\` subcommands |
| \`scripts/delivery/telemetry.py\` | Per-(phase, tier) gate_breakdown, convergence-stall counts, scenario verdict ratios |
| \`scripts/delivery/process_health.py\` | \`_spc_section()\` lazily synthesizes per-(phase, tier) min_score series; degrades gracefully on older timelines |
| \`commands/delivery/process-health.md\` | New \`--spc\` flag (preferred over command sprawl) |
| **NEW** \`scenarios/delivery/07-spc-drift-detected.md\` | 10 declining sessions → flag fires |
| **NEW** \`scenarios/delivery/08-spc-stable-no-flag.md\` | 20 stable + 7 pre-warmup → zero flags |
| **NEW** \`docs/spc.md\` | 128-line plain-English chart-reading guide |

**Net diff: +810 / -28 LOC.**

## Severity classification

- \`1_outside_3sigma\` + \`8_consecutive_one_side\` → \`critical\`
- \`2_of_3_zone_b\` + \`4_of_5_zone_c\` + \`trending_down\` + \`drop_pct_threshold\` → \`warn\`

## Smoke-tested inline

\`\`\`
7 samples  → insufficient_warmup=true, drift=false  ✅ warmup gate works
12 declining → drift=true, zone=special-cause, reasons=[outside 2σ, WE trending-down (6 consecutive), EWMA slope -0.0162]  ✅ detection fires
\`\`\`

## Hard guardrails

- ✅ \`scripts/ci/validate.py\` PASS
- ✅ stdlib only (no scipy / numpy)
- ✅ \`_python.sh\` shim used in scenarios (PR #707 policy)
- ✅ Bundled bash blocks in scenarios (PR #715 lesson)
- ✅ DomainStore via established \`from _domain_store import DomainStore\` pattern
- ✅ No skill/agent/hook files modified

## Out of scope (per issue body)

- Real-time alerting / paging integrations
- ML-based anomaly detection (Shewhart / WE rules only in v1)
- Cross-project SPC (per-project only)

## Value-delay note

Per the issue, value is delayed by the 8-sample warmup. Existing telemetry will accumulate samples each session; flags become useful once any monitored metric has 8+ historical observations. Building now starts the data flywheel rather than waiting until we need the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)