### PR TITLE
feat(daemon): #768 projector handlers for wicked.consensus.gate_* (Site 3)

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -872,6 +872,222 @@ def _consensus_evidence_recorded(conn: sqlite3.Connection, event: dict) -> None:
     )
 
 
+# --- bus-cutover Site 3 (#768) handlers -----------------------------------
+#
+# Two handlers materialise phases/{phase}/reviewer-report.md from bus events,
+# producing the same on-disk file that hooks/scripts/post_tool.py's
+# _write_reviewer_report / _write_pending_reviewer_report write directly.
+#
+# Idempotency strategy (Decision #6 compatibility):
+#   The projector wrapper handles duplicate events via event_log INSERT OR IGNORE
+#   keyed on (event_id) — the same event is never presented to a handler twice
+#   in production.  Under test-harness replay (no event_log dedup), the
+#   handlers are still safe because raw_payload already contains the FULL
+#   target file content in all branches (create, append, pending).  Writing
+#   the same bytes twice is idempotent by nature.
+#
+# project_dir resolution:
+#   The payload carries project_id + phase.  We look up the project row in the
+#   DB (db.get_project) to find the `directory` field.  If the project row is
+#   absent or directory is NULL, we log a warning and skip — never infer a path
+#   from local filesystem conventions in the daemon.
+#
+# Council Condition C8 addendum (N=3 warning):
+#   With Site 3 we have three handler pairs.  The shared import pattern
+#   (_BUS_IMPORT_WARNED latch, import-fail = flag-off) is now clearly
+#   stable.  ADR for N=3 base-class extraction is deferred to Issue #771.
+
+_CONSENSUS_GATE_SEPARATOR = "\n\n---\n## Consensus Gate Evaluation\n\n"
+
+
+def _consensus_gate_completed(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.consensus.gate_completed → reviewer-report.md on disk.
+
+    Site 3 of the bus-cutover staging plan (#746, #768).  Behaviour is gated
+    on ``WG_BUS_AS_TRUTH_REVIEWER_REPORT`` via
+    ``_bus_as_truth_enabled("REVIEWER_REPORT")``:
+
+      * flag-off (default): handler is a no-op.  The projector wrapper still
+        records the event_log row as ``applied`` (Decision #6); the disk file
+        remains source of truth.
+      * flag-on: write raw_payload to phases/{phase}/reviewer-report.md.
+        - create branch (``payload.branch == "create"``): write raw_payload as
+          the full file — mirrors _write_reviewer_report's else-branch.
+        - append branch (``payload.branch == "append"``): write raw_payload as
+          the full file — raw_payload already contains the pre-appended
+          separator + yaml_block per the hook's write-then-emit contract, so a
+          simple write is byte-identical to the legacy hook.
+
+    Idempotency: writing the same raw_payload bytes twice produces the same
+    file — no duplicate-append risk.  The projector wrapper's event_log INSERT
+    OR IGNORE prevents re-presenting the same event_id to this handler.
+
+    project_dir is resolved via db.get_project(conn, project_id).directory.
+    If the project row is absent or directory is NULL, the handler warns and
+    skips (never infers filesystem paths in the daemon).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("REVIEWER_REPORT")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off (will not re-warn this process): %s",
+                exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    # Resolve project_dir from the DB.
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.consensus.gate_completed — project %r has no "
+            "directory in DB; skipping file write (project must be projected "
+            "via wicked.project.created before Site 3 handlers can write files)",
+            project_id,
+        )
+        return
+
+    phase_dir = Path(project_row["directory"]) / "phases" / str(phase)
+    report_path = phase_dir / "reviewer-report.md"
+
+    # Write raw_payload as the full file content.
+    # raw_payload is the canonical on-disk bytes: for the create branch it is
+    # the yaml_block; for the append branch it already includes the separator
+    # + yaml_block appended to the existing content.  Either way a plain write
+    # produces the byte-identical file that the legacy hook wrote.
+    try:
+        phase_dir.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(str(raw_payload), encoding="utf-8")
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.consensus.gate_completed — could not write %s: %s",
+            report_path,
+            exc,
+        )
+        return
+
+    branch = _opt(payload, "branch", "unknown")
+    logger.debug(
+        "projector: applied wicked.consensus.gate_completed "
+        "project_id=%r phase=%r branch=%r report_path=%s",
+        project_id, phase, branch, report_path,
+    )
+
+
+def _consensus_gate_pending(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.consensus.gate_pending → reviewer-report.md on disk.
+
+    Site 3 of the bus-cutover staging plan (#746, #768).  Behaviour is gated
+    on ``WG_BUS_AS_TRUTH_REVIEWER_REPORT`` via
+    ``_bus_as_truth_enabled("REVIEWER_REPORT")``:
+
+      * flag-off (default): handler is a no-op (same Decision #6 contract).
+      * flag-on: write raw_payload (pending template) to reviewer-report.md
+        ONLY when the file does not already exist.  Mirrors
+        _write_pending_reviewer_report's "Don't clobber an existing report"
+        invariant byte-for-byte.
+
+    NO-OP when file already exists — this is by design.  The pending event
+    fires on consensus evaluation failure and should never overwrite a real
+    gate result that arrived later (or was written by the legacy hook).
+
+    project_dir is resolved via db.get_project(conn, project_id).directory.
+    Same warning + skip behaviour as _consensus_gate_completed on absent row.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("REVIEWER_REPORT")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off (will not re-warn this process): %s",
+                exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    # Resolve project_dir from the DB.
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.consensus.gate_pending — project %r has no "
+            "directory in DB; skipping file write",
+            project_id,
+        )
+        return
+
+    phase_dir = Path(project_row["directory"]) / "phases" / str(phase)
+    report_path = phase_dir / "reviewer-report.md"
+
+    # NO-OP when file already exists — mirrors _write_pending_reviewer_report's
+    # "Don't clobber an existing report" invariant exactly.
+    if report_path.exists():
+        logger.debug(
+            "projector: wicked.consensus.gate_pending NO-OP — %s already exists",
+            report_path,
+        )
+        return
+
+    try:
+        phase_dir.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(str(raw_payload), encoding="utf-8")
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.consensus.gate_pending — could not write %s: %s",
+            report_path,
+            exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.consensus.gate_pending "
+        "project_id=%r phase=%r report_path=%s",
+        project_id, phase, report_path,
+    )
+
+
 def _ac_evidence_linked(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.ac.evidence_linked → add row to ac_evidence.
 
@@ -949,6 +1165,14 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # Same registered-always pattern as Site 1.
     "wicked.consensus.report_created": _consensus_report_created,
     "wicked.consensus.evidence_recorded": _consensus_evidence_recorded,
+    # Site 3 of bus-cutover (#746, #768): reviewer-report.md file projection.
+    # Both handlers gate on WG_BUS_AS_TRUTH_REVIEWER_REPORT (single flag,
+    # same env var the hook reads via _bus_as_truth_flag_on() in post_tool.py).
+    # flag-off → no-op; flag-on → write phases/{phase}/reviewer-report.md
+    # byte-identical to _write_reviewer_report / _write_pending_reviewer_report.
+    # Registered always per Decision #6 — gating happens inside each handler.
+    "wicked.consensus.gate_completed": _consensus_gate_completed,
+    "wicked.consensus.gate_pending": _consensus_gate_pending,
 }
 
 

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -897,9 +897,6 @@ def _consensus_evidence_recorded(conn: sqlite3.Connection, event: dict) -> None:
 #   (_BUS_IMPORT_WARNED latch, import-fail = flag-off) is now clearly
 #   stable.  ADR for N=3 base-class extraction is deferred to Issue #771.
 
-_CONSENSUS_GATE_SEPARATOR = "\n\n---\n## Consensus Gate Evaluation\n\n"
-
-
 def _consensus_gate_completed(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.consensus.gate_completed → reviewer-report.md on disk.
 

--- a/tests/daemon/test_projector_consensus_gate.py
+++ b/tests/daemon/test_projector_consensus_gate.py
@@ -10,9 +10,8 @@ Covers:
   * test_gate_pending_noop_when_report_exists: pre-existing report → file unchanged.
   * test_idempotent_replay_gate_completed: replay same gate_completed event twice → file
     unchanged on second apply.
-  * test_replay_matches_hook_byte_for_byte: run the legacy hook path to produce a reference
-    file, then replay via the projector → byte-identical (timestamps replaced with fixed
-    values per T1 determinism).
+  * test_projector_writes_raw_payload_verbatim: simulate legacy hook output with a fixed
+    timestamp, replay via the projector → byte-identical (T1 determinism).
   * test_both_handlers_are_registered: dispatch table contains both new event types.
   * test_flag_off_gate_completed_noop: flag-off → file not written.
   * test_flag_off_gate_pending_noop: flag-off → file not written.
@@ -44,9 +43,8 @@ import pytest
 # ---------------------------------------------------------------------------
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPTS = _REPO_ROOT / "scripts"
-_HOOKS_SCRIPTS = _REPO_ROOT / "hooks" / "scripts"
 
-for p in (_REPO_ROOT, _SCRIPTS, _HOOKS_SCRIPTS):
+for p in (_REPO_ROOT, _SCRIPTS):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
@@ -418,15 +416,16 @@ def test_idempotent_replay_gate_completed(mem_conn, tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_replay_matches_hook_byte_for_byte(mem_conn, tmp_path) -> None:
-    """Run the legacy hook path to produce a reference file, then replay via
-    the projector → byte-identical.
+def test_projector_writes_raw_payload_verbatim(mem_conn, tmp_path) -> None:
+    """Simulates the legacy hook output and verifies the projector writes it
+    byte-identically.
 
-    Timestamp non-determinism: the hook uses _now_iso() which embeds wall-clock
-    time in the YAML `reviewed_at` field.  We sidestep this by building
-    raw_payload manually with a fixed timestamp — the hook emits raw_payload
-    as the FULL file bytes, so what matters is that the projector writes those
-    bytes unchanged, not that it re-generates the yaml_block.
+    The hook would call _write_reviewer_report() which builds a YAML block via
+    _build_reviewer_report_yaml() and emits raw_payload = full file bytes.  We
+    replicate that output here with a fixed timestamp (T1 determinism requirement
+    — _now_iso() embeds wall-clock time which the hook would otherwise embed).
+    The projector's contract is to write raw_payload verbatim, so the assertion
+    is that projector output == the simulated reference bytes.
 
     Structural equivalence assertion: both files have the same lines (order-
     preserved), confirming the projector does not add/remove/transform content.

--- a/tests/daemon/test_projector_consensus_gate.py
+++ b/tests/daemon/test_projector_consensus_gate.py
@@ -1,0 +1,603 @@
+"""tests/daemon/test_projector_consensus_gate.py — Projector tests for Site 3
+bus-cutover handlers ``_consensus_gate_completed`` and
+``_consensus_gate_pending`` (#768).
+
+Covers:
+  * test_gate_completed_creates_fresh_file: empty phase dir → file matches raw_payload.
+  * test_gate_completed_appends_to_existing: pre-existing report + gate_completed event
+    → file equals raw_payload (which already contains the appended content per hook contract).
+  * test_gate_pending_writes_template_when_absent: empty phase dir → pending template written.
+  * test_gate_pending_noop_when_report_exists: pre-existing report → file unchanged.
+  * test_idempotent_replay_gate_completed: replay same gate_completed event twice → file
+    unchanged on second apply.
+  * test_replay_matches_hook_byte_for_byte: run the legacy hook path to produce a reference
+    file, then replay via the projector → byte-identical (timestamps replaced with fixed
+    values per T1 determinism).
+  * test_both_handlers_are_registered: dispatch table contains both new event types.
+  * test_flag_off_gate_completed_noop: flag-off → file not written.
+  * test_flag_off_gate_pending_noop: flag-off → file not written.
+  * test_missing_required_fields_gate_completed: missing project_id/phase/raw_payload → skip.
+  * test_missing_project_directory_in_db: project row absent → warning, skip.
+  * test_project_directory_null_in_db: project row present but directory=NULL → skip.
+
+T1: deterministic — fixed-epoch timestamps, no wall-clock reads in assertions.
+T2: no sleep-based sync.
+T3: isolated — each test gets its own tmp_path + in-memory DB via mem_conn fixture.
+T4: one concern per test function.
+T5: descriptive names.
+T6: provenance: #768 Site 3 bus-cutover.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure daemon/ and scripts/ are importable from the repo root.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_HOOKS_SCRIPTS = _REPO_ROOT / "hooks" / "scripts"
+
+for p in (_REPO_ROOT, _SCRIPTS, _HOOKS_SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — project / phase directory setup
+# ---------------------------------------------------------------------------
+
+def _setup_project_in_db(conn, project_id: str, project_dir: Path) -> None:
+    """Insert a minimal project row so db.get_project resolves project_dir."""
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+def _make_project_dir(tmp_path: Path, project_id: str = "my-proj") -> Path:
+    """Return a project directory under tmp_path (not yet created)."""
+    return tmp_path / project_id
+
+
+# ---------------------------------------------------------------------------
+# Event builders
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = 1_700_000_001
+
+_SAMPLE_YAML_BLOCK = textwrap.dedent("""\
+    ---
+    verdict: approved
+    evidence_items_checked: 2
+    reviewer: consensus-gate
+    reviewed_at: 2026-01-01T00:00:00Z
+    agreement_ratio: 0.9
+    findings: []
+    conditions: []
+    ---
+""")
+
+_SAMPLE_PENDING_BLOCK = textwrap.dedent("""\
+    ---
+    verdict: pending
+    evidence_items_checked: 0
+    reviewer: consensus-gate
+    reviewed_at: 2026-01-01T00:00:00Z
+    agreement_ratio: 0.0
+    findings: []
+    conditions: []
+    note: "consensus evaluation failed or was skipped — will be re-evaluated on next approve"
+    ---
+""")
+
+_SEPARATOR = "\n\n---\n## Consensus Gate Evaluation\n\n"
+
+
+def _make_gate_completed_create_event(
+    *,
+    event_id: int = 1,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    eval_id: str = "aabbccdd11223344",
+    raw_payload: str | None = None,
+) -> dict[str, Any]:
+    """Build a wicked.consensus.gate_completed event (create branch)."""
+    if raw_payload is None:
+        raw_payload = _SAMPLE_YAML_BLOCK
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.consensus.gate_completed",
+        "chain_id": f"{project_id}.{phase}.consensus.{eval_id}",
+        "created_at": _FIXED_TS + event_id,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "verdict": "approved",
+            "eval_id": eval_id,
+            "branch": "create",
+            "raw_payload": raw_payload,
+        },
+    }
+
+
+def _make_gate_completed_append_event(
+    *,
+    event_id: int = 2,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    eval_id: str = "aabbccdd11223344",
+    existing_content: str,
+    yaml_block: str | None = None,
+) -> dict[str, Any]:
+    """Build a wicked.consensus.gate_completed event (append branch).
+
+    raw_payload mirrors what the hook writes: existing + separator + yaml_block.
+    """
+    if yaml_block is None:
+        yaml_block = _SAMPLE_YAML_BLOCK
+    full_content = existing_content + _SEPARATOR + yaml_block
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.consensus.gate_completed",
+        "chain_id": f"{project_id}.{phase}.consensus.{eval_id}",
+        "created_at": _FIXED_TS + event_id,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "verdict": "approved",
+            "eval_id": eval_id,
+            "branch": "append",
+            "raw_payload": full_content,
+        },
+    }
+
+
+def _make_gate_pending_event(
+    *,
+    event_id: int = 1,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    eval_id: str = "aabbccdd11223344",
+    raw_payload: str | None = None,
+) -> dict[str, Any]:
+    """Build a wicked.consensus.gate_pending event."""
+    if raw_payload is None:
+        raw_payload = _SAMPLE_PENDING_BLOCK
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.consensus.gate_pending",
+        "chain_id": f"{project_id}.{phase}.consensus.{eval_id}",
+        "created_at": _FIXED_TS + event_id,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "eval_id": eval_id,
+            "raw_payload": raw_payload,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handler registration
+# ---------------------------------------------------------------------------
+
+
+def test_both_handlers_are_registered_in_dispatch_table() -> None:
+    """Site 3 handlers MUST be registered in _HANDLERS always (registered-always
+    pattern, per Decision #6 / Council Condition C5 precedent from Site 1+2).
+    Gating happens INSIDE the handler via flag check, not by removing it from
+    the table."""
+    from daemon.projector import (
+        _HANDLERS,
+        _consensus_gate_completed,
+        _consensus_gate_pending,
+    )
+
+    assert "wicked.consensus.gate_completed" in _HANDLERS, (
+        "wicked.consensus.gate_completed not registered in _HANDLERS — "
+        "#769 handler-presence gate scan will miss it."
+    )
+    assert _HANDLERS["wicked.consensus.gate_completed"] is _consensus_gate_completed
+
+    assert "wicked.consensus.gate_pending" in _HANDLERS, (
+        "wicked.consensus.gate_pending not registered in _HANDLERS."
+    )
+    assert _HANDLERS["wicked.consensus.gate_pending"] is _consensus_gate_pending
+
+
+# ---------------------------------------------------------------------------
+# Flag-off contract
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_gate_completed_noop(mem_conn, tmp_path) -> None:
+    """flag-off → file not written, project_event returns 'applied' (Decision #6)."""
+    from daemon.projector import project_event
+
+    project_id = "proj-flagoff-completed"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_completed_create_event(project_id=project_id)
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("WG_BUS_AS_TRUTH_REVIEWER_REPORT", None)
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert not report_path.exists(), (
+        "flag-off: reviewer-report.md must NOT be written when "
+        "WG_BUS_AS_TRUTH_REVIEWER_REPORT is unset."
+    )
+
+
+def test_flag_off_gate_pending_noop(mem_conn, tmp_path) -> None:
+    """flag-off → pending file not written."""
+    from daemon.projector import project_event
+
+    project_id = "proj-flagoff-pending"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_pending_event(project_id=project_id)
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("WG_BUS_AS_TRUTH_REVIEWER_REPORT", None)
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert not report_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Core write behaviour (flag-on)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_completed_creates_fresh_file(mem_conn, tmp_path) -> None:
+    """Empty phase dir, single gate_completed event → file matches raw_payload."""
+    from daemon.projector import project_event
+
+    project_id = "proj-fresh"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    raw = _SAMPLE_YAML_BLOCK
+    event = _make_gate_completed_create_event(
+        project_id=project_id, raw_payload=raw
+    )
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert report_path.exists(), "reviewer-report.md was not created."
+    assert report_path.read_text(encoding="utf-8") == raw
+
+
+def test_gate_completed_appends_to_existing(mem_conn, tmp_path) -> None:
+    """Pre-existing report + gate_completed (append branch) → file equals raw_payload.
+
+    raw_payload in the append branch already contains the separator + yaml_block
+    appended to the existing content (per the hook's write-then-emit contract),
+    so the projector just writes raw_payload and achieves the same result.
+    """
+    from daemon.projector import project_event
+
+    project_id = "proj-append"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    # Pre-populate the file as the independent-reviewer agent would have done.
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    existing_content = "## Independent Review\n\nLooks good.\n"
+    report_path = phase_dir / "reviewer-report.md"
+    report_path.write_text(existing_content, encoding="utf-8")
+
+    event = _make_gate_completed_append_event(
+        project_id=project_id,
+        existing_content=existing_content,
+    )
+    expected_full = existing_content + _SEPARATOR + _SAMPLE_YAML_BLOCK
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert report_path.read_text(encoding="utf-8") == expected_full
+
+
+def test_gate_pending_writes_template_when_absent(mem_conn, tmp_path) -> None:
+    """Empty phase dir → pending template written (mirrors _write_pending_reviewer_report)."""
+    from daemon.projector import project_event
+
+    project_id = "proj-pending-fresh"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    raw = _SAMPLE_PENDING_BLOCK
+    event = _make_gate_pending_event(project_id=project_id, raw_payload=raw)
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert report_path.exists()
+    assert report_path.read_text(encoding="utf-8") == raw
+
+
+def test_gate_pending_noop_when_report_exists(mem_conn, tmp_path) -> None:
+    """Pre-existing report + gate_pending → file unchanged (NO-OP contract).
+
+    The hook's _write_pending_reviewer_report returns immediately if the file
+    exists — never clobbers a real result.  The projector must mirror this.
+    """
+    from daemon.projector import project_event
+
+    project_id = "proj-pending-noop"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    # Pre-populate with a real report.
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    real_report = "## Real Review\n\nAll checks passed.\n"
+    report_path = phase_dir / "reviewer-report.md"
+    report_path.write_text(real_report, encoding="utf-8")
+
+    event = _make_gate_pending_event(
+        project_id=project_id,
+        raw_payload=_SAMPLE_PENDING_BLOCK,
+    )
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    # The real report MUST NOT be clobbered.
+    assert report_path.read_text(encoding="utf-8") == real_report
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_replay_gate_completed(mem_conn, tmp_path) -> None:
+    """Replaying the same gate_completed event twice → file unchanged on second apply.
+
+    The projector wrapper (event_log INSERT OR IGNORE) ensures the same event_id
+    is never re-presented in production.  This test verifies the handler itself
+    is also idempotent when called directly: writing the same bytes twice
+    produces no observable change.
+    """
+    from daemon.projector import _consensus_gate_completed  # call handler directly
+
+    project_id = "proj-idempotent"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    raw = _SAMPLE_YAML_BLOCK
+    event = _make_gate_completed_create_event(project_id=project_id, raw_payload=raw)
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        _consensus_gate_completed(mem_conn, event)
+        first_mtime = report_path.stat().st_mtime_ns
+        first_content = report_path.read_text(encoding="utf-8")
+
+        # Second apply — same event, same bytes.
+        _consensus_gate_completed(mem_conn, event)
+        second_content = report_path.read_text(encoding="utf-8")
+
+    assert first_content == second_content == raw, (
+        "Idempotency failure: second apply changed file content."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Byte-for-byte parity with legacy hook
+# ---------------------------------------------------------------------------
+
+
+def test_replay_matches_hook_byte_for_byte(mem_conn, tmp_path) -> None:
+    """Run the legacy hook path to produce a reference file, then replay via
+    the projector → byte-identical.
+
+    Timestamp non-determinism: the hook uses _now_iso() which embeds wall-clock
+    time in the YAML `reviewed_at` field.  We sidestep this by building
+    raw_payload manually with a fixed timestamp — the hook emits raw_payload
+    as the FULL file bytes, so what matters is that the projector writes those
+    bytes unchanged, not that it re-generates the yaml_block.
+
+    Structural equivalence assertion: both files have the same lines (order-
+    preserved), confirming the projector does not add/remove/transform content.
+    """
+    project_id = "proj-parity"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    # Simulate what the hook emits as raw_payload (full file bytes).
+    # Use a fixed-timestamp yaml_block for determinism (T1 requirement).
+    fixed_yaml = textwrap.dedent("""\
+        ---
+        verdict: approved
+        evidence_items_checked: 3
+        reviewer: consensus-gate
+        reviewed_at: 2026-01-01T12:00:00Z
+        agreement_ratio: 0.9
+        findings: []
+        conditions: []
+        ---
+    """)
+
+    # Reference: write the "legacy hook result" to a reference path.
+    ref_dir = tmp_path / "reference" / "phases" / "build"
+    ref_dir.mkdir(parents=True)
+    ref_path = ref_dir / "reviewer-report.md"
+    ref_path.write_text(fixed_yaml, encoding="utf-8")
+
+    # Projector replay: pass raw_payload = fixed_yaml (the full file bytes).
+    event = _make_gate_completed_create_event(
+        project_id=project_id, raw_payload=fixed_yaml
+    )
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    from daemon.projector import project_event
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    proj_content = report_path.read_text(encoding="utf-8")
+    ref_content = ref_path.read_text(encoding="utf-8")
+
+    # Byte-identical — the projector writes raw_payload verbatim.
+    assert proj_content == ref_content, (
+        "Projector output is not byte-identical to the legacy hook output.\n"
+        f"Projector wrote {len(proj_content)} chars; reference has {len(ref_content)} chars."
+    )
+
+    # Structural equivalence: same non-empty lines in the same order.
+    proj_lines = [l for l in proj_content.splitlines() if l.strip()]
+    ref_lines = [l for l in ref_content.splitlines() if l.strip()]
+    assert proj_lines == ref_lines
+
+
+# ---------------------------------------------------------------------------
+# Defensive: missing required fields
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_id_gate_completed(mem_conn, tmp_path) -> None:
+    """Missing project_id → skips, never raises, returns 'applied'."""
+    from daemon.projector import project_event
+
+    event = _make_gate_completed_create_event()
+    del event["payload"]["project_id"]
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+
+
+def test_missing_phase_gate_completed(mem_conn, tmp_path) -> None:
+    """Missing phase → skips."""
+    from daemon.projector import project_event
+
+    project_id = "proj-missing-phase"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_completed_create_event(project_id=project_id)
+    del event["payload"]["phase"]
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+
+
+def test_missing_raw_payload_gate_completed(mem_conn, tmp_path) -> None:
+    """Missing raw_payload → skips, file not created."""
+    from daemon.projector import project_event
+
+    project_id = "proj-missing-raw"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_completed_create_event(project_id=project_id)
+    del event["payload"]["raw_payload"]
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert not report_path.exists()
+
+
+def test_missing_required_fields_gate_pending(mem_conn, tmp_path) -> None:
+    """Missing raw_payload in gate_pending → skips, file not created."""
+    from daemon.projector import project_event
+
+    project_id = "proj-pending-missing-raw"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_pending_event(project_id=project_id)
+    del event["payload"]["raw_payload"]
+    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert not report_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Defensive: project_dir resolution failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_directory_in_db(mem_conn, tmp_path) -> None:
+    """Project row absent → warning logged, file not written."""
+    from daemon.projector import project_event
+
+    # Intentionally do NOT insert a project row into the DB.
+    event = _make_gate_completed_create_event(project_id="ghost-project")
+    report_path = (
+        tmp_path / "ghost-project" / "phases" / "build" / "reviewer-report.md"
+    )
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    assert not report_path.exists(), (
+        "File must not be written when project row is absent from DB."
+    )
+
+
+def test_project_directory_null_in_db(mem_conn, tmp_path) -> None:
+    """Project row present but directory=NULL → warning, file not written."""
+    from daemon.projector import project_event
+
+    project_id = "proj-null-dir"
+    mem_conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, None, "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    mem_conn.commit()
+
+    event = _make_gate_completed_create_event(project_id=project_id)
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        status = project_event(mem_conn, event)
+
+    assert status == "applied"
+    # No file path to check since we don't know where it would go —
+    # the point is it does not raise.


### PR DESCRIPTION
## Summary

- Adds `_consensus_gate_completed` and `_consensus_gate_pending` to `daemon/projector.py` (Site 3 of the bus-cutover staging plan, #746)
- Both handlers write `phases/{phase}/reviewer-report.md` byte-identical to the legacy `_write_reviewer_report` / `_write_pending_reviewer_report` paths in `hooks/scripts/post_tool.py`
- 15 new tests in `tests/daemon/test_projector_consensus_gate.py` covering all acceptance scenarios from the issue

## Design

### Handler: `_consensus_gate_completed`

- Resolves `project_dir` via `db.get_project(conn, project_id).directory`
- Writes `raw_payload` verbatim to `phases/{phase}/reviewer-report.md`
- `raw_payload` is the FULL file bytes in all branches (create = yaml_block; append = existing + separator + yaml_block) — same contract as Sites 1+2
- Idempotent: writing same bytes twice produces same file

### Handler: `_consensus_gate_pending`

- NO-OP when file already exists — mirrors `_write_pending_reviewer_report`'s clobber guard exactly
- Writes `raw_payload` (pending template) only when file is absent

### Shared patterns (inherited from Sites 1+2)

- `_BUS_IMPORT_WARNED` latch (Council Condition C7)
- Import-fail = flag-off (fail-open contract)
- Registered-always in `_HANDLERS` (Decision #6 — gating inside handler)
- Flag: `WG_BUS_AS_TRUTH_REVIEWER_REPORT` — **default stays OFF, no flag flip in this PR**

### Idempotency note

The projector wrapper's `event_log INSERT OR IGNORE` keyed on `event_id` prevents re-presenting the same event to a handler in production. The handler itself is additionally idempotent (write same bytes = same file) for test-harness replay.

## Test plan

- [x] `test_gate_completed_creates_fresh_file` — empty phase dir → file matches raw_payload
- [x] `test_gate_completed_appends_to_existing` — pre-existing report → file = raw_payload (full appended content)
- [x] `test_gate_pending_writes_template_when_absent` — empty phase dir → pending template written
- [x] `test_gate_pending_noop_when_report_exists` — pre-existing report → file unchanged
- [x] `test_idempotent_replay_gate_completed` — same event applied twice → file unchanged on second apply
- [x] `test_replay_matches_hook_byte_for_byte` — projector output byte-identical to reference file
- [x] `test_both_handlers_are_registered` — dispatch table contains both new event types
- [x] `test_flag_off_*` (2 tests) — flag-off → file not written, returns `'applied'`
- [x] Defensive tests: missing fields, absent project row, null directory
- [x] `pytest tests/daemon/ -v` → **331 passed, 2 deselected**

## Scope boundaries

- **NO changes** to `hooks/scripts/post_tool.py` — legacy hook untouched
- **NO changes** to event payload shape — `raw_payload` is full file bytes per Sites 1+2 contract
- **NO flag flip** — `WG_BUS_AS_TRUTH_REVIEWER_REPORT` defaults stay OFF
- **NOT in scope**: #769 (handler-presence gate in `reconcile_v2`) — Site 3 handlers must land first; #769's scan becomes meaningful after this PR merges
- **NOT in scope**: #770 (payload contract / unbounded-growth ADR)

## Handler dispatch registration line (for #769 reference)

```python
"wicked.consensus.gate_completed": _consensus_gate_completed,
"wicked.consensus.gate_pending": _consensus_gate_pending,
```

Both in the `_HANDLERS` dict at `daemon/projector.py`.

Closes #768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)