### PR TITLE
feat(crew): resume_projector — per-project snapshot over bus projector (#734 part A)

### DIFF
--- a/scenarios/crew/resume-projector-cross-session.md
+++ b/scenarios/crew/resume-projector-cross-session.md
@@ -1,0 +1,209 @@
+---
+name: resume-projector-cross-session
+title: Resume Projector — Snapshot Survives a Fresh Session and Identifies Active Phase
+description: A session writes resume.json from the projector; a separate process reads it and correctly identifies the active phase without rebuilding from logs (#734)
+type: testing
+difficulty: intermediate
+estimated_minutes: 10
+---
+
+# Resume Projector — Cross-Session Snapshot
+
+The resume projector (#734) joins `daemon/projector.py` SQLite tables into
+a per-project `crew/{project}/resume.json` snapshot. This scenario asserts
+the **cross-session resume** contract:
+
+1. Session A writes the snapshot (replay subcommand)
+2. Session B (a fresh process — no shared state, no shared session_id)
+   reads the snapshot file and correctly identifies the project's active
+   phase, gate history, and active task count
+
+The bus event log remains the source of truth. The snapshot is a derived
+projection; reading it should never require the projector daemon to be
+running, only the file to exist on disk.
+
+## Setup
+
+```bash
+export TEST_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import tempfile
+print(tempfile.mkdtemp(prefix='wg-resume-cross-session-'))
+")
+echo "TEST_DIR=${TEST_DIR}"
+export PROJECT_ID="resume-demo"
+export PROJECT_DIR="${TEST_DIR}/${PROJECT_ID}"
+export DB_PATH="${TEST_DIR}/projections.db"
+```
+
+**Expected**: `TEST_DIR=...` printed.
+
+## Step 1: Stand up a minimal projector DB with a populated project
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import os, sqlite3, json
+db_path = os.environ['DB_PATH']
+project_id = os.environ['PROJECT_ID']
+conn = sqlite3.connect(db_path)
+conn.executescript("""
+    CREATE TABLE projects (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL, workspace TEXT, directory TEXT,
+        archetype TEXT, complexity_score REAL, rigor_tier TEXT,
+        current_phase TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
+        chain_id TEXT, yolo_revoked_count INTEGER NOT NULL DEFAULT 0,
+        last_revoke_reason TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE phases (
+        project_id TEXT NOT NULL, phase TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'pending', gate_score REAL,
+        gate_verdict TEXT, gate_reviewer TEXT,
+        started_at INTEGER, terminal_at INTEGER,
+        rework_iterations INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL,
+        PRIMARY KEY (project_id, phase));
+    CREATE TABLE event_log (
+        event_id INTEGER PRIMARY KEY, event_type TEXT NOT NULL, chain_id TEXT,
+        payload_json TEXT NOT NULL, projection_status TEXT NOT NULL,
+        error_message TEXT, ingested_at INTEGER NOT NULL);
+    CREATE TABLE tasks (
+        id TEXT PRIMARY KEY, session_id TEXT NOT NULL, subject TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending', chain_id TEXT, event_type TEXT,
+        metadata TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+""")
+conn.execute("INSERT INTO projects (id,name,archetype,complexity_score,rigor_tier,current_phase,status,chain_id,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+    (project_id, "Resume Demo", "code-repo", 7, "full", "build", "active", f"{project_id}.root", 1700000000, 1700001000))
+conn.execute("INSERT INTO phases (project_id,phase,state,gate_score,gate_verdict,gate_reviewer,started_at,terminal_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+    (project_id, "clarify", "approved", 0.85, "APPROVE", "rev-1", 1700000100, 1700000200, 1700000200))
+conn.execute("INSERT INTO phases (project_id,phase,state,gate_score,gate_verdict,gate_reviewer,started_at,terminal_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+    (project_id, "design", "approved", 0.78, "APPROVE", "rev-2", 1700000300, 1700000400, 1700000400))
+conn.execute("INSERT INTO phases (project_id,phase,state,updated_at) VALUES (?,?,?,?)",
+    (project_id, "build", "in_progress", 1700001000))
+conn.execute("INSERT INTO event_log (event_id,event_type,chain_id,payload_json,projection_status,ingested_at) VALUES (?,?,?,?,?,?)",
+    (1, "wicked.gate.decided", f"{project_id}.clarify",
+     json.dumps({"phase":"clarify","result":"APPROVE","score":0.85,"reviewer":"rev-1"}),
+     "applied", 1700000200))
+conn.execute("INSERT INTO tasks (id,session_id,status,chain_id,created_at,updated_at) VALUES (?,?,?,?,?,?)",
+    ("t1", "session-A", "in_progress", f"{project_id}.build", 1700001000, 1700001100))
+conn.commit()
+conn.close()
+print("seeded projector DB")
+PYEOF
+```
+
+**Expected**: `seeded projector DB`
+
+## Step 2: Session A — write the snapshot via the replay CLI
+
+```bash
+WG_PROJECTOR_DB_PATH="${DB_PATH}" sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/resume_projector.py" \
+  replay "${PROJECT_ID}" "${PROJECT_DIR}"
+```
+
+**Expected**: `WROTE: ${PROJECT_DIR}/resume.json`
+
+```bash
+test -f "${PROJECT_DIR}/resume.json" && echo "PASS: snapshot file exists"
+```
+
+## Step 3: Session B — fresh subshell, read the snapshot WITHOUT the projector DB env
+
+This proves the snapshot is self-contained. Session B does not see the
+projector DB; it only sees the on-disk `resume.json`.
+
+```bash
+(
+  unset WG_PROJECTOR_DB_PATH
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+    "${CLAUDE_PLUGIN_ROOT}/scripts/crew/resume_projector.py" \
+    read "${PROJECT_DIR}"
+) | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, sys
+snap = json.loads(sys.stdin.read())
+assert snap['project_id'] == 'resume-demo', f'wrong project_id: {snap[\"project_id\"]!r}'
+assert snap['project']['current_phase'] == 'build', f'wrong current_phase: {snap[\"project\"][\"current_phase\"]!r}'
+assert snap['project']['archetype'] == 'code-repo'
+assert snap['project']['complexity_score'] == 7
+assert snap['active_tasks_count'] == 1
+phases_by_name = {p['phase']: p for p in snap['phases']}
+assert 'clarify' in phases_by_name and phases_by_name['clarify']['gate_verdict'] == 'APPROVE'
+assert 'design' in phases_by_name and phases_by_name['design']['gate_verdict'] == 'APPROVE'
+assert 'build' in phases_by_name and phases_by_name['build']['state'] == 'in_progress'
+assert snap['pointers']['dispatch_log'] == 'phases/build/dispatch-log.jsonl'
+print('PASS: session B read the snapshot and identified active phase=build')
+"
+```
+
+**Expected**: `PASS: session B read the snapshot and identified active phase=build`
+
+## Step 4: Verify subcommand reports OK against unchanged projector
+
+```bash
+WG_PROJECTOR_DB_PATH="${DB_PATH}" sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/resume_projector.py" \
+  verify "${PROJECT_ID}" "${PROJECT_DIR}"
+```
+
+**Expected**: `OK`
+
+## Step 5: Mutate the projector — verify must surface divergence WITHOUT rewriting
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import os, sqlite3, json
+conn = sqlite3.connect(os.environ['DB_PATH'])
+conn.execute("INSERT INTO event_log (event_id,event_type,chain_id,payload_json,projection_status,ingested_at) VALUES (?,?,?,?,?,?)",
+    (99, "wicked.gate.decided", f"{os.environ['PROJECT_ID']}.build",
+     json.dumps({"phase":"build","result":"REJECT","score":0.2}),
+     "applied", 1700002000))
+conn.commit()
+conn.close()
+print("mutated projector with new REJECT event")
+PYEOF
+
+# Capture the on-disk snapshot bytes BEFORE verify.
+before=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import hashlib, pathlib
+print(hashlib.sha256(pathlib.Path('${PROJECT_DIR}/resume.json').read_bytes()).hexdigest())
+")
+
+# verify must report DIVERGED and exit non-zero — but must NOT rewrite the file.
+WG_PROJECTOR_DB_PATH="${DB_PATH}" sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/resume_projector.py" \
+  verify "${PROJECT_ID}" "${PROJECT_DIR}"
+verify_exit=$?
+
+after=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import hashlib, pathlib
+print(hashlib.sha256(pathlib.Path('${PROJECT_DIR}/resume.json').read_bytes()).hexdigest())
+")
+
+if [ "$verify_exit" = "0" ]; then
+  echo "FAIL: verify exit code was 0; expected non-zero on divergence"
+  exit 1
+fi
+
+if [ "$before" != "$after" ]; then
+  echo "FAIL: verify silently rewrote the snapshot — contract violation"
+  exit 1
+fi
+
+echo "PASS: verify reported divergence and did not rewrite on-disk snapshot"
+```
+
+**Expected**: a `DIVERGED:` line printed by the CLI, then `PASS: verify reported divergence and did not rewrite on-disk snapshot`.
+
+## Success Criteria
+
+- [ ] Step 2: `replay` writes `resume.json` to the project_dir
+- [ ] Step 3: a separate process can read the snapshot WITHOUT access to the projector DB and correctly identify the active phase, gate history, and active task count
+- [ ] Step 4: `verify` returns exit 0 when projector and snapshot agree
+- [ ] Step 5: `verify` returns non-zero on divergence AND does not rewrite the on-disk snapshot
+
+## Cleanup
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import os, shutil
+shutil.rmtree(os.environ['TEST_DIR'], ignore_errors=True)
+"
+unset TEST_DIR PROJECT_ID PROJECT_DIR DB_PATH
+```

--- a/scripts/crew/resume_projector.py
+++ b/scripts/crew/resume_projector.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""resume_projector.py — per-project resume snapshot derived from the bus projector (#734).
+
+The bus projector (`daemon/projector.py`) already consumes 13 event types
+and writes them into a SQLite database (`daemon/db.py`). This module joins
+the projector's tables into a per-project ``resume.json`` snapshot, written
+atomically to ``crew/{project}/resume.json`` so a fresh session can read
+"where am I" in one file lookup instead of replaying the bus.
+
+The snapshot is a **derived projection** — never the source of truth. The
+bus event log remains authoritative. ``verify`` re-derives the snapshot from
+the projector and reports divergence; it deliberately refuses to silently
+overwrite a snapshot that disagrees, so corruption surfaces instead of
+hiding.
+
+Stdlib-only. The hook bootstrap can import this safely.
+
+Public API
+----------
+    build_snapshot(project_id, db_path=None)            -> dict
+    write_snapshot(project_id, project_dir, ...)        -> Path
+    read_snapshot(project_dir)                          -> dict | None
+    verify_snapshot(project_id, project_dir, ...)       -> tuple[bool, str]
+    snapshot_path(project_dir)                          -> Path
+    SCHEMA_VERSION                                      -> str
+
+CLI
+---
+    resume_projector.py replay <project_id> <project_dir>
+    resume_projector.py read   <project_dir>
+    resume_projector.py verify <project_id> <project_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Snapshot file inside ``crew/{project}/``.
+SNAPSHOT_FILENAME = "resume.json"
+
+#: Snapshot schema version. Bump on incompatible field changes.
+SCHEMA_VERSION = "1.0.0"
+
+#: Pointers the snapshot exposes for each project. Paths are RELATIVE to the
+#: project_dir so the snapshot is portable between machines.
+_POINTER_TEMPLATES = {
+    "process_plan": "process-plan.md",
+    "dispatch_log": "phases/{phase}/dispatch-log.jsonl",
+    "gate_result": "phases/{phase}/gate-result.json",
+    "conditions_manifest": "phases/{phase}/conditions-manifest.json",
+    "reeval_log": "phases/{phase}/reeval-log.jsonl",
+}
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _connect(db_path: "str | None" = None) -> "sqlite3.Connection | None":
+    """Open the projector DB read-only. Return ``None`` if the DB does not exist.
+
+    Resolution order: explicit ``db_path`` arg → ``WG_PROJECTOR_DB_PATH`` env →
+    daemon default (``~/.something-wicked/wicked-garden-daemon/projections.db``).
+    Read-only because resume_projector never mutates the projector tables.
+    """
+    resolved: str
+    if db_path:
+        resolved = db_path
+    elif os.environ.get("WG_PROJECTOR_DB_PATH"):
+        resolved = os.environ["WG_PROJECTOR_DB_PATH"]
+    else:
+        resolved = str(
+            Path.home()
+            / ".something-wicked"
+            / "wicked-garden-daemon"
+            / "projections.db"
+        )
+    if not Path(resolved).is_file():
+        return None
+    # Read-only URI mode keeps us honest about not mutating the projector.
+    conn = sqlite3.connect(f"file:{resolved}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot construction
+# ---------------------------------------------------------------------------
+
+def build_snapshot(project_id: str, db_path: "str | None" = None) -> dict:
+    """Return the snapshot dict for ``project_id`` derived from the projector.
+
+    Returns a snapshot with ``project: null`` and empty lists when the project
+    is not in the projector (lets callers persist a stub instead of erroring).
+    Never raises on missing DB — returns the empty snapshot in that case too.
+    The bus event log is the source of truth; this function is a read-only
+    derivation over what the projector has already projected.
+    """
+    snapshot = _empty_snapshot(project_id)
+
+    conn = _connect(db_path)
+    if conn is None:
+        snapshot["projector_available"] = False
+        return snapshot
+    snapshot["projector_available"] = True
+
+    try:
+        snapshot["project"] = _read_project(conn, project_id)
+        snapshot["phases"] = _read_phases(conn, project_id)
+        snapshot["gate_history"] = _read_gate_history(conn, project_id)
+        snapshot["active_tasks_count"] = _read_active_tasks_count(conn, project_id)
+        snapshot["last_event"] = _read_last_event(conn, project_id)
+    finally:
+        conn.close()
+
+    snapshot["pointers"] = _build_pointers(snapshot)
+    return snapshot
+
+
+def _empty_snapshot(project_id: str) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "project_id": project_id,
+        "snapshot_taken_at": _now_iso(),
+        "projector_available": False,
+        "project": None,
+        "phases": [],
+        "gate_history": [],
+        "active_tasks_count": 0,
+        "last_event": None,
+        "pointers": {},
+    }
+
+
+def _read_project(conn: sqlite3.Connection, project_id: str) -> "dict | None":
+    row = conn.execute(
+        """
+        SELECT id, name, workspace, directory, archetype, complexity_score,
+               rigor_tier, current_phase, status, chain_id,
+               yolo_revoked_count, last_revoke_reason,
+               created_at, updated_at
+        FROM projects WHERE id = ?
+        """,
+        (project_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _read_phases(conn: sqlite3.Connection, project_id: str) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT phase, state, gate_score, gate_verdict, gate_reviewer,
+               started_at, terminal_at, rework_iterations, updated_at
+        FROM phases WHERE project_id = ?
+        ORDER BY started_at IS NULL, started_at, phase
+        """,
+        (project_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _read_gate_history(conn: sqlite3.Connection, project_id: str) -> list[dict]:
+    """Read gate verdicts from event_log.
+
+    Filters by ``chain_id LIKE '{project_id}.%'`` because the bus chain_id
+    is always rooted at the project. event_log doesn't have project_id
+    directly — chain_id is the projection key.
+    """
+    rows = conn.execute(
+        """
+        SELECT event_id, event_type, chain_id, payload_json, ingested_at
+        FROM event_log
+        WHERE event_type = 'wicked.gate.decided'
+          AND chain_id LIKE ?
+        ORDER BY event_id ASC
+        """,
+        (f"{project_id}.%",),
+    ).fetchall()
+    history: list[dict] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
+        except (TypeError, ValueError):
+            payload = {}
+        history.append({
+            "event_id": r["event_id"],
+            "chain_id": r["chain_id"],
+            "phase": payload.get("phase"),
+            "verdict": payload.get("result") or payload.get("verdict"),
+            "score": payload.get("score"),
+            "min_score": payload.get("min_score"),
+            "reviewer": payload.get("reviewer") or payload.get("source_agent"),
+            "decided_at": r["ingested_at"],
+        })
+    return history
+
+
+def _read_active_tasks_count(conn: sqlite3.Connection, project_id: str) -> int:
+    """Count tasks whose chain_id is rooted at this project and are still open."""
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS n FROM tasks
+        WHERE chain_id LIKE ?
+          AND status IN ('pending', 'in_progress')
+        """,
+        (f"{project_id}.%",),
+    ).fetchone()
+    return int(row["n"]) if row else 0
+
+
+def _read_last_event(conn: sqlite3.Connection, project_id: str) -> "dict | None":
+    """Latest event for this project, by event_id (event_log primary key is monotonic)."""
+    row = conn.execute(
+        """
+        SELECT event_id, event_type, chain_id, ingested_at
+        FROM event_log
+        WHERE chain_id LIKE ?
+        ORDER BY event_id DESC LIMIT 1
+        """,
+        (f"{project_id}.%",),
+    ).fetchone()
+    if not row:
+        return None
+    return {
+        "event_id": row["event_id"],
+        "event_type": row["event_type"],
+        "chain_id": row["chain_id"],
+        "ingested_at": row["ingested_at"],
+    }
+
+
+def _build_pointers(snapshot: dict) -> dict:
+    project = snapshot.get("project") or {}
+    current_phase = project.get("current_phase") or ""
+    out = {}
+    for key, template in _POINTER_TEMPLATES.items():
+        if "{phase}" in template and not current_phase:
+            continue
+        out[key] = template.format(phase=current_phase) if "{phase}" in template else template
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Snapshot persistence
+# ---------------------------------------------------------------------------
+
+def snapshot_path(project_dir: "str | Path") -> Path:
+    """Return the canonical ``resume.json`` path for a project_dir."""
+    return Path(project_dir) / SNAPSHOT_FILENAME
+
+
+def read_snapshot(project_dir: "str | Path") -> "dict | None":
+    """Read ``resume.json`` from disk. Return ``None`` on missing or unreadable.
+
+    Never raises. Corrupted JSON returns ``None`` so the caller can decide
+    whether to replay from the projector or surface the corruption.
+    """
+    path = snapshot_path(project_dir)
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return None
+
+
+def write_snapshot(
+    project_id: str,
+    project_dir: "str | Path",
+    db_path: "str | None" = None,
+) -> Path:
+    """Build the snapshot for ``project_id`` and write it atomically.
+
+    Returns the path on success. Uses ``tempfile + os.replace`` for crash
+    safety — same idiom as ``conditions_manifest.py`` and ``solo_mode.py``.
+    Creates the project_dir if it does not exist; never mutates the
+    projector DB.
+    """
+    snapshot = build_snapshot(project_id, db_path=db_path)
+    target = snapshot_path(project_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{SNAPSHOT_FILENAME}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, indent=2, sort_keys=True)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, target)
+    except Exception:
+        # Best-effort cleanup; never leak temps.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def verify_snapshot(
+    project_id: str,
+    project_dir: "str | Path",
+    db_path: "str | None" = None,
+) -> "tuple[bool, str]":
+    """Re-derive the snapshot from the projector and compare with on-disk.
+
+    Returns ``(True, "")`` when on-disk matches a freshly-built snapshot
+    on the load-bearing fields (project state, phases, gate history,
+    active task count, last event id). Returns ``(False, reason)`` on
+    divergence. The ``snapshot_taken_at`` timestamp is intentionally
+    excluded from the comparison.
+
+    NEVER auto-rewrites on divergence — corruption must surface, not hide.
+    Caller decides whether to overwrite via ``write_snapshot``.
+    """
+    on_disk = read_snapshot(project_dir)
+    if on_disk is None:
+        return False, "no on-disk snapshot to verify (use write_snapshot to create)"
+    fresh = build_snapshot(project_id, db_path=db_path)
+
+    diff_fields: list[str] = []
+    for field in ("schema_version", "project_id", "project", "phases",
+                  "gate_history", "active_tasks_count", "last_event"):
+        if on_disk.get(field) != fresh.get(field):
+            diff_fields.append(field)
+
+    if not diff_fields:
+        return True, ""
+    return False, (
+        f"snapshot diverges from projector on {len(diff_fields)} field(s): "
+        f"{', '.join(diff_fields)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli_replay(args: argparse.Namespace) -> int:
+    path = write_snapshot(args.project_id, args.project_dir, db_path=args.db_path)
+    print(f"WROTE: {path}")
+    return 0
+
+
+def _cli_read(args: argparse.Namespace) -> int:
+    snap = read_snapshot(args.project_dir)
+    if snap is None:
+        print("NO SNAPSHOT")
+        return 1
+    print(json.dumps(snap, indent=2, sort_keys=True))
+    return 0
+
+
+def _cli_verify(args: argparse.Namespace) -> int:
+    ok, reason = verify_snapshot(args.project_id, args.project_dir, db_path=args.db_path)
+    if ok:
+        print("OK")
+        return 0
+    print(f"DIVERGED: {reason}")
+    return 1
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-project resume snapshot over the bus projector (#734)."
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Override the projector DB path (default: WG_PROJECTOR_DB_PATH "
+             "or ~/.something-wicked/wicked-garden-daemon/projections.db).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_replay = sub.add_parser(
+        "replay",
+        help="Build and atomically write resume.json from the projector.",
+    )
+    p_replay.add_argument("project_id")
+    p_replay.add_argument("project_dir")
+    p_replay.set_defaults(func=_cli_replay)
+
+    p_read = sub.add_parser("read", help="Print the on-disk resume.json.")
+    p_read.add_argument("project_dir")
+    p_read.set_defaults(func=_cli_read)
+
+    p_verify = sub.add_parser(
+        "verify",
+        help="Re-derive and compare against on-disk; non-zero on divergence.",
+    )
+    p_verify.add_argument("project_id")
+    p_verify.add_argument("project_dir")
+    p_verify.set_defaults(func=_cli_verify)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/crew/resume_projector.py
+++ b/scripts/crew/resume_projector.py
@@ -68,15 +68,22 @@ _POINTER_TEMPLATES = {
 # ---------------------------------------------------------------------------
 
 def _connect(db_path: "str | None" = None) -> "sqlite3.Connection | None":
-    """Open the projector DB read-only. Return ``None`` if the DB does not exist.
+    """Open the projector DB read-only. Return ``None`` if unavailable.
 
-    Resolution order: explicit ``db_path`` arg → ``WG_PROJECTOR_DB_PATH`` env →
-    daemon default (``~/.something-wicked/wicked-garden-daemon/projections.db``).
-    Read-only because resume_projector never mutates the projector tables.
+    Resolution order: explicit ``db_path`` arg → ``WG_DAEMON_DB`` env (matches
+    ``daemon/db.py``) → ``WG_PROJECTOR_DB_PATH`` env (legacy alias kept so
+    existing call sites don't break) → daemon default
+    (``~/.something-wicked/wicked-garden-daemon/projections.db``).
+
+    Returns ``None`` on any of: missing file, sqlite3.Error (corrupt DB,
+    permission denied, locked, etc.), URI construction failure. Never
+    raises — fail-open is the contract for hooks and CLI consumers.
     """
     resolved: str
     if db_path:
         resolved = db_path
+    elif os.environ.get("WG_DAEMON_DB"):
+        resolved = os.environ["WG_DAEMON_DB"]
     elif os.environ.get("WG_PROJECTOR_DB_PATH"):
         resolved = os.environ["WG_PROJECTOR_DB_PATH"]
     else:
@@ -88,10 +95,30 @@ def _connect(db_path: "str | None" = None) -> "sqlite3.Connection | None":
         )
     if not Path(resolved).is_file():
         return None
-    # Read-only URI mode keeps us honest about not mutating the projector.
-    conn = sqlite3.connect(f"file:{resolved}?mode=ro", uri=True)
+    try:
+        # Path.as_uri() handles spaces, '#', '?', and other special chars
+        # correctly per RFC 8089 — safer than f"file:{resolved}".
+        uri = Path(resolved).absolute().as_uri() + "?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+    except (sqlite3.Error, ValueError, OSError):
+        return None
     conn.row_factory = sqlite3.Row
     return conn
+
+
+# SQLite LIKE treats '_' and '%' as wildcards. Project ids commonly contain
+# underscores (e.g. ``test_proj``), which would match unintended chains
+# (``test_proj`` matches ``test-proj``, ``testxproj``, etc.). Escape with
+# '!' as the escape character — used in ESCAPE '!' clauses below.
+def _like_escape_chain_prefix(project_id: str) -> str:
+    """Return ``{project_id}.%`` with LIKE wildcards in project_id escaped."""
+    escaped = (
+        project_id
+        .replace("!", "!!")
+        .replace("_", "!_")
+        .replace("%", "!%")
+    )
+    return f"{escaped}.%"
 
 
 def _now_iso() -> str:
@@ -186,10 +213,10 @@ def _read_gate_history(conn: sqlite3.Connection, project_id: str) -> list[dict]:
         SELECT event_id, event_type, chain_id, payload_json, ingested_at
         FROM event_log
         WHERE event_type = 'wicked.gate.decided'
-          AND chain_id LIKE ?
+          AND chain_id LIKE ? ESCAPE '!'
         ORDER BY event_id ASC
         """,
-        (f"{project_id}.%",),
+        (_like_escape_chain_prefix(project_id),),
     ).fetchall()
     history: list[dict] = []
     for r in rows:
@@ -215,10 +242,10 @@ def _read_active_tasks_count(conn: sqlite3.Connection, project_id: str) -> int:
     row = conn.execute(
         """
         SELECT COUNT(*) AS n FROM tasks
-        WHERE chain_id LIKE ?
+        WHERE chain_id LIKE ? ESCAPE '!'
           AND status IN ('pending', 'in_progress')
         """,
-        (f"{project_id}.%",),
+        (_like_escape_chain_prefix(project_id),),
     ).fetchone()
     return int(row["n"]) if row else 0
 
@@ -229,10 +256,10 @@ def _read_last_event(conn: sqlite3.Connection, project_id: str) -> "dict | None"
         """
         SELECT event_id, event_type, chain_id, ingested_at
         FROM event_log
-        WHERE chain_id LIKE ?
+        WHERE chain_id LIKE ? ESCAPE '!'
         ORDER BY event_id DESC LIMIT 1
         """,
-        (f"{project_id}.%",),
+        (_like_escape_chain_prefix(project_id),),
     ).fetchone()
     if not row:
         return None
@@ -267,15 +294,17 @@ def snapshot_path(project_dir: "str | Path") -> Path:
 def read_snapshot(project_dir: "str | Path") -> "dict | None":
     """Read ``resume.json`` from disk. Return ``None`` on missing or unreadable.
 
-    Never raises. Corrupted JSON returns ``None`` so the caller can decide
-    whether to replay from the projector or surface the corruption.
+    Never raises. Decodes UTF-8 STRICTLY (no ``errors="replace"``) so a
+    corrupted byte sequence becomes ``None`` instead of a silently-normalized
+    document that happens to parse as JSON. Caller decides whether to
+    replay from the projector or surface the corruption.
     """
     path = snapshot_path(project_dir)
     if not path.is_file():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
-    except (OSError, ValueError):
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError):
         return None
 
 
@@ -305,10 +334,26 @@ def write_snapshot(
             json.dump(snapshot, f, indent=2, sort_keys=True)
             f.write("\n")
             f.flush()
-            os.fsync(f.fileno())
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # Best-effort durability: fsync isn't supported on every
+                # filesystem (some FUSE mounts, tmpfs in containers).
+                # Mirrors conditions_manifest.atomic_write_json behavior.
+                pass
         os.replace(tmp, target)
+        # Best-effort parent-directory fsync for crash-after-rename
+        # durability on POSIX. Silently skipped on Windows / FUSE / etc.
+        try:
+            dir_fd = os.open(str(target.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except (OSError, AttributeError):
+            pass
     except Exception:
-        # Best-effort cleanup; never leak temps.
+        # Cleanup; never leak temps.
         try:
             tmp.unlink(missing_ok=True)
         except OSError:
@@ -325,13 +370,26 @@ def verify_snapshot(
     """Re-derive the snapshot from the projector and compare with on-disk.
 
     Returns ``(True, "")`` when on-disk matches a freshly-built snapshot
-    on the load-bearing fields (project state, phases, gate history,
-    active task count, last event id). Returns ``(False, reason)`` on
-    divergence. The ``snapshot_taken_at`` timestamp is intentionally
-    excluded from the comparison.
+    on these load-bearing fields:
 
-    NEVER auto-rewrites on divergence — corruption must surface, not hide.
-    Caller decides whether to overwrite via ``write_snapshot``.
+      * ``schema_version`` — incompatible-schema detection
+      * ``project_id`` — wrong-project detection
+      * ``project`` — full project row dict from the projector
+      * ``phases`` — full per-phase list from the projector
+      * ``gate_history`` — full gate-decided event list for this project
+      * ``active_tasks_count`` — pending + in_progress task count
+      * ``last_event`` — the FULL latest-event dict (event_id, event_type,
+        chain_id, ingested_at). Comparing the dict (not just event_id)
+        catches event_type or chain_id changes the projector recorded
+        that a file-based snapshot might still claim are stale.
+
+    The ``snapshot_taken_at`` timestamp is intentionally excluded.
+    ``projector_available`` and ``pointers`` are excluded because they
+    are derived locally per-call, not from projector state.
+
+    Returns ``(False, reason)`` on any divergence. NEVER auto-rewrites —
+    corruption must surface, not hide. Caller decides whether to overwrite
+    via ``write_snapshot``.
     """
     on_disk = read_snapshot(project_dir)
     if on_disk is None:

--- a/tests/crew/test_resume_projector.py
+++ b/tests/crew/test_resume_projector.py
@@ -20,10 +20,16 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+# Add scripts/ (NOT scripts/crew/) so `from crew.X import` works as a
+# package import. tests/crew/conftest.py applies the same setup under
+# pytest; this block keeps unittest working too. Do NOT insert
+# scripts/crew/ at index 0 — it shadows the crew/ package namespace and
+# breaks sibling tests in the same process (see conftest docstring).
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
-import resume_projector as rp  # noqa: E402  (after sys.path edit)
+from crew import resume_projector as rp  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +246,65 @@ class TestBuildSnapshot(unittest.TestCase):
             self.assertEqual(
                 snap["pointers"]["dispatch_log"],
                 "phases/build/dispatch-log.jsonl",
+            )
+
+    def test_underscore_in_project_id_does_not_match_unrelated(self):
+        """LIKE wildcard escape regression: ``test_proj`` MUST NOT match ``testxproj``.
+
+        SQLite ``LIKE`` treats ``_`` as a single-character wildcard, so an
+        unescaped ``test_proj.%`` would match ``testxproj.clarify``. This
+        test seeds two sibling projects whose ids differ only by the
+        underscore being literal vs. a wildcard match, and verifies the
+        snapshot for ``test_proj`` does not see ``testxproj``'s events.
+        """
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            conn = sqlite3.connect(str(db))
+            # Real project: literal underscore.
+            conn.execute(
+                """INSERT INTO projects (id, name, current_phase, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                ("test_proj", "Underscore Project", "build", 1, 1),
+            )
+            # Sibling that LIKE wildcards would falsely match without ESCAPE.
+            conn.execute(
+                """INSERT INTO projects (id, name, current_phase, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                ("testxproj", "Wildcard Confusion", "design", 2, 2),
+            )
+            # An event on the SIBLING — must not bleed into test_proj's snapshot.
+            conn.execute(
+                """INSERT INTO event_log
+                   (event_id, event_type, chain_id, payload_json,
+                    projection_status, ingested_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (1, "wicked.gate.decided", "testxproj.clarify",
+                 json.dumps({"phase": "clarify", "result": "REJECT"}),
+                 "applied", 1700000100),
+            )
+            # Active task on the SIBLING.
+            conn.execute(
+                """INSERT INTO tasks (id, session_id, status, chain_id,
+                                       created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                ("t-bleed", "s", "in_progress", "testxproj.build", 1, 1),
+            )
+            conn.commit()
+            conn.close()
+
+            snap = rp.build_snapshot("test_proj", db_path=str(db))
+            self.assertEqual(
+                snap["gate_history"], [],
+                "LIKE wildcard escape failed: sibling project's events bled in",
+            )
+            self.assertEqual(
+                snap["active_tasks_count"], 0,
+                "LIKE wildcard escape failed: sibling project's tasks bled in",
+            )
+            self.assertIsNone(
+                snap["last_event"],
+                "LIKE wildcard escape failed: sibling project's events bled in",
             )
 
     def test_pointers_skip_phase_template_when_no_current_phase(self):

--- a/tests/crew/test_resume_projector.py
+++ b/tests/crew/test_resume_projector.py
@@ -1,0 +1,391 @@
+"""Unit tests for scripts/crew/resume_projector.py (#734).
+
+Covers:
+    * build_snapshot — empty DB, missing project, fully populated
+    * write_snapshot — atomic write, no temp leakage on crash
+    * read_snapshot — missing / corrupt / well-formed
+    * verify_snapshot — match, diverged, missing on-disk
+
+Stdlib + unittest only; provisions a real SQLite DB matching daemon/db.py
+schema rather than mocking, because mocking sqlite3 hides driver-level
+bugs that the projector hits in production.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+
+import resume_projector as rp  # noqa: E402  (after sys.path edit)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _init_projector_schema(db_path: Path) -> None:
+    """Create the minimal projector schema this module reads from.
+
+    Mirrors the relevant subset of daemon/db.py — projects, phases,
+    event_log, tasks. Other tables (council_*, ac_*, hook_*, etc.) are
+    not read by resume_projector and are omitted to keep the fixture
+    small.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE projects (
+            id                  TEXT PRIMARY KEY,
+            name                TEXT NOT NULL,
+            workspace           TEXT,
+            directory           TEXT,
+            archetype           TEXT,
+            complexity_score    REAL,
+            rigor_tier          TEXT,
+            current_phase       TEXT NOT NULL DEFAULT '',
+            status              TEXT NOT NULL DEFAULT 'active',
+            chain_id            TEXT,
+            yolo_revoked_count  INTEGER NOT NULL DEFAULT 0,
+            last_revoke_reason  TEXT,
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL
+        );
+        CREATE TABLE phases (
+            project_id          TEXT NOT NULL,
+            phase               TEXT NOT NULL,
+            state               TEXT NOT NULL DEFAULT 'pending',
+            gate_score          REAL,
+            gate_verdict        TEXT,
+            gate_reviewer       TEXT,
+            started_at          INTEGER,
+            terminal_at         INTEGER,
+            rework_iterations   INTEGER NOT NULL DEFAULT 0,
+            updated_at          INTEGER NOT NULL,
+            PRIMARY KEY (project_id, phase)
+        );
+        CREATE TABLE event_log (
+            event_id            INTEGER PRIMARY KEY,
+            event_type          TEXT NOT NULL,
+            chain_id            TEXT,
+            payload_json        TEXT NOT NULL,
+            projection_status   TEXT NOT NULL,
+            error_message       TEXT,
+            ingested_at         INTEGER NOT NULL
+        );
+        CREATE TABLE tasks (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT NOT NULL,
+            subject     TEXT NOT NULL DEFAULT '',
+            status      TEXT NOT NULL DEFAULT 'pending',
+            chain_id    TEXT,
+            event_type  TEXT,
+            metadata    TEXT,
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_project(
+    db_path: Path,
+    project_id: str = "demo-proj",
+    current_phase: str = "build",
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """INSERT INTO projects
+           (id, name, archetype, complexity_score, rigor_tier,
+            current_phase, status, chain_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (project_id, "Demo Project", "code-repo", 7, "full",
+         current_phase, "active", f"{project_id}.root", 1700000000, 1700001000),
+    )
+    conn.execute(
+        """INSERT INTO phases
+           (project_id, phase, state, gate_score, gate_verdict, gate_reviewer,
+            started_at, terminal_at, rework_iterations, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (project_id, "clarify", "approved", 0.85, "APPROVE", "rev-1",
+         1700000100, 1700000200, 0, 1700000200),
+    )
+    conn.execute(
+        """INSERT INTO phases
+           (project_id, phase, state, gate_score, gate_verdict, gate_reviewer,
+            started_at, terminal_at, rework_iterations, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (project_id, "design", "approved", 0.78, "APPROVE", "rev-2",
+         1700000300, 1700000400, 1, 1700000400),
+    )
+    conn.execute(
+        """INSERT INTO phases
+           (project_id, phase, state, updated_at)
+           VALUES (?, ?, ?, ?)""",
+        (project_id, current_phase, "in_progress", 1700001000),
+    )
+    # Two gate-decided events.
+    conn.execute(
+        """INSERT INTO event_log
+           (event_id, event_type, chain_id, payload_json,
+            projection_status, ingested_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (1, "wicked.gate.decided", f"{project_id}.clarify",
+         json.dumps({"phase": "clarify", "result": "APPROVE",
+                     "score": 0.85, "min_score": 0.7, "reviewer": "rev-1"}),
+         "applied", 1700000200),
+    )
+    conn.execute(
+        """INSERT INTO event_log
+           (event_id, event_type, chain_id, payload_json,
+            projection_status, ingested_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (2, "wicked.gate.decided", f"{project_id}.design",
+         json.dumps({"phase": "design", "result": "APPROVE",
+                     "score": 0.78, "min_score": 0.7, "reviewer": "rev-2"}),
+         "applied", 1700000400),
+    )
+    # An unrelated event for a sibling project — must NOT bleed in.
+    conn.execute(
+        """INSERT INTO event_log
+           (event_id, event_type, chain_id, payload_json,
+            projection_status, ingested_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (3, "wicked.gate.decided", "other-proj.clarify",
+         json.dumps({"phase": "clarify", "result": "REJECT", "score": 0.4}),
+         "applied", 1700000500),
+    )
+    # Active task on this project + a completed task that shouldn't count.
+    conn.execute(
+        """INSERT INTO tasks
+           (id, session_id, status, chain_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("t1", "sess-1", "in_progress", f"{project_id}.build", 1700001000, 1700001100),
+    )
+    conn.execute(
+        """INSERT INTO tasks
+           (id, session_id, status, chain_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("t2", "sess-1", "completed", f"{project_id}.clarify", 1700000100, 1700000200),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# build_snapshot
+# ---------------------------------------------------------------------------
+
+class TestBuildSnapshot(unittest.TestCase):
+    def test_missing_db_returns_empty_with_unavailable_flag(self):
+        snap = rp.build_snapshot("anything", db_path="/nonexistent/path/projections.db")
+        self.assertEqual(snap["schema_version"], rp.SCHEMA_VERSION)
+        self.assertEqual(snap["project_id"], "anything")
+        self.assertFalse(snap["projector_available"])
+        self.assertIsNone(snap["project"])
+        self.assertEqual(snap["phases"], [])
+        self.assertEqual(snap["gate_history"], [])
+        self.assertEqual(snap["active_tasks_count"], 0)
+        self.assertIsNone(snap["last_event"])
+
+    def test_unknown_project_returns_empty_but_db_available(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            snap = rp.build_snapshot("ghost", db_path=str(db))
+            self.assertTrue(snap["projector_available"])
+            self.assertIsNone(snap["project"])
+            self.assertEqual(snap["phases"], [])
+            self.assertEqual(snap["gate_history"], [])
+
+    def test_populated_project_round_trip(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db, project_id="demo-proj", current_phase="build")
+            snap = rp.build_snapshot("demo-proj", db_path=str(db))
+
+            self.assertTrue(snap["projector_available"])
+            self.assertEqual(snap["project"]["name"], "Demo Project")
+            self.assertEqual(snap["project"]["archetype"], "code-repo")
+            self.assertEqual(snap["project"]["current_phase"], "build")
+
+            phases_by_name = {p["phase"]: p for p in snap["phases"]}
+            self.assertIn("clarify", phases_by_name)
+            self.assertIn("design", phases_by_name)
+            self.assertIn("build", phases_by_name)
+            self.assertEqual(phases_by_name["clarify"]["gate_verdict"], "APPROVE")
+            self.assertEqual(phases_by_name["design"]["rework_iterations"], 1)
+
+            self.assertEqual(len(snap["gate_history"]), 2)
+            self.assertEqual(snap["gate_history"][0]["phase"], "clarify")
+            self.assertEqual(snap["gate_history"][0]["verdict"], "APPROVE")
+            self.assertEqual(snap["gate_history"][1]["phase"], "design")
+
+            # Sibling project's events must not leak in.
+            for entry in snap["gate_history"]:
+                self.assertTrue(entry["chain_id"].startswith("demo-proj."))
+
+            self.assertEqual(snap["active_tasks_count"], 1)  # t1, not t2
+            self.assertEqual(snap["last_event"]["event_id"], 2)
+            self.assertIn("dispatch_log", snap["pointers"])
+            self.assertEqual(
+                snap["pointers"]["dispatch_log"],
+                "phases/build/dispatch-log.jsonl",
+            )
+
+    def test_pointers_skip_phase_template_when_no_current_phase(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            # Seed project with empty current_phase.
+            conn = sqlite3.connect(str(db))
+            conn.execute(
+                """INSERT INTO projects
+                   (id, name, current_phase, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                ("nophase", "No Phase", "", 1, 1),
+            )
+            conn.commit()
+            conn.close()
+            snap = rp.build_snapshot("nophase", db_path=str(db))
+            self.assertIn("process_plan", snap["pointers"])  # always present
+            self.assertNotIn("dispatch_log", snap["pointers"])  # phase-templated, skipped
+
+
+# ---------------------------------------------------------------------------
+# write_snapshot + read_snapshot
+# ---------------------------------------------------------------------------
+
+class TestWriteAndRead(unittest.TestCase):
+    def test_atomic_write_and_round_trip(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db)
+            project_dir = Path(tmp) / "projects" / "demo-proj"
+            written = rp.write_snapshot("demo-proj", project_dir, db_path=str(db))
+            self.assertTrue(written.is_file())
+            self.assertEqual(written.name, "resume.json")
+
+            loaded = rp.read_snapshot(project_dir)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded["project_id"], "demo-proj")
+            self.assertEqual(loaded["active_tasks_count"], 1)
+
+            # No leftover temp files in the project dir.
+            leftover = [p.name for p in project_dir.iterdir()
+                        if p.name.startswith(".resume.json.")]
+            self.assertEqual(leftover, [], f"temp leak: {leftover}")
+
+    def test_read_snapshot_missing_returns_none(self):
+        with TemporaryDirectory() as tmp:
+            self.assertIsNone(rp.read_snapshot(Path(tmp)))
+
+    def test_read_snapshot_corrupt_returns_none(self):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            (project_dir / "resume.json").write_text("{ not valid json", encoding="utf-8")
+            self.assertIsNone(rp.read_snapshot(project_dir))
+
+
+# ---------------------------------------------------------------------------
+# verify_snapshot
+# ---------------------------------------------------------------------------
+
+class TestVerifySnapshot(unittest.TestCase):
+    def test_verify_missing_snapshot(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db)
+            ok, reason = rp.verify_snapshot(
+                "demo-proj", Path(tmp) / "no-snapshot-here", db_path=str(db)
+            )
+            self.assertFalse(ok)
+            self.assertIn("no on-disk snapshot", reason)
+
+    def test_verify_match(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db)
+            project_dir = Path(tmp) / "demo-proj"
+            rp.write_snapshot("demo-proj", project_dir, db_path=str(db))
+            ok, reason = rp.verify_snapshot("demo-proj", project_dir, db_path=str(db))
+            self.assertTrue(ok, f"expected match, got: {reason!r}")
+            self.assertEqual(reason, "")
+
+    def test_verify_diverged_after_db_mutation(self):
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db)
+            project_dir = Path(tmp) / "demo-proj"
+            rp.write_snapshot("demo-proj", project_dir, db_path=str(db))
+
+            # Mutate the projector — adds a new gate event.
+            conn = sqlite3.connect(str(db))
+            conn.execute(
+                """INSERT INTO event_log
+                   (event_id, event_type, chain_id, payload_json,
+                    projection_status, ingested_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (10, "wicked.gate.decided", "demo-proj.build",
+                 json.dumps({"phase": "build", "result": "CONDITIONAL",
+                             "score": 0.65, "min_score": 0.7}),
+                 "applied", 1700002000),
+            )
+            conn.commit()
+            conn.close()
+
+            ok, reason = rp.verify_snapshot("demo-proj", project_dir, db_path=str(db))
+            self.assertFalse(ok)
+            self.assertIn("diverges", reason)
+            self.assertIn("gate_history", reason)
+
+    def test_verify_does_not_silently_overwrite(self):
+        """Critical contract — verify must NEVER auto-rewrite on divergence."""
+        with TemporaryDirectory() as tmp:
+            db = Path(tmp) / "projections.db"
+            _init_projector_schema(db)
+            _seed_project(db)
+            project_dir = Path(tmp) / "demo-proj"
+            rp.write_snapshot("demo-proj", project_dir, db_path=str(db))
+
+            original_bytes = (project_dir / "resume.json").read_bytes()
+
+            # Mutate the projector so verify fails.
+            conn = sqlite3.connect(str(db))
+            conn.execute(
+                """INSERT INTO event_log
+                   (event_id, event_type, chain_id, payload_json,
+                    projection_status, ingested_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (11, "wicked.gate.decided", "demo-proj.build",
+                 json.dumps({"phase": "build", "result": "REJECT", "score": 0.2}),
+                 "applied", 1700003000),
+            )
+            conn.commit()
+            conn.close()
+
+            ok, _ = rp.verify_snapshot("demo-proj", project_dir, db_path=str(db))
+            self.assertFalse(ok)
+            # On-disk MUST be unchanged.
+            self.assertEqual(
+                (project_dir / "resume.json").read_bytes(),
+                original_bytes,
+                "verify_snapshot silently rewrote on-disk — contract violation",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Part A of #734** — adds `scripts/crew/resume_projector.py`, a read-only resume snapshot that joins `daemon/projector.py` SQLite tables (projects, phases, event_log, tasks) into a per-project `crew/{project}/resume.json`
- The snapshot is a **derived projection** — never the source of truth. The bus event log remains authoritative.
- Two follow-up PRs land: Part B (PreToolUse lint), Part C (3 emit additions per the #735 audit)

## Why this exists

#732 established that wicked-bus is the source of truth and TaskList + garden chain are projections. #735 audited every disk write under `scripts/crew/` and `hooks/scripts/` and found that `daemon/projector.py` already exists, projecting 13 event types. This PR builds the **resume snapshot subscriber** that joins those existing projector tables into a per-project view a fresh session can read in one file lookup.

## What's in this PR

### `scripts/crew/resume_projector.py` (stdlib-only)

Public API:
- `build_snapshot(project_id, db_path=None)` → dict — joins projector tables
- `write_snapshot(project_id, project_dir, ...)` → Path — atomic temp + os.replace
- `read_snapshot(project_dir)` → dict | None — never raises on missing/corrupt
- `verify_snapshot(project_id, project_dir, ...)` → tuple[bool, str] — re-derive and compare; **NEVER silently rewrites on divergence** (load-bearing contract for bus-as-truth)

CLI:
- `replay <project_id> <project_dir>` — atomically write resume.json
- `read <project_dir>` — print on-disk snapshot
- `verify <project_id> <project_dir>` — re-derive vs on-disk, exit non-zero on divergence

Schema versioned (`resume_snapshot_schema: 1.0.0`). Read-only sqlite3 in URI mode keeps the projector honest. Atomic writes via `tempfile + os.replace + fsync` — same idiom as `conditions_manifest.py` and `solo_mode.py`.

### `tests/crew/test_resume_projector.py`

11 unit tests:
- `TestBuildSnapshot` (4) — missing DB returns empty + flag; unknown project; populated project round-trip with cross-project bleed prevention; pointers skip phase-templated when no current_phase
- `TestWriteAndRead` (3) — atomic write + round-trip + no temp leak; missing read; corrupt read
- `TestVerifySnapshot` (4) — missing snapshot; match; diverged after DB mutation; **does not silently overwrite** (the load-bearing contract — explicit assertion that the on-disk bytes are unchanged after a divergence-triggering verify)

Provisions a real SQLite DB matching `daemon/db.py` schema rather than mocking sqlite3 — mocks hide driver-level bugs that hit production.

### `scenarios/crew/resume-projector-cross-session.md`

End-to-end acceptance scenario (5 steps):
1. Stand up a minimal projector DB
2. Session A `replay` writes resume.json
3. Session B reads in a **fresh subshell with `WG_PROJECTOR_DB_PATH` unset** — proves the snapshot is self-contained
4. `verify` returns OK against unchanged projector
5. Mutate projector → `verify` reports divergence AND on-disk SHA256 unchanged

## What's NOT in this PR (deferred to Part B and Part C of #734)

- **Part B** — PreToolUse lint for orphan writes to `gate-result.json`, `dispatch-log.jsonl`, `conditions-manifest.json`, `reviewer-report.md` (warn mode this release, strict next)
- **Part C** — 3 emit additions for writes the resume view needs that are still silent: `dispatch_log.py:330–331` and `consensus_gate.py:428,463`

Splitting keeps PRs focused. Part A is fully usable on its own — once `daemon/projector.py` runs and emits land, calling `resume_projector.py replay` produces a working snapshot.

## Test plan

- [x] 11/11 unit tests pass
- [x] Cross-session scenario passes inline
- [x] `verify` does not silently rewrite (asserted via SHA256 in both unit test and scenario)
- [x] Atomic write leaves no temp files in the project_dir
- [x] Read-only sqlite3 connection prevents accidental projector mutation

## Cross-references

- Part of #734 (resume projector + lint)
- Builds on #735 (audit findings)
- Decision memory: `bus-as-truth-event-sourced-crew-state.md` (semantic tier)
- Existing projector: `daemon/projector.py:_HANDLERS` (13 event types, all consumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)