### PR TITLE
feat(crew): #723 stack signals as factor inputs (no presets, no parallel state)

### DIFF
--- a/commands/smaht/briefing.md
+++ b/commands/smaht/briefing.md
@@ -81,8 +81,30 @@ Group events from the timeline by type:
 
 ### 4. Synthesize Briefing
 
+Before composing the briefing, name the **detected stack** back to the user
+so it is obvious wicked-garden has read the project shape (#723 — stack
+identity is a projection of the repo, never a hand-edited preset).
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/_stack_signals.py" \
+   "${PWD}" 2>/dev/null
+```
+
+If `language` is not `unknown`, include this single line at the top of the
+briefing (omit entirely when language is `unknown`):
+
+```
+Detected stack: {language} ({package_manager}, frameworks: {frameworks}). Archetype: {archetype}.
+```
+
+In JSON-mode briefings, surface the same projection under a top-level
+`detected_stack` field; do not invent a parallel state file.
+
 ```markdown
 ## Session Briefing ({days}d window)
+
+Detected stack: python (uv, frameworks: click). Archetype: code-repo.
 
 ### Recent Decisions
 {events from mem domain — decisions stored, patterns learned}

--- a/scenarios/crew/stack-signals-react-detected.md
+++ b/scenarios/crew/stack-signals-react-detected.md
@@ -1,0 +1,223 @@
+---
+name: stack-signals-react-detected
+title: Stack Signals — React App is Detected and Surfaced Through the Rubric
+description: A React + TypeScript repo is detected by `_stack_signals.detect_stack`, the 9-factor rubric absorbs the `has_ui` signal as a +1 band on `user_facing_impact`, and the briefing surface names "React" back to the user. No `presets/` directory and no `.wicked-garden/config.yml` are created.
+type: testing
+difficulty: intermediate
+estimated_minutes: 5
+---
+
+# Stack Signals — React App Detected (#723)
+
+This scenario asserts the reframe of #723: stack identity is a *projection*
+of the repo, absorbed by the 9-factor rubric as a small score adjustment.
+
+The pain being solved: when wicked-garden runs against a React app, the
+session should *name* React back to the user. The original framing wanted
+hand-curated `presets/` files; the reframe routes the same legibility win
+through the rubric the facilitator already runs.
+
+What this scenario verifies:
+
+1. `crew._stack_signals.detect_stack` correctly identifies React + TypeScript
+   from a `package.json` + `tsconfig.json` + `.tsx` file.
+2. `crew.factor_questionnaire._apply_stack_adjustments` bumps
+   `user_facing_impact` exactly one band toward higher risk because
+   `has_ui=True`, capped at LOW.
+3. The briefing surface (used in the smaht briefing command) names
+   "React" back to the user via the additive `detected_stack` field.
+4. **No** `presets/` directory and **no** `.wicked-garden/config.yml`
+   are created — the rubric path replaces the preset path.
+
+## Setup
+
+```bash
+export TEST_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import tempfile
+print(tempfile.mkdtemp(prefix='wg-stack-react-'))
+")
+echo "TEST_DIR=${TEST_DIR}"
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, pathlib
+test_dir = pathlib.Path(os.environ['TEST_DIR'])
+
+(test_dir / "package.json").write_text(json.dumps({
+    "name": "react-demo",
+    "version": "0.1.0",
+    "dependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+    },
+    "devDependencies": {"typescript": "^5.0.0"},
+}, indent=2), encoding="utf-8")
+
+(test_dir / "tsconfig.json").write_text("{}", encoding="utf-8")
+
+src = test_dir / "src"
+src.mkdir()
+(src / "App.tsx").write_text(
+    "export const App = () => null;\n",
+    encoding="utf-8",
+)
+print(f"react demo project written at {test_dir}")
+PYEOF
+```
+
+**Expected**: `react demo project written at /…/wg-stack-react-…`
+
+## Step 1: detect_stack identifies React + TypeScript and sets has_ui=True
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from crew._stack_signals import detect_stack
+result = detect_stack('${TEST_DIR}')
+print(json.dumps(result, indent=2, sort_keys=True))
+assert result['language'] == 'typescript', f'language: {result[\"language\"]}'
+assert result['package_manager'] == 'npm', f'pm: {result[\"package_manager\"]}'
+assert 'react' in result['frameworks'], f'frameworks: {result[\"frameworks\"]}'
+assert result['has_ui'] is True, 'has_ui must be True for React + .tsx'
+assert result['has_api_surface'] is False, 'no api framework -> False'
+print('PASS: React + TypeScript stack detected with has_ui=True')
+"
+```
+
+**Expected**: `PASS: React + TypeScript stack detected with has_ui=True`
+
+## Step 2: rubric absorbs the signal as a +1 band on user_facing_impact
+
+This is the load-bearing reframe step: the rubric already drives every
+adaptive-rigor decision. The stack signal feeds *into* it rather than
+running a parallel preset selector.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from crew._stack_signals import detect_stack
+from crew.factor_questionnaire import score_all, _apply_stack_adjustments
+
+# Baseline: an all-no questionnaire response → all factors HIGH (safest).
+base = score_all({})
+assert base['user_facing_impact']['reading'] == 'HIGH', \
+    f'baseline must start HIGH, got {base[\"user_facing_impact\"][\"reading\"]}'
+
+stack = detect_stack('${TEST_DIR}')
+adjusted, audit = _apply_stack_adjustments(base, stack)
+
+# +1 band toward higher risk: HIGH -> MEDIUM (cap at LOW).
+assert adjusted['user_facing_impact']['reading'] == 'MEDIUM', (
+    f'expected +1 band to MEDIUM, got {adjusted[\"user_facing_impact\"][\"reading\"]}'
+)
+
+# Audit trail must record the adjustment so reviewers can see *why*.
+ufi_audit = [e for e in audit if e['factor'] == 'user_facing_impact']
+assert ufi_audit, f'audit trail empty; got: {audit}'
+assert ufi_audit[0]['adjustment'] == '+1'
+assert ufi_audit[0]['reason'] == 'stack:has_ui'
+assert ufi_audit[0]['from'] == 'HIGH'
+assert ufi_audit[0]['to'] == 'MEDIUM'
+assert ufi_audit[0]['capped'] is False
+
+print('PASS: user_facing_impact bumped HIGH -> MEDIUM with audit reason stack:has_ui')
+"
+```
+
+**Expected**: `PASS: user_facing_impact bumped HIGH -> MEDIUM with audit reason stack:has_ui`
+
+## Step 3: archetype_detect carries detected_stack so the briefing can name it
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from crew.archetype_detect import detect_archetype
+
+result = detect_archetype({
+    'files': ['package.json', 'tsconfig.json', 'src/App.tsx'],
+    'project_dir': '${TEST_DIR}',
+})
+
+# detected_stack is purely additive — archetype enum is unchanged.
+assert 'detected_stack' in result, 'detected_stack field missing'
+stack = result['detected_stack']
+assert stack['language'] == 'typescript', f'language: {stack[\"language\"]}'
+assert 'react' in stack['frameworks'], f'frameworks: {stack[\"frameworks\"]}'
+assert stack['has_ui'] is True
+
+# The briefing-style line that should be named back to the user.
+line = (
+    f\"Detected stack: {stack['language']} ({stack['package_manager']}, \"
+    f\"frameworks: {', '.join(stack['frameworks'])}). \"
+    f\"Archetype: {result['archetype']}.\"
+)
+print(line)
+assert 'react' in line.lower(), 'briefing line must name React back to the user'
+print('PASS: briefing names React back to the user')
+"
+```
+
+**Expected** (last two lines):
+
+```
+Detected stack: typescript (npm, frameworks: react, react-dom). Archetype: code-repo.
+PASS: briefing names React back to the user
+```
+
+## Step 4: NO presets/ directory and NO .wicked-garden/config.yml are created
+
+The reframe explicitly forbids parallel state. This step asserts that
+running detection does not create those forbidden surfaces — they would
+have been the symptoms of the original framing.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import pathlib
+test_dir = pathlib.Path('${TEST_DIR}')
+
+forbidden = [
+    test_dir / 'presets',
+    test_dir / '.wicked-garden' / 'config.yml',
+    test_dir / '.wicked-garden' / 'config.yaml',
+    test_dir / 'wicked-garden.yml',
+]
+for path in forbidden:
+    assert not path.exists(), (
+        f'forbidden parallel-state file appeared: {path} — '
+        'the reframe requires zero new state surfaces'
+    )
+
+# Also guard against the .wicked-garden directory itself being silently
+# created (it would be a regression toward parallel state).
+assert not (test_dir / '.wicked-garden').exists(), (
+    '.wicked-garden/ directory created — stack detection must be a '
+    'projection, never a persisted artifact'
+)
+
+print('PASS: no presets/ dir, no .wicked-garden/config.yml — projection only')
+"
+```
+
+**Expected**: `PASS: no presets/ dir, no .wicked-garden/config.yml — projection only`
+
+## Success Criteria
+
+- [ ] `detect_stack` returns `language=typescript`, `has_ui=True`, `react` in frameworks
+- [ ] `_apply_stack_adjustments` bumps `user_facing_impact` HIGH -> MEDIUM with audit reason `stack:has_ui`
+- [ ] `detect_archetype` result carries `detected_stack` as an additive field (archetype enum unchanged)
+- [ ] Briefing-style line names "React" back to the user
+- [ ] No `presets/` directory created
+- [ ] No `.wicked-garden/config.yml` (or `.yaml`) file created
+- [ ] No `.wicked-garden/` directory created at all
+
+## Cleanup
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import os, shutil
+shutil.rmtree(os.environ['TEST_DIR'], ignore_errors=True)
+"
+unset TEST_DIR
+```

--- a/scripts/crew/_stack_signals.py
+++ b/scripts/crew/_stack_signals.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""_stack_signals.py — Stack-shape projection for the 9-factor rubric (#723).
+
+Detects language, package manager, frameworks, and surface flags (UI / API)
+from a project's manifest files. The result is a *projection* — read fresh
+on every call from disk. Never persisted, never cached, never written to a
+config file. Stack identity is not state; it is a derivation of the files
+already in the repo.
+
+Used by:
+  - scripts/crew/factor_questionnaire.py — bumps user_facing_impact when
+    has_ui is True, bumps blast_radius when has_api_surface is True. Caps
+    each adjustment at +1 band (HIGH -> MEDIUM -> LOW).
+  - scripts/crew/archetype_detect.py — adds detected_stack to the result so
+    callers can name the stack back to the user.
+  - smaht briefing surface — names the detected stack in plain English.
+
+Public API:
+    detect_stack(repo_root: Path) -> dict
+
+ETHOS alignment:
+  - Project shape determines ceremony — the rubric absorbs the shape, not
+    a hand-curated preset list.
+  - No new state surface — no .wicked-garden/config.yml, no presets/ dir.
+  - Fail-open — language=unknown on any error, never raises.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+# ---------------------------------------------------------------------------
+# Constants — no magic values (R3)
+# ---------------------------------------------------------------------------
+
+# Cap directory recursion depth to keep the scan cheap on large repos.
+# 3 levels covers project root + immediate package dirs (e.g. src/, packages/x/).
+MAX_SCAN_DEPTH = 3
+
+# Directories we never descend into — vendored or ignored content has no
+# bearing on the project's own stack identity.
+SKIP_DIR_NAMES: frozenset[str] = frozenset({
+    "node_modules",
+    "venv",
+    ".venv",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".pytest_cache",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+})
+
+# Frameworks recognised across ecosystems. Keep this list small and
+# focused — the value is in correctly identifying *that* a framework is
+# present, not in cataloguing every npm package.
+KNOWN_FRAMEWORKS: frozenset[str] = frozenset({
+    # JS/TS UI
+    "react", "react-dom", "vue", "svelte", "@angular/core", "next", "nuxt",
+    "remix", "solid-js", "preact",
+    # JS/TS API
+    "express", "fastify", "koa", "hapi", "@nestjs/core", "@hono/node-server", "hono",
+    # Python UI / API
+    "fastapi", "flask", "django", "starlette", "quart", "sanic", "tornado",
+    # Python CLI
+    "click", "typer", "argparse-manpage", "rich-cli", "fire",
+    # Go web
+    "gin", "echo", "fiber", "chi",
+    # Rust web
+    "actix-web", "axum", "rocket", "warp",
+    # Java web
+    "spring-boot", "spring-web",
+})
+
+UI_FRAMEWORKS: frozenset[str] = frozenset({
+    "react", "react-dom", "vue", "svelte", "@angular/core", "next", "nuxt",
+    "remix", "solid-js", "preact",
+})
+
+API_FRAMEWORKS: frozenset[str] = frozenset({
+    "express", "fastify", "koa", "hapi", "@nestjs/core", "@hono/node-server", "hono",
+    "fastapi", "flask", "django", "starlette", "quart", "sanic", "tornado",
+    "gin", "echo", "fiber", "chi",
+    "actix-web", "axum", "rocket", "warp",
+    "spring-boot", "spring-web",
+})
+
+UI_FILE_SUFFIXES: frozenset[str] = frozenset({".tsx", ".jsx"})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def detect_stack(repo_root: Path) -> Dict[str, Any]:
+    """Return a stack-shape projection for repo_root.
+
+    Args:
+        repo_root: Path to the project's root directory.
+
+    Returns:
+        {
+            "language":        "python" | "typescript" | "javascript" |
+                                "go" | "rust" | "java" | "unknown",
+            "package_manager": "uv" | "pip" | "npm" | "pnpm" | "yarn" |
+                                "go-mod" | "cargo" | "maven" | "unknown",
+            "frameworks":      sorted list[str] of detected framework keys,
+            "has_ui":          bool — UI framework present OR .tsx/.jsx in src/,
+            "has_api_surface": bool — API framework present in deps,
+            "signals": {
+                "files_seen": list[str] (relative paths, capped),
+                "deps_seen":  list[str] (raw dep keys observed),
+            },
+        }
+
+    Never raises — all errors collapse to language=unknown with empty signals.
+    """
+    try:
+        return _detect_stack_inner(Path(repo_root))
+    except Exception as exc:  # R4: surface the failure mode in signals
+        return _unknown_result(error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _unknown_result(error: str | None = None) -> Dict[str, Any]:
+    signals: Dict[str, List[str]] = {"files_seen": [], "deps_seen": []}
+    if error:
+        signals["files_seen"].append(f"error: {error}")
+    return {
+        "language": "unknown",
+        "package_manager": "unknown",
+        "frameworks": [],
+        "has_ui": False,
+        "has_api_surface": False,
+        "signals": signals,
+    }
+
+
+def _detect_stack_inner(repo_root: Path) -> Dict[str, Any]:
+    if not repo_root.exists() or not repo_root.is_dir():
+        return _unknown_result(error="repo_root does not exist or is not a directory")
+
+    files_seen: List[str] = []
+    deps_seen: Set[str] = set()
+    frameworks: Set[str] = set()
+
+    # Probe manifest files at the project root.
+    pyproject = repo_root / "pyproject.toml"
+    requirements = repo_root / "requirements.txt"
+    package_json = repo_root / "package.json"
+    tsconfig = repo_root / "tsconfig.json"
+    go_mod = repo_root / "go.mod"
+    cargo_toml = repo_root / "Cargo.toml"
+    pom_xml = repo_root / "pom.xml"
+    build_gradle_groovy = repo_root / "build.gradle"
+    build_gradle_kts = repo_root / "build.gradle.kts"
+
+    # Lockfiles influence package_manager selection.
+    uv_lock = repo_root / "uv.lock"
+    pnpm_lock = repo_root / "pnpm-lock.yaml"
+    yarn_lock = repo_root / "yarn.lock"
+    package_lock = repo_root / "package-lock.json"
+
+    # ---- Language + package manager precedence ----
+    # Python wins over JS/TS when both are present at the root, because
+    # pyproject.toml is always project-root in Python convention while
+    # package.json may belong to a frontend subdir of a Python project.
+    language = "unknown"
+    package_manager = "unknown"
+
+    if pyproject.exists():
+        language = "python"
+        package_manager = "uv" if uv_lock.exists() else "pip"
+        files_seen.append("pyproject.toml")
+        if uv_lock.exists():
+            files_seen.append("uv.lock")
+        py_deps = _read_python_deps(pyproject, requirements)
+        deps_seen.update(py_deps)
+    elif package_json.exists():
+        files_seen.append("package.json")
+        if tsconfig.exists():
+            language = "typescript"
+            files_seen.append("tsconfig.json")
+        else:
+            language = "javascript"
+        if pnpm_lock.exists():
+            package_manager = "pnpm"
+            files_seen.append("pnpm-lock.yaml")
+        elif yarn_lock.exists():
+            package_manager = "yarn"
+            files_seen.append("yarn.lock")
+        else:
+            package_manager = "npm"
+            if package_lock.exists():
+                files_seen.append("package-lock.json")
+        js_deps = _read_node_deps(package_json)
+        deps_seen.update(js_deps)
+    elif go_mod.exists():
+        language = "go"
+        package_manager = "go-mod"
+        files_seen.append("go.mod")
+    elif cargo_toml.exists():
+        language = "rust"
+        package_manager = "cargo"
+        files_seen.append("Cargo.toml")
+    elif pom_xml.exists() or build_gradle_groovy.exists() or build_gradle_kts.exists():
+        language = "java"
+        package_manager = "maven"
+        if pom_xml.exists():
+            files_seen.append("pom.xml")
+        if build_gradle_groovy.exists():
+            files_seen.append("build.gradle")
+        if build_gradle_kts.exists():
+            files_seen.append("build.gradle.kts")
+    elif requirements.exists():
+        # Bare requirements.txt without pyproject.toml → still python+pip.
+        language = "python"
+        package_manager = "pip"
+        files_seen.append("requirements.txt")
+        deps_seen.update(_read_python_deps(None, requirements))
+
+    # ---- Frameworks ----
+    for dep in deps_seen:
+        key = dep.lower().strip()
+        if key in KNOWN_FRAMEWORKS:
+            frameworks.add(key)
+
+    # ---- has_ui ----
+    has_ui = any(f in UI_FRAMEWORKS for f in frameworks)
+    if not has_ui:
+        # Walk src/ for .tsx/.jsx files (cheap — capped depth, skip vendors).
+        src_dir = repo_root / "src"
+        if src_dir.is_dir():
+            for ui_file in _walk_for_extensions(src_dir, UI_FILE_SUFFIXES, repo_root):
+                has_ui = True
+                files_seen.append(ui_file)
+                break  # one match is enough
+
+    # ---- has_api_surface ----
+    has_api_surface = any(f in API_FRAMEWORKS for f in frameworks)
+
+    return {
+        "language": language,
+        "package_manager": package_manager,
+        "frameworks": sorted(frameworks),
+        "has_ui": has_ui,
+        "has_api_surface": has_api_surface,
+        "signals": {
+            "files_seen": files_seen[:20],  # cap for sanity
+            "deps_seen": sorted(deps_seen)[:50],
+        },
+    }
+
+
+def _read_python_deps(pyproject: Path | None, requirements: Path) -> Set[str]:
+    """Extract dependency names from pyproject.toml + requirements.txt.
+
+    Best-effort regex parser — we want package *names* not full pinned
+    specs, and the stdlib does not ship a TOML parser before 3.11. Falls
+    back gracefully on anything it can't read.
+    """
+    deps: Set[str] = set()
+
+    if pyproject is not None and pyproject.exists():
+        try:
+            text = pyproject.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            text = ""
+
+        # [project.dependencies] = ["click>=8.0", "requests"]
+        # [tool.poetry.dependencies] table form: click = "^8.0"
+        deps.update(_extract_pep621_deps(text))
+        deps.update(_extract_poetry_deps(text))
+
+    if requirements.exists():
+        try:
+            for raw in requirements.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = raw.split("#", 1)[0].strip()
+                if not line:
+                    continue
+                # name[extras]==1.0 → name
+                m = re.match(r"^([A-Za-z0-9_.\-]+)", line)
+                if m:
+                    deps.add(m.group(1).lower())
+        except OSError:
+            pass
+
+    return deps
+
+
+def _extract_pep621_deps(toml_text: str) -> Set[str]:
+    """Best-effort PEP 621 [project] dependencies extractor."""
+    out: Set[str] = set()
+
+    # Find the [project] table body and look for dependencies = [ ... ].
+    proj = re.search(
+        r"^\[project\]\s*$(.*?)(?=^\[|\Z)",
+        toml_text,
+        re.DOTALL | re.MULTILINE,
+    )
+    if proj:
+        body = proj.group(1)
+        deps_block = re.search(
+            r"dependencies\s*=\s*\[(.*?)\]",
+            body,
+            re.DOTALL,
+        )
+        if deps_block:
+            for raw in re.findall(r'"([^"]+)"|\'([^\']+)\'', deps_block.group(1)):
+                spec = (raw[0] or raw[1]).strip()
+                m = re.match(r"^([A-Za-z0-9_.\-]+)", spec)
+                if m:
+                    out.add(m.group(1).lower())
+
+    # Optional dependencies: [project.optional-dependencies] table.
+    for tbl in re.finditer(
+        r"^\[project\.optional-dependencies\]\s*$(.*?)(?=^\[|\Z)",
+        toml_text,
+        re.DOTALL | re.MULTILINE,
+    ):
+        for arr in re.finditer(r"\[(.*?)\]", tbl.group(1), re.DOTALL):
+            for raw in re.findall(r'"([^"]+)"|\'([^\']+)\'', arr.group(1)):
+                spec = (raw[0] or raw[1]).strip()
+                m = re.match(r"^([A-Za-z0-9_.\-]+)", spec)
+                if m:
+                    out.add(m.group(1).lower())
+
+    return out
+
+
+def _extract_poetry_deps(toml_text: str) -> Set[str]:
+    """Best-effort Poetry [tool.poetry.dependencies] extractor."""
+    out: Set[str] = set()
+    poetry = re.search(
+        r"^\[tool\.poetry\.dependencies\]\s*$(.*?)(?=^\[|\Z)",
+        toml_text,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not poetry:
+        return out
+    for line in poetry.group(1).splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if not stripped or "=" not in stripped:
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key and key.lower() != "python":
+            out.add(key.lower())
+    return out
+
+
+def _read_node_deps(package_json: Path) -> Set[str]:
+    """Extract dependency keys from package.json (deps + devDeps + peerDeps)."""
+    deps: Set[str] = set()
+    try:
+        text = package_json.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return deps  # corrupt JSON → no deps detected, language stays detected
+
+    if not isinstance(data, dict):
+        return deps
+
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            for name in section.keys():
+                if isinstance(name, str):
+                    deps.add(name.lower())
+
+    return deps
+
+
+def _walk_for_extensions(
+    root: Path,
+    suffixes: frozenset[str],
+    repo_root: Path,
+) -> List[str]:
+    """Yield relative paths under root with matching suffixes, depth-capped.
+
+    Returns at most a handful — callers usually break on first hit. Skips
+    SKIP_DIR_NAMES so node_modules content cannot trip framework detection.
+    """
+    matches: List[str] = []
+    root = root.resolve()
+    repo_root = repo_root.resolve()
+
+    def _walk(current: Path, depth: int) -> None:
+        if depth > MAX_SCAN_DEPTH:
+            return
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            name = entry.name
+            if name in SKIP_DIR_NAMES:
+                continue
+            if name.startswith("."):
+                continue
+            try:
+                if entry.is_dir():
+                    _walk(entry, depth + 1)
+                elif entry.is_file() and entry.suffix.lower() in suffixes:
+                    try:
+                        rel = str(entry.relative_to(repo_root)).replace("\\", "/")
+                    except ValueError:
+                        rel = entry.name
+                    matches.append(rel)
+                    if len(matches) >= 5:
+                        return
+            except OSError:
+                continue
+
+    _walk(root, depth=0)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# CLI helper — useful for ad-hoc inspection and the scenario file
+# ---------------------------------------------------------------------------
+
+def _main(argv: List[str] | None = None) -> int:
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Print stack-shape projection for a project directory.",
+    )
+    parser.add_argument("repo_root", type=Path, help="Project root directory")
+    args = parser.parse_args(argv)
+    result = detect_stack(args.repo_root)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(_main())

--- a/scripts/crew/archetype_detect.py
+++ b/scripts/crew/archetype_detect.py
@@ -37,6 +37,18 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+# Stack-shape projection (#723). Imported lazily-tolerant: if the module is
+# absent for any reason the archetype result still ships, just without the
+# additive `detected_stack` field. Stack identity is a *projection*, never
+# persisted state.
+try:
+    from crew._stack_signals import detect_stack as _detect_stack  # type: ignore
+except Exception:  # pragma: no cover — optional dependency at runtime
+    try:
+        from _stack_signals import detect_stack as _detect_stack  # type: ignore
+    except Exception:
+        _detect_stack = None  # type: ignore
+
 # ---------------------------------------------------------------------------
 # Module-level constants
 # ---------------------------------------------------------------------------
@@ -543,6 +555,12 @@ def detect_archetype(
     try:
         return _detect_archetype_inner(project_dir, plan_path)
     except Exception as exc:
+        # Resolve a plausible stack-projection root from whatever raw input
+        # the caller passed, but never raise from this fallback branch.
+        if isinstance(project_dir, dict):
+            stack_root: "Path | str | None" = project_dir.get("project_dir") or "."
+        else:
+            stack_root = project_dir
         return {
             "archetype": "code-repo",
             "confidence": 0.3,
@@ -550,6 +568,7 @@ def detect_archetype(
             "priority_matched": 7,
             "fallback": True,
             "detector_version": DETECTOR_VERSION,
+            "detected_stack": _safe_detect_stack(stack_root),
         }
 
 
@@ -595,6 +614,8 @@ def _detect_archetype_inner(
         (6, "docs-only",             lambda: _detect_docs_only(files, plan_text, project_dir)),
     ]
 
+    detected_stack = _safe_detect_stack(project_dir)
+
     for priority, archetype, detector in checks:
         confidence, signals = detector()
         if confidence > 0.0:
@@ -605,6 +626,7 @@ def _detect_archetype_inner(
                 "priority_matched": priority,
                 "fallback": False,
                 "detector_version": DETECTOR_VERSION,
+                "detected_stack": detected_stack,
             }
 
     # Fallback: code-repo
@@ -616,7 +638,39 @@ def _detect_archetype_inner(
         "priority_matched": 7,
         "fallback": True,
         "detector_version": DETECTOR_VERSION,
+        "detected_stack": detected_stack,
     }
+
+
+def _safe_detect_stack(project_dir: "Path | str | None") -> Dict[str, Any]:
+    """Run the stack-shape projector with belt-and-braces guards.
+
+    The archetype detector is the gate-keeper for downstream phase routing,
+    so it must never raise. The stack signal is purely additive — return a
+    safe default on any error so the archetype path is unaffected.
+    """
+    if _detect_stack is None:
+        return {
+            "language": "unknown",
+            "package_manager": "unknown",
+            "frameworks": [],
+            "has_ui": False,
+            "has_api_surface": False,
+            "signals": {"files_seen": [], "deps_seen": []},
+        }
+    try:
+        if project_dir is None:
+            return _detect_stack(Path("."))
+        return _detect_stack(Path(project_dir) if not isinstance(project_dir, Path) else project_dir)
+    except Exception as exc:  # pragma: no cover — defensive
+        return {
+            "language": "unknown",
+            "package_manager": "unknown",
+            "frameworks": [],
+            "has_ui": False,
+            "has_api_surface": False,
+            "signals": {"files_seen": [f"error: {exc}"], "deps_seen": []},
+        }
 
 
 def _collect_project_files(project_dir: Path) -> List[str]:

--- a/scripts/crew/factor_questionnaire.py
+++ b/scripts/crew/factor_questionnaire.py
@@ -219,6 +219,123 @@ _RISK_INVERSION: Dict[Reading, str] = {
     "LOW": "high_risk",
 }
 
+# ---------------------------------------------------------------------------
+# Stack-shape adjustments (#723)
+#
+# Reframe of #723: stack identity is a *projection* — the rubric absorbs
+# stack signals as small score adjustments rather than carrying a separate
+# preset selector. Each adjustment moves the reading at most one band toward
+# higher risk; LOW (the riskiest band) is the cap. Adjustments are visible
+# in the rubric output so downstream reviewers can audit them.
+#
+# Band order from safest -> riskiest: HIGH -> MEDIUM -> LOW. MAX_BAND is LOW.
+# ---------------------------------------------------------------------------
+
+MAX_BAND: Reading = "LOW"
+
+# Bump table for +1 band (more risk). LOW saturates at LOW.
+_BUMP_ONE_BAND: Dict[Reading, Reading] = {
+    "HIGH": "MEDIUM",
+    "MEDIUM": "LOW",
+    "LOW": "LOW",
+}
+
+
+def _bump_one_band(reading: Reading) -> Reading:
+    """Move a reading one band toward higher risk, saturating at MAX_BAND."""
+    return _BUMP_ONE_BAND.get(reading, reading)
+
+
+def _apply_stack_adjustments(
+    scores: Dict[str, Dict],
+    detected_stack: Dict | None,
+) -> Tuple[Dict[str, Dict], list]:
+    """Apply +1-band rubric adjustments based on stack-shape projection.
+
+    Args:
+        scores: Output of ``score_all`` — outer key = factor name, value =
+                {"reading": ..., "risk_level": ..., "why": ...}.
+        detected_stack: The projection from ``crew._stack_signals.detect_stack``.
+                When None or missing keys, no adjustment is made.
+
+    Returns:
+        (adjusted_scores, audit_entries) — ``adjusted_scores`` is a deep copy
+        with bumped readings/risk_level/why entries; ``audit_entries`` is a
+        list of ``{"factor": str, "adjustment": "+1", "reason": str,
+        "from": Reading, "to": Reading}`` records suitable for inclusion in
+        the rubric output.
+
+    Adjustments applied:
+        - has_ui          -> user_facing_impact  +1 band (cap at LOW)
+        - has_api_surface -> blast_radius        +1 band (cap at LOW)
+
+    Each rule fires at most once. Multiple rules can apply to the same
+    factor in principle, but never to one factor at +2 — the per-factor
+    cap is +1 band per call. Stack identity is read fresh from disk on
+    every call; this function never persists or caches anything.
+    """
+    audit: list = []
+
+    # Defensive copy — never mutate the caller's dict.
+    adjusted: Dict[str, Dict] = {
+        name: dict(entry) for name, entry in scores.items()
+    }
+
+    if not detected_stack or not isinstance(detected_stack, dict):
+        return adjusted, audit
+
+    bumps: Tuple[Tuple[str, str, str], ...] = (
+        # (stack_flag, factor_name, audit_reason)
+        ("has_ui", "user_facing_impact", "stack:has_ui"),
+        ("has_api_surface", "blast_radius", "stack:has_api_surface"),
+    )
+
+    # Track which factors have already been bumped this call so we never
+    # apply +2 to a single factor even if a future bump rule overlaps.
+    already_bumped: set = set()
+
+    for flag, factor, reason in bumps:
+        if not detected_stack.get(flag):
+            continue
+        if factor in already_bumped:
+            continue
+        if factor not in adjusted:
+            # Caller passed partial scores; skip rather than raise.
+            continue
+
+        before: Reading = adjusted[factor].get("reading", "HIGH")  # type: ignore[assignment]
+        after = _bump_one_band(before)
+        if after == before:
+            # Already at MAX_BAND — record as a no-op so the audit shows
+            # the rule fired but the cap held.
+            audit.append({
+                "factor": factor,
+                "adjustment": "+1",
+                "reason": reason,
+                "from": before,
+                "to": after,
+                "capped": True,
+            })
+            already_bumped.add(factor)
+            continue
+
+        adjusted[factor]["reading"] = after
+        adjusted[factor]["risk_level"] = _RISK_INVERSION[after]
+        existing_why = adjusted[factor].get("why", "")
+        suffix = f"; {reason} +1 band ({before} -> {after})"
+        adjusted[factor]["why"] = f"{existing_why}{suffix}".lstrip("; ")
+        audit.append({
+            "factor": factor,
+            "adjustment": "+1",
+            "reason": reason,
+            "from": before,
+            "to": after,
+            "capped": False,
+        })
+        already_bumped.add(factor)
+
+    return adjusted, audit
+
 
 def score_all(answers: Dict[str, Dict[str, bool]]) -> Dict[str, Dict]:
     """Score all 9 factors from a nested answers dict.

--- a/scripts/crew/factor_questionnaire.py
+++ b/scripts/crew/factor_questionnaire.py
@@ -337,12 +337,25 @@ def _apply_stack_adjustments(
     return adjusted, audit
 
 
-def score_all(answers: Dict[str, Dict[str, bool]]) -> Dict[str, Dict]:
+def score_all(
+    answers: Dict[str, Dict[str, bool]],
+    *,
+    detected_stack: Dict | None = None,
+) -> Dict[str, Dict]:
     """Score all 9 factors from a nested answers dict.
 
     Args:
         answers: Outer key = factor name, inner key = question id, value = bool.
                  Missing factors default to empty (all-no).
+        detected_stack: Optional projection from
+            ``crew._stack_signals.detect_stack``. When provided, the helper
+            ``_apply_stack_adjustments`` runs after factor scoring and bumps
+            ``user_facing_impact`` by +1 band when ``has_ui`` is true and
+            ``blast_radius`` by +1 band when ``has_api_surface`` is true.
+            The audit trail of bumps is exposed via the ``_stack_audit``
+            key in the returned dict (sentinel name keeps it from colliding
+            with any future factor name). When ``None``, scoring behaves
+            exactly as it did before #723 — backward-compatible.
 
     Returns:
         Dict matching the factors block of output-schema.md:
@@ -353,11 +366,12 @@ def score_all(answers: Dict[str, Dict[str, bool]]) -> Dict[str, Dict]:
                 "why": "..."
             },
             ...
+            "_stack_audit": [...]   # only present when detected_stack passed
         }
         Existing consumers reading `reading` are unaffected. New consumers should
         prefer `risk_level` to avoid the direction-inversion footgun.
     """
-    result = {}
+    result: Dict[str, Dict] = {}
     for name, rubric in QUESTIONNAIRE.items():
         reading, why = score_factor(rubric, answers.get(name, {}))
         result[name] = {
@@ -365,6 +379,12 @@ def score_all(answers: Dict[str, Dict[str, bool]]) -> Dict[str, Dict]:
             "risk_level": _RISK_INVERSION[reading],
             "why": why,
         }
+    if detected_stack is not None:
+        # Stack-shape projection feeds the rubric. Adjustment is capped at
+        # +1 band per factor and audited in the returned _stack_audit key.
+        adjusted, audit = _apply_stack_adjustments(result, detected_stack)
+        adjusted["_stack_audit"] = audit  # type: ignore[assignment]
+        return adjusted
     return result
 
 

--- a/tests/crew/test_factor_questionnaire.py
+++ b/tests/crew/test_factor_questionnaire.py
@@ -871,3 +871,41 @@ def test_operational_risk_o5_saas_scale_full_signal_is_low():
         f"All-YES operational_risk must yield LOW; o5 contributes 2pts. "
         f"Got {reading!r}. Trace: {why}"
     )
+
+
+
+def test_score_all_wires_detected_stack_into_adjustments():
+    """The critical #740 review fix — score_all must call _apply_stack_adjustments.
+
+    Without this wiring the entire #723 feature was dead code: callers of
+    score_all() received un-adjusted scores even when stack signals were
+    present. This test asserts the wiring is in place by passing a
+    detected_stack with has_ui=True and verifying user_facing_impact moves.
+    """
+    import sys
+    from pathlib import Path
+    _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    from crew import factor_questionnaire as fq
+
+    # Empty answers → all factors at HIGH (safest reading).
+    base = fq.score_all({})
+    assert "user_facing_impact" in base
+    base_reading = base["user_facing_impact"]["reading"]
+
+    # Same answers, with detected_stack signaling has_ui=True. Adjustment
+    # should bump user_facing_impact by 1 band (HIGH -> MEDIUM).
+    detected = {"has_ui": True, "has_api_surface": False}
+    adjusted = fq.score_all({}, detected_stack=detected)
+    assert adjusted["user_facing_impact"]["reading"] != base_reading, (
+        "score_all did not apply _apply_stack_adjustments — feature is dead"
+    )
+
+    # Audit trail must be in the result so callers can observe what changed.
+    assert "_stack_audit" in adjusted
+    audit = adjusted["_stack_audit"]
+    assert any(e["factor"] == "user_facing_impact" for e in audit)
+
+    # Without detected_stack, no audit key is added (backward compat).
+    assert "_stack_audit" not in fq.score_all({})

--- a/tests/crew/test_stack_signals.py
+++ b/tests/crew/test_stack_signals.py
@@ -1,0 +1,414 @@
+"""tests/crew/test_stack_signals.py — Unit tests for _stack_signals (#723).
+
+Provenance: AC for #723 — stack signals as factor inputs (no presets,
+no parallel state). Detection is *per call*, never persisted.
+
+T1: deterministic — no randomness, no sleep, no network
+T2: no sleep-based sync
+T3: isolated — every test uses its own tempdir
+T4: single focus per test
+T5: descriptive names
+T6: each docstring cites its rationale
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# conftest.py in this directory inserts scripts/ into sys.path. Belt-and-braces
+# in case this file is collected before conftest runs in some harnesses.
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from crew import _stack_signals  # noqa: E402
+from crew._stack_signals import detect_stack  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_repo(files: dict) -> Path:
+    """Create a temp repo with {relative_path: content} files."""
+    tmp = Path(tempfile.mkdtemp(prefix="wg-stack-"))
+    for rel, content in files.items():
+        fp = tmp / rel
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content, encoding="utf-8")
+    return tmp
+
+
+PYPROJECT_CLICK = """\
+[project]
+name = "demo-cli"
+version = "0.1.0"
+dependencies = [
+    "click>=8.0",
+    "requests",
+]
+"""
+
+PACKAGE_JSON_REACT = """\
+{
+  "name": "react-demo",
+  "version": "0.1.0",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}
+"""
+
+PACKAGE_JSON_EXPRESS = """\
+{
+  "name": "node-api",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public API contract
+# ---------------------------------------------------------------------------
+
+def test_detect_stack_returns_required_keys():
+    """Result always carries the documented keys, even on an empty repo."""
+    tmp = _make_repo({})
+    result = detect_stack(tmp)
+    for key in ("language", "package_manager", "frameworks",
+                "has_ui", "has_api_surface", "signals"):
+        assert key in result, f"missing key: {key}"
+    assert "files_seen" in result["signals"]
+    assert "deps_seen" in result["signals"]
+
+
+def test_detect_stack_never_raises_on_missing_root():
+    """Vanishingly bad input collapses to language=unknown rather than raising."""
+    bogus = Path(tempfile.gettempdir()) / "wg-stack-does-not-exist-xyz123"
+    if bogus.exists():
+        bogus.rmdir()
+    result = detect_stack(bogus)
+    assert result["language"] == "unknown"
+    assert result["frameworks"] == []
+    assert result["has_ui"] is False
+    assert result["has_api_surface"] is False
+
+
+# ---------------------------------------------------------------------------
+# Per-stack detection
+# ---------------------------------------------------------------------------
+
+def test_python_cli_with_click_detected():
+    """pyproject.toml + click in deps -> language=python, framework=click, no UI/API."""
+    tmp = _make_repo({"pyproject.toml": PYPROJECT_CLICK})
+    result = detect_stack(tmp)
+    assert result["language"] == "python"
+    assert result["package_manager"] == "pip"  # no uv.lock
+    assert "click" in result["frameworks"]
+    assert result["has_ui"] is False
+    assert result["has_api_surface"] is False
+
+
+def test_python_with_uv_lock_uses_uv_package_manager():
+    """uv.lock present -> package_manager=uv (instead of pip)."""
+    tmp = _make_repo({
+        "pyproject.toml": PYPROJECT_CLICK,
+        "uv.lock": "# uv lockfile placeholder\n",
+    })
+    result = detect_stack(tmp)
+    assert result["language"] == "python"
+    assert result["package_manager"] == "uv"
+
+
+def test_web_react_typescript_detected():
+    """package.json with react + tsconfig.json + .tsx file -> ts + has_ui."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_REACT,
+        "tsconfig.json": "{}",
+        "src/App.tsx": "export const App = () => null;\n",
+    })
+    result = detect_stack(tmp)
+    assert result["language"] == "typescript"
+    assert result["package_manager"] == "npm"  # no pnpm/yarn lock
+    assert "react" in result["frameworks"]
+    assert result["has_ui"] is True
+    assert result["has_api_surface"] is False
+
+
+def test_node_express_api_detected():
+    """package.json with express -> has_api_surface=True."""
+    tmp = _make_repo({"package.json": PACKAGE_JSON_EXPRESS})
+    result = detect_stack(tmp)
+    assert result["language"] == "javascript"  # no tsconfig.json
+    assert result["package_manager"] == "npm"
+    assert "express" in result["frameworks"]
+    assert result["has_api_surface"] is True
+    assert result["has_ui"] is False
+
+
+def test_pnpm_lockfile_picked_over_yarn_and_npm():
+    """pnpm-lock.yaml -> package_manager=pnpm."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_REACT,
+        "tsconfig.json": "{}",
+        "pnpm-lock.yaml": "lockfileVersion: '6.0'\n",
+    })
+    result = detect_stack(tmp)
+    assert result["package_manager"] == "pnpm"
+
+
+def test_yarn_lockfile_picked_when_no_pnpm_lock():
+    """yarn.lock -> package_manager=yarn."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_EXPRESS,
+        "yarn.lock": "# yarn lockfile v1\n",
+    })
+    result = detect_stack(tmp)
+    assert result["package_manager"] == "yarn"
+
+
+def test_go_mod_detected():
+    """go.mod -> language=go, package_manager=go-mod."""
+    tmp = _make_repo({"go.mod": "module example.com/demo\ngo 1.21\n"})
+    result = detect_stack(tmp)
+    assert result["language"] == "go"
+    assert result["package_manager"] == "go-mod"
+
+
+def test_cargo_toml_detected():
+    """Cargo.toml -> language=rust, package_manager=cargo."""
+    tmp = _make_repo({"Cargo.toml": "[package]\nname = 'demo'\nversion = '0.1.0'\n"})
+    result = detect_stack(tmp)
+    assert result["language"] == "rust"
+    assert result["package_manager"] == "cargo"
+
+
+def test_pom_xml_detected_as_java_maven():
+    """pom.xml -> language=java, package_manager=maven."""
+    tmp = _make_repo({"pom.xml": "<project></project>"})
+    result = detect_stack(tmp)
+    assert result["language"] == "java"
+    assert result["package_manager"] == "maven"
+
+
+def test_build_gradle_detected_as_java():
+    """build.gradle -> language=java, package_manager=maven (gradle bucketed under maven)."""
+    tmp = _make_repo({"build.gradle": "plugins { id 'java' }\n"})
+    result = detect_stack(tmp)
+    assert result["language"] == "java"
+    assert result["package_manager"] == "maven"
+
+
+# ---------------------------------------------------------------------------
+# Empty / corrupt inputs
+# ---------------------------------------------------------------------------
+
+def test_empty_repo_returns_unknown():
+    """Empty repo -> language=unknown, all flags False, no frameworks."""
+    tmp = _make_repo({})
+    result = detect_stack(tmp)
+    assert result["language"] == "unknown"
+    assert result["package_manager"] == "unknown"
+    assert result["frameworks"] == []
+    assert result["has_ui"] is False
+    assert result["has_api_surface"] is False
+
+
+def test_corrupt_package_json_does_not_raise():
+    """Malformed JSON yields language=javascript (file present) with empty deps, no exception."""
+    tmp = _make_repo({"package.json": "{not valid json"})
+    result = detect_stack(tmp)
+    # language is still detected from the file's existence; deps come up empty.
+    assert result["language"] == "javascript"
+    assert result["frameworks"] == []
+    assert result["has_ui"] is False
+    assert result["has_api_surface"] is False
+
+
+# ---------------------------------------------------------------------------
+# Skipped directories
+# ---------------------------------------------------------------------------
+
+def test_node_modules_not_walked_for_ui_signal():
+    """A .tsx file inside node_modules/ must not trip has_ui."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_EXPRESS,  # express -> has_api_surface, no UI
+        "src/node_modules/some-pkg/Component.tsx": "export const x = 1;\n",
+    })
+    result = detect_stack(tmp)
+    assert result["has_ui"] is False, (
+        f"node_modules .tsx file should not be walked, got files_seen="
+        f"{result['signals']['files_seen']}"
+    )
+
+
+def test_venv_not_walked_for_ui_signal():
+    """A .tsx file inside .venv/ must not trip has_ui."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_EXPRESS,
+        "src/.venv/lib/Component.tsx": "export const x = 1;\n",
+    })
+    result = detect_stack(tmp)
+    assert result["has_ui"] is False
+
+
+# ---------------------------------------------------------------------------
+# Mixed-stack precedence — Python wins because pyproject.toml is canonical
+# project-root, while package.json frequently belongs to a frontend subdir.
+# ---------------------------------------------------------------------------
+
+def test_python_wins_over_node_when_both_at_root():
+    """pyproject.toml + package.json at the same root -> language=python."""
+    tmp = _make_repo({
+        "pyproject.toml": PYPROJECT_CLICK,
+        "package.json": PACKAGE_JSON_REACT,
+        "tsconfig.json": "{}",
+    })
+    result = detect_stack(tmp)
+    assert result["language"] == "python"
+    assert result["package_manager"] == "pip"
+    # React deps under a sibling package.json are intentionally ignored at
+    # this layer — the precedence rule is documented and deterministic.
+    assert "react" not in result["frameworks"]
+
+
+# ---------------------------------------------------------------------------
+# Bare requirements.txt support
+# ---------------------------------------------------------------------------
+
+def test_requirements_txt_only_detected_as_python_pip():
+    """A bare requirements.txt with click -> python+pip+click."""
+    tmp = _make_repo({"requirements.txt": "click==8.1.7\nrequests\n"})
+    result = detect_stack(tmp)
+    assert result["language"] == "python"
+    assert result["package_manager"] == "pip"
+    assert "click" in result["frameworks"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+def test_max_scan_depth_is_a_named_constant():
+    """No magic value: scan depth is a module-level named constant (R3)."""
+    assert isinstance(_stack_signals.MAX_SCAN_DEPTH, int)
+    assert _stack_signals.MAX_SCAN_DEPTH >= 1
+
+
+def test_skip_dir_names_includes_critical_vendors():
+    """SKIP_DIR_NAMES must always include node_modules, venv, .venv, .git."""
+    skip = _stack_signals.SKIP_DIR_NAMES
+    for name in ("node_modules", "venv", ".venv", ".git"):
+        assert name in skip, f"{name!r} missing from SKIP_DIR_NAMES"
+
+
+# ---------------------------------------------------------------------------
+# Integration with factor_questionnaire — the rubric absorbs stack signals
+# ---------------------------------------------------------------------------
+
+from crew.factor_questionnaire import (  # noqa: E402
+    score_all,
+    _apply_stack_adjustments,
+    MAX_BAND,
+)
+
+
+def test_apply_stack_adjustments_bumps_user_facing_impact_when_has_ui():
+    """has_ui=True -> user_facing_impact moves one band toward higher risk."""
+    base = score_all({})  # all factors HIGH (safest)
+    assert base["user_facing_impact"]["reading"] == "HIGH"
+    detected = {"has_ui": True, "has_api_surface": False}
+    adjusted, audit = _apply_stack_adjustments(base, detected)
+    assert adjusted["user_facing_impact"]["reading"] == "MEDIUM"
+    assert any(
+        e["factor"] == "user_facing_impact" and e["reason"] == "stack:has_ui"
+        for e in audit
+    )
+
+
+def test_apply_stack_adjustments_bumps_blast_radius_when_api_surface():
+    """has_api_surface=True -> blast_radius moves one band toward higher risk."""
+    base = score_all({})
+    detected = {"has_ui": False, "has_api_surface": True}
+    adjusted, audit = _apply_stack_adjustments(base, detected)
+    assert adjusted["blast_radius"]["reading"] == "MEDIUM"
+    assert any(e["reason"] == "stack:has_api_surface" for e in audit)
+
+
+def test_apply_stack_adjustments_caps_at_max_band():
+    """LOW reading stays LOW even with the bump rule active (cap at MAX_BAND)."""
+    base = score_all({})
+    # Manually push user_facing_impact to LOW to test saturation.
+    base["user_facing_impact"]["reading"] = "LOW"
+    base["user_facing_impact"]["risk_level"] = "high_risk"
+    detected = {"has_ui": True, "has_api_surface": False}
+    adjusted, audit = _apply_stack_adjustments(base, detected)
+    assert adjusted["user_facing_impact"]["reading"] == MAX_BAND
+    capped = [e for e in audit if e["factor"] == "user_facing_impact"]
+    assert capped and capped[0]["capped"] is True
+
+
+def test_apply_stack_adjustments_no_op_when_detected_stack_none():
+    """No projection -> no adjustment, empty audit."""
+    base = score_all({})
+    adjusted, audit = _apply_stack_adjustments(base, None)
+    assert adjusted == base
+    assert audit == []
+
+
+def test_apply_stack_adjustments_does_not_mutate_input():
+    """Input dict is never mutated (defensive copy)."""
+    base = score_all({})
+    snapshot_reading = base["user_facing_impact"]["reading"]
+    _apply_stack_adjustments(base, {"has_ui": True, "has_api_surface": True})
+    assert base["user_facing_impact"]["reading"] == snapshot_reading
+
+
+# ---------------------------------------------------------------------------
+# archetype_detect integration — the additive detected_stack field
+# ---------------------------------------------------------------------------
+
+from crew.archetype_detect import detect_archetype  # noqa: E402
+
+
+def test_archetype_detect_includes_detected_stack_field():
+    """detect_archetype result carries detected_stack as an additive projection."""
+    tmp = _make_repo({
+        "package.json": PACKAGE_JSON_REACT,
+        "tsconfig.json": "{}",
+        "src/App.tsx": "export const App = () => null;\n",
+    })
+    result = detect_archetype({"files": ["src/App.tsx", "package.json"], "project_dir": str(tmp)})
+    assert "detected_stack" in result
+    assert result["detected_stack"]["language"] == "typescript"
+    assert result["detected_stack"]["has_ui"] is True
+
+
+def test_archetype_detect_detected_stack_safe_on_bad_input():
+    """Even when archetype detection raises, detected_stack is present + correctly shaped.
+
+    The exact `language` value depends on what the fallback root resolves to
+    (None -> current working dir), so assert structural correctness rather
+    than a specific language value. The point is the field is *always there*
+    and is *always safe to read*.
+    """
+    result = detect_archetype(None)  # type: ignore[arg-type]
+    assert "detected_stack" in result
+    stack = result["detected_stack"]
+    for key in ("language", "package_manager", "frameworks",
+                "has_ui", "has_api_surface", "signals"):
+        assert key in stack, f"missing key in fallback detected_stack: {key}"
+    assert isinstance(stack["frameworks"], list)
+    assert isinstance(stack["has_ui"], bool)
+    assert isinstance(stack["has_api_surface"], bool)


### PR DESCRIPTION
## Summary

Implements the reframed solution negotiated for #723 — see the reframe comment: https://github.com/mikeparcewski/wicked-garden/issues/723#issuecomment-4363962241.

The original framing ("stack presets") collided with three ETHOS commitments — adaptive rigor over fixed presets, no parallel state surface, and the closed-list problem. This PR ships the alternative the comment proposed: stack signals are *projection inputs* to the existing 9-factor rubric. Stack identity is read fresh on every call. Zero new state surface.

## Load-bearing constraint

- Stack identity is a **projection** — never persisted, never cached, never written to a config file
- Zero new state surfaces
- **No** ` presets/` directory created (and tests assert it cannot be)
- **No** `.wicked-garden/config.yml` created (and tests assert it cannot be)
- The 9-factor rubric absorbs stack signals via small score adjustments capped at +1 band per factor

## What landed

### New files

- **`scripts/crew/_stack_signals.py`** — `detect_stack(repo_root)` returns `language` / `package_manager` / `frameworks` / `has_ui` / `has_api_surface` / `signals`. Stdlib-only. Cap scan depth at 3 levels. Skips `node_modules`, `.venv`, `venv`, `.git`, etc. Never raises — collapses to `language=unknown` on any error.
- **`tests/crew/test_stack_signals.py`** — 27 tests covering Python (uv/pip), TypeScript+React, JavaScript+Express, pnpm/yarn/npm precedence, Go, Rust, Java, empty repo, corrupt JSON, `node_modules` exclusion, mixed-stack precedence (Python wins because pyproject.toml is canonical project-root), `_apply_stack_adjustments` +1-band bumps + saturation at MAX_BAND, no-mutation invariant, and `archetype_detect` integration.
- **`scenarios/crew/stack-signals-react-detected.md`** — end-to-end walkthrough proving React is detected, the rubric absorbs `has_ui` as +1 band on `user_facing_impact` (HIGH -> MEDIUM), the briefing names "React" back to the user, and **no** `presets/` or `.wicked-garden/config.yml` is created (asserted negatively).

### Modified files

- **`scripts/crew/archetype_detect.py`** — adds `detected_stack` field to the result. Purely additive: archetype enum and detection logic untouched. Defensive `_safe_detect_stack` wrapper guarantees the field is always present and well-shaped, even on the exception fallback path.
- **`scripts/crew/factor_questionnaire.py`** — adds `_apply_stack_adjustments(scores, detected_stack)` that bumps `user_facing_impact` when `has_ui` and `blast_radius` when `has_api_surface`. Each adjustment caps at +1 band (`HIGH -> MEDIUM -> LOW`); `LOW` saturates at `LOW`. Returns `(adjusted_scores, audit_entries)` so reviewers can audit *why* a band moved. Defensive copy — never mutates the caller's dict.
- **`commands/smaht/briefing.md`** — adds the legibility line at the top of the briefing: `Detected stack: {language} ({package_manager}, frameworks: {frameworks}). Archetype: {archetype}.`. Omitted when language is `unknown`. JSON-mode briefings get a parallel `detected_stack` field.

### Files explicitly NOT touched

- `hooks/scripts/pre_tool.py`
- `scripts/crew/resolve.py` (PR #739)
- `scripts/crew/conditions_manifest.py` (PR #739)
- `scripts/crew/guide.py` (parallel #725 PR)
- `scripts/_bus.py` (PR #739)
- `commands/crew/resolve.md` (PR #739)
- Any `presets/` directory (must NOT exist)
- Any `.wicked-garden/config.yml` (must NOT exist)

## Test plan

- [ ] `sh scripts/_python.sh -m pytest tests/crew/test_stack_signals.py -v` — 27/27 pass locally
- [ ] `sh scripts/_python.sh -m pytest tests/crew/` — 1224/1224 pass locally (no existing crew test broken)
- [ ] Walk through `scenarios/crew/stack-signals-react-detected.md` end-to-end in a temp dir
- [ ] Verify no `presets/` directory exists in the repo after merge
- [ ] Verify no `.wicked-garden/config.yml` exists in the repo after merge
- [ ] Spot-check that `detect_archetype` callers that ignore the new `detected_stack` field continue to work (backward-compat — additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)