### PR TITLE
feat(crew): #750 spike — reconcile_v2 ADR + post-cutover test contract meta-test

### DIFF
--- a/docs/v9/adr-reconcile-v2.md
+++ b/docs/v9/adr-reconcile-v2.md
@@ -1,0 +1,148 @@
+# ADR: Post-cutover reconciler — `reconcile_v2.py` co-existence
+
+**Status**: Accepted (subject to Site 3 implementation feedback)
+**Date**: 2026-05-02
+**Decided by**: Pre-Site-3 design jam on issue #750
+**Supersedes**: nothing
+**Superseded by**: nothing
+
+## Context
+
+`scripts/crew/reconcile.py` is today's drift detector. It compares two
+on-disk stores — the wicked-crew `process-plan.json` tree and the native
+`tasks/` session tree — and reports drift classes (`missing_native`,
+`stale_status`, `orphan_native`, `phase_drift`). It is a **store-vs-store**
+comparison.
+
+The bus cutover (#746) inverts this. After Site 3 lands the
+`reviewer-report.md` cutover, the `wicked.gate.decided` event becomes the
+source of truth and the on-disk artifacts become *projections* of those
+events (per `docs/v9/bus-cutover-staging-plan.md` §5). The drift question
+shifts from "do the two stores agree?" to "does every event have its
+projection, and does every projection trace to an event?" That is a
+**projection-vs-event** comparison — a fundamentally different shape.
+
+The staging plan §5 spells out the new JSON output schema and the three
+post-cutover drift classes (`projection-stale`, `event-without-projection`,
+`projection-without-event`). It does NOT pin the Python entry-point
+contract, which leaves Site 3's implementer guessing at:
+
+- whether to grow `reconcile.py` with a `--post-cutover` flag, or ship a
+  new module
+- what `reconcile_all()` should return when the projector DB is missing
+- how the test suite should select between v1 and v2 detectors during
+  the cutover window when both must keep working
+
+The pre-merge council on PR #749 (synthetic-drift suite) deferred this
+decision to the Site 3 PR by filing #750. The pre-Site-3 design jam on
+#750 reopened it because Site 3 cannot start without an answer.
+
+## Options considered
+
+- **(a) Extend `reconcile.py` with a `--post-cutover` flag.** REJECTED.
+  The two reconcilers compare different things — one walks the tasks
+  store, the other walks the projector DB. Sharing a module would force
+  every detector function to grow `if cutover_complete:` branches that
+  ossify under test. The cutover window is finite (~5 releases); the
+  flag would outlive its purpose.
+- **(b) New module `scripts/crew/reconcile_v2.py` co-existing during
+  the cutover window. v1 deprecated when Site 5 lands; removed in
+  release N+5.** ACCEPTED.
+- **(c) Replace `reconcile.py` in place at Site 3.** REJECTED. The
+  staging plan keeps Sites 1-4 running with v1 detectors live (Sites
+  4-5 still hold pre-cutover artifacts). A rollback at any of those
+  sites would have to re-implement v1 from git history, which is the
+  exact "no rollback path" foot-gun the staging plan was written to
+  avoid.
+
+## Decision
+
+Ship `scripts/crew/reconcile_v2.py` alongside `scripts/crew/reconcile.py`.
+Both run during the cutover window; tests can import either explicitly.
+v1 is deprecated when Site 5 lands and removed in release N+5 (one full
+release at the new shape under flag-default-on, mirroring the JSON
+schema bump in staging plan §5 lines 515-519).
+
+## API contract (subject to Site 3 implementer pushback)
+
+```python
+def reconcile_all(daemon_db_path: Path | str | None = None) -> List[dict]:
+    """Returns the post-cutover drift report per staging plan §5 schema.
+
+    Result list shape:
+        [
+          {
+            "project_slug": "...",
+            "events_for_project": int,
+            "projections_materialized": {...},
+            "drift": [
+              {"type": "projection-stale", ...},
+              {"type": "event-without-projection", ...},
+              {"type": "projection-without-event", ...}
+            ],
+            "summary": {...}
+          },
+          ...
+        ]
+
+    Empty list when daemon_db_path is None or projector DB unavailable —
+    NEVER raises. Caller distinguishes "no projects" from "couldn't read"
+    by inspecting the per-project entries (an empty top-level list means
+    the projector was unreachable; a list with entries means projects
+    were scanned and zero drifted).
+    """
+```
+
+CLI surface:
+
+- `--all` and `--project <slug>` flags supported (mirror v1 surface so
+  existing operator muscle-memory transfers)
+- `--post-cutover` flag NOT introduced (separate module instead — see
+  Decision)
+- `--json` output schema bumps a major version per staging plan §5 line
+  516; v1's `--json` schema stays untouched until v1 is removed
+
+## Consequences
+
+- Tests can import `reconcile` (v1) or `reconcile_v2` explicitly — no
+  `if cutover_complete:` branches in production OR test code
+- Site 5's deprecation PR is a clean module removal, not an in-place
+  refactor with mixed-shape diffs
+- The synthetic-drift suite's three post-cutover test classes
+  (`ProjectionStaleTests`, `EventWithoutProjectionTests`,
+  `ProjectionWithoutEventTests`) will import `reconcile_v2` once Site
+  3 ships it; until then they assert fixture state only (the deferral
+  documented in #750)
+- Until Site 3 lands `reconcile_v2`, the meta-test in
+  `tests/crew/test_synthetic_drift.py::TestPostCutoverContract` treats
+  the import of `reconcile_v2` as the contract; the test passes
+  trivially today and tightens automatically the moment the module is
+  importable
+
+## Honest caveats
+
+- The `reconcile_all()` signature above is a **strong default**, NOT a
+  contract. The Site 3 implementer can push back — the post-cutover
+  detector logic may want different ergonomics (e.g. a streaming
+  iterator instead of a list, or a `Result[T, E]` shape instead of
+  empty-list-as-unavailable). Pushback is normal; this ADR exists to
+  give Site 3 a target, not to lock it in.
+- Treating the empty list as the "projector unavailable" signal is one
+  option. Raising a typed exception (`ProjectorUnavailable`) might be
+  cleaner. Decide at Site 3 with concrete usage data.
+- The deprecation window (release N+5) is calibrated to the staging
+  plan's existing schedule — if Site 3-5 slips, the window slips with
+  it. Re-baseline at Site 5 implementation.
+
+## References
+
+- Issue #750 (this ADR's home — defers detector assertions to Site 3)
+- Issue #746 (the umbrella step-3 cutover this enables)
+- Issue #749 (the synthetic-drift suite that surfaces the gap)
+- `docs/v9/bus-cutover-staging-plan.md` §5 (the JSON schema this ADR
+  provides a Python wrapping for)
+- `scripts/crew/reconcile.py` (the v1 module this ADR co-exists with)
+- `scripts/crew/synthetic_drift.py` (the fixture builder; see
+  `_DAEMON_DB_BEARING` for the canonical post-cutover class set)
+- Pre-Site-3 design jam on #750 (the conversation this decision came
+  out of)

--- a/docs/v9/bus-cutover-staging-plan.md
+++ b/docs/v9/bus-cutover-staging-plan.md
@@ -518,6 +518,16 @@ release as the LAST cutover flip (N+5) so one full release runs at the
 new shape under flag-default-on before strict mode removes the opt-out
 at N+6.
 
+**Implementation contract** (per ADR `docs/v9/adr-reconcile-v2.md`,
+decided 2026-05-02 via the pre-Site-3 design jam on issue #750): the
+post-cutover reconciler ships as a new module
+`scripts/crew/reconcile_v2.py` co-existing with v1 during the cutover
+window. v1 is deprecated when Site 5 lands and removed in release N+5.
+Site 3's PR ships `reconcile_v2.py` and the detector assertions in
+`tests/crew/test_synthetic_drift.py`'s three post-cutover test classes
+per the meta-test contract already locked in #750
+(`TestPostCutoverContract` — see the ADR for the exact rule).
+
 ### Required template patterns for Sites 2-5 projection tables (#753 + #754)
 
 The pre-merge council on PR #751 (Site 1) named two template warts that

--- a/tests/crew/test_synthetic_drift.py
+++ b/tests/crew/test_synthetic_drift.py
@@ -21,6 +21,7 @@ Stdlib + pytest only — no extra deps.
 """
 from __future__ import annotations
 
+import ast
 import json
 import os
 import sqlite3
@@ -540,6 +541,182 @@ class CliSmokeTests(unittest.TestCase):
                 rc = synthetic_drift.main(["teardown", "--manifest", str(manifest_path)])
             self.assertEqual(rc, 0)
             self.assertFalse(Path(manifest["process_plan_path"]).is_file())
+
+
+# ---------------------------------------------------------------------------
+# Post-cutover contract meta-test (Issue #750, ADR adr-reconcile-v2.md)
+# ---------------------------------------------------------------------------
+
+class TestPostCutoverContract(unittest.TestCase):
+    """Meta-test: every post-cutover synthetic-drift test class MUST be
+    exercised by a test method that imports/references ``reconcile_v2``
+    (the post-cutover reconciler shipped by Site 3 of #746).
+
+    Today, before Site 3 lands ``scripts/crew/reconcile_v2.py``, this
+    test passes trivially: NO test in this file references
+    ``reconcile_v2`` yet, and NO post-cutover test asserts against a
+    reconciler — they all assert fixture state only (the documented
+    council deferral on #750).
+
+    The moment ``reconcile_v2`` lands AND the post-cutover test classes
+    grow real detector assertions, this meta-test starts enforcing the
+    contract: any test method inside a class that targets a
+    post-cutover drift class MUST reference ``reconcile_v2`` somewhere
+    in its body. This blocks the "fixture-shape only assertion"
+    pattern from sneaking back in.
+
+    No escape hatch (no ``# fixture-only-OK`` comment marker). If a
+    test is genuinely fixture-only it does not belong in
+    ``test_synthetic_drift.py`` — move it to a unit test for the
+    fixture builder.
+
+    Adapts to real ``synthetic_drift`` structure:
+      - canonical post-cutover set is ``synthetic_drift._DAEMON_DB_BEARING``
+        (a frozenset of drift class names)
+      - test classes for those drift classes follow the convention of
+        embedding the kebab-case slug as PascalCase in the class name
+        (e.g. ``projection-stale`` -> ``ProjectionStale*``)
+
+    See ``docs/v9/adr-reconcile-v2.md`` for the contract this enforces.
+    """
+
+    # When Site 3 ships reconcile_v2, the meta-test transitions from
+    # "trivially passes" to "actively enforces". The transition is
+    # automatic — no flag flip needed.
+    _RECONCILE_V2_MODULE = "reconcile_v2"
+
+    def _post_cutover_drift_classes(self) -> set[str]:
+        """Return the canonical set of post-cutover drift classes, or
+        an empty set if the underlying registry is missing.
+
+        Skips gracefully if ``synthetic_drift`` is restructured so
+        ``_DAEMON_DB_BEARING`` no longer exists — the meta-test should
+        never fail because the registry layout changed.
+        """
+        registry = getattr(synthetic_drift, "_DAEMON_DB_BEARING", None)
+        if registry is None:
+            return set()
+        try:
+            return {str(c) for c in registry}
+        except TypeError:
+            return set()
+
+    @staticmethod
+    def _slug_to_pascal(slug: str) -> str:
+        """``projection-stale`` -> ``ProjectionStale``. Stable for matching
+        against PascalCase class names in the test file."""
+        parts = slug.replace("_", "-").split("-")
+        return "".join(p[:1].upper() + p[1:].lower() for p in parts if p)
+
+    @staticmethod
+    def _identifiers_in_node(node: ast.AST) -> set[str]:
+        """Collect every identifier and module reference under ``node``.
+
+        Captures Name, Attribute, ImportFrom (module + aliases), and
+        Import (module names). This is conservative on purpose — we
+        want any reference to ``reconcile_v2`` to count, not just
+        explicit imports, because a test could receive the module via
+        a fixture.
+        """
+        idents: set[str] = set()
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name):
+                idents.add(sub.id)
+            elif isinstance(sub, ast.Attribute):
+                idents.add(sub.attr)
+            elif isinstance(sub, ast.ImportFrom):
+                if sub.module:
+                    idents.add(sub.module)
+                for alias in sub.names:
+                    idents.add(alias.name)
+                    if alias.asname:
+                        idents.add(alias.asname)
+            elif isinstance(sub, ast.Import):
+                for alias in sub.names:
+                    idents.add(alias.name)
+                    if alias.asname:
+                        idents.add(alias.asname)
+        return idents
+
+    def test_every_post_cutover_class_has_a_reconciler_test(self) -> None:
+        # Local import keeps top-of-file imports unchanged for readers
+        # tracing the v1 test suite.
+        import ast as _ast  # noqa: F401  -- kept explicit for the docstring contract
+
+        post_cutover_classes = self._post_cutover_drift_classes()
+        if not post_cutover_classes:
+            # Registry layout changed or post-cutover set was emptied.
+            # Skip rather than failing — the contract is "test EVERY
+            # post-cutover class", not "fail when the set is empty".
+            self.skipTest(
+                "synthetic_drift._DAEMON_DB_BEARING is missing or empty; "
+                "meta-test has nothing to enforce"
+            )
+
+        # Module-existence gate. If ``scripts/crew/reconcile_v2.py``
+        # does not exist on disk, Site 3 has not landed yet — the
+        # contract passes trivially. This is the documented deferral
+        # path from #750 + adr-reconcile-v2.md. We check for the FILE
+        # rather than try to import (importing would mutate sys.modules
+        # and could interact with the existing ``import reconcile``
+        # statement at the top of this file).
+        reconcile_v2_path = (
+            _REPO_ROOT / "scripts" / "crew" / f"{self._RECONCILE_V2_MODULE}.py"
+        )
+        if not reconcile_v2_path.is_file():
+            return  # trivial pass — Site 3 has not landed yet
+
+        # Site 3 has landed (reconcile_v2.py exists on disk). The
+        # contract becomes enforceable: every post-cutover class needs
+        # at least one test that references reconcile_v2.
+        test_file = Path(__file__).resolve()
+        source = test_file.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        violations: list[str] = []
+
+        for drift_class in sorted(post_cutover_classes):
+            pascal = self._slug_to_pascal(drift_class)
+            matching_classes: list[ast.ClassDef] = []
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef) and pascal in node.name:
+                    matching_classes.append(node)
+
+            if not matching_classes:
+                # A post-cutover drift class with no test class targeting
+                # it is a coverage gap, not a meta-test failure. Other
+                # tests in this file (AllSupportedClassesBuildableTests)
+                # already assert manifest-level coverage. Skip here.
+                continue
+
+            has_v2_assertion = False
+            for cls in matching_classes:
+                for item in cls.body:
+                    if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        continue
+                    if not item.name.startswith("test_"):
+                        continue
+                    idents = self._identifiers_in_node(item)
+                    if self._RECONCILE_V2_MODULE in idents:
+                        has_v2_assertion = True
+                        break
+                if has_v2_assertion:
+                    break
+
+            if not has_v2_assertion:
+                violations.append(
+                    f"  {drift_class}: classes "
+                    f"{[c.name for c in matching_classes]} have no test "
+                    f"method that references {self._RECONCILE_V2_MODULE!r}; "
+                    f"add a detector assertion (see ADR adr-reconcile-v2.md)"
+                )
+
+        self.assertEqual(
+            violations, [],
+            "Post-cutover synthetic-drift tests MUST assert against "
+            "reconcile_v2's detector output, not just fixture state. "
+            "Per ADR docs/v9/adr-reconcile-v2.md and Issue #750.\n"
+            "Violations:\n" + "\n".join(violations)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pre-Site-3 design jam on #750 recommended **Option 3**: lock the
post-cutover-test contract NOW so Site 3 of #746 has a concrete API
target, and the synthetic-drift suite cannot silently regress to
fixture-shape-only assertions. This is gating Site 3 of the umbrella
bus cutover (#746) — the post-cutover reconciler needs a stable place
to land.

Three small files, parallel-safe with Site 2 (cutover) which is in
flight in a sibling worktree:

1. **`docs/v9/adr-reconcile-v2.md`** (NEW) — ADR for the post-cutover
   reconciler. Decides on co-existing `scripts/crew/reconcile_v2.py`
   alongside v1 during the cutover window. Rejects: `--post-cutover`
   flag on v1, and in-place replacement.
2. **`tests/crew/test_synthetic_drift.py`** (EXTENDED, ~170 LOC) —
   adds `TestPostCutoverContract`. Walks the file's AST, finds test
   classes targeting each entry in `synthetic_drift._DAEMON_DB_BEARING`,
   and asserts at least one test method per class references
   `reconcile_v2`. Today the contract passes trivially because
   `scripts/crew/reconcile_v2.py` does not exist; the moment Site 3
   ships it, the contract auto-tightens.
3. **`docs/v9/bus-cutover-staging-plan.md`** (small update) — adds a
   paragraph to §5 pointing to the ADR.

## Honest caveats

- The `reconcile_all()` signature in the ADR is a **strong default,
  NOT a contract**. The Site 3 implementer can push back — pushback
  is expected and welcomed.
- Detector assertions land WITH Site 3, not in this spike. That is
  the original deferral on #750 and remains true.
- The contract enforcement is "module exists on disk" not "module is
  importable" — chosen to avoid mutating `sys.modules` from inside a
  meta-test that already imports `reconcile`.

## What this PR does NOT touch (parallel-safe)

Site 2 files (in flight in sibling worktree):
- `scripts/crew/consensus_gate.py`
- `daemon/projector.py`
- `daemon/db.py`
- `scripts/_bus.py`
- `scripts/crew/phase_manager.py`

Also intentionally untouched:
- `scripts/crew/synthetic_drift.py` (only its tests are extended)
- `scripts/crew/reconcile.py` (v1 stays untouched)
- `scripts/crew/reconcile_v2.py` (Site 3 ships it)

## Test plan

- [x] `sh scripts/_python.sh -m pytest tests/crew/test_synthetic_drift.py -v` — 14 passed, 4 skipped (4 skipped match baseline; daemon DB not available locally). Was 13+4 before this PR; meta-test adds 1.
- [x] Contract enforcement verified by simulation: `touch scripts/crew/reconcile_v2.py` → meta-test fails with all 3 post-cutover classes flagged by name; `rm` → meta-test passes again.
- [x] Stdlib-only (no new dependencies).
- [x] Cross-platform — uses `pathlib`, `ast`, `unittest`; no shell-only constructs.

## References

- Closes #750 — the spike satisfies the issue's intent (lock the
  contract, ADR the reconciler shape, defer detector assertions to
  Site 3 with an automatic-tightening guard rail)
- Gates Site 3 of #746 (the post-cutover reconciler implementation)
- Follow-up to #749 (synthetic-drift suite) and #751 (Site 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)