### PR TITLE
feat(crew): #722 affected_repos advisory + sibling-plugin design note (no DAG, no worktrees)

### DIFF
--- a/agents/crew/process-facilitator.md
+++ b/agents/crew/process-facilitator.md
@@ -135,6 +135,28 @@ absorb scenario authoring into build. For each phase, emit: `name`, `why` (one s
 `archetype_detect.detect_archetype()` when available; see
 `skills/propose-process/refs/evidence-framing.md`.
 
+**Multi-repo guidance (Issue #722)**: when the selected archetype is
+`multi-repo`, do **not** model the work as a single crew project that
+spans repos. Instead:
+
+1. Open one crew project per repo and link them with a shared
+   `chain_id` prefix (e.g. `cross-feature-X.repo-foo.root`,
+   `cross-feature-X.repo-bar.root`). The bus's chain hierarchy is the
+   coordination surface — N siblings under one root, NOT a new write
+   store.
+2. Populate the optional `affected_repos: [string]` field on each
+   project's `process-plan.json` so `crew:status` and `smaht:briefing`
+   surface the multi-repo context as an advisory line. The field is
+   read-only metadata (no DAG, no worktree provisioning, no validation
+   beyond shape) — the facilitator picks the names; downstream
+   tooling renders them.
+3. For richer cross-repo workflow (worktree provisioning, merge-order
+   DAG, cross-repo evidence aggregation), point the user at
+   `docs/v9/sibling-plugin-monorepo.md`. That doc is the design brief
+   for the future `wicked-garden-monorepo` sibling v9 plugin; core crew
+   intentionally stays out of that machinery until a sibling-plugin
+   author signs up to build it.
+
 - `test_required` — bool. False only for pure docs, rename with no behavior change, or
   config flag flips with no new code paths.
 - `test_types` — subset of `{unit, integration, api, ui, acceptance, migration, security,

--- a/commands/crew/status.md
+++ b/commands/crew/status.md
@@ -54,6 +54,33 @@ Based on available plugins:
 - **Level 2**: Only wicked-brain (no specialized plugins)
 - **Level 1**: Standalone (no optional plugins)
 
+### 4b. Surface `affected_repos` (advisory, optional — Issue #722)
+
+If the active project's `process-plan.json` declares `affected_repos`,
+render a single advisory line. The helper script is fail-open: it
+prints nothing when the field is unset, missing, or malformed, so this
+block stays silent on every legacy project.
+
+```bash
+# Resolve the project dir from find-active output (Step 1) and pipe it
+# through the renderer. Empty output → nothing to display.
+PROJECT_DIR="${project_dir}"  # from find-active --json above
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+   render --project-dir "${PROJECT_DIR}" 2>/dev/null
+```
+
+Render the output (when non-empty) as its own line above the Phase
+Progress table. Format is fixed (so downstream parsers can match):
+
+```
+Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)
+```
+
+The full DAG-of-repos workflow (worktrees, merge ordering, cross-repo
+evidence) lives in the `wicked-garden-monorepo` sibling plugin — see
+the doc above for the design brief.
+
 ### 5. Display Status
 
 ```markdown

--- a/commands/smaht/briefing.md
+++ b/commands/smaht/briefing.md
@@ -167,6 +167,30 @@ Detected stack: {language} ({package_manager}, frameworks: {frameworks}). Archet
 In JSON-mode briefings, surface the same projection under a top-level
 `detected_stack` field; do not invent a parallel state file.
 
+**Affected repos (#722, advisory):** when the active project (or the one
+named via `--project`) carries an optional `affected_repos` list in its
+`process-plan.json`, surface it as a single advisory line directly under
+the `Detected stack:` line. The helper script below is fail-open: it
+prints NOTHING when the field is missing, empty, or malformed, so this
+block stays silent on every legacy project. The full DAG / worktrees /
+cross-repo evidence workflow lives in the `wicked-garden-monorepo`
+sibling plugin (see `docs/v9/sibling-plugin-monorepo.md`).
+
+```bash
+# Resolve the active project's directory the same way Step 4 does.
+# When PROJECT_DIR is empty (no active project), the helper still
+# accepts a missing path and stays silent.
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+   render --project-dir "${PROJECT_DIR:-/dev/null}" 2>/dev/null
+```
+
+Format (when non-empty):
+
+```
+Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)
+```
+
 ```markdown
 ## Session Briefing ({days}d window)
 

--- a/docs/v9/sibling-plugin-monorepo.md
+++ b/docs/v9/sibling-plugin-monorepo.md
@@ -1,0 +1,402 @@
+# wicked-garden-monorepo — Sibling Plugin Design Brief
+
+Issue: #722 (reframe — see jam analysis at
+<https://github.com/mikeparcewski/wicked-garden/issues/722#issuecomment-4364107563>)
+Status: **deferred** — no work started in core; this doc is the brief
+for a future sibling-plugin author. Demand criteria below.
+
+---
+
+## Why this is a sibling plugin
+
+Wicked-garden core stays small on purpose. From `ETHOS.md`:
+
+> **Local-first, graceful degradation, always works standalone.** Every
+> tool degrades cleanly when its dependencies are absent. No required
+> network calls, no required external services.
+>
+> **Not closed.** Third-party plugins integrate via the v9 drop-in
+> contract. Specialized domains belong in their own plugins, not in
+> wicked-garden core.
+
+The original framing of #722 added substantial new core surface — a
+`repos:` block on `process-plan`, a `multi_repo.py` module, a
+DAG validator, worktree lifecycle hooks, cross-repo evidence
+aggregation, a per-archetype gate-adjudicator extension. ~800–1200 LOC
+of always-on machinery, owned by core, paid for by every user, used by
+~2% of teams.
+
+The reframe (this doc) keeps wicked-garden core honest:
+
+1. Core ships an **advisory hint only** — the optional
+   `affected_repos: [string]` field on `process-plan.json`, surfaced as
+   one line in `crew:status` and `smaht:briefing`, plus a one-paragraph
+   nudge in the multi-repo archetype prompt. ~150 LOC, zero new failure
+   surfaces, fully backward-compatible.
+2. Cross-repo orchestration — the DAG, worktrees, merge ordering,
+   evidence aggregation — lives in **`wicked-garden-monorepo`**, a
+   sibling v9 plugin built when there is real demand. Until then, this
+   document is the design brief that keeps the option alive without
+   bloating core.
+
+The canonical sibling-plugin example is **wicked-testing**
+(`/Users/michael.parcewski/Projects/wicked-testing`). It demonstrates
+every contract beat: scope-stating manifest, v9 discovery-shape skill
+descriptions, optional bus/brain integration, no duplication of core
+or native tools. `wicked-garden-monorepo` should follow the same shape
+— see `docs/v9/drop-in-plugin-contract.md` for the full ruleset.
+
+---
+
+## Demand criteria — when to actually build it
+
+The plugin should be authored when **either** of:
+
+1. **Five or more user issues** ask for one of the deferred capabilities
+   (worktree provisioning, merge-order DAG, cross-repo evidence
+   aggregation, per-repo gate-adjudicator extension). Less than five →
+   the advisory hint plus per-repo crew sessions is doing the job.
+2. **A sibling-plugin author signs up** to own the plugin end-to-end
+   (write the code, maintain the discovery-shape skill descriptions,
+   keep the marketplace listing current). The drop-in contract requires
+   plugin authors, not wicked-garden maintainers, to own their plugin's
+   lifecycle.
+
+If neither holds, leave the advisory hint in place and revisit on the
+next major release. Premature plugin authoring is the same anti-pattern
+as premature core abstraction — both pay maintenance cost up front for
+hypothetical future demand.
+
+---
+
+## Architecture — bus-as-truth alignment
+
+The brain memory `bus-as-truth-event-sourced-crew-state` and PR #738
+(closed) established the load-bearing rule: crew state is event-sourced
+through wicked-bus chains, not synthesized into parallel write stores.
+A cross-repo project is the same shape as a single-repo project, just
+**N chain_id siblings under one root**:
+
+```
+root chain:    cross-feature-X.root
+              ├── repo-foo:  cross-feature-X.repo-foo.root
+              │              ├── cross-feature-X.repo-foo.clarify
+              │              ├── cross-feature-X.repo-foo.design
+              │              └── cross-feature-X.repo-foo.build
+              ├── repo-bar:  cross-feature-X.repo-bar.root
+              │              └── ...
+              └── repo-baz:  cross-feature-X.repo-baz.root
+                             └── ...
+```
+
+The plugin **MUST NOT** add a fourth write store. The bus event log
+already carries every artifact landing, gate verdict, and phase
+transition the plugin needs to coordinate across repos. The plugin's
+job is to shape, query, and aggregate those events — not to mirror
+them into a new database.
+
+This is the same rule wicked-testing follows: it owns its `.wicked-testing/`
+SQLite ledger for **operational** evidence (run records, scenario
+files), but **decisions, patterns, and gotchas** route through
+`wicked-brain:memory`. wicked-garden-monorepo's `repos.json` (described
+below) is operational state local to the plugin; cross-repo
+**decisions** still route through wicked-brain memory.
+
+---
+
+## Schema — repo DAG (full version, owned by the plugin)
+
+The plugin's `process-plan` extension upgrades the advisory
+`affected_repos: [string]` field that core ships into a richer
+`repos:` block. The plugin reads this block; core never touches it.
+
+```jsonc
+{
+  // ... all existing wicked-garden process-plan fields ...
+
+  // Advisory list — produced by the facilitator, read by core
+  // crew:status / smaht:briefing surfaces. Always present in
+  // multi-repo plans; the plugin's repos: block expands it.
+  "affected_repos": ["repo-foo", "repo-bar", "repo-baz"],
+
+  // Plugin-owned block. Core ignores this entirely.
+  "repos": {
+    "repo-foo": {
+      "url":          "git@github.com:org/repo-foo.git",
+      "default_branch": "main",
+      "worktree_path":  ".worktrees/repo-foo",   // resolved by the plugin
+      "merge_order":    1,                        // 1-based; lower lands first
+      "depends_on":     [],                       // names of repos that must
+                                                  // ship first (DAG edges)
+      "owns_artifacts": ["api-contract"],         // canonical-source repo for
+                                                  // these named artifacts
+      "rollback_plan":  "phases/build/rollback-foo.md"
+    },
+    "repo-bar": {
+      "url":          "git@github.com:org/repo-bar.git",
+      "default_branch": "main",
+      "worktree_path":  ".worktrees/repo-bar",
+      "merge_order":    2,
+      "depends_on":     ["repo-foo"],             // DAG edge
+      "owns_artifacts": [],
+      "rollback_plan":  "phases/build/rollback-bar.md"
+    },
+    "repo-baz": {
+      "url":          "git@github.com:org/repo-baz.git",
+      "default_branch": "main",
+      "worktree_path":  ".worktrees/repo-baz",
+      "merge_order":    2,
+      "depends_on":     ["repo-foo"],
+      "owns_artifacts": [],
+      "rollback_plan":  "phases/build/rollback-baz.md"
+    }
+  }
+}
+```
+
+DAG validation rules the plugin enforces (none of these belong in core):
+
+- Every key in `repos` MUST appear in `affected_repos` (and vice
+  versa) — no silent drift between the advisory list and the plugin's
+  block.
+- `depends_on` references MUST resolve to other keys in `repos` —
+  no dangling edges, no self-loops.
+- The DAG MUST be acyclic — cycles fail closed with a structured
+  error citing the offending edge.
+- `merge_order` MUST be consistent with `depends_on` (a repo cannot
+  have a lower merge_order than any of its dependencies) — the plugin
+  derives `merge_order` from `depends_on` if the field is omitted.
+- `owns_artifacts` entries MUST be unique across all repos — no two
+  repos own the same canonical artifact.
+
+---
+
+## Worktree lifecycle (plugin-owned)
+
+Worktree provisioning is a per-repo operation governed by the plugin:
+
+1. **Provision** — at the start of the build phase, the plugin walks
+   `repos[]`, runs `git -C {repo_url_clone} worktree add {worktree_path}`
+   for each entry, and emits
+   `wicked.multirepo.worktree.provisioned` per repo (with the active
+   crew `chain_id` so wicked-garden's chain-aware smaht scoring lights
+   up the events).
+2. **Track** — the plugin maintains `repos.json` under
+   `.wicked-garden-monorepo/repos.json` as **operational** state (the
+   wicked-testing equivalent of `.wicked-testing/evidence/`). This is
+   plugin-local; it does NOT shadow core's `process-plan.json`.
+3. **Conflict handling** — when a worktree's `git status` shows
+   uncommitted changes at provisioning time, the plugin fails closed
+   with an explicit error and a `wicked.multirepo.worktree.conflict`
+   event. No silent overwrite.
+4. **Cleanup** — at project archive (or explicit teardown command),
+   the plugin runs `git worktree remove {worktree_path}` for each
+   tracked repo and emits `wicked.multirepo.worktree.removed`.
+5. **Idempotency** — re-running provision MUST be safe. If a worktree
+   already exists at the expected path on the expected branch, the
+   plugin emits `wicked.multirepo.worktree.reused` instead of failing.
+
+See the brain memory `parallel-agent-rate-limit-collision-gotcha` —
+when the plugin fans out provisioning across N repos, it MUST throttle
+to avoid the same rate-limit collision wicked-garden's parallel
+dispatch path has tripped on before.
+
+---
+
+## Cross-repo merge ordering
+
+The plugin watches build-phase completions across the chain siblings
+and emits `wicked.multirepo.merge.ordered` events that **core crew
+consumes** as advisory hints. Core's behaviour:
+
+- When `wicked.multirepo.merge.ordered` arrives with the active chain's
+  `chain_id`, the chain-aware smaht events adapter scores it 0.8+ and
+  surfaces the advised next-merge repo in `crew:status`.
+- Core does NOT enforce the order — it surfaces the recommendation and
+  lets the user (or the plugin's own dispatch agent) act on it.
+- The plugin's merge-order policy lives entirely in the plugin: read
+  the DAG, watch build-completion events, emit the next-up repo.
+
+Event shape:
+
+```json
+{
+  "event_type": "wicked.multirepo.merge.ordered",
+  "chain_id":   "cross-feature-X.root",
+  "next_up":    "repo-foo",
+  "blocked_on": [],
+  "rationale":  "merge_order=1, depends_on=[]",
+  "ts":         "2026-05-02T12:00:00Z"
+}
+```
+
+---
+
+## Cross-repo evidence aggregation
+
+Evidence aggregation is the plugin's most distinctive value
+proposition — Claude cannot replicate it in three native tool calls
+(it requires a graph traversal over chain siblings). The plugin's
+evidence skill:
+
+1. Reads gate-result events from each chain sibling
+   (`cross-feature-X.repo-foo.review.gate`,
+   `cross-feature-X.repo-bar.review.gate`, etc.).
+2. Aggregates the per-repo verdicts into a combined cross-repo verdict
+   using BLEND (the same `0.4 × min + 0.6 × avg` core uses for
+   multi-reviewer aggregation in `gate_dispatch.py`). One repo's strong
+   REJECT pulls the combined verdict down proportionally.
+3. Emits a single `wicked.multirepo.evidence.aggregated` event with
+   the combined verdict, per-repo breakdowns, and a path to the
+   aggregated evidence bundle.
+4. Surfaces the combined verdict in `crew:status` via a
+   `### Cross-Repo Evidence` additive section (rendered only when at
+   least one chain sibling has a gate result).
+
+---
+
+## Plugin manifest scope statement
+
+Per `docs/v9/drop-in-plugin-contract.md` §2, the manifest's
+`description` field is the scope statement core's routing layer reads
+to decide what to defer:
+
+```jsonc
+{
+  "name": "wicked-garden-monorepo",
+  "version": "0.1.0",
+  "description": "Cross-repo SDLC for wicked-garden — worktree
+    provisioning, merge-order DAG, and cross-repo evidence aggregation
+    for projects that span 2+ repositories. Reads the optional
+    `affected_repos` advisory field on wicked-garden process-plans and
+    extends it with a plugin-owned `repos:` block. Optional bus + brain
+    integration. Standalone — works without wicked-garden installed
+    when used as a pure git-worktree orchestrator.",
+  "skills": [
+    {
+      "name": "wicked-garden-monorepo:provision",
+      "description": "Provisions per-repo git worktrees from a process-plan's `repos:` block. Use when: starting the build phase of a multi-repo project, re-provisioning after a checkout reset, validating that all repos are at the expected branches. NOT for: single-repo projects (use core crew), shallow clones (use Bash directly)."
+    },
+    {
+      "name": "wicked-garden-monorepo:order",
+      "description": "Computes the next merge target from the DAG of `repos[].depends_on`. Use when: a build phase just completed and you need to know which repo to merge next, the DAG itself needs validation. NOT for: single-repo merges (use git directly)."
+    },
+    {
+      "name": "wicked-garden-monorepo:aggregate-evidence",
+      "description": "Aggregates per-repo gate-result events from chain siblings into a single cross-repo verdict using BLEND. Use when: a cross-repo review gate needs a combined verdict, the per-repo evidence bundles need to be folded into one. NOT for: per-repo evidence collection (each chain sibling's review gate already does that)."
+    }
+  ],
+  "agents": [
+    {"name": "wicked-garden-monorepo:dag-validator"},
+    {"name": "wicked-garden-monorepo:worktree-provisioner"},
+    {"name": "wicked-garden-monorepo:merge-orchestrator"},
+    {"name": "wicked-garden-monorepo:evidence-aggregator"}
+  ]
+}
+```
+
+Each skill description follows the v9 discovery conventions
+(verb-first, `Use when:` triggers, `NOT for:` anti-triggers, no-wrapper
+test passing). The aggregate-evidence skill is the plugin's no-wrapper
+proof point — the BLEND aggregation across chain siblings cannot be
+reproduced in three native tool calls.
+
+---
+
+## Bus events emitted (canonical naming)
+
+Per `docs/v9/drop-in-plugin-contract.md` §4, event names follow
+`{domain}:{action}:{outcome}` (lowercase, colon-separated):
+
+```
+wicked.multirepo.dag.validated         {chain_id, repos[], cycles[]}
+wicked.multirepo.worktree.provisioned  {chain_id, repo, worktree_path}
+wicked.multirepo.worktree.conflict     {chain_id, repo, reason}
+wicked.multirepo.worktree.reused       {chain_id, repo, worktree_path}
+wicked.multirepo.worktree.removed      {chain_id, repo}
+wicked.multirepo.merge.ordered         {chain_id, next_up, blocked_on, rationale}
+wicked.multirepo.merge.completed       {chain_id, repo, sha}
+wicked.multirepo.evidence.aggregated   {chain_id, verdict, per_repo, bundle_path}
+```
+
+All events MUST carry the active crew `chain_id` so wicked-garden's
+chain-aware smaht events adapter scores them 0.8+ and surfaces them in
+the ambient context Claude sees at every turn. This is the same hook
+wicked-testing uses for its `wicked.verdict.recorded` events.
+
+---
+
+## What core promises (and does not promise)
+
+Core wicked-garden ships **only**:
+
+- The optional `affected_repos: [string]` field on `process-plan.json`,
+  validated for shape (list of non-empty strings) by
+  `scripts/crew/validate_plan.py`. No DAG, no semantic validation.
+- A read-only renderer (`scripts/crew/affected_repos.py render`) that
+  surfaces the field as one advisory line in `crew:status` and
+  `smaht:briefing`. Fail-open: missing / empty / malformed → silence.
+- A one-paragraph nudge in the multi-repo archetype prompt of
+  `agents/crew/process-facilitator.md` Step 6 telling the facilitator
+  to open one crew project per repo and link via shared `chain_id`
+  prefix.
+- This design doc.
+
+Core wicked-garden does **not** ship:
+
+- A `repos:` block reader, writer, or validator
+- Worktree provisioning, tracking, or cleanup
+- A merge-order DAG validator
+- Cross-repo evidence aggregation
+- A per-archetype `multi-repo` extension to the gate adjudicator
+- A `multi_repo.py` module of any kind
+
+Those are the plugin's value proposition. Until the plugin exists, the
+advisory hint plus per-repo crew sessions cover the 80% case at 10% of
+the cost.
+
+---
+
+## Authoring checklist for the future plugin author
+
+Before opening the plugin's first PR (per
+`docs/v9/drop-in-plugin-contract.md` §"Authoring checklist"):
+
+- [ ] Every skill description passes the five v9 discovery conventions
+- [ ] No skill wraps a native tool — apply the no-wrapper test
+- [ ] No skill duplicates core (the `affected_repos` advisory line
+      stays in core; the plugin owns the DAG and everything downstream)
+- [ ] Each SKILL.md is ≤200 lines; depth in `refs/`
+- [ ] Manifest `description` is the scope statement quoted above (or a
+      tightened variant — keep "standalone" and "optional integration")
+- [ ] Bus events follow the `{domain}:{action}:{outcome}` shape and
+      carry `chain_id` for chain-aware smaht scoring
+- [ ] Cross-session decisions route through `wicked-brain:memory` —
+      operational `repos.json` is plugin-local, but architectural
+      decisions are not
+- [ ] Worktree provisioning throttles fan-out (parallel-agent
+      rate-limit memory)
+- [ ] Plugin works standalone when wicked-garden is absent (it can
+      still provision worktrees from a hand-written `repos.json`); bus
+      and brain integration are optional but encouraged
+
+---
+
+## Related references
+
+- `ETHOS.md` lines 60–66 — "Not closed. Third-party plugins integrate
+  via the v9 drop-in contract."
+- `docs/v9/drop-in-plugin-contract.md` — the contract every sibling
+  plugin follows; wicked-testing is the canonical example.
+- `docs/v9/discovery-conventions.md` — skill-description rules.
+- `scripts/crew/affected_repos.py` — the core renderer this plugin
+  extends.
+- `scripts/crew/validate_plan.py` — the schema validator that accepts
+  the optional `affected_repos` field.
+- `scripts/crew/archetype_detect.py::_detect_multi_repo` — the
+  archetype detector that triggers the multi-repo prompt.
+- Issue #722 + jam analysis at
+  <https://github.com/mikeparcewski/issues/722#issuecomment-4364107563>
+- PR #738 / Brain memory `bus-as-truth-event-sourced-crew-state` — the
+  load-bearing rule that cross-repo state stays in the bus, not in a
+  parallel write store.

--- a/scenarios/crew/affected-repos-advisory.md
+++ b/scenarios/crew/affected-repos-advisory.md
@@ -1,0 +1,271 @@
+---
+name: affected-repos-advisory
+title: Affected Repos — Advisory Field Round-Trips Through Plan, Status, and Briefing
+description: Issue #722 — the optional `affected_repos` list on process-plan.json validates, parses, and surfaces as a single advisory line in crew:status and smaht:briefing helpers; legacy plans without the field stay silent
+type: testing
+difficulty: intermediate
+estimated_minutes: 5
+---
+
+# Affected Repos — Advisory Field End-to-End
+
+This scenario asserts the four-beat round-trip of the `affected_repos`
+advisory field added by the Issue #722 reframe (multi-repo as advisory
+only, no DAG, no worktree provisioning, no cross-repo evidence
+aggregation — those are deferred to the `wicked-garden-monorepo`
+sibling plugin per `docs/v9/sibling-plugin-monorepo.md`).
+
+The four beats:
+
+1. The validator accepts a well-shaped `affected_repos` list and
+   rejects malformed shapes.
+2. The renderer prints the advisory line for the `crew:status` Step 4b
+   surface.
+3. The same renderer feeds the `smaht:briefing` "Affected repos:" line.
+4. A legacy plan without the field stays silent — backward-compat is
+   load-bearing for the millions of single-repo projects.
+
+## Setup
+
+```bash
+export TEST_DIR=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import tempfile
+print(tempfile.mkdtemp(prefix='wg-affected-repos-'))
+")
+echo "TEST_DIR=${TEST_DIR}"
+```
+
+## Step 1: Provision a process-plan.json with `affected_repos: [foo, bar]`
+
+The plan mirrors the minimal valid shape `validate_plan.py` requires
+(top-level keys, factors block, one specialist, one phase, one task)
+plus the new optional `affected_repos` field.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, pathlib, sys
+test_dir = pathlib.Path(os.environ['TEST_DIR'])
+
+# Build the fixture using the same REQUIRED_FACTOR_KEYS the validator
+# enforces, so the scenario stays in lockstep with the schema.
+sys.path.insert(0, str(pathlib.Path(os.environ.get('CLAUDE_PLUGIN_ROOT', '.')) / 'scripts' / 'crew'))
+import validate_plan as vp
+
+plan = {
+    "project_slug": "affected-repos-scenario",
+    "summary": "Issue #722 advisory round-trip fixture.",
+    "rigor_tier": "standard",
+    "complexity": 3,
+    "factors": {
+        key: {"reading": "LOW", "risk_level": "high_risk", "why": "fixture"}
+        for key in vp.REQUIRED_FACTOR_KEYS
+    },
+    "specialists": [{"name": "backend-engineer", "why": "writes the code"}],
+    "phases": [
+        {"name": "build", "why": "do the work", "primary": ["backend-engineer"]}
+    ],
+    "tasks": [
+        {
+            "id": "t1",
+            "title": "Implement",
+            "phase": "build",
+            "blockedBy": [],
+            "metadata": {
+                "chain_id": "affected-repos-scenario.root",
+                "event_type": "coding-task",
+                "source_agent": "facilitator",
+                "phase": "build",
+                "rigor_tier": "standard",
+            },
+        }
+    ],
+    "affected_repos": ["foo", "bar"],
+}
+
+(test_dir / "process-plan.json").write_text(json.dumps(plan, indent=2), encoding="utf-8")
+
+# Confirm the validator round-trips the field (no violations).
+violations = vp.validate(plan)
+assert violations == [], f"Expected zero violations, got: {violations}"
+print("PASS: process-plan.json written and validates clean")
+PYEOF
+```
+
+**Expected**: `PASS: process-plan.json written and validates clean`
+
+## Step 2: crew:status helper renders the advisory line
+
+The `crew:status` command (Step 4b) calls
+`scripts/crew/affected_repos.py render --project-dir ...`. Exercise the
+exact CLI shape the command uses.
+
+```bash
+result=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+  render --project-dir "${TEST_DIR}")
+echo "${result}"
+
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+out = sys.stdin.read().strip()
+assert out.startswith('Affected repos: foo, bar'), f'unexpected prefix: {out!r}'
+assert 'advisory' in out, f'missing advisory tag: {out!r}'
+assert 'docs/v9/sibling-plugin-monorepo.md' in out, f'missing doc pointer: {out!r}'
+print('PASS: crew:status helper renders the advisory line correctly')
+"
+```
+
+**Expected**:
+```
+Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)
+PASS: crew:status helper renders the advisory line correctly
+```
+
+## Step 3: smaht:briefing helper renders the same advisory line
+
+The briefing surface uses the identical CLI invocation (`render
+--project-dir ...`) — verify the contract holds when the same plan is
+read by what the briefing calls.
+
+```bash
+result=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+  render --project-dir "${TEST_DIR}")
+
+echo "${result}" | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+out = sys.stdin.read().strip()
+assert out == 'Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)', \
+    f'briefing surface drifted from status surface: {out!r}'
+print('PASS: smaht:briefing helper renders the same line as crew:status')
+"
+```
+
+**Expected**: `PASS: smaht:briefing helper renders the same line as crew:status`
+
+## Step 4: Backward compatibility — legacy plan without `affected_repos` stays silent
+
+This is the load-bearing assertion: every existing wicked-garden
+project must continue to render as it did before #722. The renderer
+must print **nothing** when the field is absent.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, pathlib, sys
+test_dir = pathlib.Path(os.environ['TEST_DIR'])
+sys.path.insert(0, str(pathlib.Path(os.environ.get('CLAUDE_PLUGIN_ROOT', '.')) / 'scripts' / 'crew'))
+import validate_plan as vp
+
+# Same plan as Step 1 minus affected_repos — represents every legacy
+# project on disk.
+plan = {
+    "project_slug": "legacy-single-repo",
+    "summary": "Legacy plan without affected_repos.",
+    "rigor_tier": "standard",
+    "complexity": 3,
+    "factors": {
+        key: {"reading": "LOW", "risk_level": "high_risk", "why": "fixture"}
+        for key in vp.REQUIRED_FACTOR_KEYS
+    },
+    "specialists": [{"name": "backend-engineer", "why": "writes the code"}],
+    "phases": [
+        {"name": "build", "why": "do the work", "primary": ["backend-engineer"]}
+    ],
+    "tasks": [
+        {
+            "id": "t1",
+            "title": "Implement",
+            "phase": "build",
+            "blockedBy": [],
+            "metadata": {
+                "chain_id": "legacy-single-repo.root",
+                "event_type": "coding-task",
+                "source_agent": "facilitator",
+                "phase": "build",
+                "rigor_tier": "standard",
+            },
+        }
+    ],
+}
+
+assert "affected_repos" not in plan, "fixture invariant: legacy plan must not declare the field"
+assert vp.validate(plan) == [], "legacy plan must validate cleanly"
+
+(test_dir / "process-plan.json").write_text(json.dumps(plan, indent=2), encoding="utf-8")
+print("legacy plan written")
+PYEOF
+
+# Renderer MUST stay silent — empty stdout means crew:status / briefing
+# skip the section entirely (preserves the pre-#722 output verbatim).
+result=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+  render --project-dir "${TEST_DIR}")
+
+if [ -z "${result}" ]; then
+  echo "PASS: renderer stayed silent on legacy plan (backward-compat preserved)"
+else
+  echo "FAIL: renderer emitted output for legacy plan: ${result}"
+  exit 1
+fi
+```
+
+**Expected**:
+```
+legacy plan written
+PASS: renderer stayed silent on legacy plan (backward-compat preserved)
+```
+
+## Step 5: Renderer rejects malformed shape silently (fail-open)
+
+The renderer is fail-open by design — `crew:status` and `smaht:briefing`
+must NEVER break because the plan got mangled. The validator is the
+component that surfaces shape errors.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <<'PYEOF'
+import json, os, pathlib
+test_dir = pathlib.Path(os.environ['TEST_DIR'])
+# Smuggle an invalid shape (string instead of list). The validator
+# would reject this; the renderer must silently render nothing.
+(test_dir / "process-plan.json").write_text(
+    json.dumps({"affected_repos": "this-is-not-a-list"}),
+    encoding="utf-8",
+)
+print("malformed plan written")
+PYEOF
+
+result=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/affected_repos.py" \
+  render --project-dir "${TEST_DIR}")
+
+if [ -z "${result}" ]; then
+  echo "PASS: renderer fail-open on malformed shape"
+else
+  echo "FAIL: renderer emitted output for malformed plan: ${result}"
+  exit 1
+fi
+```
+
+**Expected**:
+```
+malformed plan written
+PASS: renderer fail-open on malformed shape
+```
+
+## Success Criteria
+
+- [ ] Step 1: process-plan.json with `affected_repos: [foo, bar]` validates clean
+- [ ] Step 2: `crew:status` helper renders the exact advisory line with the doc pointer
+- [ ] Step 3: `smaht:briefing` helper renders the same line as `crew:status` (single contract)
+- [ ] Step 4: legacy plan without `affected_repos` produces empty output (backward compat)
+- [ ] Step 5: renderer fails open on malformed shape (no exception, no broken briefing)
+
+## Cleanup
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import os, shutil
+shutil.rmtree(os.environ['TEST_DIR'], ignore_errors=True)
+"
+unset TEST_DIR
+```

--- a/scripts/crew/affected_repos.py
+++ b/scripts/crew/affected_repos.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""affected_repos.py — Render the optional `affected_repos` advisory line (#722).
+
+Surfaces the OPTIONAL ``affected_repos`` field from a project's
+``process-plan.json`` as a single human-readable line. This is the read
+side of the multi-repo *advisory* surface added by issue #722 — the
+write side is the field on the existing process-plan, populated by the
+facilitator (or the user directly editing the plan).
+
+There is intentionally no DAG, no merge-order validator, no worktree
+provisioning, no cross-repo evidence aggregation. Those belong to a
+sibling v9 plugin (``wicked-garden-monorepo``); see
+``docs/v9/sibling-plugin-monorepo.md`` for the full design brief and
+demand criteria for when that plugin should actually get built.
+
+Usage:
+    affected_repos.py render --plan path/to/process-plan.json
+    affected_repos.py render --project-dir path/to/project
+    affected_repos.py json   --plan path/to/process-plan.json
+
+Behaviour:
+  - When ``affected_repos`` is missing, empty, or malformed, the CLI
+    prints NOTHING and exits 0. Callers can pipe the output directly
+    into the briefing / status template — silence means "skip this
+    section." This keeps the surface backward-compatible: existing
+    projects that never set the field show no new line.
+  - When the field is present and non-empty, the CLI prints exactly:
+
+        Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)
+
+    The repo names are rendered in the order they appear in the plan
+    (no sorting — the facilitator's order may carry signal).
+
+Stdlib-only. Cross-platform (no shell features). Fail-open: any read or
+parse error is swallowed and the script exits 0 with no output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Doc pointer kept as a module constant so the test can assert the line
+# text without re-deriving the URL. R3: no magic strings in callers.
+ADVISORY_DOC = "docs/v9/sibling-plugin-monorepo.md"
+ADVISORY_LINE_PREFIX = "Affected repos:"
+ADVISORY_LINE_SUFFIX = f"(advisory — see {ADVISORY_DOC})"
+
+
+# ---------------------------------------------------------------------------
+# Public API — pure functions, no I/O. Easy to test without fixtures.
+# ---------------------------------------------------------------------------
+
+def extract_affected_repos(plan: dict) -> List[str]:
+    """Return the cleaned ``affected_repos`` list from *plan*.
+
+    Defensive parser: accepts only the documented shape (list of
+    non-empty strings). Anything else returns an empty list — the field
+    is advisory and never blocks. Validation of malformed shapes is the
+    job of ``scripts/crew/validate_plan.py``; this function exists to
+    *render* what's there, not to police it.
+    """
+    if not isinstance(plan, dict):
+        return []
+    raw = plan.get("affected_repos")
+    if not isinstance(raw, list):
+        return []
+    cleaned: List[str] = []
+    for entry in raw:
+        if isinstance(entry, str) and entry.strip():
+            cleaned.append(entry.strip())
+    return cleaned
+
+
+def render_line(repos: List[str]) -> str:
+    """Render the advisory line. Empty list → empty string (skip)."""
+    if not repos:
+        return ""
+    names = ", ".join(repos)
+    return f"{ADVISORY_LINE_PREFIX} {names} {ADVISORY_LINE_SUFFIX}"
+
+
+def render_from_plan(plan: dict) -> str:
+    """Convenience: extract + render in one call."""
+    return render_line(extract_affected_repos(plan))
+
+
+# ---------------------------------------------------------------------------
+# I/O — guarded so the CLI is fail-open
+# ---------------------------------------------------------------------------
+
+def _resolve_plan_path(plan_path: Optional[Path], project_dir: Optional[Path]) -> Optional[Path]:
+    """Pick the plan file path. ``plan_path`` wins over ``project_dir``."""
+    if plan_path is not None:
+        return plan_path
+    if project_dir is not None:
+        return project_dir / "process-plan.json"
+    return None
+
+
+def _load_plan(path: Path) -> Optional[dict]:
+    """Read and parse the plan file. Returns None on any error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _add_source_args(p: argparse.ArgumentParser) -> None:
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--plan",
+        type=Path,
+        help="Path to process-plan.json (preferred when the caller already knows it).",
+    )
+    src.add_argument(
+        "--project-dir",
+        type=Path,
+        help="Project directory; resolves to <dir>/process-plan.json.",
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render the optional affected_repos advisory line (#722).",
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    render_parser = sub.add_parser(
+        "render",
+        help="Print the human-readable advisory line, or nothing when unset.",
+    )
+    _add_source_args(render_parser)
+
+    json_parser = sub.add_parser(
+        "json",
+        help="Print {\"affected_repos\": [...]} as JSON for programmatic callers.",
+    )
+    _add_source_args(json_parser)
+
+    args = parser.parse_args(argv)
+
+    path = _resolve_plan_path(getattr(args, "plan", None), getattr(args, "project_dir", None))
+    if path is None:
+        # argparse's mutually_exclusive_group(required=True) should
+        # prevent this, but defence-in-depth: stay silent rather than
+        # crashing the briefing when called from a shell pipeline.
+        return 0
+
+    plan = _load_plan(path)
+    if plan is None:
+        # Plan missing or unparseable. The advisory line is purely
+        # additive — never escalate this to an error that breaks
+        # crew:status / smaht:briefing rendering.
+        return 0
+
+    repos = extract_affected_repos(plan)
+
+    if args.action == "render":
+        line = render_line(repos)
+        if line:
+            sys.stdout.write(line + "\n")
+        return 0
+
+    if args.action == "json":
+        sys.stdout.write(json.dumps({"affected_repos": repos}) + "\n")
+        return 0
+
+    return 0  # pragma: no cover — argparse rejects unknown actions earlier
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -93,6 +93,7 @@ _SECTION_ANCHORS = {
     "tasks": "§ Schema — tasks",
     "rigor_tier": "§ rigor_tier enum (minimal|standard|full)",
     "complexity": "§ complexity bounds (0..7)",
+    "affected_repos": "§ affected_repos (advisory, optional)",
 }
 
 
@@ -126,6 +127,27 @@ def _check_top_level(plan: dict, violations: list) -> None:
         c = plan["complexity"]
         if not isinstance(c, int) or not (0 <= c <= 7):
             violations.append(f"complexity — must be an integer in [0, 7], got {c!r}")
+
+    # Issue #722: optional advisory `affected_repos` field. Read-only
+    # metadata for the multi-repo archetype — no DAG, no worktree
+    # provisioning, no validation beyond shape. Plans omitting the key
+    # behave exactly as today (backward compat). The full DAG-of-repos
+    # workflow is deferred to the `wicked-garden-monorepo` sibling plugin
+    # (see docs/v9/sibling-plugin-monorepo.md).
+    if "affected_repos" in plan:
+        repos = plan["affected_repos"]
+        if not isinstance(repos, list):
+            violations.append(
+                "affected_repos — must be a list of strings (advisory field, "
+                "see docs/v9/sibling-plugin-monorepo.md)"
+            )
+        else:
+            for i, entry in enumerate(repos):
+                if not isinstance(entry, str) or not entry.strip():
+                    violations.append(
+                        f"affected_repos[{i}] — every entry must be a "
+                        f"non-empty string, got {entry!r}"
+                    )
 
 
 def _check_factors(plan: dict, violations: list) -> None:
@@ -494,6 +516,11 @@ _INVALID_FIXTURES = [
             "reversibility": {"reading": "LOW", "risk_level": "low_risk", "why": "idk"},
         },
     }),
+    # #722: affected_repos must be a list when present
+    ("affected_repos not a list", lambda p: {**p, "affected_repos": "foo"}),
+    # #722: affected_repos entries must be non-empty strings
+    ("affected_repos contains a non-string", lambda p: {**p, "affected_repos": ["foo", 42]}),
+    ("affected_repos contains an empty string", lambda p: {**p, "affected_repos": ["foo", "  "]}),
 ]
 
 

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -79,9 +79,27 @@ rubric against a scenario's expected-outcome block.
   "anticipated_reevaluations": [
     {"trigger": "if clarify phase surfaces a bigger scope than expected",
      "likely_impact": "augment with migration-engineer + data specialist"}
-  ]
+  ],
+
+  "affected_repos": ["repo-foo", "repo-bar"]
 }
 ```
+
+## affected_repos (advisory, optional)
+
+Optional `affected_repos: [string]` field added by Issue #722. When
+the archetype is `multi-repo`, populate this list with the repository
+short-names the project touches. Crew core treats it as **read-only
+advisory metadata**:
+
+- `crew:status` and `smaht:briefing` surface a single advisory line
+  (`Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)`).
+- Validator rules: must be a list of non-empty strings if present;
+  empty list / missing field are both valid (backward-compatible).
+- No DAG, no worktree provisioning, no merge-order validation, no
+  cross-repo evidence aggregation. Those workflows are deferred to the
+  `wicked-garden-monorepo` sibling v9 plugin —
+  see `docs/v9/sibling-plugin-monorepo.md` for the design brief.
 
 Note: each factor entry carries BOTH `reading` (HIGH/MEDIUM/LOW; HIGH = safest,
 LOW = riskiest, for backward compatibility) AND `risk_level`

--- a/tests/crew/test_affected_repos.py
+++ b/tests/crew/test_affected_repos.py
@@ -1,0 +1,313 @@
+"""tests/crew/test_affected_repos.py — Issue #722.
+
+Covers the optional advisory ``affected_repos`` field surfaced by the
+multi-repo reframe:
+
+  - ``scripts/crew/validate_plan.py`` accepts the field when shaped as a
+    list of non-empty strings, rejects malformed shapes, and stays
+    backward-compatible (omitting the field is a clean pass).
+  - ``scripts/crew/affected_repos.py`` renders the advisory line
+    cleanly for crew:status / smaht:briefing consumers.
+
+Test rules (T1-T6):
+  T1: deterministic — pure function calls with self-contained dicts.
+  T2: no sleep-based sync.
+  T3: isolated — each test builds its own fixture from scratch.
+  T4: single behavior per test.
+  T5: descriptive names cite #722 intent.
+  T6: every docstring cites Issue #722.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS / "crew") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS / "crew"))
+
+import affected_repos  # noqa: E402
+import validate_plan  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _base_plan() -> dict:
+    """Return a minimal valid process-plan dict. Issue #722."""
+    return {
+        "project_slug": "affected-repos-fixture",
+        "summary": "Fixture for Issue #722 affected_repos coverage.",
+        "rigor_tier": "standard",
+        "complexity": 3,
+        "factors": {
+            key: {"reading": "LOW", "risk_level": "high_risk", "why": "fixture"}
+            for key in validate_plan.REQUIRED_FACTOR_KEYS
+        },
+        "specialists": [{"name": "backend-engineer", "why": "writes the code"}],
+        "phases": [
+            {"name": "build", "why": "do the work", "primary": ["backend-engineer"]}
+        ],
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "Implement",
+                "phase": "build",
+                "blockedBy": [],
+                "metadata": {
+                    "chain_id": "affected-repos-fixture.root",
+                    "event_type": "coding-task",
+                    "source_agent": "facilitator",
+                    "phase": "build",
+                    "rigor_tier": "standard",
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# validate_plan — schema acceptance / rejection
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_plan_without_affected_repos():
+    """Issue #722: backward-compat — plans without the field stay clean."""
+    plan = _base_plan()
+    assert "affected_repos" not in plan
+    assert validate_plan.validate(plan) == []
+
+
+def test_validate_accepts_well_shaped_affected_repos():
+    """Issue #722: list of non-empty strings is the documented shape."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "bar", "baz"]
+    assert validate_plan.validate(plan) == []
+
+
+def test_validate_accepts_empty_affected_repos_list():
+    """Issue #722: an empty list is shape-valid (advisory absence)."""
+    plan = _base_plan()
+    plan["affected_repos"] = []
+    assert validate_plan.validate(plan) == []
+
+
+def test_validate_rejects_affected_repos_as_string():
+    """Issue #722: a bare string is not a list — must be rejected."""
+    plan = _base_plan()
+    plan["affected_repos"] = "foo"
+    violations = validate_plan.validate(plan)
+    assert any(
+        "affected_repos" in v and "must be a list of strings" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_rejects_affected_repos_with_non_string_entry():
+    """Issue #722: every entry must be a string — numbers reject."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", 42]
+    violations = validate_plan.validate(plan)
+    assert any(
+        "affected_repos[1]" in v and "non-empty string" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_rejects_affected_repos_with_blank_entry():
+    """Issue #722: whitespace-only strings are not real repo names."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "   "]
+    violations = validate_plan.validate(plan)
+    assert any(
+        "affected_repos[1]" in v and "non-empty string" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_rejects_affected_repos_as_dict():
+    """Issue #722: dict shape (e.g. attempted DAG) is out of scope."""
+    plan = _base_plan()
+    # The full DAG belongs to the sibling-plugin design; if a user
+    # tries to smuggle it in here we want a clear "shape" error.
+    plan["affected_repos"] = {"foo": ["bar"]}
+    violations = validate_plan.validate(plan)
+    assert any(
+        "affected_repos" in v and "must be a list of strings" in v
+        for v in violations
+    ), violations
+
+
+def test_validate_warnings_unaffected_by_affected_repos():
+    """Issue #722: the field never produces warnings."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "bar"]
+    # warnings() returns advisory dicts; affected_repos must not feed it.
+    out = validate_plan.warnings(plan)
+    assert all("affected_repos" not in (w.get("code") or "") for w in out)
+    assert all("affected_repos" not in (w.get("message") or "") for w in out)
+
+
+# ---------------------------------------------------------------------------
+# affected_repos.py — renderer
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_empty_list_when_field_missing():
+    """Issue #722: missing field → no repos to render."""
+    assert affected_repos.extract_affected_repos({}) == []
+
+
+def test_extract_returns_empty_list_when_field_is_not_a_list():
+    """Issue #722: defensive — a malformed field renders silently."""
+    assert affected_repos.extract_affected_repos({"affected_repos": "foo"}) == []
+    assert affected_repos.extract_affected_repos({"affected_repos": 42}) == []
+
+
+def test_extract_drops_non_string_and_blank_entries():
+    """Issue #722: clean the list before rendering — never crash."""
+    repos = affected_repos.extract_affected_repos(
+        {"affected_repos": ["foo", "", 42, "  ", "bar"]}
+    )
+    assert repos == ["foo", "bar"]
+
+
+def test_extract_preserves_order():
+    """Issue #722: facilitator order may carry signal — do not sort."""
+    repos = affected_repos.extract_affected_repos(
+        {"affected_repos": ["zeta", "alpha", "mu"]}
+    )
+    assert repos == ["zeta", "alpha", "mu"]
+
+
+def test_render_line_returns_empty_string_when_no_repos():
+    """Issue #722: empty list → empty string → caller skips the section."""
+    assert affected_repos.render_line([]) == ""
+
+
+def test_render_line_includes_advisory_doc_pointer():
+    """Issue #722: every rendered line cites the sibling-plugin doc."""
+    line = affected_repos.render_line(["foo", "bar"])
+    assert line.startswith("Affected repos: foo, bar ")
+    assert "advisory" in line
+    assert "docs/v9/sibling-plugin-monorepo.md" in line
+
+
+def test_render_from_plan_round_trips_well_shaped_plan():
+    """Issue #722: end-to-end render from a realistic plan dict."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "bar"]
+    line = affected_repos.render_from_plan(plan)
+    assert "foo, bar" in line
+    assert "advisory" in line
+
+
+def test_render_from_plan_silent_for_legacy_plan():
+    """Issue #722: backward-compat — legacy plans render no advisory."""
+    plan = _base_plan()
+    assert affected_repos.render_from_plan(plan) == ""
+
+
+def test_render_from_plan_silent_for_empty_list():
+    """Issue #722: empty list is the same as absent, by design."""
+    plan = _base_plan()
+    plan["affected_repos"] = []
+    assert affected_repos.render_from_plan(plan) == ""
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour — exercises the path crew:status / smaht:briefing follow
+# ---------------------------------------------------------------------------
+
+
+def _write_plan(tmp_path: Path, plan: dict) -> Path:
+    plan_path = tmp_path / "process-plan.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    return plan_path
+
+
+def test_cli_render_prints_line_when_repos_set(tmp_path, capsys):
+    """Issue #722: `render --plan ...` prints exactly one advisory line."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "bar"]
+    plan_path = _write_plan(tmp_path, plan)
+
+    rc = affected_repos.main(["render", "--plan", str(plan_path)])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("Affected repos: foo, bar")
+    assert "advisory" in out
+
+
+def test_cli_render_prints_nothing_when_repos_unset(tmp_path, capsys):
+    """Issue #722: silence on legacy plans — nothing piped to status."""
+    plan = _base_plan()
+    plan_path = _write_plan(tmp_path, plan)
+
+    rc = affected_repos.main(["render", "--plan", str(plan_path)])
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_render_silent_when_plan_missing(tmp_path, capsys):
+    """Issue #722: missing plan must never break the briefing pipeline."""
+    rc = affected_repos.main([
+        "render",
+        "--plan",
+        str(tmp_path / "does-not-exist.json"),
+    ])
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_render_silent_when_plan_unparseable(tmp_path, capsys):
+    """Issue #722: malformed JSON falls back to silence (fail-open)."""
+    plan_path = tmp_path / "process-plan.json"
+    plan_path.write_text("not json at all {", encoding="utf-8")
+
+    rc = affected_repos.main(["render", "--plan", str(plan_path)])
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_render_resolves_project_dir(tmp_path, capsys):
+    """Issue #722: --project-dir resolves to <dir>/process-plan.json."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["alpha"]
+    _write_plan(tmp_path, plan)
+
+    rc = affected_repos.main(["render", "--project-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("Affected repos: alpha")
+
+
+def test_cli_json_emits_stable_shape(tmp_path, capsys):
+    """Issue #722: `json` mode is for programmatic consumers (smaht briefing)."""
+    plan = _base_plan()
+    plan["affected_repos"] = ["foo", "bar"]
+    plan_path = _write_plan(tmp_path, plan)
+
+    rc = affected_repos.main(["json", "--plan", str(plan_path)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"affected_repos": ["foo", "bar"]}
+
+
+def test_cli_json_emits_empty_list_for_legacy_plan(tmp_path, capsys):
+    """Issue #722: legacy plan → JSON consumers see [] not an error."""
+    plan = _base_plan()
+    plan_path = _write_plan(tmp_path, plan)
+
+    rc = affected_repos.main(["json", "--plan", str(plan_path)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"affected_repos": []}


### PR DESCRIPTION
## Summary

Reframes #722 from a 800–1200 LOC core multi-repo subsystem into a ~150 LOC advisory hint plus a design brief for the future `wicked-garden-monorepo` sibling v9 plugin. Per the [jam analysis](https://github.com/mikeparcewski/wicked-garden/issues/722#issuecomment-4364107563) and the bus-as-truth memory established by PR #738, multi-repo projects model naturally as N `chain_id` siblings under one root — not as a fourth core write store.

Closes #722.

## Six deliverables (all backward-compatible)

| # | Surface | Change |
|---|---------|--------|
| 1 | `scripts/crew/validate_plan.py` | Optional `affected_repos: [string]` field, validated for shape only (list of non-empty strings). 3 new selftest fixtures. |
| 2 | `scripts/crew/affected_repos.py` (new) | Fail-open renderer: prints `Affected repos: foo, bar (advisory — see docs/v9/sibling-plugin-monorepo.md)` or stays silent. |
| 3 | `commands/crew/status.md` | New Step 4b surfaces the advisory line. |
| 4 | `commands/smaht/briefing.md` | Same line right after `Detected stack:`. |
| 5 | `agents/crew/process-facilitator.md` | Multi-repo archetype prompt recommends one crew project per repo + shared `chain_id` prefix. |
| 6 | `docs/v9/sibling-plugin-monorepo.md` (new) | 400-line design brief for the future plugin author — repo DAG schema, worktree lifecycle, merge ordering, evidence aggregation, demand criteria. |

## Tests

- `tests/crew/test_affected_repos.py` — 24 new test cases covering schema acceptance/rejection, renderer output shape, CLI fail-open behaviour, and end-to-end round-trip (plan → status helper → briefing helper).
- `scenarios/crew/affected-repos-advisory.md` — 5-step acceptance scenario asserting the round-trip plus backward-compat (legacy plan stays silent).
- Full crew test suite: **1320 passed, 0 regressions**.

## Deliberately deferred to the sibling plugin (NOT shipped here)

These all live in `docs/v9/sibling-plugin-monorepo.md` for the future `wicked-garden-monorepo` plugin author:

- `repos:` block reader / writer / DAG validator
- Per-repo worktree provisioning + cleanup
- Merge-order DAG validation
- Cross-repo evidence aggregation
- Per-archetype gate-adjudicator extension
- `multi_repo.py` module of any kind

Demand criteria for actually building the sibling plugin: 5+ user issues OR a sibling-plugin author signs up.

## Test plan

- [ ] `sh scripts/_python.sh -m pytest tests/crew/ -q` → 1320 passed, 0 failed
- [ ] `sh scripts/_python.sh scripts/crew/validate_plan.py --selftest` → `selftest PASS`
- [ ] `/wg-test scenarios/crew/affected-repos-advisory` → all 5 steps PASS
- [ ] Manually invoke `affected_repos.py render --project-dir <plan_with_field>` → prints advisory line
- [ ] Manually invoke `affected_repos.py render --project-dir <legacy_plan>` → empty output
- [ ] Manually invoke `affected_repos.py render --project-dir <missing_path>` → empty output (fail-open)
- [ ] Spot-check `crew:status` and `smaht:briefing` against a project with `affected_repos: [foo, bar]` to confirm the line surfaces in the right place

🤖 Generated with [Claude Code](https://claude.com/claude-code)