### PR TITLE
feat(crew): #725 phase + archetype-aware guide filtering (curated frontmatter subset)

### DIFF
--- a/.claude/commands/wg-check.md
+++ b/.claude/commands/wg-check.md
@@ -489,6 +489,32 @@ echo "  disable-model-invocation: true — $dmi_true skills (user-only invocatio
 echo "  portability: portable — $portable skills (cross-platform compatible)"
 ```
 
+### 5d. Relevance Frontmatter (Issue #725 — context-aware crew:guide)
+
+Scan `commands/**/*.md` and `skills/**/*.md` for the `phase_relevance` and
+`archetype_relevance` frontmatter fields used by `crew:guide` to filter
+suggestions by current archetype + phase.
+
+**Mode**: warn-only this release. The reframe lands frontmatter on a CURATED
+15-command subset (the daily-driver list); the remaining ~225 commands/skills
+get filled in by a follow-up bulk-pass PR. Once that PR ships, set
+`WG_RELEVANCE_LINT=deny` as the default to fail CI on missing fields.
+
+**Env var**: `WG_RELEVANCE_LINT=warn|deny|off` (default `warn`).
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT:-.}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_relevance_frontmatter.py" 2>/dev/null \
+  || python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_relevance_frontmatter.py" 2>/dev/null \
+  || python "${CLAUDE_PLUGIN_ROOT:-.}/scripts/wg/check_relevance_frontmatter.py"
+```
+
+**Output shape**:
+
+- `OK: ...` when every command/skill declares both fields.
+- `WARN: missing relevance frontmatter — N files: a, b, c (and N more)` in
+  warn mode (exit 0).
+- `ERROR: ...` (exit 1) in deny mode — flips on after the bulk-pass PR.
+
 ### 6. Capability-Based Discovery Compliance
 
 Skills should discover integrations by capability, not hardcoded tool names.
@@ -1061,6 +1087,7 @@ a short "TODO: implement" body) and replace it in the follow-up.
 | Agent description budget (≤600 chars) | ✓/⚠ |
 | Skill portability compliance | ✓/✗ |
 | Skill invocation control audit | ✓/info |
+| Relevance frontmatter (#725) | ✓/⚠ |
 | Specialist schema | ✓/✗/- |
 | Capability compliance | ✓/✗ |
 | Implementation rationalization | ✓/✗ |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Then start a project:
 
 The plugin detects your stack, assembles specialists, and runs enforced phases. wicked-testing must be installed for test and review phases to work.
 
+### Start here
+
+Use `/wicked-garden:crew:guide` once a project is active — it ranks "what to do next" against the current phase + detected archetype. With no active project, `/wicked-garden:help` lists every command. Discovery is context-aware via `crew:guide`, not a curated subset.
+
 ## What's the relationship with wicked-testing?
 
 wicked-garden orchestrates the full SDLC — crew workflow, phase management, gate enforcement, memory, and context assembly. wicked-testing is a separate peer plugin that owns all QE behavior: test planning, authoring, execution, and review. The two communicate through a stable public contract (agent `subagent_type` names, bus events, and an evidence manifest schema). wicked-garden's crew gate dispatches QE agents by their `wicked-testing:*` subagent names and subscribes to `wicked.verdict.recorded` for results. You can use wicked-testing independently on projects that don't use wicked-garden's crew workflow. See the [wicked-garden integration guide](https://github.com/mikeparcewski/wicked-testing/blob/main/docs/WICKED-GARDEN.md) for the full contract.

--- a/commands/crew/approve.md
+++ b/commands/crew/approve.md
@@ -1,6 +1,8 @@
 ---
 description: Approve a phase and advance to next stage
 argument-hint: "<phase> [project-name] [--override-reviewer]"
+phase_relevance: ["clarify", "design", "build", "test", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:approve

--- a/commands/crew/execute.md
+++ b/commands/crew/execute.md
@@ -1,5 +1,7 @@
 ---
 description: Execute current phase work with adaptive role engagement
+phase_relevance: ["build", "test"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:execute

--- a/commands/crew/guide.md
+++ b/commands/crew/guide.md
@@ -1,6 +1,8 @@
 ---
 description: "Context-aware next-step suggestions — what should I do next? Stuck? Need next steps? Use this for context-aware command discovery."
 argument-hint: "[workspace]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:guide
@@ -11,6 +13,12 @@ and a one-line rationale. Use this when you are stuck, unsure what to run
 next, or want context-aware command discovery.
 
 > **Read-only** — this command never writes state.
+
+> **Context-aware (Issue #725)**: when an active crew project exists, the
+> suggestion list is filtered by the project's current phase + detected
+> archetype. With no active project, the bootstrap entry-point set surfaces
+> instead — derived from `phase_relevance: ["bootstrap"]` frontmatter, not a
+> hand-curated starter list.
 
 ## Instructions
 

--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -1,6 +1,8 @@
 ---
 description: Start a new wicked-crew project with outcome clarification
 argument-hint: "<project description>"
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:start

--- a/commands/crew/status.md
+++ b/commands/crew/status.md
@@ -1,5 +1,7 @@
 ---
 description: Show current project status, phase, and next steps
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:status

--- a/commands/engineering/review.md
+++ b/commands/engineering/review.md
@@ -1,6 +1,8 @@
 ---
 description: Code review with senior engineering perspective on quality, patterns, and maintainability
 argument-hint: "[file or directory path] [--focus security|performance|patterns|tests] [--scenarios] [--persona <name>]"
+phase_relevance: ["build", "review"]
+archetype_relevance: ["code-repo", "schema-migration", "config-infra"]
 ---
 
 # /wicked-garden:engineering:review

--- a/commands/help.md
+++ b/commands/help.md
@@ -1,5 +1,7 @@
 ---
 description: Show all available wicked-garden domains and commands
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:help

--- a/commands/jam/quick.md
+++ b/commands/jam/quick.md
@@ -1,6 +1,8 @@
 ---
 description: Quick exploration with fewer personas and one round
 argument-hint: "<idea or question>"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:quick

--- a/commands/persona/as.md
+++ b/commands/persona/as.md
@@ -1,6 +1,8 @@
 ---
 description: Invoke a named persona to perform a task with a specific perspective
 argument-hint: "<persona-name> <task description>"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:persona:as

--- a/commands/product/acceptance.md
+++ b/commands/product/acceptance.md
@@ -1,6 +1,8 @@
 ---
 description: Define acceptance criteria from requirements and design
 argument-hint: "<requirements/design path> [--story US-ID] [--feature name] [--format gherkin|table|markdown] [--scenarios]"
+phase_relevance: ["test", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:acceptance

--- a/commands/search/blast-radius.md
+++ b/commands/search/blast-radius.md
@@ -4,6 +4,8 @@ description: |
   dependencies (what this uses) and dependents (what uses this) via the graph index.
   NOT for full data lineage tracing (use search:lineage) or general code search (use wicked-brain:search).
 argument-hint: "<symbol> [--depth N]"
+phase_relevance: ["build", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:blast-radius

--- a/commands/search/hotspots.md
+++ b/commands/search/hotspots.md
@@ -1,6 +1,8 @@
 ---
 description: Find the most-referenced symbols in the codebase — classes, functions, and modules with the highest connectivity
 argument-hint: "[--limit <n>] [--layer <layer>] [--type <type>]"
+phase_relevance: ["build", "test", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:hotspots

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -2,6 +2,8 @@
 allowed-tools: ["AskUserQuestion", "Bash", "Read", "Write", "Skill", "Agent"]
 description: "Configure wicked-garden connection and onboard the current codebase"
 argument-hint: "[--reconfigure]"
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:setup

--- a/commands/where-am-i.md
+++ b/commands/where-am-i.md
@@ -2,6 +2,8 @@
 allowed-tools: ["Bash"]
 description: "Emit a compact path manifest (plugin, source, project, brain, bus) for the current session"
 argument-hint: "[--fence] [--env]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:where-am-i

--- a/scenarios/crew/guide-phase-archetype-filter.md
+++ b/scenarios/crew/guide-phase-archetype-filter.md
@@ -1,0 +1,211 @@
+---
+name: guide-phase-archetype-filter
+title: crew:guide — Phase + Archetype-Aware Filtering (Issue #725)
+description: Verify that crew:guide filters command suggestions by the active project's current phase + detected archetype, and falls back to the bootstrap entry-point set when no project is active.
+type: testing
+difficulty: intermediate
+estimated_minutes: 6
+---
+
+# crew:guide — Phase + Archetype-Aware Filtering (Issue #725)
+
+This scenario drives the new `filter_for_context` + `read_active_project_context`
++ `bootstrap_entry_points` surface added to `scripts/crew/guide.py`. It asserts
+the three reframe behaviours:
+
+1. With an active `docs-only` project on `build`, the filtered command set
+   excludes archetype-specific commands like `engineering:review` (declared
+   `archetype_relevance: ["code-repo", "schema-migration", "config-infra"]`).
+2. Switching the same project to `clarify` flips the relevant set to
+   clarify-tagged commands (`jam:quick`, `propose-process`).
+3. With no active project, `bootstrap_entry_points` returns commands tagged
+   `phase_relevance: ["bootstrap"]` — the entry-point set, derived from
+   frontmatter, not a hand-curated starter list.
+
+## Setup
+
+```bash
+export TEST_PROJECT="wg-scenario-guide-filter"
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export CLAUDE_PROJECT_NAME="wg-scenario-guide-filter"
+
+export PROJECT_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, shutil, sys
+sys.path.insert(0, os.path.join(os.environ['PLUGIN_ROOT'], 'scripts'))
+from _paths import get_local_path
+projects_root = get_local_path('wicked-crew', 'projects')
+project = os.environ['TEST_PROJECT']
+(projects_root / f"{project}.json").unlink(missing_ok=True)
+shutil.rmtree(projects_root / project, ignore_errors=True)
+project_dir = projects_root / project
+project_dir.mkdir(parents=True)
+data = {
+    "id": project,
+    "name": project,
+    "workspace": os.environ['CLAUDE_PROJECT_NAME'],
+    "current_phase": "build",
+    "archetype": "docs-only",
+    "phase_plan": ["clarify", "design", "build", "test", "review"],
+    "phases": {p: {"status": "pending"} for p in ["clarify", "design", "build", "test", "review"]},
+}
+(projects_root / f"{project}.json").write_text(json.dumps(data, indent=2))
+(project_dir / "project.json").write_text(json.dumps(data, indent=2))
+print(project_dir)
+PYEOF
+)
+echo "PROJECT_DIR=${PROJECT_DIR}"
+```
+
+**Expected**: `PROJECT_DIR=...` printed.
+
+## Step 1: docs-only + build → filtered set excludes archetype-locked commands
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_ROOT}', 'scripts'))
+os.environ['CLAUDE_PROJECT_NAME'] = '${CLAUDE_PROJECT_NAME}'
+
+from crew import guide
+
+ctx = guide.read_active_project_context()
+assert ctx is not None, 'expected active project context'
+assert ctx['archetype'] == 'docs-only', f'archetype={ctx[\"archetype\"]!r}'
+assert ctx['current_phase'] == 'build', f'phase={ctx[\"current_phase\"]!r}'
+
+commands = guide.read_command_metadata(os.path.join('${PLUGIN_ROOT}', 'commands'))
+filtered = guide.filter_for_context(
+    commands, phase=ctx['current_phase'], archetype=ctx['archetype']
+)
+ids = {c['id'] for c in filtered}
+
+# Wildcards must survive both filters.
+assert 'wicked-garden:help' in ids, 'help (wildcard/wildcard) should pass'
+assert 'wicked-garden:crew:guide' in ids, 'guide (wildcard/wildcard) should pass'
+# Build-tagged + wildcard archetype.
+assert 'wicked-garden:search:blast-radius' in ids, 'blast-radius (build, *) should pass'
+# Build-tagged but archetype excludes docs-only — must drop.
+assert 'wicked-garden:engineering:review' not in ids, 'engineering:review must drop on docs-only'
+# bootstrap-only commands must drop on build phase.
+assert 'wicked-garden:setup' not in ids, 'setup (bootstrap-only) must drop on build'
+print('PASS: docs-only + build filter excludes archetype-locked + bootstrap-only commands')
+"
+```
+
+**Expected**: `PASS: docs-only + build filter excludes archetype-locked + bootstrap-only commands`
+
+## Step 2: change phase to clarify → clarify-tagged commands surface
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, sys
+sys.path.insert(0, os.path.join(os.environ['PLUGIN_ROOT'], 'scripts'))
+from _paths import get_local_path
+projects_root = get_local_path('wicked-crew', 'projects')
+project = os.environ['TEST_PROJECT']
+data = json.loads((projects_root / f"{project}.json").read_text())
+data['current_phase'] = 'clarify'
+(projects_root / f"{project}.json").write_text(json.dumps(data, indent=2))
+(projects_root / project / "project.json").write_text(json.dumps(data, indent=2))
+print('phase flipped to clarify')
+PYEOF
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_ROOT}', 'scripts'))
+os.environ['CLAUDE_PROJECT_NAME'] = '${CLAUDE_PROJECT_NAME}'
+
+from crew import guide
+
+ctx = guide.read_active_project_context()
+assert ctx['current_phase'] == 'clarify', f'expected clarify, got {ctx[\"current_phase\"]!r}'
+
+commands = guide.read_command_metadata(os.path.join('${PLUGIN_ROOT}', 'commands'))
+filtered = guide.filter_for_context(
+    commands, phase=ctx['current_phase'], archetype=ctx['archetype']
+)
+ids = {c['id'] for c in filtered}
+
+# Clarify+design tagged.
+assert 'wicked-garden:jam:quick' in ids, 'jam:quick (clarify, design) should pass'
+# approve covers clarify.
+assert 'wicked-garden:crew:approve' in ids, 'crew:approve covers clarify'
+# Build-only tagged commands must drop now that phase is clarify.
+assert 'wicked-garden:search:blast-radius' not in ids, 'blast-radius (build, review) must drop on clarify'
+print('PASS: clarify phase surfaces jam:quick + crew:approve, drops build-only commands')
+"
+```
+
+**Expected**: `PASS: clarify phase surfaces jam:quick + crew:approve, drops build-only commands`
+
+## Step 3: no active project → bootstrap entry-point set
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, sys
+sys.path.insert(0, os.path.join(os.environ['PLUGIN_ROOT'], 'scripts'))
+from _paths import get_local_path
+projects_root = get_local_path('wicked-crew', 'projects')
+project = os.environ['TEST_PROJECT']
+# Mark the project complete so read_active_project_context returns None.
+data = json.loads((projects_root / f"{project}.json").read_text())
+data['current_phase'] = 'complete'
+(projects_root / f"{project}.json").write_text(json.dumps(data, indent=2))
+(projects_root / project / "project.json").write_text(json.dumps(data, indent=2))
+print('project marked complete')
+PYEOF
+
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_ROOT}', 'scripts'))
+os.environ['CLAUDE_PROJECT_NAME'] = '${CLAUDE_PROJECT_NAME}'
+
+from crew import guide
+
+ctx = guide.read_active_project_context()
+assert ctx is None, f'expected None on completed project, got {ctx!r}'
+
+commands = guide.read_command_metadata(os.path.join('${PLUGIN_ROOT}', 'commands'))
+entry_points = guide.bootstrap_entry_points(commands)
+ids = {c['id'] for c in entry_points}
+
+# Daily-driver bootstrap commands must surface.
+assert 'wicked-garden:setup' in ids, 'setup must be in bootstrap set'
+assert 'wicked-garden:crew:start' in ids, 'crew:start must be in bootstrap set'
+
+# Add skills to the source so propose-process is also visible to the entry point set.
+# Skill ids are path-derived: skills/propose-process/SKILL.md -> wicked-garden:propose-process:SKILL.
+skills_records = guide.read_command_metadata(os.path.join('${PLUGIN_ROOT}', 'skills'))
+skill_entry = guide.bootstrap_entry_points(skills_records)
+skill_ids = {c['id'] for c in skill_entry}
+assert any('propose-process' in sid for sid in skill_ids), \
+    f'propose-process skill must be in bootstrap set, got {sorted(skill_ids)!r}'
+
+print('PASS: no active project — bootstrap entry-point set surfaces setup + crew:start + propose-process')
+"
+```
+
+**Expected**: `PASS: no active project — bootstrap entry-point set surfaces setup + crew:start + propose-process`
+
+## Success Criteria
+
+- [ ] Step 1: `docs-only` + `build` filter excludes `engineering:review` and bootstrap-only commands.
+- [ ] Step 2: switching to `clarify` surfaces `jam:quick` + `crew:approve` and drops build-only commands.
+- [ ] Step 3: with the project marked complete, `bootstrap_entry_points` returns the entry-point set derived from frontmatter (no hand-curated list).
+
+## Cleanup
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import os, shutil, sys
+sys.path.insert(0, os.path.join(os.environ['PLUGIN_ROOT'], 'scripts'))
+from _paths import get_local_path
+projects_root = get_local_path('wicked-crew', 'projects')
+project = os.environ['TEST_PROJECT']
+(projects_root / f"{project}.json").unlink(missing_ok=True)
+shutil.rmtree(projects_root / project, ignore_errors=True)
+print('cleaned up')
+PYEOF
+
+unset TEST_PROJECT PROJECT_DIR PLUGIN_ROOT CLAUDE_PROJECT_NAME
+```

--- a/scripts/crew/guide.py
+++ b/scripts/crew/guide.py
@@ -412,18 +412,55 @@ def _parse_frontmatter_with_lists(text: str) -> dict:
     if not m:
         return out
     block = m.group(1)
-    for line in block.splitlines():
+    lines = block.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         kv = re.match(r"^([\w][\w_-]*):\s*(.*)$", line)
         if not kv:
+            i += 1
             continue
         key, raw = kv.group(1), kv.group(2).strip()
-        if raw.startswith("["):
+        if raw in ("|", ">"):
+            # YAML block scalar — collect indented continuation lines.
+            # Either folded (>) or literal (|); we treat both as plain
+            # text join since nothing in the schema needs the distinction.
+            val_lines: list = []
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                if not nxt.strip():
+                    val_lines.append("")
+                    i += 1
+                    continue
+                # Continuation lines must be indented more than the key.
+                # Bare "key: " in column 0 means the block ended.
+                if nxt[:1] in (" ", "\t"):
+                    val_lines.append(nxt.strip())
+                    i += 1
+                else:
+                    break
+            joined = "\n".join(val_lines).strip("\n")
+            if raw == ">":
+                # Folded scalar — collapse internal newlines to spaces.
+                joined = " ".join(s for s in joined.split("\n") if s)
+            out[key] = joined
+        elif raw.startswith("[") and raw.endswith("]"):
             out[key] = _parse_inline_list(raw)
         else:
             # Strip surrounding quotes for scalar string values.
             if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
                 raw = raw[1:-1]
             out[key] = raw
+            i += 1
+            continue
+        # When we handled a `|`/`>` block we already incremented i past
+        # the consumed lines; for the inline-list and scalar branches the
+        # ``continue`` above (or the lack of `i += 1` here for inline-list)
+        # would leave i unchanged, so handle that explicitly:
+        if raw in ("|", ">"):
+            continue  # i already advanced inside the block-scalar loop
+        i += 1
     return out
 
 
@@ -457,6 +494,13 @@ def read_command_metadata(commands_dir: Path) -> list[dict]:
 
     out: list[dict] = []
     for md in sorted(commands_dir.rglob("*.md")):
+        # Skip non-command documentation files. README.md, CHANGELOG.md,
+        # and underscore-prefixed files are not slash commands and would
+        # produce false-positive missing-relevance lint warnings.
+        if md.name in ("README.md", "CHANGELOG.md", "CONTRIBUTING.md"):
+            continue
+        if md.name.startswith("_"):
+            continue
         try:
             text = md.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/scripts/crew/guide.py
+++ b/scripts/crew/guide.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -52,6 +53,30 @@ _PYTHON_SH = Path(__file__).resolve().parents[1] / "_python.sh"
 _PHASE_ADVANCE_CMD = "/wicked-garden:crew:execute"
 _GATE_CMD = "/wicked-garden:crew:gate"
 _START_CMD = "/wicked-garden:crew:start <description>"
+
+# ---------------------------------------------------------------------------
+# Phase + archetype-aware filtering (Issue #725 reframe)
+# ---------------------------------------------------------------------------
+#
+# Each command may declare two relevance fields in its YAML frontmatter:
+#
+#     phase_relevance: ["build", "review"]      # crew phases this command fits
+#     archetype_relevance: ["code-repo", ...]   # archetypes this command fits
+#
+# The wildcard ``["*"]`` matches every value. Missing frontmatter does not drop
+# a command from the result — it's annotated with ``"missing-relevance"`` so
+# the gap surfaces instead of silently filtering useful commands away. A
+# wg-check lint warns on missing fields (warn-only this release; flips to deny
+# after the bulk-pass PR — see ``scripts/wg/check_relevance_frontmatter.py``).
+#
+# The bootstrap entry-point set is the union of commands tagged with
+# ``"bootstrap"`` in ``phase_relevance``. It's surfaced when no active crew
+# project exists, replacing the hand-curated "starter list" the issue
+# originally proposed.
+
+WILDCARD: str = "*"
+BOOTSTRAP_PHASE: str = "bootstrap"
+MISSING_RELEVANCE_ANNOTATION: str = "missing-relevance"
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +366,260 @@ def format_output(suggestions: list[dict]) -> str:
         lines.append(f"   {s['rationale']}")
         lines.append("")
     return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter scanner + relevance filters (Issue #725)
+# ---------------------------------------------------------------------------
+
+# Match commands/{domain}/{name}.md or commands/{name}.md and emit a
+# colon-namespaced id. Frontmatter parsing is intentionally tiny and stdlib —
+# the canonical pattern lives in hooks/scripts/pre_tool.py::_parse_frontmatter
+# but it doesn't decode list values, which we need here.
+
+_FRONTMATTER_BLOCK = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+_INLINE_LIST = re.compile(r"\[(.*?)\]")
+_QUOTED_TOKEN = re.compile(r"""['"]([^'"]+)['"]|([^,\s'"]+)""")
+
+
+def _parse_inline_list(raw: str) -> list[str]:
+    """Parse a YAML inline list like ``["a", "b", c]`` to ``["a", "b", "c"]``.
+
+    Returns ``[]`` if the value isn't an inline list. Multiline list syntax
+    (`- item\n- item`) is intentionally not supported here — relevance fields
+    are meant to be short and inline so they stay readable in frontmatter.
+    """
+    m = _INLINE_LIST.match(raw.strip())
+    if not m:
+        return []
+    body = m.group(1)
+    out: list[str] = []
+    for tok in _QUOTED_TOKEN.finditer(body):
+        value = tok.group(1) if tok.group(1) is not None else tok.group(2)
+        if value:
+            out.append(value.strip())
+    return out
+
+
+def _parse_frontmatter_with_lists(text: str) -> dict:
+    """Frontmatter parser that understands inline-list values.
+
+    Returns a dict where scalar fields stay as strings and inline-list fields
+    become ``list[str]``. Missing frontmatter returns an empty dict.
+    """
+    out: dict = {}
+    m = _FRONTMATTER_BLOCK.match(text)
+    if not m:
+        return out
+    block = m.group(1)
+    for line in block.splitlines():
+        kv = re.match(r"^([\w][\w_-]*):\s*(.*)$", line)
+        if not kv:
+            continue
+        key, raw = kv.group(1), kv.group(2).strip()
+        if raw.startswith("["):
+            out[key] = _parse_inline_list(raw)
+        else:
+            # Strip surrounding quotes for scalar string values.
+            if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+                raw = raw[1:-1]
+            out[key] = raw
+    return out
+
+
+def _command_id_from_path(path: Path, commands_root: Path) -> str:
+    """Build the colon-namespaced id from a commands/**.md path.
+
+    ``commands/setup.md`` → ``wicked-garden:setup``
+    ``commands/crew/start.md`` → ``wicked-garden:crew:start``
+    """
+    rel = path.relative_to(commands_root).with_suffix("")
+    return ":".join(("wicked-garden",) + rel.parts)
+
+
+def read_command_metadata(commands_dir: Path) -> list[dict]:
+    """Walk ``commands/**/*.md`` and return per-command metadata dicts.
+
+    Each entry has:
+        id: ``wicked-garden:domain:name`` (or ``wicked-garden:name`` at root)
+        path: absolute path to the .md file
+        description: scalar description string (empty if missing)
+        phase_relevance: list[str] | None (None when the field is absent)
+        archetype_relevance: list[str] | None (None when the field is absent)
+
+    The function never raises on individual file errors — bad frontmatter or
+    unreadable files are skipped, which matches the read-only inspector
+    contract of guide.py.
+    """
+    commands_dir = Path(commands_dir)
+    if not commands_dir.is_dir():
+        return []
+
+    out: list[dict] = []
+    for md in sorted(commands_dir.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        fm = _parse_frontmatter_with_lists(text)
+        out.append(
+            {
+                "id": _command_id_from_path(md, commands_dir),
+                "path": str(md),
+                "description": fm.get("description", "") or "",
+                "phase_relevance": (
+                    fm["phase_relevance"]
+                    if isinstance(fm.get("phase_relevance"), list)
+                    else None
+                ),
+                "archetype_relevance": (
+                    fm["archetype_relevance"]
+                    if isinstance(fm.get("archetype_relevance"), list)
+                    else None
+                ),
+            }
+        )
+    return out
+
+
+def _matches_value(declared: list[str] | None, target: str) -> tuple[bool, bool]:
+    """Return (included, missing) for a single command.
+
+    ``included``: True if the declared list matches ``target`` OR is wildcard.
+                  Also True when declared is None (so missing frontmatter
+                  doesn't silently drop the command — see annotation contract).
+    ``missing``:  True when the field is absent (declared is None). Lets
+                  callers attach a ``missing-relevance`` annotation instead of
+                  silently letting the command through unflagged.
+    """
+    if declared is None:
+        return True, True
+    if not declared:
+        return False, False
+    if WILDCARD in declared:
+        return True, False
+    return target in declared, False
+
+
+def filter_by_phase(commands: list[dict], phase: str) -> list[dict]:
+    """Return commands relevant to ``phase`` (wildcard + missing both pass).
+
+    Each returned dict is a shallow copy — callers may add an
+    ``annotations`` field (list[str]) without mutating the original record.
+    """
+    out: list[dict] = []
+    for cmd in commands:
+        included, missing = _matches_value(cmd.get("phase_relevance"), phase)
+        if not included:
+            continue
+        record = dict(cmd)
+        if missing:
+            existing = list(record.get("annotations") or [])
+            if MISSING_RELEVANCE_ANNOTATION not in existing:
+                existing.append(MISSING_RELEVANCE_ANNOTATION)
+            record["annotations"] = existing
+        out.append(record)
+    return out
+
+
+def filter_by_archetype(commands: list[dict], archetype: str) -> list[dict]:
+    """Return commands relevant to ``archetype`` (wildcard + missing both pass)."""
+    out: list[dict] = []
+    for cmd in commands:
+        included, missing = _matches_value(cmd.get("archetype_relevance"), archetype)
+        if not included:
+            continue
+        record = dict(cmd)
+        if missing:
+            existing = list(record.get("annotations") or [])
+            if MISSING_RELEVANCE_ANNOTATION not in existing:
+                existing.append(MISSING_RELEVANCE_ANNOTATION)
+            record["annotations"] = existing
+        out.append(record)
+    return out
+
+
+def filter_for_context(
+    commands: list[dict],
+    *,
+    phase: str | None,
+    archetype: str | None,
+) -> list[dict]:
+    """Combined phase × archetype filter.
+
+    Either filter is skipped when the corresponding argument is None — this is
+    the bootstrap path where archetype hasn't been picked yet. ``annotations``
+    accumulates across both filters when a command is missing both fields.
+    """
+    if phase is None and archetype is None:
+        return [dict(c) for c in commands]
+    result = list(commands)
+    if phase is not None:
+        result = filter_by_phase(result, phase)
+    if archetype is not None:
+        result = filter_by_archetype(result, archetype)
+    return result
+
+
+def bootstrap_entry_points(commands: list[dict]) -> list[dict]:
+    """Return the entry-point set: commands whose phase_relevance includes
+    ``"bootstrap"``.
+
+    This replaces the hand-curated starter list the original issue proposed.
+    The set is derived from frontmatter, not a separate JSON manifest, so the
+    catalog stays the single source of truth.
+    """
+    out: list[dict] = []
+    for cmd in commands:
+        phases = cmd.get("phase_relevance")
+        if isinstance(phases, list) and BOOTSTRAP_PHASE in phases:
+            out.append(dict(cmd))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Active project context (DomainStore-backed, hook-mode safe)
+# ---------------------------------------------------------------------------
+
+def read_active_project_context() -> dict | None:
+    """Return ``{"archetype": ..., "current_phase": ...}`` for the active
+    crew project, or ``None`` when no project is active in this workspace.
+
+    Mirrors the workspace-scoped lookup used by
+    ``hooks/scripts/pre_tool.py::_find_active_crew_project`` so guide and
+    pre_tool agree on which project counts as "active". DomainStore is opened
+    in ``hook_mode=True`` so this can be called from hot paths without
+    triggering integration discovery side-effects.
+    """
+    workspace = os.environ.get("CLAUDE_PROJECT_NAME") or Path.cwd().name
+    try:
+        from _domain_store import DomainStore  # noqa: WPS433 — local import keeps cold start cheap
+        ds = DomainStore("wicked-crew", hook_mode=True)
+        projects = ds.list("projects") or []
+    except Exception:
+        return None
+
+    for project in sorted(
+        projects,
+        key=lambda x: x.get("updated_at", x.get("created_at", "")),
+        reverse=True,
+    ):
+        if project.get("archived"):
+            continue
+        if workspace and project.get("workspace", "") != workspace:
+            continue
+        phase = project.get("current_phase", "")
+        if phase and phase not in ("complete", "done", ""):
+            archetype = project.get("archetype")
+            if not archetype:
+                metadata = project.get("metadata") or {}
+                archetype = metadata.get("archetype")
+            return {
+                "archetype": archetype,
+                "current_phase": phase,
+                "project_name": project.get("name", ""),
+            }
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/wg/check_relevance_frontmatter.py
+++ b/scripts/wg/check_relevance_frontmatter.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""scripts/wg/check_relevance_frontmatter.py — phase + archetype frontmatter lint.
+
+Scans ``commands/**/*.md`` and ``skills/**/*.md`` for the
+``phase_relevance`` and ``archetype_relevance`` fields introduced by the
+Issue #725 reframe (context-aware ``crew:guide``).
+
+Modes (env: ``WG_RELEVANCE_LINT``)
+  - ``warn`` (default for this release): emit a single WARN line listing the
+    first ``MAX_LISTED`` offending paths and exit 0. Allows the curated
+    15-command subset to land without forcing a 240-file bulk pass.
+  - ``deny``: same scan, but exit non-zero so CI fails. The next release flips
+    the default after the bulk-pass follow-up PR ships.
+  - ``off``: skip the scan entirely (rollback lever for emergencies).
+
+Why warn-only this release: the reframe ships frontmatter on a CURATED
+15-command subset (the daily-driver list). Bulk-editing the remaining ~225
+commands/skills is intentionally deferred to a follow-up PR so reviewers can
+audit one diff at a time. Once that PR lands, flip the default to ``deny``.
+
+R1: no dead code — every helper is called from main().
+R3: constants named (``MAX_LISTED``, ``ENV_MODE`` etc.).
+R4: errors surface — broken frontmatter prints a WARN, doesn't silently pass.
+R5: subprocess-free — pure stdlib, no external calls.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants  (R3)
+# ---------------------------------------------------------------------------
+
+ENV_MODE: str = "WG_RELEVANCE_LINT"
+MODE_WARN: str = "warn"
+MODE_DENY: str = "deny"
+MODE_OFF: str = "off"
+DEFAULT_MODE: str = MODE_WARN
+VALID_MODES: tuple[str, ...] = (MODE_WARN, MODE_DENY, MODE_OFF)
+MAX_LISTED: int = 5
+
+REQUIRED_FIELDS: tuple[str, ...] = ("phase_relevance", "archetype_relevance")
+
+# Repo root resolution: this file lives at scripts/wg/, so parents[2] is repo.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Frontmatter detector — same shape as scripts/crew/guide.py and
+# hooks/scripts/pre_tool.py. Kept inline so this stays stdlib-only.
+_FRONTMATTER_BLOCK = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+def _resolve_mode() -> str:
+    """Read the lint mode from the environment, defaulting to ``warn``.
+
+    Unknown values fall back to ``warn`` and emit a stderr notice — silent
+    drops would let typos turn lint into a no-op.
+    """
+    raw = (os.environ.get(ENV_MODE) or DEFAULT_MODE).strip().lower()
+    if raw not in VALID_MODES:
+        sys.stderr.write(
+            f"WARNING: {ENV_MODE}={raw!r} is not one of {VALID_MODES} — "
+            f"falling back to {DEFAULT_MODE!r}\n"
+        )
+        return DEFAULT_MODE
+    return raw
+
+
+def _has_field(text: str, field: str) -> bool:
+    """Return True if ``text`` declares ``field`` in its YAML frontmatter."""
+    m = _FRONTMATTER_BLOCK.match(text)
+    if not m:
+        return False
+    block = m.group(1)
+    pattern = re.compile(rf"^{re.escape(field)}\s*:", re.MULTILINE)
+    return bool(pattern.search(block))
+
+
+def _scan_one(path: Path) -> set[str]:
+    """Return the set of REQUIRED_FIELDS missing from ``path``."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # Unreadable file — surface every field as missing so it doesn't
+        # silently pass.
+        return set(REQUIRED_FIELDS)
+    return {f for f in REQUIRED_FIELDS if not _has_field(text, f)}
+
+
+def _iter_targets(repo_root: Path) -> list[Path]:
+    """Yield every ``commands/**/*.md`` and ``skills/**/*.md`` path."""
+    out: list[Path] = []
+    for sub in ("commands", "skills"):
+        root = repo_root / sub
+        if root.is_dir():
+            out.extend(sorted(root.rglob("*.md")))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    """Entry point — returns the process exit code.
+
+    Supports an optional ``--root <path>`` flag for tests; defaults to the
+    repo root inferred from this file's location.
+    """
+    repo_root = _REPO_ROOT
+    if "--root" in argv:
+        idx = argv.index("--root")
+        if idx + 1 < len(argv):
+            repo_root = Path(argv[idx + 1]).resolve()
+
+    mode = _resolve_mode()
+    if mode == MODE_OFF:
+        sys.stdout.write(f"OK: {ENV_MODE}=off — relevance frontmatter lint skipped\n")
+        return 0
+
+    targets = _iter_targets(repo_root)
+    offenders: list[Path] = []
+    for path in targets:
+        missing = _scan_one(path)
+        if missing:
+            offenders.append(path)
+
+    if not offenders:
+        sys.stdout.write(
+            "OK: every command/skill declares phase_relevance + archetype_relevance\n"
+        )
+        return 0
+
+    listed = ", ".join(
+        str(p.relative_to(repo_root)) for p in offenders[:MAX_LISTED]
+    )
+    suffix = "" if len(offenders) <= MAX_LISTED else f" (and {len(offenders) - MAX_LISTED} more)"
+    label = "ERROR" if mode == MODE_DENY else "WARN"
+    sys.stdout.write(
+        f"{label}: missing relevance frontmatter — {len(offenders)} files: "
+        f"{listed}{suffix}\n"
+    )
+    if mode == MODE_WARN:
+        sys.stdout.write(
+            f"NOTE: {ENV_MODE}={MODE_WARN} (warn-only this release; flips to "
+            f"{MODE_DENY!r} after the bulk-pass follow-up PR — Issue #725).\n"
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/skills/propose-process/SKILL.md
+++ b/skills/propose-process/SKILL.md
@@ -13,6 +13,8 @@ description: |
   initial task chain for `/wicked-garden:crew:start`, or invoked on `TaskCompleted` to
   prune / augment / re-tier the remaining chain. Also used by
   `/wicked-garden:crew:just-finish` (yolo mode) to drive autonomous completion.
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
 ---
 
 # Propose Process (Delegation Shim)

--- a/tests/crew/test_guide_filtering.py
+++ b/tests/crew/test_guide_filtering.py
@@ -305,3 +305,66 @@ def test_read_command_metadata_parses_inline_lists_and_id_namespace():
 def test_read_command_metadata_returns_empty_when_dir_missing():
     """AC: walking a non-existent directory returns ``[]`` (read-only contract)."""
     assert guide.read_command_metadata(Path("/nonexistent/wg-guide-test")) == []
+
+
+
+def test_frontmatter_parser_handles_multiline_block_scalar():
+    """#741 review fix: | and > YAML block scalars must be captured.
+
+    skills/propose-process/SKILL.md and others use ``description: |``
+    with the body on indented continuation lines. The simple-line
+    parser would have captured only the ``|`` literal, leaving
+    description empty and breaking guide rendering.
+    """
+    import sys
+    from pathlib import Path
+    _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    from crew.guide import _parse_frontmatter_with_lists
+
+    text = """---
+name: example
+description: |
+  This is a multi-line
+  description with two
+  paragraphs.
+phase_relevance: ["build"]
+---
+
+# body
+"""
+    fm = _parse_frontmatter_with_lists(text)
+    assert fm.get("name") == "example"
+    assert "multi-line" in fm.get("description", ""), (
+        f"block scalar parser failed; got: {fm.get('description')!r}"
+    )
+    assert "paragraphs" in fm.get("description", "")
+    assert fm.get("phase_relevance") == ["build"]
+
+
+def test_read_command_metadata_skips_readme_files(tmp_path):
+    """#741 review fix: rglob must not pick up README.md / CHANGELOG."""
+    import sys
+    from pathlib import Path
+    _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    from crew.guide import read_command_metadata
+
+    cmd_dir = tmp_path / "commands"
+    cmd_dir.mkdir()
+    (cmd_dir / "README.md").write_text("# README — not a command\n")
+    (cmd_dir / "CHANGELOG.md").write_text("# CHANGELOG\n")
+    (cmd_dir / "_internal.md").write_text("# internal\n")
+    (cmd_dir / "real-cmd.md").write_text(
+        "---\nname: real-cmd\ndescription: real\n---\n# Real command\n"
+    )
+
+    entries = read_command_metadata(cmd_dir)
+    ids = [e["id"] for e in entries]
+    assert "wicked-garden:real-cmd" in ids
+    for entry in entries:
+        assert "README" not in entry["id"]
+        assert "CHANGELOG" not in entry["id"]
+        assert "_internal" not in entry["id"]

--- a/tests/crew/test_guide_filtering.py
+++ b/tests/crew/test_guide_filtering.py
@@ -1,0 +1,307 @@
+"""tests/crew/test_guide_filtering.py — phase + archetype-aware guide filtering.
+
+Provenance: Issue #725 reframe — context-aware ``crew:guide`` (no starter mode).
+T1: deterministic — pure-function filters, no I/O beyond tempdir for the
+    metadata-walk test.
+T3: isolated — each metadata-walk test scopes to its own tempdir.
+T4: each test asserts one filter behaviour.
+T5: descriptive names — name encodes the relevance combination under test.
+T6: each docstring cites the AC it covers.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# conftest.py inserts scripts/ at sys.path[0] for `from crew import ...`.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from crew import guide  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Sample command catalog
+#
+# Mirrors the shape produced by ``read_command_metadata``: id + path +
+# description + phase_relevance + archetype_relevance. Records here use a
+# spread of declared-list / wildcard / missing-field combinations so each
+# branch of the matcher is covered by at least one test below.
+# ---------------------------------------------------------------------------
+
+def _record(
+    cid: str,
+    *,
+    phases: list[str] | None,
+    archetypes: list[str] | None,
+    description: str = "",
+) -> dict:
+    return {
+        "id": cid,
+        "path": f"/fake/{cid.replace(':', '_')}.md",
+        "description": description,
+        "phase_relevance": phases,
+        "archetype_relevance": archetypes,
+    }
+
+
+@pytest.fixture()
+def sample_commands() -> list[dict]:
+    return [
+        # Build-relevant in any archetype.
+        _record(
+            "wicked-garden:engineering:review",
+            phases=["build", "review"],
+            archetypes=["code-repo", "schema-migration"],
+        ),
+        # Bootstrap entry-point set (relevant when no project active).
+        _record(
+            "wicked-garden:setup",
+            phases=["bootstrap"],
+            archetypes=["*"],
+        ),
+        # Wildcard on both — always relevant.
+        _record(
+            "wicked-garden:help",
+            phases=["*"],
+            archetypes=["*"],
+        ),
+        # Build-only, archetype-specific.
+        _record(
+            "wicked-garden:search:blast-radius",
+            phases=["build", "review"],
+            archetypes=["*"],
+        ),
+        # Clarify-only.
+        _record(
+            "wicked-garden:jam:quick",
+            phases=["clarify", "design"],
+            archetypes=["*"],
+        ),
+        # Missing both fields entirely — must be retained with annotation.
+        _record(
+            "wicked-garden:legacy:undocumented",
+            phases=None,
+            archetypes=None,
+        ),
+        # Bootstrap + entry-point alongside crew start.
+        _record(
+            "wicked-garden:crew:start",
+            phases=["bootstrap"],
+            archetypes=["*"],
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AC: filter_by_phase
+# ---------------------------------------------------------------------------
+
+def test_filter_by_phase_returns_only_build_relevant_or_wildcard(sample_commands):
+    """AC: ``filter_by_phase("build", ...)`` keeps ``["build"]`` + ``["*"]`` + missing."""
+    result = guide.filter_by_phase(sample_commands, "build")
+    ids = {c["id"] for c in result}
+
+    assert "wicked-garden:engineering:review" in ids  # explicit build
+    assert "wicked-garden:search:blast-radius" in ids  # explicit build
+    assert "wicked-garden:help" in ids  # wildcard
+    assert "wicked-garden:legacy:undocumented" in ids  # missing → kept w/ annotation
+
+    # Negatives — these phases don't include build.
+    assert "wicked-garden:setup" not in ids  # bootstrap-only
+    assert "wicked-garden:crew:start" not in ids  # bootstrap-only
+    assert "wicked-garden:jam:quick" not in ids  # clarify+design
+
+
+def test_filter_by_phase_drops_non_matching_explicit_lists(sample_commands):
+    """AC: explicitly-declared lists that exclude the target phase are dropped."""
+    result = guide.filter_by_phase(sample_commands, "clarify")
+    ids = {c["id"] for c in result}
+
+    assert "wicked-garden:jam:quick" in ids  # clarify+design
+    assert "wicked-garden:engineering:review" not in ids  # build,review only
+    assert "wicked-garden:search:blast-radius" not in ids
+
+
+# ---------------------------------------------------------------------------
+# AC: filter_by_archetype
+# ---------------------------------------------------------------------------
+
+def test_filter_by_archetype_keeps_docs_only_or_wildcard(sample_commands):
+    """AC: ``filter_by_archetype("docs-only", ...)`` keeps wildcard + missing."""
+    result = guide.filter_by_archetype(sample_commands, "docs-only")
+    ids = {c["id"] for c in result}
+
+    # Wildcards survive any archetype.
+    assert "wicked-garden:help" in ids
+    assert "wicked-garden:setup" in ids
+    assert "wicked-garden:search:blast-radius" in ids
+
+    # engineering:review declares ["code-repo", "schema-migration"] — drop.
+    assert "wicked-garden:engineering:review" not in ids
+
+
+def test_archetype_wildcard_matches_every_archetype_filter(sample_commands):
+    """AC: ``["*"]`` matches every archetype filter, regardless of value."""
+    for archetype in ("code-repo", "docs-only", "config-infra", "schema-migration"):
+        result = guide.filter_by_archetype(sample_commands, archetype)
+        ids = {c["id"] for c in result}
+        assert "wicked-garden:help" in ids, archetype
+        assert "wicked-garden:setup" in ids, archetype
+
+
+# ---------------------------------------------------------------------------
+# AC: combined filter (intersection of phase + archetype)
+# ---------------------------------------------------------------------------
+
+def test_filter_for_context_intersects_phase_and_archetype(sample_commands):
+    """AC: combined filter is the AND of phase + archetype matchers."""
+    result = guide.filter_for_context(
+        sample_commands, phase="build", archetype="docs-only"
+    )
+    ids = {c["id"] for c in result}
+
+    # Wildcard survives both filters.
+    assert "wicked-garden:help" in ids
+    # Build wildcard archetype.
+    assert "wicked-garden:search:blast-radius" in ids
+    # Build but archetype excludes docs-only.
+    assert "wicked-garden:engineering:review" not in ids
+    # Clarify-only — fails phase filter.
+    assert "wicked-garden:jam:quick" not in ids
+
+
+def test_filter_for_context_keeps_code_repo_specific_command_in_build(sample_commands):
+    """AC: archetype-specific commands surface in their declared archetype."""
+    result = guide.filter_for_context(
+        sample_commands, phase="build", archetype="code-repo"
+    )
+    ids = {c["id"] for c in result}
+
+    assert "wicked-garden:engineering:review" in ids
+    assert "wicked-garden:search:blast-radius" in ids
+
+
+# ---------------------------------------------------------------------------
+# AC: missing frontmatter → annotated, NOT silently dropped
+# ---------------------------------------------------------------------------
+
+def test_missing_frontmatter_command_is_kept_with_annotation(sample_commands):
+    """AC: commands without relevance fields stay in results, tagged
+    ``missing-relevance``. Silently dropping would hide bugs."""
+    result = guide.filter_for_context(
+        sample_commands, phase="build", archetype="code-repo"
+    )
+    legacy = [c for c in result if c["id"] == "wicked-garden:legacy:undocumented"]
+
+    assert len(legacy) == 1
+    annotations = legacy[0].get("annotations") or []
+    assert guide.MISSING_RELEVANCE_ANNOTATION in annotations
+
+
+def test_missing_frontmatter_annotation_is_idempotent(sample_commands):
+    """AC: running both filters on a missing-field command emits the annotation
+    exactly once — no duplicates from chaining filter_by_phase + by_archetype."""
+    result = guide.filter_for_context(
+        sample_commands, phase="test", archetype="docs-only"
+    )
+    legacy = [c for c in result if c["id"] == "wicked-garden:legacy:undocumented"]
+
+    assert len(legacy) == 1
+    annotations = legacy[0].get("annotations") or []
+    assert annotations.count(guide.MISSING_RELEVANCE_ANNOTATION) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC: bootstrap entry-point set (no active project)
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_entry_points_returns_only_phase_bootstrap_commands(sample_commands):
+    """AC: bootstrap mode returns commands tagged ``phase_relevance: ["bootstrap"]``."""
+    result = guide.bootstrap_entry_points(sample_commands)
+    ids = {c["id"] for c in result}
+
+    assert ids == {"wicked-garden:setup", "wicked-garden:crew:start"}
+
+
+# ---------------------------------------------------------------------------
+# AC: empty input → empty result
+# ---------------------------------------------------------------------------
+
+def test_filter_on_empty_command_list_returns_empty():
+    """AC: empty input yields empty output across every entry point."""
+    assert guide.filter_by_phase([], "build") == []
+    assert guide.filter_by_archetype([], "code-repo") == []
+    assert guide.filter_for_context([], phase="build", archetype="code-repo") == []
+    assert guide.bootstrap_entry_points([]) == []
+
+
+# ---------------------------------------------------------------------------
+# read_command_metadata — frontmatter walker (small tempdir-backed test)
+# ---------------------------------------------------------------------------
+
+_SAMPLE_BUILD_REVIEW = """---
+description: "Sample build/review command"
+phase_relevance: ["build", "review"]
+archetype_relevance: ["code-repo"]
+---
+
+# /wicked-garden:sample:edit
+"""
+
+_SAMPLE_NO_FRONTMATTER = """# /wicked-garden:sample:legacy
+
+No frontmatter at all.
+"""
+
+_SAMPLE_DESCRIPTION_ONLY = """---
+description: "Has description, no relevance fields"
+---
+
+# /wicked-garden:sample:partial
+"""
+
+
+def test_read_command_metadata_parses_inline_lists_and_id_namespace():
+    """AC: ``read_command_metadata`` walks commands/**/*.md, parses inline-list
+    relevance fields, and emits ``wicked-garden:domain:name`` ids."""
+    with tempfile.TemporaryDirectory(prefix="wg-guide-fm-") as td:
+        commands_dir = Path(td) / "commands"
+        (commands_dir / "sample").mkdir(parents=True)
+        (commands_dir / "sample" / "edit.md").write_text(_SAMPLE_BUILD_REVIEW)
+        (commands_dir / "sample" / "legacy.md").write_text(_SAMPLE_NO_FRONTMATTER)
+        (commands_dir / "sample" / "partial.md").write_text(_SAMPLE_DESCRIPTION_ONLY)
+        (commands_dir / "root.md").write_text(_SAMPLE_BUILD_REVIEW)
+
+        records = guide.read_command_metadata(commands_dir)
+
+        by_id = {r["id"]: r for r in records}
+
+        # Domain-namespaced id.
+        edit = by_id["wicked-garden:sample:edit"]
+        assert edit["phase_relevance"] == ["build", "review"]
+        assert edit["archetype_relevance"] == ["code-repo"]
+        assert edit["description"] == "Sample build/review command"
+
+        # Root command (no domain).
+        assert "wicked-garden:root" in by_id
+
+        # No frontmatter → both relevance fields are None (not []).
+        legacy = by_id["wicked-garden:sample:legacy"]
+        assert legacy["phase_relevance"] is None
+        assert legacy["archetype_relevance"] is None
+
+        # Description present but relevance fields absent.
+        partial = by_id["wicked-garden:sample:partial"]
+        assert partial["description"] == "Has description, no relevance fields"
+        assert partial["phase_relevance"] is None
+        assert partial["archetype_relevance"] is None
+
+
+def test_read_command_metadata_returns_empty_when_dir_missing():
+    """AC: walking a non-existent directory returns ``[]`` (read-only contract)."""
+    assert guide.read_command_metadata(Path("/nonexistent/wg-guide-test")) == []


### PR DESCRIPTION
## Summary

Resolves #725 via the negotiated reframe documented at https://github.com/mikeparcewski/wicked-garden/issues/725#issuecomment-4363963216 — instead of a global "starter" mode that fights ETHOS in five places, extend the existing `crew:guide` to filter command suggestions by the active project's current phase + detected archetype, and surface a frontmatter-derived bootstrap entry-point set when no project is active.

- New filtering surface in `scripts/crew/guide.py`: `read_command_metadata`, `filter_by_phase`, `filter_by_archetype`, `filter_for_context`, `bootstrap_entry_points`, and `read_active_project_context`. Existing `build_suggestions` / `format_output` call sites untouched (backward compat).
- Curated 15-command subset gets `phase_relevance` + `archetype_relevance` frontmatter (the daily-driver list). Remaining ~225 commands/skills are intentionally deferred to a follow-up bulk-pass PR so reviewers can audit one diff at a time.
- New `scripts/wg/check_relevance_frontmatter.py` lint wired into `wg-check`. **Warn-only this release** (`WG_RELEVANCE_LINT=warn|deny|off`, default `warn`); flips to `deny` after the bulk-pass PR ships.
- README "Start here" points to `/wicked-garden:crew:guide` (in a project) and `/wicked-garden:help` (no project).

## What is NOT in this PR (per the reframe)

- No `/wicked-garden:starter` command.
- No `docs/starter-skills.json`.
- No 30-day promote/demote telemetry rule.
- No bulk frontmatter pass over the remaining ~225 commands/skills (deferred follow-up).

## Files changed

**Created**
- `tests/crew/test_guide_filtering.py` (12 tests, all pass)
- `scenarios/crew/guide-phase-archetype-filter.md`
- `scripts/wg/check_relevance_frontmatter.py`

**Modified**
- `scripts/crew/guide.py` — new functions only, existing API untouched
- `commands/crew/guide.md` — frontmatter + behaviour note
- 14 daily-driver commands/skills — frontmatter additions only
- `.claude/commands/wg-check.md` — wires the new lint
- `README.md` — "Start here" section (4 added lines)

## Deferred follow-up

A separate PR will run the bulk frontmatter pass over the remaining ~225 commands/skills, then flip `WG_RELEVANCE_LINT` default from `warn` to `deny`. Tracking under #725.

## Test plan

- [x] `sh scripts/_python.sh -m pytest tests/crew/test_guide_filtering.py -v` — 12/12 pass
- [x] `sh scripts/_python.sh -m pytest tests/crew/ -q` — 1209 pass, no regressions
- [x] Manual dry-run of all 3 scenario steps against a temp project (docs-only/build → clarify → no-project)
- [x] `sh scripts/_python.sh scripts/wg/check_relevance_frontmatter.py` — exits 0 in warn mode with WARN line listing missing files (398 → 383 after this PR's 15 additions)
- [x] `WG_RELEVANCE_LINT=deny` mode exits 1 with ERROR
- [x] `WG_RELEVANCE_LINT=off` mode exits 0 and skips
- [ ] CI: confirm `wg-check` surfaces the new section without regressing existing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)