### PR TITLE
feat(crew): bus emits for dispatch-log + consensus artifacts (#734 part C, closes #732)

### DIFF
--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -524,14 +524,27 @@ _BUS_EMIT_LINT_PARENT_MARKERS = ("phases",)
 #: emit" only counts if its event_type is in this set — otherwise an
 #: unrelated ``wicked.project.created`` at session start would buy 60s of
 #: silent orphan-write passes, which is exactly the false-negative the
-#: lint exists to catch. Part C (#734) will add wicked.consensus.* and
-#: wicked.crew.dispatch_log_entry_appended once those emit points land.
+#: lint exists to catch.
+#:
+#: Pairing rationale per target:
+#:   gate-result.json        ← wicked.gate.decided
+#:   conditions-manifest.json ← wicked.gate.decided (CONDITIONAL branch)
+#:   dispatch-log.jsonl      ← wicked.dispatch.log_entry_appended (Part C)
+#:   reviewer-report.md      ← wicked.consensus.report_created /
+#:                             wicked.consensus.evidence_recorded (Part C)
+#:
+#: Phase + project lifecycle events stay in the set because callers may
+#: write multiple state files in the wake of a single phase/project event.
 _BUS_EMIT_LINT_PAIR_EVENTS = (
     "wicked.gate.decided",
     "wicked.gate.blocked",
     "wicked.rework.triggered",
     "wicked.phase.transitioned",
     "wicked.project.completed",
+    # Part C of #734 — new emits paired with their target artifact writes
+    "wicked.dispatch.log_entry_appended",
+    "wicked.consensus.report_created",
+    "wicked.consensus.evidence_recorded",
 )
 
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -170,6 +170,24 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "delivery.telemetry",
         "description": "Cross-session quality metric drifted past baseline threshold (special-cause or >=15% drop)",
     },
+    # Crew domain — Part C of #734 (bus-as-truth emit additions paired with
+    # the load-bearing artifact writes the resume projector + bus-emit lint
+    # need to track. See PR #735 audit for the silent-write inventory.)
+    "wicked.dispatch.log_entry_appended": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.dispatch",
+        "description": "HMAC-signed dispatch-log.jsonl entry appended (orphan-check sentinel)",
+    },
+    "wicked.consensus.report_created": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.consensus",
+        "description": "Consensus gate report written to consensus-report.json",
+    },
+    "wicked.consensus.evidence_recorded": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.consensus",
+        "description": "Consensus rejection evidence written to consensus-evidence.json (audit trail)",
+    },
 }
 
 # Payload deny-list — these fields must NEVER appear in bus payloads.

--- a/scripts/crew/consensus_gate.py
+++ b/scripts/crew/consensus_gate.py
@@ -423,6 +423,7 @@ def _write_consensus_report(
     }
 
     report_path = project_dir / "phases" / phase / "consensus-report.json"
+    write_succeeded = False
     try:
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(json.dumps(report, indent=2, default=str))
@@ -430,10 +431,35 @@ def _write_consensus_report(
             "[consensus-gate] Wrote consensus report to %s",
             report_path,
         )
+        write_succeeded = True
     except OSError as exc:
         logger.warning(
             "[consensus-gate] Failed to write consensus report: %s", exc,
         )
+
+    # Part C of #734: emit AFTER successful write so the bus-emit lint and
+    # resume projector can subscribe to consensus activity. Fail-open.
+    if write_succeeded:
+        try:
+            from _bus import emit_event  # type: ignore[import]
+            project_id = project_dir.name
+            emit_event(
+                "wicked.consensus.report_created",
+                {
+                    "project_id": project_id,
+                    "phase": phase,
+                    "decision": result.decision,
+                    "confidence": result.confidence,
+                    "agreement_ratio": scores.get("agreement_ratio", 0.0),
+                    "participants": result.participants,
+                    "rounds": result.rounds,
+                },
+                chain_id=f"{project_id}.{phase}",
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(
+                "[consensus-gate] bus emit failed (fail-open): %s", exc,
+            )
 
 
 def _write_consensus_evidence(
@@ -458,10 +484,37 @@ def _write_consensus_evidence(
     }
 
     evidence_path = project_dir / "phases" / phase / "consensus-evidence.json"
+    write_succeeded = False
     try:
         evidence_path.parent.mkdir(parents=True, exist_ok=True)
         evidence_path.write_text(json.dumps(evidence, indent=2, default=str))
+        write_succeeded = True
     except OSError as exc:
         logger.warning(
             "[consensus-gate] Failed to write consensus evidence: %s", exc,
         )
+
+    # Part C of #734: emit AFTER successful write so the bus-emit lint and
+    # resume projector can subscribe to consensus rejection evidence.
+    # Fail-open.
+    if write_succeeded:
+        try:
+            from _bus import emit_event  # type: ignore[import]
+            project_id = project_dir.name
+            emit_event(
+                "wicked.consensus.evidence_recorded",
+                {
+                    "project_id": project_id,
+                    "phase": phase,
+                    "result": consensus_result.get("result"),
+                    "reason": consensus_result.get("reason"),
+                    "consensus_confidence": consensus_result.get("consensus_confidence"),
+                    "agreement_ratio": consensus_result.get("agreement_ratio"),
+                    "participants": consensus_result.get("participants"),
+                },
+                chain_id=f"{project_id}.{phase}",
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(
+                "[consensus-gate] bus emit failed (fail-open): %s", exc,
+            )

--- a/scripts/crew/dispatch_log.py
+++ b/scripts/crew/dispatch_log.py
@@ -325,10 +325,12 @@ def append(
     except ImportError:  # pragma: no cover — defensive
         pass  # fail-open: rotation module unavailable, append continues unbounded
 
+    write_succeeded = False
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fp:
             fp.write(json.dumps(record, separators=(",", ":")) + "\n")
+        write_succeeded = True
     except OSError as exc:
         # Non-fatal: dispatch can still proceed; downstream orphan check
         # will warn on the missing record.
@@ -336,6 +338,36 @@ def append(
             "[wicked-garden:gate-result] dispatch-log append failed "
             f"(phase={phase}, reviewer={reviewer}): {exc}.\n"
         )
+
+    # Part C of #734: emit AFTER successful write so the bus-emit lint and
+    # the resume projector can subscribe to dispatch activity. Fail-open —
+    # a missing emit must not break the dispatch flow (orphan-check still
+    # catches missing entries via the file-based path).
+    if write_succeeded:
+        try:
+            from _bus import emit_event  # type: ignore[import]
+            project_id = Path(project_dir).name
+            chain_id = f"{project_id}.{phase}.{gate}" if gate else f"{project_id}.{phase}"
+            emit_event(
+                "wicked.dispatch.log_entry_appended",
+                {
+                    "project_id": project_id,
+                    "phase": phase,
+                    "gate": gate,
+                    "reviewer": reviewer,
+                    "dispatch_id": dispatch_id,
+                    "dispatcher_agent": dispatcher_agent,
+                    "expected_result_path": expected_result_path,
+                    "dispatched_at": record["dispatched_at"],
+                    "hmac_present": "hmac" in record,
+                },
+                chain_id=chain_id,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            sys.stderr.write(
+                "[wicked-garden:gate-result] dispatch-log bus emit failed "
+                f"(phase={phase}, reviewer={reviewer}): {exc}\n"
+            )
 
 
 def read_entries(project_dir: Path, phase: str) -> List[Dict[str, Any]]:

--- a/scripts/crew/dispatch_log.py
+++ b/scripts/crew/dispatch_log.py
@@ -346,7 +346,8 @@ def append(
     if write_succeeded:
         try:
             from _bus import emit_event  # type: ignore[import]
-            project_id = Path(project_dir).name
+            # project_dir is already typed as Path in the signature; no wrap needed.
+            project_id = project_dir.name
             chain_id = f"{project_id}.{phase}.{gate}" if gate else f"{project_id}.{phase}"
             emit_event(
                 "wicked.dispatch.log_entry_appended",

--- a/tests/crew/test_emit_additions_part_c.py
+++ b/tests/crew/test_emit_additions_part_c.py
@@ -1,0 +1,214 @@
+"""Unit tests for #734 Part C emit additions in dispatch_log.py + consensus_gate.py.
+
+Verifies that:
+    * dispatch_log.append emits wicked.dispatch.log_entry_appended after the
+      JSONL write succeeds (not before — projector must see write-then-emit
+      ordering)
+    * consensus_gate._write_consensus_report emits
+      wicked.consensus.report_created
+    * consensus_gate._write_consensus_evidence emits
+      wicked.consensus.evidence_recorded
+    * each emit fail-opens — bus errors must not break the calling write path
+    * each emit only fires when the underlying write succeeded (no orphan
+      emits when the disk write failed)
+
+Mocks _bus.emit_event to avoid spawning real subprocesses.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from crew import dispatch_log as dl  # noqa: E402
+
+
+class TestDispatchLogEmits(unittest.TestCase):
+    def test_emit_after_successful_append(self):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            with patch("crew.dispatch_log._bus_emit_helper", create=True), \
+                 patch("crew.dispatch_log.emit_event", create=True) as mock_emit, \
+                 patch.object(dl, "_compute_hmac", return_value="deadbeef"), \
+                 patch.object(dl, "_current_hmac_secret", return_value=b"secret"):
+                # Patch the actual import inside the function — emit_event is
+                # imported lazily from _bus, so we patch that namespace.
+                import _bus  # type: ignore[import]
+                with patch.object(_bus, "emit_event") as mock_emit_real:
+                    dl.append(
+                        project_dir,
+                        "build",
+                        reviewer="rev-1",
+                        gate="testability",
+                        dispatch_id="abc123",
+                    )
+                    self.assertTrue(mock_emit_real.called,
+                                    "emit_event should be called after successful append")
+                    args, kwargs = mock_emit_real.call_args
+                    self.assertEqual(args[0], "wicked.dispatch.log_entry_appended")
+                    payload = args[1]
+                    self.assertEqual(payload["project_id"], "demo-proj")
+                    self.assertEqual(payload["phase"], "build")
+                    self.assertEqual(payload["gate"], "testability")
+                    self.assertEqual(payload["reviewer"], "rev-1")
+                    self.assertEqual(payload["dispatch_id"], "abc123")
+                    self.assertTrue(payload["hmac_present"])
+                    self.assertEqual(kwargs.get("chain_id"), "demo-proj.build.testability")
+
+    def test_no_emit_when_write_fails(self):
+        """Disk write fails → no orphan emit. Otherwise the projector
+        would record a phantom dispatch that never made it to disk.
+
+        Patches ``Path.open`` (which the dispatch-log path uses) rather
+        than ``builtins.open`` — patching builtins.open would also break
+        the lazy ``from _bus import emit_event`` import inside the
+        function, masking what the test is trying to measure.
+        """
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            with patch.object(dl, "_compute_hmac", return_value="deadbeef"), \
+                 patch.object(dl, "_current_hmac_secret", return_value=b"secret"), \
+                 patch("crew.dispatch_log.Path.open",
+                       side_effect=OSError("disk full")):
+                import _bus  # type: ignore[import]
+                with patch.object(_bus, "emit_event") as mock_emit:
+                    dl.append(
+                        project_dir,
+                        "build",
+                        reviewer="rev-1",
+                        gate="testability",
+                        dispatch_id="abc123",
+                    )
+                    # Filter to just the Part-C emit (rotate may emit others).
+                    target_calls = [
+                        c for c in mock_emit.call_args_list
+                        if c.args
+                        and c.args[0] == "wicked.dispatch.log_entry_appended"
+                    ]
+                    self.assertEqual(target_calls, [],
+                                     "emit must NOT fire when the disk write failed")
+
+    def test_emit_failure_does_not_break_dispatch(self):
+        """Bus emit raising must not propagate — fail-open contract."""
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            with patch.object(dl, "_compute_hmac", return_value="deadbeef"), \
+                 patch.object(dl, "_current_hmac_secret", return_value=b"secret"):
+                import _bus  # type: ignore[import]
+                with patch.object(_bus, "emit_event",
+                                  side_effect=RuntimeError("bus down")):
+                    # Must NOT raise.
+                    dl.append(
+                        project_dir,
+                        "build",
+                        reviewer="rev-1",
+                        gate="testability",
+                        dispatch_id="abc123",
+                    )
+                    # And the JSONL line must still be on disk.
+                    log_path = dl._resolve_log_path(project_dir, "build")
+                    self.assertTrue(log_path.is_file())
+                    line = log_path.read_text(encoding="utf-8").strip()
+                    record = json.loads(line)
+                    self.assertEqual(record["reviewer"], "rev-1")
+
+
+class TestConsensusEmits(unittest.TestCase):
+    """Use the public _write_consensus_* helpers via direct import."""
+
+    def _build_result_obj(self):
+        # ConsensusResult lives in jam.consensus (re-exported by consensus_gate).
+        from jam.consensus import ConsensusResult, DissentingView
+        return ConsensusResult(
+            decision="APPROVE",
+            confidence=0.85,
+            participants=2,
+            rounds=2,
+            consensus_points=[{"point": "fast", "agreement": 2, "of": 2}],
+            dissenting_views=[
+                DissentingView(persona="rev-c", view="too fast",
+                               strength="moderate")
+            ],
+            open_questions=["scope?"],
+        )
+
+    def test_report_emit_after_successful_write(self):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            from crew import consensus_gate as cg
+            result = self._build_result_obj()
+            scores = {"agreement_ratio": 0.92, "divergent_points": []}
+            import _bus  # type: ignore[import]
+            with patch.object(_bus, "emit_event") as mock_emit:
+                cg._write_consensus_report(project_dir, "design", result, scores)
+                # Find the report-created emit (there should be exactly one).
+                report_calls = [c for c in mock_emit.call_args_list
+                                if c.args and c.args[0] == "wicked.consensus.report_created"]
+                self.assertEqual(len(report_calls), 1,
+                                 f"expected one report emit, got {len(report_calls)}")
+                payload = report_calls[0].args[1]
+                self.assertEqual(payload["project_id"], "demo-proj")
+                self.assertEqual(payload["phase"], "design")
+                self.assertEqual(payload["decision"], "APPROVE")
+                self.assertAlmostEqual(payload["agreement_ratio"], 0.92)
+                self.assertEqual(report_calls[0].kwargs.get("chain_id"),
+                                 "demo-proj.design")
+
+    def test_evidence_emit_after_successful_write(self):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            from crew import consensus_gate as cg
+            consensus_result = {
+                "result": "REJECT",
+                "reason": "agreement below threshold",
+                "consensus_confidence": 0.4,
+                "agreement_ratio": 0.45,
+                "dissenting_views": [],
+                "participants": ["rev-a", "rev-b"],
+            }
+            import _bus  # type: ignore[import]
+            with patch.object(_bus, "emit_event") as mock_emit:
+                cg._write_consensus_evidence(project_dir, "review", consensus_result)
+                evidence_calls = [c for c in mock_emit.call_args_list
+                                  if c.args and c.args[0] == "wicked.consensus.evidence_recorded"]
+                self.assertEqual(len(evidence_calls), 1)
+                payload = evidence_calls[0].args[1]
+                self.assertEqual(payload["project_id"], "demo-proj")
+                self.assertEqual(payload["phase"], "review")
+                self.assertEqual(payload["result"], "REJECT")
+                self.assertEqual(evidence_calls[0].kwargs.get("chain_id"),
+                                 "demo-proj.review")
+
+    def test_evidence_no_emit_when_write_fails(self):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp) / "demo-proj"
+            project_dir.mkdir()
+            from crew import consensus_gate as cg
+            consensus_result = {"result": "REJECT", "reason": "x"}
+            with patch("crew.consensus_gate.Path.write_text",
+                       side_effect=OSError("disk full")):
+                import _bus  # type: ignore[import]
+                with patch.object(_bus, "emit_event") as mock_emit:
+                    cg._write_consensus_evidence(project_dir, "review", consensus_result)
+                    evidence_calls = [c for c in mock_emit.call_args_list
+                                      if c.args and c.args[0] == "wicked.consensus.evidence_recorded"]
+                    self.assertEqual(evidence_calls, [],
+                                     "must not emit when disk write failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Part C of #734** — adds the 3 emit additions the audit (PR #735) identified as load-bearing-but-silent
- Each emit fires only after its underlying disk write succeeds — no orphan emits
- Each emit fail-opens — bus errors don't break the calling write path
- Adds the new event types to the bus-emit lint's pair-events list so the lint stops false-positive-warning on these writes in production
- **Closes the #732 umbrella** for this release cycle (step 3 — TaskList + garden chain cutover — remains gated on PR #690 reconciler drift data per council C2)

## Why this exists

PR #735 audit identified the 5 highest-risk silent-write call sites. Part B (#737) added the lint that warns on orphan writes to those targets. But until the writes actually emit, the lint would warn on every legitimate `dispatch-log.jsonl` and `consensus-report.json` write — eroding the lint's signal-to-noise. Part C adds the emits so the lint becomes correct in the steady state.

## Emit additions

### 1. `scripts/crew/dispatch_log.py append()`
- Event: `wicked.dispatch.log_entry_appended`
- Chain: `{project_id}.{phase}.{gate}`
- Fires after the JSONL line is on disk
- Pays off Part B lint immediately for `dispatch-log.jsonl` writes

### 2. `scripts/crew/consensus_gate.py _write_consensus_report()`
- Event: `wicked.consensus.report_created`
- Chain: `{project_id}.{phase}`
- Fires after `consensus-report.json` is written

### 3. `scripts/crew/consensus_gate.py _write_consensus_evidence()`
- Event: `wicked.consensus.evidence_recorded`
- Chain: `{project_id}.{phase}`
- Fires after `consensus-evidence.json` is written (rejection audit trail)

## Catalog updates

- **`scripts/_bus.py`** — added 3 entries to `BUS_EVENT_MAP` under `crew.dispatch` and `crew.consensus` subdomains. **Required**: `emit_event` silently no-ops on unregistered event types, so without these the emits would never fire.
- **`hooks/scripts/pre_tool.py`** — added the 3 new event types to `_BUS_EMIT_LINT_PAIR_EVENTS` so the lint correctly recognizes them as pairing for `dispatch-log.jsonl`, `consensus-report.json`, and `consensus-evidence.json` writes.

## Test plan

- [x] 6 new unit tests (`tests/crew/test_emit_additions_part_c.py`):
  - dispatch emit fires after successful append (payload + chain assertions)
  - dispatch emit does NOT fire when disk write fails (no orphan emits — would corrupt projector with phantom dispatches)
  - dispatch emit failure does not propagate (fail-open; JSONL still on disk)
  - consensus report emit fires after successful write
  - consensus evidence emit fires after successful write
  - consensus evidence does NOT emit when disk write fails
- [x] **51 tests pass cross-suite** (Part B lint + resume_projector + new Part C). No regressions.

## What this closes

| Issue | Status |
|-------|--------|
| #732 (bus-as-truth umbrella) | Closes — all 3 staged sub-issues delivered for this release |
| #734 (resume projector + lint + emits) | Closes — Parts A, B, C all merged |
| #735 (audit) | Already closed in PR #735 |

Step 3 of #732 (full TaskList + garden chain cutover to projections) remains gated on PR #690 reconciler drift data per the council's C2 condition. Re-evaluate in ~2 weeks once drift telemetry has accumulated.

## Cross-references

- Closes #732, #734
- Built on #735 (audit), #736 (Part A), #737 (Part B)
- Decision memory: `bus-as-truth-event-sourced-crew-state.md`
- Gotcha memory: `sqlite-like-wildcard-escape-gotcha.md`
- Decision memory: `lint-fail-open-when-cannot-verify-decision.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)