### PR TITLE
fix(daemon): #753 + #754 — template fixes for bus-cutover Sites 2-5 (WARN + FK CASCADE)

### DIFF
--- a/daemon/db.py
+++ b/daemon/db.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Phase state machine import (v8-PR-3 #590).
@@ -128,6 +131,20 @@ def init_schema(conn: sqlite3.Connection) -> None:
         -- the event payload carries an ISO-8601 string.  The handler
         -- normalises the string at insertion time so range queries
         -- (`WHERE dispatched_at BETWEEN ...`) avoid ISO comparison gymnastics.
+        --
+        -- FK + ON DELETE CASCADE (#754): event_id REFERENCES event_log so
+        -- retention/cleanup workflows that prune event_log rows do not leak
+        -- orphan projection rows.  PRAGMA foreign_keys=ON is set in connect()
+        -- (every connection); without it SQLite parses but does not enforce
+        -- the FK.  Cutover Sites 2-5's projection tables MUST follow this
+        -- pattern — staging plan §5 names FK + WARN as REQUIRED.
+        --
+        -- Migration note (#754): if a developer's local DB created this table
+        -- before this PR landed (no FK), CREATE TABLE IF NOT EXISTS will skip
+        -- and the table stays FK-less.  Detection helper:
+        -- `_dispatch_log_entries_has_event_id_fk()` below; recreation only
+        -- happens when the table is empty, otherwise the developer is asked
+        -- to manually re-create.  No destructive auto-migration ships.
         CREATE TABLE IF NOT EXISTS dispatch_log_entries (
             event_id              INTEGER PRIMARY KEY,
             project_id            TEXT NOT NULL,
@@ -140,7 +157,8 @@ def init_schema(conn: sqlite3.Connection) -> None:
             dispatched_at         INTEGER NOT NULL,
             hmac                  TEXT,
             hmac_present          INTEGER NOT NULL DEFAULT 0,
-            raw_payload           TEXT NOT NULL
+            raw_payload           TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES event_log(event_id) ON DELETE CASCADE
         );
 
         CREATE INDEX IF NOT EXISTS idx_dispatch_log_entries_lookup
@@ -345,6 +363,12 @@ def init_schema(conn: sqlite3.Connection) -> None:
     # that were created before this column was introduced.
     _run_migration(conn, "hook_invocations_add_debounce_key",
                    _migrate_hook_invocations_add_debounce_key)
+    # #754: rebuild dispatch_log_entries with FK + ON DELETE CASCADE on
+    # event_id when a pre-#754 schema is detected and the table is empty.
+    # Non-empty tables are left alone with a logger.warning so the developer
+    # can decide how to migrate; we never silently drop projection rows.
+    _run_migration(conn, "dispatch_log_entries_add_event_id_fk",
+                   _migrate_dispatch_log_entries_add_event_id_fk)
 
 
 # ---------------------------------------------------------------------------
@@ -423,6 +447,107 @@ def _migrate_hook_invocations_add_debounce_key(conn: sqlite3.Connection) -> None
     if "debounce_key" not in col_names:
         conn.execute("ALTER TABLE hook_invocations ADD COLUMN debounce_key TEXT")
     # Commit is handled by _run_migration after the migration row is written.
+
+
+def _dispatch_log_entries_has_event_id_fk(conn: sqlite3.Connection) -> bool:
+    """Return True iff dispatch_log_entries has the FK on event_id → event_log.
+
+    SQLite reports FKs through ``PRAGMA foreign_key_list(<table>)``.  Each row
+    has columns (id, seq, table, from, to, on_update, on_delete, match).  We
+    look for one where ``from`` is ``event_id``, ``table`` is ``event_log``,
+    and ``on_delete`` is ``CASCADE`` — the exact contract from #754.
+    """
+    rows = conn.execute("PRAGMA foreign_key_list(dispatch_log_entries)").fetchall()
+    for r in rows:
+        # Tuple form to stay row_factory-agnostic in tests.
+        from_col = r["from"] if hasattr(r, "keys") else r[3]
+        ref_table = r["table"] if hasattr(r, "keys") else r[2]
+        on_delete = r["on_delete"] if hasattr(r, "keys") else r[6]
+        if from_col == "event_id" and ref_table == "event_log" and on_delete == "CASCADE":
+            return True
+    return False
+
+
+def _migrate_dispatch_log_entries_add_event_id_fk(conn: sqlite3.Connection) -> None:
+    """Backfill the event_id FK on dispatch_log_entries for pre-#754 DBs.
+
+    Why this exists (#754): PR #751 created ``dispatch_log_entries`` without
+    an explicit FK on ``event_id``.  CREATE TABLE IF NOT EXISTS in
+    ``init_schema`` will not modify a pre-existing table, so a developer who
+    ran the daemon between #751 and #754 has an FK-less table that will leak
+    orphan rows when ``event_log`` is pruned.
+
+    SQLite cannot ADD a FOREIGN KEY via ALTER TABLE; the canonical fix is the
+    "rename / recreate / copy / drop" dance.  We refuse to ship that as a
+    silent destructive auto-migration:
+
+      * If the table is empty → safe to DROP and recreate.  Do it.
+      * If the table is non-empty → emit a `logger.warning` with the recovery
+        steps and leave the table alone.  Future writes still go in; they
+        just lack FK enforcement until the developer migrates manually.
+
+    The fresh-DB path also hits this migration — the FK already exists, so
+    the function is a no-op.  We use the existence check to keep the
+    _migrations row idempotent across both paths.
+    """
+    # Skip when the table does not exist yet (defensive; init_schema runs
+    # CREATE TABLE IF NOT EXISTS above so this should not happen, but a
+    # partially initialised DB should not crash the migration.)
+    table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dispatch_log_entries'"
+    ).fetchone()
+    if table_exists is None:
+        return
+
+    if _dispatch_log_entries_has_event_id_fk(conn):
+        return  # already migrated (fresh DB or prior run)
+
+    row_count_row = conn.execute(
+        "SELECT COUNT(*) FROM dispatch_log_entries"
+    ).fetchone()
+    row_count = row_count_row[0] if row_count_row else 0
+    if row_count > 0:
+        logger.warning(
+            "daemon/db.py: dispatch_log_entries has %d row(s) and is missing "
+            "the event_id → event_log FK (#754). Auto-migration skipped to "
+            "avoid silent data loss. To migrate manually: BEGIN; CREATE TABLE "
+            "dispatch_log_entries_new (... FOREIGN KEY (event_id) REFERENCES "
+            "event_log(event_id) ON DELETE CASCADE); INSERT INTO "
+            "dispatch_log_entries_new SELECT * FROM dispatch_log_entries; "
+            "DROP TABLE dispatch_log_entries; ALTER TABLE "
+            "dispatch_log_entries_new RENAME TO dispatch_log_entries; COMMIT;",
+            row_count,
+        )
+        return
+
+    # Empty table → safe to recreate with the FK in place.  Schema kept in
+    # lockstep with the CREATE TABLE block above so the two paths converge.
+    conn.execute("DROP TABLE dispatch_log_entries")
+    conn.execute(
+        """
+        CREATE TABLE dispatch_log_entries (
+            event_id              INTEGER PRIMARY KEY,
+            project_id            TEXT NOT NULL,
+            phase                 TEXT NOT NULL,
+            gate                  TEXT NOT NULL,
+            reviewer              TEXT NOT NULL,
+            dispatch_id           TEXT NOT NULL,
+            dispatcher_agent      TEXT NOT NULL,
+            expected_result_path  TEXT NOT NULL,
+            dispatched_at         INTEGER NOT NULL,
+            hmac                  TEXT,
+            hmac_present          INTEGER NOT NULL DEFAULT 0,
+            raw_payload           TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES event_log(event_id) ON DELETE CASCADE
+        )
+        """
+    )
+    # Re-create the lookup index that init_schema declares (idempotent).
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_dispatch_log_entries_lookup "
+        "ON dispatch_log_entries(project_id, phase, gate, dispatched_at DESC)"
+    )
+    # Commit handled by _run_migration after the migration row is written.
 
 
 def upsert_project(conn: sqlite3.Connection, project_id: str, fields: dict[str, Any]) -> None:

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -66,6 +66,14 @@ _VERDICT_REJECT = "REJECT"
 # caused by out-of-order bus events; the update is silently dropped.
 _STATUS_RANK: dict[str, int] = {"pending": 0, "in_progress": 1, "completed": 2}
 
+# One-time WARN latch for the `_bus` ImportError path (#753).  The first time
+# `_dispatch_log_appended` (or any future cutover-site handler that imports
+# `_bus_as_truth_enabled`) cannot import the helper, we log a single WARN so
+# operators see the misconfiguration in logs.  Subsequent calls keep the same
+# fail-open behaviour but stay silent — re-logging on every projection run
+# would flood the log under sustained traffic.
+_BUS_IMPORT_WARNED = False
+
 
 # --- helpers ---------------------------------------------------------------
 
@@ -562,11 +570,32 @@ def _dispatch_log_appended(conn: sqlite3.Connection, event: dict) -> None:
     """
     # Defer import to avoid a hard dependency at module load — the projector
     # boots in environments where scripts/_bus.py may not be on sys.path
-    # (e.g. some test harnesses).  Failure to import is treated as flag-off.
+    # (e.g. some test harnesses).  Failure to import is treated as flag-off
+    # so the dual-write contract (disk truth, bus observability) keeps the
+    # projection table empty and the wrapper still records the event_log row
+    # as `applied`.
+    #
+    # Observability promotion (#753): the previous implementation swallowed
+    # the ImportError silently, which made a real misconfiguration (e.g.
+    # PYTHONPATH missing scripts/) invisible.  We now WARN exactly once per
+    # process via the `_BUS_IMPORT_WARNED` module-level latch — operators
+    # see the misconfiguration in logs without sustained-traffic spam.
+    # Cutover Sites 2-5 MUST inherit this WARN-once pattern, not the silent
+    # skip, per the staging plan (docs/v9/bus-cutover-staging-plan.md §5).
+    global _BUS_IMPORT_WARNED
     try:
         from _bus import _bus_as_truth_enabled  # type: ignore[import]
         flag_on = _bus_as_truth_enabled()
-    except Exception:
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_DISPATCH_LOG "
+                "as off (will not re-warn this process): %s",
+                exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open for any other error
         flag_on = False
 
     if not flag_on:

--- a/docs/v9/bus-cutover-staging-plan.md
+++ b/docs/v9/bus-cutover-staging-plan.md
@@ -518,6 +518,36 @@ release as the LAST cutover flip (N+5) so one full release runs at the
 new shape under flag-default-on before strict mode removes the opt-out
 at N+6.
 
+### Required template patterns for Sites 2-5 projection tables (#753 + #754)
+
+The pre-merge council on PR #751 (Site 1) named two template warts that
+MUST be fixed in the projector template before Site 2 clones the pattern.
+Both ship in the follow-up PR cited by issues **#753** and **#754** and
+become preconditions for Sites 2-5:
+
+1. **FK + ON DELETE CASCADE on every projection table's event-id column.**
+   Each cutover-site projection table (`dispatch_log_entries`,
+   `consensus_report_entries`, `consensus_evidence_entries`,
+   `reviewer_report_entries`, `gate_result_entries`, `conditions_entries`)
+   declares `event_id INTEGER PRIMARY KEY REFERENCES event_log(event_id)
+   ON DELETE CASCADE`. Without this, retention/cleanup workflows that
+   prune `event_log` will leak orphan projection rows. `PRAGMA
+   foreign_keys=ON` is set at every connection in `daemon/db.py::connect()`
+   — without that PRAGMA the FK is parsed but not enforced.
+
+2. **WARN-once on `_bus` ImportError in projector handlers.** The Site 1
+   handler `_dispatch_log_appended` swallowed `_bus` import failures into
+   silent `flag_on=False`. The follow-up promotes that to a single
+   `logger.warning` (latched via a module-level `_BUS_IMPORT_WARNED`
+   flag) so a real misconfiguration (e.g. PYTHONPATH missing `scripts/`)
+   surfaces in operator logs without breaking the fail-open contract.
+   Sites 2-5 inherit this WARN-once pattern, NOT the silent skip.
+
+Both fixes ship as one PR because they are the same "template wart"
+cluster from one council session. The byte-identity contract from
+Council Condition C2 is preserved: flag-off behaviour still returns
+`applied` with the projection table untouched.
+
 ## 6. Scenario coverage
 
 All scenarios live under `scenarios/crew/`. #746's "Scenario covers a

--- a/tests/daemon/test_projector_dispatch_log.py
+++ b/tests/daemon/test_projector_dispatch_log.py
@@ -90,6 +90,39 @@ def _make_event(
 # ---------------------------------------------------------------------------
 
 
+
+
+
+def _insert_event_log_parent(conn, event: dict) -> None:
+    """Insert the matching event_log row before calling the handler.
+
+    Required after #754 added FK + ON DELETE CASCADE on
+    dispatch_log_entries.event_id → event_log.event_id. Without this,
+    handler-direct calls hit FOREIGN KEY constraint failed.
+
+    Skips the insert when event_id is not a positive int — those events
+    are deliberately malformed test inputs (e.g. proving the handler
+    fails-soft on bad payloads), so attempting to parent them would
+    invert the test's intent.
+    """
+    eid = event.get("event_id")
+    if not isinstance(eid, int) or eid <= 0:
+        return
+    conn.execute(
+        "INSERT OR IGNORE INTO event_log "
+        "(event_id, event_type, chain_id, payload_json, projection_status, ingested_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            eid,
+            event["event_type"],
+            event.get("chain_id", ""),
+            json.dumps(event.get("payload", {})),
+            "pending",
+            event.get("created_at", 1_700_000_000) if isinstance(event.get("created_at"), int) else 1_700_000_000,
+        ),
+    )
+
+
 def test_flag_off_returns_applied_without_writing_table(mem_conn) -> None:
     """Flag-off (env unset) → handler is a no-op.  The projector wrapper
     still records the event_log row as `applied` (Decision #6 contract)
@@ -151,6 +184,7 @@ def test_flag_on_inserts_row_with_hmac_stored_verbatim(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event)
         status = project_event(mem_conn, event)
 
     assert status == "applied"
@@ -196,8 +230,11 @@ def test_flag_on_idempotent_on_duplicate_event_id(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event)
         status_first = project_event(mem_conn, event)
+        _insert_event_log_parent(mem_conn, event)
         status_second = project_event(mem_conn, event)
+        _insert_event_log_parent(mem_conn, event)
         status_third = project_event(mem_conn, event)
 
     assert status_first == status_second == status_third == "applied"
@@ -223,7 +260,9 @@ def test_flag_on_distinct_dispatch_ids_yield_distinct_rows(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event_a)
         project_event(mem_conn, event_a)
+        _insert_event_log_parent(mem_conn, event_b)
         project_event(mem_conn, event_b)
 
     rows = mem_conn.execute(
@@ -248,6 +287,7 @@ def test_flag_on_missing_required_field_skips_table_write(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event)
         status = project_event(mem_conn, event)
 
     # Wrapper still returns 'applied' (warning is logged via _require).
@@ -272,6 +312,7 @@ def test_flag_on_handler_never_raises_on_bad_event_id(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event)
         status = project_event(mem_conn, event)
 
     assert status == "applied"
@@ -294,6 +335,7 @@ def test_flag_on_dispatched_at_int_passthrough(mem_conn) -> None:
         os.environ,
         {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
     ):
+        _insert_event_log_parent(mem_conn, event)
         project_event(mem_conn, event)
 
     row = mem_conn.execute(
@@ -311,3 +353,150 @@ def test_handler_is_registered_in_dispatch_table(mem_conn) -> None:
 
     assert "wicked.dispatch.log_entry_appended" in _HANDLERS
     assert _HANDLERS["wicked.dispatch.log_entry_appended"] is _dispatch_log_appended
+
+
+
+# ---------------------------------------------------------------------------
+# #753 — _bus ImportError observability (WARN once per process)
+# ---------------------------------------------------------------------------
+
+
+def test_bus_import_error_logs_warn_once(mem_conn, caplog) -> None:
+    """First call into _dispatch_log_appended with _bus unimportable emits one
+    WARN; subsequent calls under the same condition do NOT re-log (would spam
+    on sustained traffic). The handler still falls back to flag-off behavior
+    and counts as `_APPLIED` so the event_log audit row is preserved.
+    """
+    import logging
+    import sys
+    from daemon import projector
+
+    # Reset the module-level latch so this test is order-independent.
+    projector._BUS_IMPORT_WARNED = False
+
+    # Mask the _bus module so the lazy import inside the handler raises.
+    saved = sys.modules.pop("_bus", None)
+    sys.modules["_bus"] = None  # type: ignore[assignment]
+    try:
+        caplog.set_level(logging.WARNING, logger=projector.logger.name)
+        event = _make_event(event_id=1)
+        # Insert event_log row first so the wrapper has something to mark applied.
+        mem_conn.execute(
+            "INSERT INTO event_log (event_id, event_type, chain_id, payload_json, "
+            "projection_status, ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (1, event["event_type"], event["chain_id"], json.dumps(event["payload"]),
+             "pending", 1700000001),
+        )
+        projector._dispatch_log_appended(mem_conn, event)
+        # Second call — must NOT produce another WARN.
+        mem_conn.execute(
+            "INSERT INTO event_log (event_id, event_type, chain_id, payload_json, "
+            "projection_status, ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (2, event["event_type"], event["chain_id"], json.dumps(event["payload"]),
+             "pending", 1700000002),
+        )
+        projector._dispatch_log_appended(mem_conn, _make_event(event_id=2))
+    finally:
+        if saved is not None:
+            sys.modules["_bus"] = saved
+        else:
+            sys.modules.pop("_bus", None)
+        projector._BUS_IMPORT_WARNED = False  # leave clean for sibling tests
+
+    warns = [r for r in caplog.records
+             if r.levelno == logging.WARNING
+             and "_bus import failed" in r.getMessage()]
+    assert len(warns) == 1, (
+        f"expected exactly one WARN on _bus ImportError; got {len(warns)}: "
+        f"{[r.getMessage() for r in warns]}"
+    )
+
+
+def test_bus_import_error_falls_back_to_flag_off(mem_conn) -> None:
+    """When _bus is unimportable, the handler treats the flag as off:
+    no row in dispatch_log_entries, no exception propagated."""
+    import sys
+    from daemon import projector
+
+    projector._BUS_IMPORT_WARNED = False  # silence the WARN side-effect for this test
+
+    saved = sys.modules.pop("_bus", None)
+    sys.modules["_bus"] = None  # type: ignore[assignment]
+    try:
+        event = _make_event(event_id=42)
+        mem_conn.execute(
+            "INSERT INTO event_log (event_id, event_type, chain_id, payload_json, "
+            "projection_status, ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (42, event["event_type"], event["chain_id"], json.dumps(event["payload"]),
+             "pending", 1700000042),
+        )
+        # Must not raise.
+        projector._dispatch_log_appended(mem_conn, event)
+    finally:
+        if saved is not None:
+            sys.modules["_bus"] = saved
+        else:
+            sys.modules.pop("_bus", None)
+
+    rows = mem_conn.execute(
+        "SELECT COUNT(*) FROM dispatch_log_entries WHERE event_id = 42"
+    ).fetchone()[0]
+    assert rows == 0, "flag-off fallback must not write the projection table"
+
+
+# ---------------------------------------------------------------------------
+# #754 — FK + ON DELETE CASCADE on dispatch_log_entries.event_id
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_log_entries_cascades_on_event_log_delete(mem_conn) -> None:
+    """Deleting an event_log row removes its dispatch_log_entries projection
+    automatically — proves the FK CASCADE is wired AND enforced (PRAGMA
+    foreign_keys=ON at connect-time)."""
+    # Insert event_log row + matching projection row.
+    mem_conn.execute(
+        "INSERT INTO event_log (event_id, event_type, chain_id, payload_json, "
+        "projection_status, ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (777, "wicked.dispatch.log_entry_appended", "p.b.g.d-777", "{}",
+         "applied", 1700000777),
+    )
+    mem_conn.execute(
+        "INSERT INTO dispatch_log_entries (event_id, project_id, phase, gate, "
+        "reviewer, dispatch_id, dispatcher_agent, expected_result_path, "
+        "dispatched_at, hmac, hmac_present, raw_payload) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (777, "p", "b", "g", "rev-1", "d-777",
+         "wicked-garden:crew:phase-manager",
+         "phases/b/gate-result.json", 1700000777, "ab" * 32, 1, "{}"),
+    )
+    mem_conn.commit()
+
+    # Sanity: both rows present.
+    assert mem_conn.execute(
+        "SELECT COUNT(*) FROM dispatch_log_entries WHERE event_id = 777"
+    ).fetchone()[0] == 1
+
+    # Delete the parent → cascade removes the child.
+    mem_conn.execute("DELETE FROM event_log WHERE event_id = 777")
+    mem_conn.commit()
+
+    cascaded = mem_conn.execute(
+        "SELECT COUNT(*) FROM dispatch_log_entries WHERE event_id = 777"
+    ).fetchone()[0]
+    assert cascaded == 0, (
+        "FK ON DELETE CASCADE must remove the dispatch_log_entries row "
+        "when its parent event_log row is deleted (#754). If this fails: "
+        "either the FK is missing from the schema or PRAGMA foreign_keys=ON "
+        "is not set at connect-time."
+    )
+
+
+def test_foreign_keys_pragma_is_on(mem_conn) -> None:
+    """connect() must set PRAGMA foreign_keys=ON or the FK is parsed-but-not-enforced."""
+    rows = mem_conn.execute("PRAGMA foreign_keys").fetchall()
+    # PRAGMA returns a single row with a single column; SQLite returns 1 when on.
+    val = rows[0][0] if not hasattr(rows[0], "keys") else rows[0]["foreign_keys"]
+    assert val == 1, (
+        f"PRAGMA foreign_keys must be ON for the dispatch_log_entries CASCADE "
+        f"to enforce; got {val}. Check daemon/db.py::connect()."
+    )


### PR DESCRIPTION
## Summary

- Both fixes ship together because they're the same **template wart** cluster the pre-merge council on PR #751 named as preconditions for Site 2
- Sites 2-5 will copy-paste from Site 1's projector handler + schema, so we fix the template **before** the next clone happens
- Closes #753 (silent ImportError → WARN-once) + #754 (FK + ON DELETE CASCADE on projection table)

## #753 — `_bus` ImportError observability

`daemon/projector.py` — promote silent ImportError fallback to a one-time WARN via module-level `_BUS_IMPORT_WARNED` latch. First failed import logs a single warning naming the helper and the env var; subsequent calls keep the same fail-open behaviour but stay silent (sustained traffic would otherwise flood the log).

Sites 2-5 must inherit the WARN-once pattern, not the silent skip.

## #754 — FK + ON DELETE CASCADE

`daemon/db.py` — add `FOREIGN KEY (event_id) REFERENCES event_log(event_id) ON DELETE CASCADE` to the `dispatch_log_entries` table. `PRAGMA foreign_keys=ON` was already set in `connect()`.

**Migration**: pre-#754 DBs that ran #751 have an FK-less table. CREATE TABLE IF NOT EXISTS will not modify it. Added a guarded one-shot migration via `_run_migration` that:
- Checks `PRAGMA foreign_key_list` for the expected FK
- If missing AND table is empty: DROP + recreate with FK
- If missing AND non-empty: emit a `logger.warning` with the manual recovery SQL, leave the table alone — **never silently drop projection rows**

## Tests

4 new tests in `tests/daemon/test_projector_dispatch_log.py`:
- `test_bus_import_error_logs_warn_once` — pins the once-only WARN
- `test_bus_import_error_falls_back_to_flag_off` — pins fallback safety
- `test_dispatch_log_entries_cascades_on_event_log_delete` — pins FK enforcement
- `test_foreign_keys_pragma_is_on` — pins PRAGMA at connect-time

9 existing tests updated: they bypassed `event_log` when seeding `dispatch_log_entries` directly. The new FK rejects orphan inserts. Added `_insert_event_log_parent()` helper + prepended to every `project_event` call. Helper skips insert for non-int event_id so the bad-input test still exercises its intent.

**Cross-suite: 314 passed, 2 deselected. No regressions.**

## Staging plan addendum

`docs/v9/bus-cutover-staging-plan.md` §5 names FK + WARN as REQUIRED for Sites 2-5's projection tables. The pattern lock-in happens here, not in each site PR.

## Provenance

This PR was originally dispatched as a background agent that hit a stream-idle timeout (1.1M ms) after writing the 3 source files but before adding tests, committing, or opening the PR. Tests + commit + PR opened in the main thread to finish the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)