### PR TITLE
docs(audit): disk-write → bus-emit gap report (closes #733)

### DIFF
--- a/docs/audits/disk-write-bus-emit-gap.md
+++ b/docs/audits/disk-write-bus-emit-gap.md
@@ -1,0 +1,222 @@
+# Disk-Write → Bus-Emit Gap Audit (#733)
+
+> **Headline**: 63 disk-write call sites in `scripts/crew/` + `hooks/scripts/`. **Zero** currently emit bus events. The bus-as-truth refactor (#732) starts from a clean baseline — there is nothing to *change*, only writes to *augment* with corresponding emits.
+
+## Method
+
+- Scanned: `scripts/crew/**/*.py` (59 files) + `hooks/scripts/**/*.py` (12 files including `subscribers/`)
+- Patterns audited: `write_text`, `write_bytes`, `json.dump`, `open()` w/a/wb/ab, `os.replace`, `shutil.copy/move`, `mkdir` of state dirs, `unlink`, `rmtree`, `tempfile + os.replace`, `SessionState.save/update`
+- Bus-emit detection: `subprocess.run(["wicked-bus", "emit", ...])` or helper-function calls (e.g. `emit_validated_payloads()` in `detectors/_common.py`) in the same function scope as the write
+- Date: 2026-05-02
+
+## Combined summary
+
+| Metric | scripts/crew | hooks/scripts | Total | % |
+|--------|--------------|---------------|-------|---|
+| Total write call sites | 47 | 16 | **63** | 100% |
+| Already emit a bus event | 0 | 0 | **0** | **0%** |
+| Emit but envelope incomplete | 0 | 0 | 0 | 0% |
+| Silent (no emit at all) | 47 | 16 | **63** | **100%** |
+
+### Top 5 risky gaps across both surfaces
+
+1. **`scripts/crew/phase_manager.py:3676`** — `gate-result.json` synthesized post-blend dispatch. Verdict deterministic but written silently. Highest-risk: this is the file the orphan-check sentinel relies on.
+2. **`scripts/crew/phase_manager.py:2684`** — `conditions-manifest.json` written on gate CONDITIONAL. Core state mutation; zero emit.
+3. **`scripts/crew/dispatch_log.py:330–331`** — `dispatch-log.jsonl` append for every gate dispatch. The HMAC-signed dispatch log is the orphan-check input — it's written silently.
+4. **`hooks/scripts/post_tool.py:963, 970`** — Consensus gate `reviewer-report.md` silently written. `phase_manager` reads this file on next approval cycle — file poll, not event-driven.
+5. **`scripts/crew/conditions_manifest.py:77, 89`** — Atomic temp+`os.replace` write of `conditions-manifest.json`. Crash-safe but silent.
+
+## Findings — scripts/crew
+
+| file:line | target_path | mutation_type | emits_event | event_type | envelope_complete | proposed_event |
+|-----------|-------------|---------------|-------------|------------|-------------------|----------------|
+| solo_mode.py:328 | phases/{phase}/conditions-manifest.json.tmp | write_text | no | — | — | wicked.crew.solo-mode.conditions.manifest |
+| solo_mode.py:332 | phases/{phase}/conditions-manifest.json | replace | no | — | — | wicked.crew.solo-mode.conditions.manifest |
+| solo_mode.py:388 | phases/{phase}/inline-review-context.md | write_text | no | — | — | wicked.crew.solo-mode.review-context.created |
+| solo_mode.py:436 | phases/{phase}/gate-result.json.tmp | write_text | no | — | — | wicked.crew.solo-mode.gate-result.recorded |
+| solo_mode.py:440 | phases/{phase}/gate-result.json | replace | no | — | — | wicked.crew.solo-mode.gate-result.recorded |
+| consensus_gate.py:428 | phases/{phase}/consensus-report.json | mkdir + write_text | no | — | — | wicked.crew.consensus.report.created |
+| consensus_gate.py:463 | phases/{phase}/consensus-evidence.json | mkdir + write_text | no | — | — | wicked.crew.consensus.evidence.recorded |
+| acceptance_criteria.py:366 | phases/clarify/acceptance-criteria.json.tmp | write_text | no | — | — | wicked.crew.acceptance-criteria.migrated |
+| acceptance_criteria.py:367 | phases/clarify/acceptance-criteria.json | replace | no | — | — | wicked.crew.acceptance-criteria.migrated |
+| adopt_legacy.py:110 | project.json | write_text | no | — | — | wicked.crew.legacy.phase-plan-mode-set |
+| adopt_legacy.py:171 | phases/{phase}/reeval-log.jsonl | open(a) + write | no | — | — | wicked.crew.legacy.reeval-migrated |
+| adopt_legacy.py:179 | process-plan.md | write_text | no | — | — | wicked.crew.legacy.markdown-reeval-cleared |
+| adopt_legacy.py:209 | (various markdown files) | write_text | no | — | — | wicked.crew.legacy.bypass-reference-removed |
+| amendments.py:206 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
+| amendments.py:242 | phases/{phase}/amendments.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.amendments.recorded |
+| conditions_manifest.py:77 | phases/{phase}/conditions-manifest.json.tmp | open(w) + write + fsync | no | — | — | wicked.crew.conditions-manifest.atomic-write |
+| conditions_manifest.py:89 | phases/{phase}/conditions-manifest.json | os.replace | no | — | — | wicked.crew.conditions-manifest.atomic-write |
+| conditions_manifest.py:192 | phases/{phase}/conditions-manifest.{id}.resolution.json | atomic_write_json | no | — | — | wicked.crew.condition.resolution-sidecar |
+| conditions_manifest.py:203 | phases/{phase}/conditions-manifest.json | atomic_write_json | no | — | — | wicked.crew.condition.marked-cleared |
+| convergence.py:228 | phases/{phase}/convergence-log.jsonl | open(a) + write | no | — | — | wicked.crew.convergence.transition-recorded |
+| dispatch_log.py:329 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
+| dispatch_log.py:330–331 | phases/{phase}/dispatch-log.jsonl | open(a) + write | no | — | — | wicked.crew.dispatch-log.entry-appended |
+| gate_ingest_audit.py:160 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
+| gate_ingest_audit.py:162 | phases/{phase}/gate-ingest-audit.jsonl | open(a) + write | no | — | — | wicked.crew.gate-ingest.audit-recorded |
+| hitl_judge.py:611–613 | phases/{phase}/{filename}.json | mkdir + write_text | no | — | — | wicked.crew.hitl.decision-persisted |
+| log_retention.py:168 | archive/ (subdir) | mkdir | no | — | — | — (directory creation, not state) |
+| log_retention.py:180–181 | archive/*.jsonl.gz | gzip.open(wb) + shutil.copyfileobj | no | — | — | wicked.crew.log-retention.archive-rotated |
+| log_retention.py:200 | (active log path) | open(w) + truncate | no | — | — | wicked.crew.log-retention.log-truncated |
+| migrate_qe_evaluator_name.py:173 | *.bak | write_bytes | no | — | — | wicked.crew.migration.backup-created |
+| migrate_qe_evaluator_name.py:180 | *.tmp | write_text | no | — | — | wicked.crew.migration.temp-written |
+| migrate_qe_evaluator_name.py:191 | (original file) | os.replace | no | — | — | wicked.crew.migration.file-migrated |
+| phase_manager.py:1169 | phases/{phase}/status.md | write_text | no | — | — | wicked.crew.phase.status-initialized |
+| phase_manager.py:1600 | phases/{phase}/context.md | write_text | no | — | — | wicked.crew.phase.context-created |
+| phase_manager.py:2571 | phases/review/semantic-gap-report.json | mkdir + write_text | no | — | — | wicked.crew.semantic-alignment.report-created |
+| phase_manager.py:2684 | phases/{phase}/conditions-manifest.json | write_text | no | — | — | wicked.crew.gate.conditional-conditions-written |
+| phase_manager.py:2913 | phases/{phase}/iteration-count.json | mkdir + write_text | no | — | — | wicked.crew.iteration.count-recorded |
+| phase_manager.py:2939 | phases/{phase}/status.md | open(a) + read + write_text | no | — | — | wicked.crew.gate-override.rigor-exception-recorded |
+| phase_manager.py:2958 | phases/{phase}/status.md | open(a) + read + write_text | no | — | — | wicked.crew.deliverable.override-recorded |
+| phase_manager.py:2994 | phases/{phase}/skip-reeval-log.json | write_text | no | — | — | wicked.crew.reeval.skip-logged |
+| phase_manager.py:3415 | (task entry file) | write_text | no | — | — | wicked.crew.gate-finding.synced-to-completed |
+| phase_manager.py:3676 | phases/{phase}/gate-result.json | mkdir + write_text | no | — | — | wicked.crew.gate.verdict-synthesized |
+| phase_manager.py:4159 | phases/{phase}/status.md | write_text | no | — | — | wicked.crew.phase.skipped |
+| phase_manager.py:4343 | phases/{phase}/*.md | write_text | no | — | — | wicked.crew.adoption.legacy-memo-recorded |
+| phase_manager.py:4486 | project.md | write_text | no | — | — | wicked.crew.project.template-initialized |
+| phase_manager.py:4499 | outcome.md | write_text | no | — | — | wicked.crew.outcome.template-initialized |
+| phase_manager.py:4512 | phases/clarify/status.md | write_text | no | — | — | wicked.crew.phase.template-initialized |
+| phase_manager.py:5282 | phases/.cutover-to-mode-3.json | mkdir + write_text | no | — | — | wicked.crew.mode-switch.cutover-marker-written |
+| reeval_addendum.py:208 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
+| reeval_addendum.py:212 | phases/{phase}/reeval-log.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.reeval.addendum-appended |
+| reeval_addendum.py:244 | process-plan.addendum.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.reeval.project-log-appended |
+| traceability_generator.py:307 | phases/build/ | mkdir | no | — | — | — (directory creation, not state) |
+| traceability_generator.py:308 | phases/build/traceability-matrix.md | write_text | no | — | — | wicked.crew.traceability.matrix-generated |
+
+## Findings — scripts/crew/detectors
+
+**Note**: Detectors emit events via `emit_validated_payloads()` in `detectors/_common.py`. This audit scanned for **disk writes**, not event emissions, and found **zero** disk-write call sites in any detector module. All detectors are pure compute-to-bus with no durable state mutations. The bus-as-truth refactor leaves detectors untouched.
+
+## Findings — hooks/scripts
+
+| file:line | target_path | mutation_type | emits_event | event_type | envelope_complete | proposed_event |
+|-----------|-------------|---------------|-------------|------------|-------------------|----------------|
+| bootstrap.py:1079 | $CLAUDE_ENV_FILE (project .claude/env or ~/.claude/env) | append | no | — | — | N/A — env setup, not state |
+| bootstrap.py:1120 | ~/.something-wicked/wicked-crew/.task_suggest_shown | delete | no | — | — | N/A — idempotent flag |
+| pre_compact.py:75 | ~/.wicked-brain/memories/{tier}/ | mkdir | no | — | — | N/A — directory setup |
+| pre_compact.py:96 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | no | — | — | wicked.memory.captured (after brain index success) |
+| prompt_submit.py:88 | ~/.wicked-brain/memories/{tier}/ | mkdir | no | — | — | N/A — directory setup |
+| prompt_submit.py:109 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | no | — | — | wicked.memory.captured (session goal) |
+| post_tool.py:963 | {project_dir}/phases/{phase}/reviewer-report.md | append | no | — | — | wicked.consensus.gate-completed |
+| post_tool.py:969 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
+| post_tool.py:970 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | no | — | — | wicked.consensus.gate-completed |
+| post_tool.py:983 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
+| post_tool.py:984 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | no | — | — | wicked.consensus.gate-pending (evaluation failed) |
+| post_tool.py:1314 | $TMPDIR/wicked-trace-{session_id}.jsonl | append | no | — | — | N/A — tempdir-only trace |
+| subagent_lifecycle.py:133 | $TMPDIR/wicked-garden/traces/ | mkdir | no | — | — | N/A — tempdir-only |
+| subagent_lifecycle.py:135 | $TMPDIR/wicked-garden/traces/{session_id}.jsonl | append | no | — | — | N/A — tempdir-only trace |
+| subagent_lifecycle.py:260 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
+| subagent_lifecycle.py:280 | {project_dir}/phases/{phase}/specialist-engagement.json | atomic temp + replace | no | — | — | wicked.specialist.engagement-recorded |
+
+## Findings — hooks/scripts/subscribers
+
+### `on_gate_decided.py`
+
+This is a **bus-grain subscriber** (Issue #592, v8 PR-8) — receives `wicked.gate.decided` events and emits `wicked.hook.gate-decided-processed` events. It is the canonical example of what the bus-as-truth pattern looks like.
+
+| file:line | mutation_type | target_path | emits_event | event_type |
+|-----------|---------------|-------------|-------------|------------|
+| on_gate_decided.py:59 | emit (synthetic) | stdout → wicked-bus | **yes** | wicked.hook.gate-decided-processed |
+
+No disk writes. Pure message-passing.
+
+## Notes on SessionState writes
+
+All hooks call `SessionState.load()`, mutate fields, and call `state.update()` or `state.save()`. This persists to:
+
+```
+~/.something-wicked/wicked-garden/sessions/{session_id}.json
+```
+
+**SessionState is intentionally NOT event-sourced** — and this audit recommends keeping it that way:
+
+- Hot-path: mutated 100s of times per session (turn count, context flags, memory compliance)
+- Emitting per mutation = bus churn with no consumer value
+- Hooks already emit ops logs via `_log()` for audit purposes
+- SessionState is cache/context, not the system-of-record for any decision/gate
+
+If a future refactor makes SessionState the source of truth for gate decisions (unlikely), revisit this assumption.
+
+## Notes on memory capture writes
+
+`pre_compact.py:_write_brain_memory()` and `prompt_submit.py:_write_brain_memory()` write to disk and immediately call `_brain_api("index", ...)`. The disk write itself is silent, but the brain indexing call provides synchronous confirmation.
+
+**Recommendation for #734**: emit `wicked.memory.captured` *after* successful brain indexing returns, not before disk write — the event should reflect actual completion, not optimistic expectation.
+
+## Cross-reference: scripts/_event_schema.py
+
+The TaskCreate metadata envelope in `scripts/_event_schema.py` defines the validated shape for native task events. Bus events should mirror this where applicable.
+
+Required fields (cross-cutting):
+- `chain_id` — `{project}.root` | `{project}.{phase}` | `{project}.{phase}.{gate}` (regex enforced)
+- `source_agent` — never `just-finish-auto`, `fast-pass`, or anything starting with `auto-approve-`
+- `phase` — must appear in `.claude-plugin/phases.json` catalog when applicable
+- `event_type` — one of `task | coding-task | gate-finding | phase-transition | procedure-trigger | subtask`
+
+For `gate-finding` events at completion: `verdict ∈ {APPROVE, CONDITIONAL, REJECT}`, `min_score`, `score`. CONDITIONAL also requires `conditions_manifest_path` (Issue #570).
+
+The bus event envelope SHOULD adopt the same `chain_id` + `source_agent` + `phase` fields so projections can correlate task events with bus events without lossy joins.
+
+## Out of scope
+
+- `scripts/qe/`, `scripts/data/`, `scripts/delivery/`, `scripts/agentic/`, `scripts/persona/`, etc. — separate audit scope
+- Test files (`tests/**`)
+- Tempdir-only writes (`$TMPDIR/wicked-trace-*`) that don't persist past process exit
+- Stdlib `print()` / `sys.stdout.write()` (not persistent state)
+- `scripts/_session.py` SessionState mutations (intentionally not event-sourced — see above)
+
+## Architectural notes
+
+### Hooks fail-open by design
+
+All hooks return `{"continue": true}` on unhandled exceptions. The absence of bus events in hook code is partly a fail-open consequence — if emit fails, the hook still returns continue. The bus-as-truth refactor must preserve fail-open semantics: emit failure cannot block hook completion.
+
+### Consensus gate as a critical gap
+
+The consensus gate flow today:
+
+```
+phase_manager.approve()
+  → PostToolUse hook
+    → _handle_bash_consensus()
+      → write reviewer-report.md (silent)
+next cycle:
+  phase_manager reads reviewer-report.md (file poll, not event-driven)
+```
+
+This is a subtle fail-open: if the hook write fails silently or the file is deleted, phase progression still succeeds (gates are advisory). For #732, this should emit `wicked.consensus.gate-completed` so the gate system has an event-driven signal independent of file existence.
+
+### Atomic-write idioms are correct but silent
+
+Multiple call sites use `tempfile + os.replace` for crash-safety: `conditions_manifest.py:77,89`, `solo_mode.py:328,332,436,440`, `subagent_lifecycle.py:280`. The atomic-write pattern is correct. The gap is solely the missing emit — adding the emit AFTER the `os.replace` succeeds preserves atomicity.
+
+## Recommendations for #734
+
+For each gap in the tables above, the owner of #734 must decide:
+
+1. **Emit required (default)** — Add event payload + emit call AFTER the write succeeds (or after `os.replace` for atomic-write idioms). Use the proposed event_type from the table or refine.
+2. **Emit not applicable** — Document the exception in the projector design (e.g., env setup, idempotent flags, tempdir-only traces).
+3. **Borderline** — Templates, iteration counters, archives. Clarify in the envelope design whether these are audit events or ledger-only state.
+
+### Priority order for emit additions
+
+1. **HIGH** — Gate-result, conditions-manifest, dispatch-log, consensus reviewer-report writes. These are the orphan-check inputs and the projector's primary signals.
+2. **MEDIUM** — Phase status markers, semantic-gap report, specialist-engagement, memory captures. Useful for projection completeness but not gate-correctness.
+3. **LOW** — Templates, log rotation, legacy migration, iteration counters. Audit-trail value only.
+
+### What the projector can rely on today
+
+**Nothing.** Every disk write that the projector might want to subscribe to is currently silent. The projector design in #734 must assume:
+
+- It either drives the emit additions itself (add emits as part of #734)
+- Or it falls back to file polling on the load-bearing artifacts as an interim until per-gap PRs land
+
+Recommendation: **#734 should bundle the HIGH-priority emit additions** (gate-result, conditions-manifest, dispatch-log, consensus reviewer-report) so the projector has real subscribable events from day one. MEDIUM and LOW gaps land in follow-up PRs over the subsequent release cycle.
+
+## Cross-references
+
+- Umbrella: #732 (bus-as-truth event-sourcing refactor)
+- Step 2 (blocked on this): #734 (resume projector + lint)
+- Closes: #733
+- Builds on: PR #690 (`/wicked-garden:crew:reconcile` — drift diagnostic feeds step 3 cutover)
+- Decision memory: `bus-as-truth-event-sourced-crew-state.md` (semantic tier)

--- a/docs/audits/disk-write-bus-emit-gap.md
+++ b/docs/audits/disk-write-bus-emit-gap.md
@@ -162,11 +162,11 @@ Coverage notation:
 
 `hooks/scripts/stop.py` emits `wicked.fact.extracted` (L162) but does not write to disk in that flow — emit-only, no write to pair with.
 
-`hooks/scripts/subscribers/on_gate_decided.py` is a pure message-passing subscriber — no disk writes, emits `wicked.hook.gate-decided-processed`. Canonical example of the bus-as-truth pattern.
+`hooks/scripts/subscribers/on_gate_decided.py` is a pure message-passing subscriber — no disk writes, emits `wicked.hook.gate_decided_processed` (underscores, not hyphens — verified at L58 of the subscriber). Canonical example of the bus-as-truth pattern.
 
 ## Notes on SessionState writes
 
-All hooks call `SessionState.load()` → mutate → `state.save()`. This persists to `~/.something-wicked/wicked-garden/sessions/{session_id}.json` and is **intentionally NOT event-sourced**:
+All hooks call `SessionState.load()` → mutate → `state.save()`. This persists to `${TMPDIR or tempfile.gettempdir()}/wicked-garden-session-{session_id}.json` (per `scripts/_session.py:60-62`) and is **intentionally NOT event-sourced**:
 
 - Hot-path: 100s of mutations per session (turn count, context flags, memory compliance)
 - Per-mutation emit = bus churn with no consumer

--- a/docs/audits/disk-write-bus-emit-gap.md
+++ b/docs/audits/disk-write-bus-emit-gap.md
@@ -1,153 +1,183 @@
 # Disk-Write → Bus-Emit Gap Audit (#733)
 
-> **Headline**: 63 disk-write call sites in `scripts/crew/` + `hooks/scripts/`. **Zero** currently emit bus events. The bus-as-truth refactor (#732) starts from a clean baseline — there is nothing to *change*, only writes to *augment* with corresponding emits.
+> **Headline (revised after PR #735 review)**: 63 disk-write call sites in `scripts/crew/` + `hooks/scripts/`. After accounting for the `_bus.emit_event()` helper pattern AND coverage via the caller chain (helpers invoked from emit-bearing functions like `approve_phase` and `create_project`), the true picture is:
+>
+> - **~17 writes covered** (directly or via caller chain) by existing emits the projector already consumes
+> - **~46 writes still silent** (or covered only by lossy filesystem polling)
+> - **`daemon/projector.py` already exists** and projects 13 event types into a SQLite database — the bus-as-truth substrate is partially built
+>
+> The bus-as-truth refactor (#732) is **smaller than the v1 of this report claimed**. The remaining work is: (1) emit additions for the truly-silent writes, (2) a resume-snapshot subscriber over the existing projector tables (#734), (3) a PreToolUse lint preventing new orphan writes.
 
-## Method
+## Method (corrected after Gemini review on PR #735)
 
-- Scanned: `scripts/crew/**/*.py` (59 files) + `hooks/scripts/**/*.py` (12 files including `subscribers/`)
-- Patterns audited: `write_text`, `write_bytes`, `json.dump`, `open()` w/a/wb/ab, `os.replace`, `shutil.copy/move`, `mkdir` of state dirs, `unlink`, `rmtree`, `tempfile + os.replace`, `SessionState.save/update`
-- Bus-emit detection: `subprocess.run(["wicked-bus", "emit", ...])` or helper-function calls (e.g. `emit_validated_payloads()` in `detectors/_common.py`) in the same function scope as the write
-- Date: 2026-05-02
+**v1 method (incorrect)**: Searched for `subprocess.run(["wicked-bus", "emit", ...])` and `emit_validated_payloads()` in the same function as each disk write. Reported 0 of 63 sites emitting.
 
-## Combined summary
+**False negatives in v1**:
+
+1. The dominant emit pattern in `phase_manager.py` is `from _bus import emit_event; emit_event("wicked.X.Y", payload)` — a local helper that wraps the bus subprocess. v1's pattern set did not detect this.
+2. Many writes happen in **helper functions** called by emit-bearing parents. Example: `_write_conditions_manifest` is called from `approve_phase`, which emits `wicked.gate.decided` after the helper returns. The write is *semantically* covered by the parent's emit even though the helper is silent.
+3. `daemon/projector.py` already exists and projects 13 event types (`wicked.project.created`, `wicked.gate.decided`, `wicked.task.created`, etc.) into a SQLite database — the bus-as-truth substrate is partially built. v1 did not look for it.
+
+**v2 method (corrected)**:
+
+- Patterns scanned: same disk-write set as v1
+- Bus-emit detection: all of v1's patterns PLUS `from _bus import emit_event; emit_event(...)` PLUS coverage-by-caller-chain analysis (mapping each write to its enclosing function and tracing whether any caller emits)
+- Cross-check: `daemon/projector.py:_HANDLERS` for events already consumed
+- Date: 2026-05-02 (v2 revision)
+
+## Combined summary (v2 — corrected)
 
 | Metric | scripts/crew | hooks/scripts | Total | % |
 |--------|--------------|---------------|-------|---|
 | Total write call sites | 47 | 16 | **63** | 100% |
-| Already emit a bus event | 0 | 0 | **0** | **0%** |
-| Emit but envelope incomplete | 0 | 0 | 0 | 0% |
-| Silent (no emit at all) | 47 | 16 | **63** | **100%** |
+| Direct emit in same function | 1 | 0 | 1 | ~2% |
+| Covered indirectly via caller chain | ~16 | ~1 | ~17 | ~27% |
+| **Truly silent** (no emit, no covering caller) | ~30 | ~15 | **~45** | **~71%** |
+| N/A — directory creation, env setup, tempdir, deletes of idempotent flags | n/a | 8 | 8 | 13% (excluded from gap %) |
 
-### Top 5 risky gaps across both surfaces
+The "~" reflects that some helper functions (e.g. `cutover_action`, `skip_phase`) need a deeper trace to confirm whether their callers emit. The numbers above are conservative; #734's design must verify on a per-row basis before relying on coverage.
 
-1. **`scripts/crew/phase_manager.py:3676`** — `gate-result.json` synthesized post-blend dispatch. Verdict deterministic but written silently. Highest-risk: this is the file the orphan-check sentinel relies on.
-2. **`scripts/crew/phase_manager.py:2684`** — `conditions-manifest.json` written on gate CONDITIONAL. Core state mutation; zero emit.
-3. **`scripts/crew/dispatch_log.py:330–331`** — `dispatch-log.jsonl` append for every gate dispatch. The HMAC-signed dispatch log is the orphan-check input — it's written silently.
-4. **`hooks/scripts/post_tool.py:963, 970`** — Consensus gate `reviewer-report.md` silently written. `phase_manager` reads this file on next approval cycle — file poll, not event-driven.
-5. **`scripts/crew/conditions_manifest.py:77, 89`** — Atomic temp+`os.replace` write of `conditions-manifest.json`. Crash-safe but silent.
+## What `daemon/projector.py` already covers
 
-## Findings — scripts/crew
+| Event type | Projector handler | Source emit (today) | Disk-write sites covered |
+|------------|-------------------|---------------------|--------------------------|
+| wicked.project.created | `_project_created` (L119) | phase_manager.py:4547 | phase_manager.py:4486, 4499, 4512 |
+| wicked.project.complexity_scored | `_project_complexity_scored` (L150) | (facilitator skill) | — |
+| wicked.phase.transitioned | `_phase_transitioned` (L171) | phase_manager.py:4013 | phase_manager.py:1169 (status.md init via complete_phase) |
+| wicked.phase.auto_advanced | `_phase_auto_advanced` (L222) | _bus_consumers.py:145 | — |
+| wicked.gate.decided | `_gate_decided` (L264) | phase_manager.py:3931 | phase_manager.py:2684, 2913, 2939, 2958, 2994, 3415, 3676; conditions_manifest.py:77, 89, 192, 203 (via approve_phase caller chain) |
+| wicked.rework.triggered | `_rework_triggered` (L309) | phase_manager.py:3953 | (see above row) |
+| wicked.project.completed | `_project_completed` (L340) | phase_manager.py:4088 | — |
+| wicked.crew.yolo_revoked | `_crew_yolo_revoked` (L472) | phase_manager.py:4708 | — |
+| wicked.task.created | `_task_created` (L355) | (TaskCreate hook) | — |
+| wicked.task.updated | `_task_updated` (L391) | (TaskUpdate hook) | — |
+| wicked.task.completed | `_task_completed` (L443) | (TaskUpdate hook on terminal status) | — |
+| wicked.ac.declared | `_ac_declared` (L504) | acceptance_criteria.py (TBD) | — |
+| wicked.ac.evidence_linked | `_ac_evidence_linked` (L539) | acceptance_criteria.py (TBD) | — |
 
-| file:line | target_path | mutation_type | emits_event | event_type | envelope_complete | proposed_event |
-|-----------|-------------|---------------|-------------|------------|-------------------|----------------|
-| solo_mode.py:328 | phases/{phase}/conditions-manifest.json.tmp | write_text | no | — | — | wicked.crew.solo-mode.conditions.manifest |
-| solo_mode.py:332 | phases/{phase}/conditions-manifest.json | replace | no | — | — | wicked.crew.solo-mode.conditions.manifest |
-| solo_mode.py:388 | phases/{phase}/inline-review-context.md | write_text | no | — | — | wicked.crew.solo-mode.review-context.created |
-| solo_mode.py:436 | phases/{phase}/gate-result.json.tmp | write_text | no | — | — | wicked.crew.solo-mode.gate-result.recorded |
-| solo_mode.py:440 | phases/{phase}/gate-result.json | replace | no | — | — | wicked.crew.solo-mode.gate-result.recorded |
-| consensus_gate.py:428 | phases/{phase}/consensus-report.json | mkdir + write_text | no | — | — | wicked.crew.consensus.report.created |
-| consensus_gate.py:463 | phases/{phase}/consensus-evidence.json | mkdir + write_text | no | — | — | wicked.crew.consensus.evidence.recorded |
-| acceptance_criteria.py:366 | phases/clarify/acceptance-criteria.json.tmp | write_text | no | — | — | wicked.crew.acceptance-criteria.migrated |
-| acceptance_criteria.py:367 | phases/clarify/acceptance-criteria.json | replace | no | — | — | wicked.crew.acceptance-criteria.migrated |
-| adopt_legacy.py:110 | project.json | write_text | no | — | — | wicked.crew.legacy.phase-plan-mode-set |
-| adopt_legacy.py:171 | phases/{phase}/reeval-log.jsonl | open(a) + write | no | — | — | wicked.crew.legacy.reeval-migrated |
-| adopt_legacy.py:179 | process-plan.md | write_text | no | — | — | wicked.crew.legacy.markdown-reeval-cleared |
-| adopt_legacy.py:209 | (various markdown files) | write_text | no | — | — | wicked.crew.legacy.bypass-reference-removed |
-| amendments.py:206 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
-| amendments.py:242 | phases/{phase}/amendments.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.amendments.recorded |
-| conditions_manifest.py:77 | phases/{phase}/conditions-manifest.json.tmp | open(w) + write + fsync | no | — | — | wicked.crew.conditions-manifest.atomic-write |
-| conditions_manifest.py:89 | phases/{phase}/conditions-manifest.json | os.replace | no | — | — | wicked.crew.conditions-manifest.atomic-write |
-| conditions_manifest.py:192 | phases/{phase}/conditions-manifest.{id}.resolution.json | atomic_write_json | no | — | — | wicked.crew.condition.resolution-sidecar |
-| conditions_manifest.py:203 | phases/{phase}/conditions-manifest.json | atomic_write_json | no | — | — | wicked.crew.condition.marked-cleared |
-| convergence.py:228 | phases/{phase}/convergence-log.jsonl | open(a) + write | no | — | — | wicked.crew.convergence.transition-recorded |
-| dispatch_log.py:329 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
-| dispatch_log.py:330–331 | phases/{phase}/dispatch-log.jsonl | open(a) + write | no | — | — | wicked.crew.dispatch-log.entry-appended |
-| gate_ingest_audit.py:160 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
-| gate_ingest_audit.py:162 | phases/{phase}/gate-ingest-audit.jsonl | open(a) + write | no | — | — | wicked.crew.gate-ingest.audit-recorded |
-| hitl_judge.py:611–613 | phases/{phase}/{filename}.json | mkdir + write_text | no | — | — | wicked.crew.hitl.decision-persisted |
-| log_retention.py:168 | archive/ (subdir) | mkdir | no | — | — | — (directory creation, not state) |
-| log_retention.py:180–181 | archive/*.jsonl.gz | gzip.open(wb) + shutil.copyfileobj | no | — | — | wicked.crew.log-retention.archive-rotated |
-| log_retention.py:200 | (active log path) | open(w) + truncate | no | — | — | wicked.crew.log-retention.log-truncated |
-| migrate_qe_evaluator_name.py:173 | *.bak | write_bytes | no | — | — | wicked.crew.migration.backup-created |
-| migrate_qe_evaluator_name.py:180 | *.tmp | write_text | no | — | — | wicked.crew.migration.temp-written |
-| migrate_qe_evaluator_name.py:191 | (original file) | os.replace | no | — | — | wicked.crew.migration.file-migrated |
-| phase_manager.py:1169 | phases/{phase}/status.md | write_text | no | — | — | wicked.crew.phase.status-initialized |
-| phase_manager.py:1600 | phases/{phase}/context.md | write_text | no | — | — | wicked.crew.phase.context-created |
-| phase_manager.py:2571 | phases/review/semantic-gap-report.json | mkdir + write_text | no | — | — | wicked.crew.semantic-alignment.report-created |
-| phase_manager.py:2684 | phases/{phase}/conditions-manifest.json | write_text | no | — | — | wicked.crew.gate.conditional-conditions-written |
-| phase_manager.py:2913 | phases/{phase}/iteration-count.json | mkdir + write_text | no | — | — | wicked.crew.iteration.count-recorded |
-| phase_manager.py:2939 | phases/{phase}/status.md | open(a) + read + write_text | no | — | — | wicked.crew.gate-override.rigor-exception-recorded |
-| phase_manager.py:2958 | phases/{phase}/status.md | open(a) + read + write_text | no | — | — | wicked.crew.deliverable.override-recorded |
-| phase_manager.py:2994 | phases/{phase}/skip-reeval-log.json | write_text | no | — | — | wicked.crew.reeval.skip-logged |
-| phase_manager.py:3415 | (task entry file) | write_text | no | — | — | wicked.crew.gate-finding.synced-to-completed |
-| phase_manager.py:3676 | phases/{phase}/gate-result.json | mkdir + write_text | no | — | — | wicked.crew.gate.verdict-synthesized |
-| phase_manager.py:4159 | phases/{phase}/status.md | write_text | no | — | — | wicked.crew.phase.skipped |
-| phase_manager.py:4343 | phases/{phase}/*.md | write_text | no | — | — | wicked.crew.adoption.legacy-memo-recorded |
-| phase_manager.py:4486 | project.md | write_text | no | — | — | wicked.crew.project.template-initialized |
-| phase_manager.py:4499 | outcome.md | write_text | no | — | — | wicked.crew.outcome.template-initialized |
-| phase_manager.py:4512 | phases/clarify/status.md | write_text | no | — | — | wicked.crew.phase.template-initialized |
-| phase_manager.py:5282 | phases/.cutover-to-mode-3.json | mkdir + write_text | no | — | — | wicked.crew.mode-switch.cutover-marker-written |
-| reeval_addendum.py:208 | phases/{phase}/ | mkdir | no | — | — | — (directory creation, not state) |
-| reeval_addendum.py:212 | phases/{phase}/reeval-log.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.reeval.addendum-appended |
-| reeval_addendum.py:244 | process-plan.addendum.jsonl | open(a) + write + fsync | no | — | — | wicked.crew.reeval.project-log-appended |
-| traceability_generator.py:307 | phases/build/ | mkdir | no | — | — | — (directory creation, not state) |
-| traceability_generator.py:308 | phases/build/traceability-matrix.md | write_text | no | — | — | wicked.crew.traceability.matrix-generated |
+Plus emits OUTSIDE scripts/crew that the projector may or may not consume yet:
+
+- `scripts/qe/registry_store.py:138` — emit
+- `scripts/qe/coverage_tracker.py:379` — emit
+- `scripts/delivery/drift.py:501` — `wicked.quality.drift_detected`
+- `hooks/scripts/stop.py:162` — `wicked.fact.extracted`
+
+## Top 5 risky gaps (truly silent — no covering emit)
+
+After accounting for caller-chain coverage, the genuine high-risk gaps are:
+
+1. **`hooks/scripts/post_tool.py:963, 970`** — Consensus gate `reviewer-report.md` written silently from a hook. `phase_manager` reads this file by polling — the only file→file flow in the gate path. Highest priority for #734's lint.
+2. **`scripts/crew/dispatch_log.py:330–331`** — HMAC-signed dispatch-log.jsonl entries. The orphan-check sentinel for `gate-result.json`. Needs an emit so the projector can detect orphan-without-dispatch independently of file existence.
+3. **`scripts/crew/consensus_gate.py:428, 463`** — `consensus-report.json` + `consensus-evidence.json` written without emit. Used by gate evaluation; should emit `wicked.consensus.report.created` so projector can cache.
+4. **`scripts/crew/amendments.py:242`** + **`scripts/crew/reeval_addendum.py:212, 244`** — Append-only re-evaluation logs. Multi-session resume needs these in the projector.
+5. **`scripts/crew/phase_manager.py:1600`** (`ensure_reviewer_context`) + **`scripts/crew/phase_manager.py:2571`** (`_check_semantic_alignment_gate`) — `context.md` and `semantic-gap-report.json`. Material for the resume view.
+
+## Findings — scripts/crew (revised)
+
+Coverage notation:
+- ✅ **direct** — emit in same function
+- 🔗 **caller-chain** — helper called from emit-bearing parent; covered by parent's emit
+- ❌ **silent** — no covering emit found
+- ⊘ **n/a** — directory creation, log rotation, migration, or otherwise out of state-of-record scope
+
+| file:line | target_path | mutation_type | coverage | event_type if covered | proposed_event if silent |
+|-----------|-------------|---------------|----------|----------------------|--------------------------|
+| solo_mode.py:328 | phases/{phase}/conditions-manifest.json.tmp | write_text | ❌ | — | wicked.crew.solo-mode.conditions.manifest |
+| solo_mode.py:332 | phases/{phase}/conditions-manifest.json | replace | ❌ | — | wicked.crew.solo-mode.conditions.manifest |
+| solo_mode.py:388 | phases/{phase}/inline-review-context.md | write_text | ❌ | — | wicked.crew.solo-mode.review-context.created |
+| solo_mode.py:436 | phases/{phase}/gate-result.json.tmp | write_text | ❌ | — | wicked.crew.solo-mode.gate-result.recorded |
+| solo_mode.py:440 | phases/{phase}/gate-result.json | replace | ❌ | — | wicked.crew.solo-mode.gate-result.recorded |
+| consensus_gate.py:428 | phases/{phase}/consensus-report.json | mkdir + write_text | ❌ | — | wicked.crew.consensus.report.created |
+| consensus_gate.py:463 | phases/{phase}/consensus-evidence.json | mkdir + write_text | ❌ | — | wicked.crew.consensus.evidence.recorded |
+| acceptance_criteria.py:366 | phases/clarify/acceptance-criteria.json.tmp | write_text | ❌ | — | wicked.crew.acceptance-criteria.migrated |
+| acceptance_criteria.py:367 | phases/clarify/acceptance-criteria.json | replace | ❌ | — | wicked.crew.acceptance-criteria.migrated |
+| adopt_legacy.py:110 | project.json | write_text | ❌ | — | wicked.crew.legacy.phase-plan-mode-set |
+| adopt_legacy.py:171 | phases/{phase}/reeval-log.jsonl | open(a) + write | ❌ | — | wicked.crew.legacy.reeval-migrated |
+| adopt_legacy.py:179 | process-plan.md | write_text | ❌ | — | wicked.crew.legacy.markdown-reeval-cleared |
+| adopt_legacy.py:209 | (various markdown files) | write_text | ❌ | — | wicked.crew.legacy.bypass-reference-removed |
+| amendments.py:206 | phases/{phase}/ | mkdir | ⊘ | — | — (directory creation) |
+| amendments.py:242 | phases/{phase}/amendments.jsonl | open(a) + write + fsync | ❌ | — | wicked.crew.amendments.recorded |
+| conditions_manifest.py:77 | phases/{phase}/conditions-manifest.json.tmp | open(w) + write + fsync | 🔗 | wicked.gate.decided (when called from approve_phase) | — (consider explicit emit for direct callers) |
+| conditions_manifest.py:89 | phases/{phase}/conditions-manifest.json | os.replace | 🔗 | wicked.gate.decided (when called from approve_phase) | — |
+| conditions_manifest.py:192 | phases/{phase}/conditions-manifest.{id}.resolution.json | atomic_write_json | ❌ | — | wicked.crew.condition.resolution-sidecar |
+| conditions_manifest.py:203 | phases/{phase}/conditions-manifest.json | atomic_write_json | ❌ | — | wicked.crew.condition.marked-cleared |
+| convergence.py:228 | phases/{phase}/convergence-log.jsonl | open(a) + write | ❌ | — | wicked.crew.convergence.transition-recorded |
+| dispatch_log.py:329 | phases/{phase}/ | mkdir | ⊘ | — | — (directory creation) |
+| dispatch_log.py:330–331 | phases/{phase}/dispatch-log.jsonl | open(a) + write | ❌ | — | wicked.crew.dispatch-log.entry-appended |
+| gate_ingest_audit.py:160 | phases/{phase}/ | mkdir | ⊘ | — | — (directory creation) |
+| gate_ingest_audit.py:162 | phases/{phase}/gate-ingest-audit.jsonl | open(a) + write | ❌ | — | wicked.crew.gate-ingest.audit-recorded |
+| hitl_judge.py:611–613 | phases/{phase}/{filename}.json | mkdir + write_text | ❌ | — | wicked.crew.hitl.decision-persisted |
+| log_retention.py:168 | archive/ (subdir) | mkdir | ⊘ | — | — (directory creation) |
+| log_retention.py:180–181 | archive/*.jsonl.gz | gzip + shutil.copyfileobj | ⊘ | — | — (housekeeping; arguably emit `wicked.crew.log-rotated`) |
+| log_retention.py:200 | (active log path) | open(w) + truncate | ⊘ | — | — (housekeeping) |
+| migrate_qe_evaluator_name.py:173 | *.bak | write_bytes | ⊘ | — | — (migration) |
+| migrate_qe_evaluator_name.py:180 | *.tmp | write_text | ⊘ | — | — (migration) |
+| migrate_qe_evaluator_name.py:191 | (original file) | os.replace | ⊘ | — | — (migration) |
+| phase_manager.py:1169 | phases/{phase}/status.md | write_text | 🔗 | wicked.phase.transitioned (via complete_phase ← approve_phase) | — |
+| phase_manager.py:1600 | phases/{phase}/context.md | write_text | ❌ | — | wicked.crew.phase.context-created |
+| phase_manager.py:2571 | phases/review/semantic-gap-report.json | mkdir + write_text | 🔗 | wicked.gate.decided (called from approve_phase L3617) | — (consider explicit `wicked.crew.semantic-alignment.report-created`) |
+| phase_manager.py:2684 | phases/{phase}/conditions-manifest.json | write_text | 🔗 | wicked.gate.decided (CONDITIONAL branch) | — |
+| phase_manager.py:2913 | phases/{phase}/iteration-count.json | mkdir + write_text | 🔗 | wicked.rework.triggered (called from approve_phase L3948) | — |
+| phase_manager.py:2939 | phases/{phase}/status.md | open(a) + read + write_text | 🔗 | wicked.gate.decided (override branch) | — |
+| phase_manager.py:2958 | phases/{phase}/status.md | open(a) + read + write_text | 🔗 | wicked.gate.decided (deliverable override branch) | — |
+| phase_manager.py:2994 | phases/{phase}/skip-reeval-log.json | write_text | 🔗 | wicked.gate.decided (skip-reeval branch) | — |
+| phase_manager.py:3415 | (task entry file) | write_text | 🔗 | wicked.gate.decided (called from approve_phase L3985) | — |
+| phase_manager.py:3676 | phases/{phase}/gate-result.json | mkdir + write_text | ✅ | wicked.gate.decided (L3931, same function) | — |
+| phase_manager.py:4159 | phases/{phase}/status.md | write_text | ❌ | — | wicked.crew.phase.skipped (skip_phase has no emit today) |
+| phase_manager.py:4343 | phases/{phase}/*.md | write_text | ❌ | — | wicked.crew.adoption.legacy-memo-recorded |
+| phase_manager.py:4486 | project.md | write_text | 🔗 | wicked.project.created (L4547) | — |
+| phase_manager.py:4499 | outcome.md | write_text | 🔗 | wicked.project.created (L4547) | — |
+| phase_manager.py:4512 | phases/clarify/status.md | write_text | 🔗 | wicked.project.created (L4547) | — |
+| phase_manager.py:5282 | phases/.cutover-to-mode-3.json | mkdir + write_text | ❌ | — | wicked.crew.mode-switch.cutover-marker-written |
+| reeval_addendum.py:208 | phases/{phase}/ | mkdir | ⊘ | — | — (directory creation) |
+| reeval_addendum.py:212 | phases/{phase}/reeval-log.jsonl | open(a) + write + fsync | ❌ | — | wicked.crew.reeval.addendum-appended |
+| reeval_addendum.py:244 | process-plan.addendum.jsonl | open(a) + write + fsync | ❌ | — | wicked.crew.reeval.project-log-appended |
+| traceability_generator.py:307 | phases/build/ | mkdir | ⊘ | — | — (directory creation) |
+| traceability_generator.py:308 | phases/build/traceability-matrix.md | write_text | ❌ | — | wicked.crew.traceability.matrix-generated |
 
 ## Findings — scripts/crew/detectors
 
-**Note**: Detectors emit events via `emit_validated_payloads()` in `detectors/_common.py`. This audit scanned for **disk writes**, not event emissions, and found **zero** disk-write call sites in any detector module. All detectors are pure compute-to-bus with no durable state mutations. The bus-as-truth refactor leaves detectors untouched.
+**Note**: Detectors emit events via `emit_validated_payloads()` and have **zero** disk-write call sites. Pure compute-to-bus. The bus-as-truth refactor leaves detectors untouched.
 
-## Findings — hooks/scripts
+## Findings — hooks/scripts (revised)
 
-| file:line | target_path | mutation_type | emits_event | event_type | envelope_complete | proposed_event |
-|-----------|-------------|---------------|-------------|------------|-------------------|----------------|
-| bootstrap.py:1079 | $CLAUDE_ENV_FILE (project .claude/env or ~/.claude/env) | append | no | — | — | N/A — env setup, not state |
-| bootstrap.py:1120 | ~/.something-wicked/wicked-crew/.task_suggest_shown | delete | no | — | — | N/A — idempotent flag |
-| pre_compact.py:75 | ~/.wicked-brain/memories/{tier}/ | mkdir | no | — | — | N/A — directory setup |
-| pre_compact.py:96 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | no | — | — | wicked.memory.captured (after brain index success) |
-| prompt_submit.py:88 | ~/.wicked-brain/memories/{tier}/ | mkdir | no | — | — | N/A — directory setup |
-| prompt_submit.py:109 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | no | — | — | wicked.memory.captured (session goal) |
-| post_tool.py:963 | {project_dir}/phases/{phase}/reviewer-report.md | append | no | — | — | wicked.consensus.gate-completed |
-| post_tool.py:969 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
-| post_tool.py:970 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | no | — | — | wicked.consensus.gate-completed |
-| post_tool.py:983 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
-| post_tool.py:984 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | no | — | — | wicked.consensus.gate-pending (evaluation failed) |
-| post_tool.py:1314 | $TMPDIR/wicked-trace-{session_id}.jsonl | append | no | — | — | N/A — tempdir-only trace |
-| subagent_lifecycle.py:133 | $TMPDIR/wicked-garden/traces/ | mkdir | no | — | — | N/A — tempdir-only |
-| subagent_lifecycle.py:135 | $TMPDIR/wicked-garden/traces/{session_id}.jsonl | append | no | — | — | N/A — tempdir-only trace |
-| subagent_lifecycle.py:260 | {project_dir}/phases/{phase}/ | mkdir | no | — | — | N/A — directory setup |
-| subagent_lifecycle.py:280 | {project_dir}/phases/{phase}/specialist-engagement.json | atomic temp + replace | no | — | — | wicked.specialist.engagement-recorded |
+| file:line | target_path | mutation_type | coverage | event_type if covered | proposed_event if silent |
+|-----------|-------------|---------------|----------|----------------------|--------------------------|
+| bootstrap.py:1079 | $CLAUDE_ENV_FILE | append | ⊘ | — | — (env setup) |
+| bootstrap.py:1120 | ~/.something-wicked/wicked-crew/.task_suggest_shown | delete | ⊘ | — | — (idempotent flag) |
+| pre_compact.py:75 | ~/.wicked-brain/memories/{tier}/ | mkdir | ⊘ | — | — (directory setup) |
+| pre_compact.py:96 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | ❌ | — | wicked.memory.captured (emit AFTER brain index) |
+| prompt_submit.py:88 | ~/.wicked-brain/memories/{tier}/ | mkdir | ⊘ | — | — (directory setup) |
+| prompt_submit.py:109 | ~/.wicked-brain/memories/{tier}/mem-{uuid}.md | overwrite | ❌ | — | wicked.memory.captured (session goal) |
+| post_tool.py:963 | {project_dir}/phases/{phase}/reviewer-report.md | append | ❌ | — | wicked.consensus.gate-completed |
+| post_tool.py:969 | {project_dir}/phases/{phase}/ | mkdir | ⊘ | — | — (directory setup) |
+| post_tool.py:970 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | ❌ | — | wicked.consensus.gate-completed |
+| post_tool.py:983 | {project_dir}/phases/{phase}/ | mkdir | ⊘ | — | — (directory setup) |
+| post_tool.py:984 | {project_dir}/phases/{phase}/reviewer-report.md | overwrite | ❌ | — | wicked.consensus.gate-pending |
+| post_tool.py:1314 | $TMPDIR/wicked-trace-{session_id}.jsonl | append | ⊘ | — | — (tempdir-only trace) |
+| subagent_lifecycle.py:133 | $TMPDIR/wicked-garden/traces/ | mkdir | ⊘ | — | — (tempdir-only) |
+| subagent_lifecycle.py:135 | $TMPDIR/wicked-garden/traces/{session_id}.jsonl | append | ⊘ | — | — (tempdir-only trace) |
+| subagent_lifecycle.py:260 | {project_dir}/phases/{phase}/ | mkdir | ⊘ | — | — (directory setup) |
+| subagent_lifecycle.py:280 | {project_dir}/phases/{phase}/specialist-engagement.json | atomic temp + replace | ❌ | — | wicked.specialist.engagement-recorded |
 
-## Findings — hooks/scripts/subscribers
+`hooks/scripts/stop.py` emits `wicked.fact.extracted` (L162) but does not write to disk in that flow — emit-only, no write to pair with.
 
-### `on_gate_decided.py`
-
-This is a **bus-grain subscriber** (Issue #592, v8 PR-8) — receives `wicked.gate.decided` events and emits `wicked.hook.gate-decided-processed` events. It is the canonical example of what the bus-as-truth pattern looks like.
-
-| file:line | mutation_type | target_path | emits_event | event_type |
-|-----------|---------------|-------------|-------------|------------|
-| on_gate_decided.py:59 | emit (synthetic) | stdout → wicked-bus | **yes** | wicked.hook.gate-decided-processed |
-
-No disk writes. Pure message-passing.
+`hooks/scripts/subscribers/on_gate_decided.py` is a pure message-passing subscriber — no disk writes, emits `wicked.hook.gate-decided-processed`. Canonical example of the bus-as-truth pattern.
 
 ## Notes on SessionState writes
 
-All hooks call `SessionState.load()`, mutate fields, and call `state.update()` or `state.save()`. This persists to:
+All hooks call `SessionState.load()` → mutate → `state.save()`. This persists to `~/.something-wicked/wicked-garden/sessions/{session_id}.json` and is **intentionally NOT event-sourced**:
 
-```
-~/.something-wicked/wicked-garden/sessions/{session_id}.json
-```
+- Hot-path: 100s of mutations per session (turn count, context flags, memory compliance)
+- Per-mutation emit = bus churn with no consumer
+- SessionState is cache/context, not the system-of-record for any decision
 
-**SessionState is intentionally NOT event-sourced** — and this audit recommends keeping it that way:
-
-- Hot-path: mutated 100s of times per session (turn count, context flags, memory compliance)
-- Emitting per mutation = bus churn with no consumer value
-- Hooks already emit ops logs via `_log()` for audit purposes
-- SessionState is cache/context, not the system-of-record for any decision/gate
-
-If a future refactor makes SessionState the source of truth for gate decisions (unlikely), revisit this assumption.
-
-## Notes on memory capture writes
-
-`pre_compact.py:_write_brain_memory()` and `prompt_submit.py:_write_brain_memory()` write to disk and immediately call `_brain_api("index", ...)`. The disk write itself is silent, but the brain indexing call provides synchronous confirmation.
-
-**Recommendation for #734**: emit `wicked.memory.captured` *after* successful brain indexing returns, not before disk write — the event should reflect actual completion, not optimistic expectation.
+If a future refactor makes SessionState the source of truth for gate decisions (unlikely), revisit.
 
 ## Cross-reference: scripts/_event_schema.py
 
-The TaskCreate metadata envelope in `scripts/_event_schema.py` defines the validated shape for native task events. Bus events should mirror this where applicable.
+The TaskCreate metadata envelope in `scripts/_event_schema.py` defines the validated shape for native task events. Required cross-cutting fields:
 
-Required fields (cross-cutting):
 - `chain_id` — `{project}.root` | `{project}.{phase}` | `{project}.{phase}.{gate}` (regex enforced)
 - `source_agent` — never `just-finish-auto`, `fast-pass`, or anything starting with `auto-approve-`
 - `phase` — must appear in `.claude-plugin/phases.json` catalog when applicable
@@ -155,25 +185,30 @@ Required fields (cross-cutting):
 
 For `gate-finding` events at completion: `verdict ∈ {APPROVE, CONDITIONAL, REJECT}`, `min_score`, `score`. CONDITIONAL also requires `conditions_manifest_path` (Issue #570).
 
-The bus event envelope SHOULD adopt the same `chain_id` + `source_agent` + `phase` fields so projections can correlate task events with bus events without lossy joins.
+Bus event envelopes (when added) SHOULD adopt the same `chain_id` + `source_agent` + `phase` fields so projections can correlate task events with bus events without lossy joins.
 
 ## Out of scope
 
-- `scripts/qe/`, `scripts/data/`, `scripts/delivery/`, `scripts/agentic/`, `scripts/persona/`, etc. — separate audit scope
+- `scripts/qe/`, `scripts/data/`, `scripts/delivery/`, `scripts/agentic/`, `scripts/persona/`, etc. — separate audit scope (note: emits exist in qe/registry_store.py:138, qe/coverage_tracker.py:379, delivery/drift.py:501)
 - Test files (`tests/**`)
-- Tempdir-only writes (`$TMPDIR/wicked-trace-*`) that don't persist past process exit
-- Stdlib `print()` / `sys.stdout.write()` (not persistent state)
+- Tempdir-only writes
 - `scripts/_session.py` SessionState mutations (intentionally not event-sourced — see above)
 
 ## Architectural notes
 
+### `daemon/projector.py` is partially built
+
+The bus-as-truth substrate already exists. `daemon/projector.py:_HANDLERS` projects 13 event types into a SQLite database. This significantly downscopes #734 — the projector does not need to be built from scratch; #734 needs to:
+
+1. Add a **resume-snapshot subscriber** that joins the projector's tables into a per-project view (`crew/{project}/resume.json` derived from existing project / phase / gate / task tables)
+2. Add the PreToolUse lint that prevents new orphan writes to load-bearing artifacts
+3. Add the missing emits for the truly-silent gaps that block the resume view
+
 ### Hooks fail-open by design
 
-All hooks return `{"continue": true}` on unhandled exceptions. The absence of bus events in hook code is partly a fail-open consequence — if emit fails, the hook still returns continue. The bus-as-truth refactor must preserve fail-open semantics: emit failure cannot block hook completion.
+All hooks return `{"continue": true}` on unhandled exceptions. The bus-as-truth refactor must preserve this — emit failure cannot block hook completion. The lint should be `warn` mode for one release before flipping to `strict`.
 
-### Consensus gate as a critical gap
-
-The consensus gate flow today:
+### Consensus gate file→file flow is the worst remaining gap
 
 ```
 phase_manager.approve()
@@ -184,39 +219,28 @@ next cycle:
   phase_manager reads reviewer-report.md (file poll, not event-driven)
 ```
 
-This is a subtle fail-open: if the hook write fails silently or the file is deleted, phase progression still succeeds (gates are advisory). For #732, this should emit `wicked.consensus.gate-completed` so the gate system has an event-driven signal independent of file existence.
+This is the only file→file flow remaining in the gate path after caller-chain analysis. #734's lint should target it specifically.
 
-### Atomic-write idioms are correct but silent
+## Recommendations for #734 (revised)
 
-Multiple call sites use `tempfile + os.replace` for crash-safety: `conditions_manifest.py:77,89`, `solo_mode.py:328,332,436,440`, `subagent_lifecycle.py:280`. The atomic-write pattern is correct. The gap is solely the missing emit — adding the emit AFTER the `os.replace` succeeds preserves atomicity.
+The original recommendation ("bundle HIGH-priority emit additions") was scoped to too much work because v1's "0% emitting" headline was wrong. Revised recommendation:
 
-## Recommendations for #734
+1. **Build the resume-snapshot subscriber over `daemon/projector.py` tables**. The existing `_project_created`, `_phase_transitioned`, `_gate_decided`, `_rework_triggered`, `_project_completed`, `_task_*` handlers already populate the SQLite tables that a per-project resume view needs to join. Snapshot to `crew/{project}/resume.json` on phase transition events.
+2. **Add the PreToolUse lint** for orphan writes to `gate-result.json`, `dispatch-log.jsonl`, `conditions-manifest.json`, `reviewer-report.md`. Warn mode this release; strict next.
+3. **Bundle ONE small set of emit additions** for the writes the resume view needs that are still silent: `dispatch_log.py:330–331` (`wicked.crew.dispatch-log.entry-appended`) and `consensus_gate.py:428,463` (`wicked.consensus.report.created`). Everything else can land in follow-up PRs over the subsequent release cycle.
+4. **Defer**: solo-mode emits, legacy adoption emits, log retention emits, migration emits, hitl-judge emits. Not blocking the resume view.
 
-For each gap in the tables above, the owner of #734 must decide:
+### Priority order for emit additions in scope
 
-1. **Emit required (default)** — Add event payload + emit call AFTER the write succeeds (or after `os.replace` for atomic-write idioms). Use the proposed event_type from the table or refine.
-2. **Emit not applicable** — Document the exception in the projector design (e.g., env setup, idempotent flags, tempdir-only traces).
-3. **Borderline** — Templates, iteration counters, archives. Clarify in the envelope design whether these are audit events or ledger-only state.
-
-### Priority order for emit additions
-
-1. **HIGH** — Gate-result, conditions-manifest, dispatch-log, consensus reviewer-report writes. These are the orphan-check inputs and the projector's primary signals.
-2. **MEDIUM** — Phase status markers, semantic-gap report, specialist-engagement, memory captures. Useful for projection completeness but not gate-correctness.
-3. **LOW** — Templates, log rotation, legacy migration, iteration counters. Audit-trail value only.
-
-### What the projector can rely on today
-
-**Nothing.** Every disk write that the projector might want to subscribe to is currently silent. The projector design in #734 must assume:
-
-- It either drives the emit additions itself (add emits as part of #734)
-- Or it falls back to file polling on the load-bearing artifacts as an interim until per-gap PRs land
-
-Recommendation: **#734 should bundle the HIGH-priority emit additions** (gate-result, conditions-manifest, dispatch-log, consensus reviewer-report) so the projector has real subscribable events from day one. MEDIUM and LOW gaps land in follow-up PRs over the subsequent release cycle.
+1. **HIGH (block the resume view)** — `dispatch_log.py:330–331`, `consensus_gate.py:428,463`, `post_tool.py:963,970,984` (consensus reviewer-report.md)
+2. **MEDIUM (improve cross-session resume completeness)** — `amendments.py:242`, `reeval_addendum.py:212,244`, `subagent_lifecycle.py:280`, `phase_manager.py:1600`, `phase_manager.py:5282`
+3. **LOW (audit-trail value only)** — solo-mode flow, legacy adoption flow, log retention rotation, migration, hitl-judge persistence
 
 ## Cross-references
 
-- Umbrella: #732 (bus-as-truth event-sourcing refactor)
-- Step 2 (blocked on this): #734 (resume projector + lint)
-- Closes: #733
-- Builds on: PR #690 (`/wicked-garden:crew:reconcile` — drift diagnostic feeds step 3 cutover)
+- Closes #733
+- Umbrella: #732 (bus-as-truth)
+- Blocks: #734 (resume projector + lint) — substantially smaller than originally sized
+- Builds on: PR #690 (`/wicked-garden:crew:reconcile`)
 - Decision memory: `bus-as-truth-event-sourced-crew-state.md` (semantic tier)
+- Existing projector: `daemon/projector.py:_HANDLERS` (13 event types projected)


### PR DESCRIPTION
## Summary

- Audits every disk-write call site in `scripts/crew/**/*.py` (47 sites) and `hooks/scripts/**/*.py` (16 sites)
- Headline: **0 of 63** sites currently emit a corresponding bus event
- Gates step 2 (#734) per council condition C1 — projector code is blocked until this audit lands
- Pure documentation PR — no code changes, no behavior change

## Why this exists

#732 (bus-as-truth umbrella) commits the architecture to event-sourced state with TaskList + garden chain as projections of the bus. Before designing the projector (#734), we need to know exactly which writes are already event-sourced and which are silent. The council made this audit a hard prerequisite (C1).

## What the audit found

The bus-as-truth refactor starts from a clean baseline: there is **nothing to change**, only writes to **augment** with corresponding emits. No half-correct emit envelopes to repair.

| Surface | Total writes | Emitting today | Silent |
|---------|--------------|----------------|--------|
| scripts/crew | 47 | 0 | 47 |
| hooks/scripts | 16 | 0 | 16 |
| **Combined** | **63** | **0** | **63** |

### Top 5 risky gaps (load-bearing state written silently)

1. `phase_manager.py:3676` — gate-result.json synthesized post-blend dispatch
2. `phase_manager.py:2684` — conditions-manifest.json on gate CONDITIONAL
3. `dispatch_log.py:330-331` — HMAC-signed dispatch-log.jsonl entries
4. `post_tool.py:963,970` — consensus reviewer-report.md (hook-side)
5. `conditions_manifest.py:77,89` — atomic temp + `os.replace` path

### Intentionally excluded from emit recommendations

- **Detectors** (`scripts/crew/detectors/`) — already pure compute-to-bus with zero disk writes. Canonical example of the pattern we want everywhere else.
- **SessionState writes** (`scripts/_session.py`) — hot-path cache mutated 100s of times per session. Per-mutation emit would be bus churn with no consumer value. The audit recommends keeping it silent.
- **`hooks/scripts/subscribers/on_gate_decided.py`** — pure message-passing subscriber; no disk writes. Cited as the canonical pattern.

### Recommendation that lands in #734

The audit recommends #734 **bundle the HIGH-priority emit additions** (gate-result, conditions-manifest, dispatch-log, consensus reviewer-report) so the projector has real subscribable events from day one. MEDIUM and LOW gaps land in follow-up PRs over the subsequent release.

## Method

- Patterns scanned: `write_text`, `write_bytes`, `json.dump`, `open()` w/a/wb/ab, `os.replace`, `shutil.copy/move`, `mkdir` of state dirs, `unlink`, `rmtree`, `tempfile + os.replace`, `SessionState.save/update`
- Bus-emit detection: `subprocess.run(["wicked-bus", "emit", ...])` or `emit_validated_payloads()` call in the same function scope as the write
- Two parallel Explore subagents — one for each surface — produced independent findings; merged into the canonical report

## Test plan

- [x] Report file lands at the path #733 specified (`docs/audits/disk-write-bus-emit-gap.md`)
- [x] All 63 call sites accounted for in the per-surface tables
- [x] Cross-references to `scripts/_event_schema.py` envelope requirements
- [x] No code changes outside `docs/audits/`

## Cross-references

- Closes #733
- Umbrella: #732 (bus-as-truth)
- Blocks: #734 (projector + lint)
- Builds on: PR #690 (`/wicked-garden:crew:reconcile` — drift diagnostic feeds step 3 cutover)
- Decision memory: `bus-as-truth-event-sourced-crew-state.md` (semantic tier, stored 2026-05-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)