### PR TITLE
feat(crew): #770 per-section payload for Site 3 reviewer-report.md

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -872,19 +872,29 @@ def _consensus_evidence_recorded(conn: sqlite3.Connection, event: dict) -> None:
     )
 
 
-# --- bus-cutover Site 3 (#768) handlers -----------------------------------
+# --- bus-cutover Site 3 (#768, #770) handlers -----------------------------------
 #
 # Two handlers materialise phases/{phase}/reviewer-report.md from bus events,
 # producing the same on-disk file that hooks/scripts/post_tool.py's
 # _write_reviewer_report / _write_pending_reviewer_report write directly.
 #
-# Idempotency strategy (Decision #6 compatibility):
-#   The projector wrapper handles duplicate events via event_log INSERT OR IGNORE
-#   keyed on (event_id) — the same event is never presented to a handler twice
-#   in production.  Under test-harness replay (no event_log dedup), the
-#   handlers are still safe because raw_payload already contains the FULL
-#   target file content in all branches (create, append, pending).  Writing
-#   the same bytes twice is idempotent by nature.
+# Payload contract (#770 — per-section events):
+#   raw_payload = the just-written content (yaml_block), NOT the cumulative
+#   file.  Matches Site 1 (wicked.dispatch.log_entry_appended) per-entry shape.
+#   The _consensus_gate_completed handler applies branch detection:
+#   - create (file absent): write raw_payload as the full new file.
+#   - append (file exists): read existing + separator + raw_payload.
+#   _consensus_gate_pending: raw_payload is always the full pending template
+#   (this branch only creates fresh files, so shape is unchanged).
+#
+# Idempotency strategy (Decision #6 — with #770 correction):
+#   The daemon consumer does NOT deduplicate events before calling handlers
+#   (append_event_log uses INSERT OR REPLACE, not INSERT OR IGNORE — the
+#   handler is called for every event in the batch).  The append branch
+#   therefore guards with a substring scan: check whether
+#   (separator + raw_payload) is already in the existing file; skip if
+#   present.  Create and pending branches are idempotent by nature
+#   (writing the same bytes twice yields the same file).
 #
 # project_dir resolution:
 #   The payload carries project_id + phase.  We look up the project row in the
@@ -892,32 +902,44 @@ def _consensus_evidence_recorded(conn: sqlite3.Connection, event: dict) -> None:
 #   absent or directory is NULL, we log a warning and skip — never infer a path
 #   from local filesystem conventions in the daemon.
 #
-# Council Condition C8 addendum (N=3 warning):
+# Council Condition C8 addendum (N=3):
 #   With Site 3 we have three handler pairs.  The shared import pattern
 #   (_BUS_IMPORT_WARNED latch, import-fail = flag-off) is now clearly
 #   stable.  ADR for N=3 base-class extraction is deferred to Issue #771.
 
+_REVIEWER_REPORT_SEPARATOR = "\n\n---\n## Consensus Gate Evaluation\n\n"
+
+
 def _consensus_gate_completed(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.consensus.gate_completed → reviewer-report.md on disk.
 
-    Site 3 of the bus-cutover staging plan (#746, #768).  Behaviour is gated
-    on ``WG_BUS_AS_TRUTH_REVIEWER_REPORT`` via
+    Site 3 of the bus-cutover staging plan (#746, #768, #770).  Behaviour is
+    gated on ``WG_BUS_AS_TRUTH_REVIEWER_REPORT`` via
     ``_bus_as_truth_enabled("REVIEWER_REPORT")``:
 
       * flag-off (default): handler is a no-op.  The projector wrapper still
         records the event_log row as ``applied`` (Decision #6); the disk file
         remains source of truth.
-      * flag-on: write raw_payload to phases/{phase}/reviewer-report.md.
-        - create branch (``payload.branch == "create"``): write raw_payload as
-          the full file — mirrors _write_reviewer_report's else-branch.
-        - append branch (``payload.branch == "append"``): write raw_payload as
-          the full file — raw_payload already contains the pre-appended
-          separator + yaml_block per the hook's write-then-emit contract, so a
-          simple write is byte-identical to the legacy hook.
+      * flag-on: materialise reviewer-report.md from the per-section payload.
+        - create branch (``payload.branch == "create"`` or file absent):
+          write raw_payload as the full new file — mirrors
+          _write_reviewer_report's else-branch.
+        - append branch (``payload.branch == "append"`` and file exists):
+          read existing file, apply the standard ``_REVIEWER_REPORT_SEPARATOR``,
+          and append raw_payload (the just-written yaml_block).  This produces
+          the same cumulative bytes the legacy hook wrote — resolves the
+          architectural tension surfaced in PR #764 Copilot review (#770):
+          bounded payload AND projector replayability are both achieved.
 
-    Idempotency: writing the same raw_payload bytes twice produces the same
-    file — no duplicate-append risk.  The projector wrapper's event_log INSERT
-    OR IGNORE prevents re-presenting the same event_id to this handler.
+    Idempotency on the append branch (Decision #6 + #770):
+      The daemon consumer calls project_event for every event in a batch
+      without a prior event_id lookup (``append_event_log`` uses INSERT OR
+      REPLACE, not INSERT OR IGNORE — it does not short-circuit before the
+      handler fires).  Naive re-application of an append event would
+      double-append.  Guard: check whether (separator + raw_payload) is
+      already a substring of the existing file; skip if present.  This is
+      not redundant dead code — it is the only layer that prevents duplicate
+      appends on replay.
 
     project_dir is resolved via db.get_project(conn, project_id).directory.
     If the project row is absent or directory is NULL, the handler warns and
@@ -969,14 +991,34 @@ def _consensus_gate_completed(conn: sqlite3.Connection, event: dict) -> None:
     phase_dir = Path(project_row["directory"]) / "phases" / str(phase)
     report_path = phase_dir / "reviewer-report.md"
 
-    # Write raw_payload as the full file content.
-    # raw_payload is the canonical on-disk bytes: for the create branch it is
-    # the yaml_block; for the append branch it already includes the separator
-    # + yaml_block appended to the existing content.  Either way a plain write
-    # produces the byte-identical file that the legacy hook wrote.
+    branch = _opt(payload, "branch", "unknown")
+
     try:
-        phase_dir.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(str(raw_payload), encoding="utf-8")
+        if report_path.exists() and branch == "append":
+            # Append mode: read existing bytes, apply separator, append payload.
+            # raw_payload = the yaml_block that was just written by the hook
+            # (per-section payload contract, #770).
+            existing = report_path.read_text(encoding="utf-8")
+            section = _REVIEWER_REPORT_SEPARATOR + str(raw_payload)
+
+            # Idempotency guard: skip if this exact section was already appended.
+            # Scan the existing file for (separator + raw_payload).  Required
+            # because the daemon consumer does not deduplicate before calling
+            # handlers (append_event_log uses INSERT OR REPLACE, not INSERT OR
+            # IGNORE — handler fires for every event in the batch, #770).
+            if section in existing:
+                logger.debug(
+                    "projector: wicked.consensus.gate_completed — section already "
+                    "present in %s; skipping duplicate append",
+                    report_path,
+                )
+                return
+
+            report_path.write_text(existing + section, encoding="utf-8")
+        else:
+            # Create mode (file absent or create branch): write payload as fresh file.
+            phase_dir.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(str(raw_payload), encoding="utf-8")
     except OSError as exc:
         logger.warning(
             "projector: wicked.consensus.gate_completed — could not write %s: %s",
@@ -985,7 +1027,6 @@ def _consensus_gate_completed(conn: sqlite3.Connection, event: dict) -> None:
         )
         return
 
-    branch = _opt(payload, "branch", "unknown")
     logger.debug(
         "projector: applied wicked.consensus.gate_completed "
         "project_id=%r phase=%r branch=%r report_path=%s",
@@ -1162,12 +1203,14 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # Same registered-always pattern as Site 1.
     "wicked.consensus.report_created": _consensus_report_created,
     "wicked.consensus.evidence_recorded": _consensus_evidence_recorded,
-    # Site 3 of bus-cutover (#746, #768): reviewer-report.md file projection.
-    # Both handlers gate on WG_BUS_AS_TRUTH_REVIEWER_REPORT (single flag,
-    # same env var the hook reads via _bus_as_truth_flag_on() in post_tool.py).
-    # flag-off → no-op; flag-on → write phases/{phase}/reviewer-report.md
-    # byte-identical to _write_reviewer_report / _write_pending_reviewer_report.
-    # Registered always per Decision #6 — gating happens inside each handler.
+    # Site 3 of bus-cutover (#746, #768, #770): reviewer-report.md file
+    # projection.  Both handlers gate on WG_BUS_AS_TRUTH_REVIEWER_REPORT
+    # (single flag, same env var the hook reads via _bus_as_truth_flag_on()
+    # in post_tool.py).  flag-off → no-op; flag-on → write
+    # phases/{phase}/reviewer-report.md byte-identical to the legacy hook.
+    # Payload contract: raw_payload = just-written section (per-section shape,
+    # #770).  Append branch applies file-existence branch detection + SHA-256
+    # idempotency guard.  Registered always per Decision #6.
     "wicked.consensus.gate_completed": _consensus_gate_completed,
     "wicked.consensus.gate_pending": _consensus_gate_pending,
 }

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -1209,8 +1209,9 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # in post_tool.py).  flag-off → no-op; flag-on → write
     # phases/{phase}/reviewer-report.md byte-identical to the legacy hook.
     # Payload contract: raw_payload = just-written section (per-section shape,
-    # #770).  Append branch applies file-existence branch detection + SHA-256
-    # idempotency guard.  Registered always per Decision #6.
+    # #770).  Append branch applies file-existence branch detection + substring
+    # scan idempotency guard (separator + raw_payload already in file → skip).
+    # Registered always per Decision #6.
     "wicked.consensus.gate_completed": _consensus_gate_completed,
     "wicked.consensus.gate_pending": _consensus_gate_pending,
 }

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -998,9 +998,11 @@ def _write_reviewer_report(
 
         # Emit AFTER write — write-then-emit invariant (Sites 1+2 precedent).
         # Flag check: only emit when Site 3 cutover is enabled.
-        # raw_payload = full file bytes — matches Sites 1+2 contract for
-        # projector byte-for-byte replay.  Unbounded-growth concern tracked
-        # as issue #770 for proper ADR resolution.
+        # raw_payload = yaml_block (just the appended section, NOT the full
+        # cumulative file).  Matches Site 1 per-entry contract (#770 resolution):
+        # the projector reads the existing file, applies the standard separator,
+        # and appends the payload — bounded payload + projector replayability
+        # both achieved.
         if _bus_as_truth_flag_on():
             from _bus import emit_event  # noqa: PLC0415 — lazy import per hook pattern
             emit_event(
@@ -1011,7 +1013,7 @@ def _write_reviewer_report(
                     "verdict": verdict,
                     "eval_id": eval_id,
                     "branch": "append",
-                    "raw_payload": new_content,
+                    "raw_payload": yaml_block,
                 },
                 chain_id=f"{project_id}.{phase}.consensus.{eval_id}",
             )
@@ -1021,9 +1023,10 @@ def _write_reviewer_report(
         report_path.write_text(yaml_block, encoding="utf-8")
 
         # Emit AFTER write — write-then-emit invariant (Sites 1+2 precedent).
-        # raw_payload = full file bytes — matches Sites 1+2 contract for
-        # projector byte-for-byte replay.  Unbounded-growth concern tracked
-        # as issue #770 for proper ADR resolution.
+        # raw_payload = yaml_block (the full file content on the create branch,
+        # since the file is fresh).  Per-section contract (#770): yaml_block IS
+        # the entire new file here, so create + append branches are both
+        # "just-written content" semantics.
         if _bus_as_truth_flag_on():
             from _bus import emit_event  # noqa: PLC0415 — lazy import per hook pattern
             emit_event(
@@ -1066,9 +1069,9 @@ def _write_pending_reviewer_report(phase_dir: "Path", eval_id: str) -> None:
         report_path.write_text(pending_content, encoding="utf-8")
 
         # Emit AFTER write — write-then-emit invariant.
-        # raw_payload = full file bytes — matches Sites 1+2 contract for
-        # projector byte-for-byte replay.  Unbounded-growth concern tracked
-        # as issue #770 for proper ADR resolution.
+        # raw_payload = pending_content (the full pending template, which IS
+        # the just-written content — this branch always creates a fresh file).
+        # Per-section contract (#770): pending branch was already correct shape.
         if _bus_as_truth_flag_on():
             from _bus import emit_event  # noqa: PLC0415 — lazy import per hook pattern
             emit_event(

--- a/tests/daemon/test_projector_consensus_gate.py
+++ b/tests/daemon/test_projector_consensus_gate.py
@@ -1,17 +1,20 @@
 """tests/daemon/test_projector_consensus_gate.py — Projector tests for Site 3
 bus-cutover handlers ``_consensus_gate_completed`` and
-``_consensus_gate_pending`` (#768).
+``_consensus_gate_pending`` (#768, #770).
 
 Covers:
   * test_gate_completed_creates_fresh_file: empty phase dir → file matches raw_payload.
   * test_gate_completed_appends_to_existing: pre-existing report + gate_completed event
-    → file equals raw_payload (which already contains the appended content per hook contract).
+    (append branch, raw_payload = yaml_block) → file equals existing + separator + yaml_block.
   * test_gate_pending_writes_template_when_absent: empty phase dir → pending template written.
   * test_gate_pending_noop_when_report_exists: pre-existing report → file unchanged.
-  * test_idempotent_replay_gate_completed: replay same gate_completed event twice → file
-    unchanged on second apply.
-  * test_projector_writes_raw_payload_verbatim: simulate legacy hook output with a fixed
-    timestamp, replay via the projector → byte-identical (T1 determinism).
+  * test_idempotent_replay_gate_completed: replay same gate_completed (create) event twice
+    → file unchanged on second apply.
+  * test_idempotent_append_replay_no_double_append: replay same gate_completed (append) event
+    twice → no double-append (SHA-256 fingerprint guard, #770).
+  * test_projector_reconstructs_cumulative_file_from_yaml_block: simulate legacy hook output,
+    replay per-section payload via the projector → projector output byte-identical to legacy
+    hook output (T1 determinism).
   * test_both_handlers_are_registered: dispatch table contains both new event types.
   * test_flag_off_gate_completed_noop: flag-off → file not written.
   * test_flag_off_gate_pending_noop: flag-off → file not written.
@@ -24,7 +27,7 @@ T2: no sleep-based sync.
 T3: isolated — each test gets its own tmp_path + in-memory DB via mem_conn fixture.
 T4: one concern per test function.
 T5: descriptive names.
-T6: provenance: #768 Site 3 bus-cutover.
+T6: provenance: #768 #770 Site 3 bus-cutover.
 """
 from __future__ import annotations
 
@@ -142,11 +145,13 @@ def _make_gate_completed_append_event(
 ) -> dict[str, Any]:
     """Build a wicked.consensus.gate_completed event (append branch).
 
-    raw_payload mirrors what the hook writes: existing + separator + yaml_block.
+    raw_payload = yaml_block only (per-section payload contract, #770).
+    The projector reads the existing file, applies _SEPARATOR, and appends
+    raw_payload — reconstructing the cumulative file without carrying it in
+    the event.
     """
     if yaml_block is None:
         yaml_block = _SAMPLE_YAML_BLOCK
-    full_content = existing_content + _SEPARATOR + yaml_block
     return {
         "event_id": event_id,
         "event_type": "wicked.consensus.gate_completed",
@@ -158,7 +163,7 @@ def _make_gate_completed_append_event(
             "verdict": "approved",
             "eval_id": eval_id,
             "branch": "append",
-            "raw_payload": full_content,
+            "raw_payload": yaml_block,
         },
     }
 
@@ -290,11 +295,12 @@ def test_gate_completed_creates_fresh_file(mem_conn, tmp_path) -> None:
 
 
 def test_gate_completed_appends_to_existing(mem_conn, tmp_path) -> None:
-    """Pre-existing report + gate_completed (append branch) → file equals raw_payload.
+    """Pre-existing report + gate_completed (append branch, per-section payload)
+    → file equals existing + separator + yaml_block.
 
-    raw_payload in the append branch already contains the separator + yaml_block
-    appended to the existing content (per the hook's write-then-emit contract),
-    so the projector just writes raw_payload and achieves the same result.
+    raw_payload is now just the yaml_block (per-section contract, #770).
+    The projector reads the existing file, applies _SEPARATOR, and appends
+    raw_payload — reconstructing the same cumulative file the legacy hook wrote.
     """
     from daemon.projector import project_event
 
@@ -309,10 +315,12 @@ def test_gate_completed_appends_to_existing(mem_conn, tmp_path) -> None:
     report_path = phase_dir / "reviewer-report.md"
     report_path.write_text(existing_content, encoding="utf-8")
 
+    # Append event carries only the yaml_block (per-section payload, #770).
     event = _make_gate_completed_append_event(
         project_id=project_id,
         existing_content=existing_content,
     )
+    # Expected: existing + separator + yaml_block (byte-identical to legacy hook output).
     expected_full = existing_content + _SEPARATOR + _SAMPLE_YAML_BLOCK
 
     with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
@@ -380,12 +388,10 @@ def test_gate_pending_noop_when_report_exists(mem_conn, tmp_path) -> None:
 
 
 def test_idempotent_replay_gate_completed(mem_conn, tmp_path) -> None:
-    """Replaying the same gate_completed event twice → file unchanged on second apply.
+    """Replaying the same gate_completed (create branch) event twice → file unchanged.
 
-    The projector wrapper (event_log INSERT OR IGNORE) ensures the same event_id
-    is never re-presented in production.  This test verifies the handler itself
-    is also idempotent when called directly: writing the same bytes twice
-    produces no observable change.
+    Create branch is idempotent by nature: writing the same bytes twice yields
+    the same file.  Verify explicitly.
     """
     from daemon.projector import _consensus_gate_completed  # call handler directly
 
@@ -399,7 +405,6 @@ def test_idempotent_replay_gate_completed(mem_conn, tmp_path) -> None:
 
     with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
         _consensus_gate_completed(mem_conn, event)
-        first_mtime = report_path.stat().st_mtime_ns
         first_content = report_path.read_text(encoding="utf-8")
 
         # Second apply — same event, same bytes.
@@ -411,32 +416,77 @@ def test_idempotent_replay_gate_completed(mem_conn, tmp_path) -> None:
     )
 
 
+def test_idempotent_append_replay_no_double_append(mem_conn, tmp_path) -> None:
+    """Replaying the same gate_completed (append branch) event twice → no double-append.
+
+    The daemon consumer does NOT deduplicate before calling handlers (append_event_log
+    uses INSERT OR REPLACE, not INSERT OR IGNORE).  The handler guards with a substring
+    scan: the second apply detects the section is already present and skips — leaving
+    the file unchanged.  (#770 idempotency requirement.)
+    """
+    from daemon.projector import _consensus_gate_completed
+
+    project_id = "proj-append-idempotent"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    existing_content = "## Independent Review\n\nAll good.\n"
+    report_path = phase_dir / "reviewer-report.md"
+    report_path.write_text(existing_content, encoding="utf-8")
+
+    event = _make_gate_completed_append_event(
+        project_id=project_id,
+        existing_content=existing_content,
+    )
+    expected_after_first = existing_content + _SEPARATOR + _SAMPLE_YAML_BLOCK
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}):
+        # First apply — append the section.
+        _consensus_gate_completed(mem_conn, event)
+        after_first = report_path.read_text(encoding="utf-8")
+        assert after_first == expected_after_first, (
+            "First append produced unexpected content."
+        )
+
+        # Second apply — same event; SHA-256 guard must skip the duplicate.
+        _consensus_gate_completed(mem_conn, event)
+        after_second = report_path.read_text(encoding="utf-8")
+
+    assert after_second == after_first, (
+        "Idempotency failure: second append-branch apply double-appended the section.\n"
+        f"After first ({len(after_first)} chars): {after_first!r}\n"
+        f"After second ({len(after_second)} chars): {after_second!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
-# Byte-for-byte parity with legacy hook
+# Byte-for-byte parity with legacy hook (per-section payload, #770)
 # ---------------------------------------------------------------------------
 
 
-def test_projector_writes_raw_payload_verbatim(mem_conn, tmp_path) -> None:
-    """Simulates the legacy hook output and verifies the projector writes it
-    byte-identically.
+def test_projector_reconstructs_cumulative_file_from_yaml_block(mem_conn, tmp_path) -> None:
+    """Simulates the full legacy hook sequence and verifies the projector
+    reconstructs the byte-identical cumulative file from per-section payloads.
 
-    The hook would call _write_reviewer_report() which builds a YAML block via
-    _build_reviewer_report_yaml() and emits raw_payload = full file bytes.  We
-    replicate that output here with a fixed timestamp (T1 determinism requirement
-    — _now_iso() embeds wall-clock time which the hook would otherwise embed).
-    The projector's contract is to write raw_payload verbatim, so the assertion
-    is that projector output == the simulated reference bytes.
+    Scenario: independent-reviewer writes a review header, then the hook fires
+    and appends a consensus section.  Legacy hook output = header + separator +
+    yaml_block.  Projector receives raw_payload = yaml_block (per-section, #770)
+    with the file pre-seeded with the header.
 
-    Structural equivalence assertion: both files have the same lines (order-
-    preserved), confirming the projector does not add/remove/transform content.
+    Assertion: projector output is byte-identical to the legacy hook cumulative
+    output.  T1 determinism: fixed timestamp in yaml_block, no wall-clock reads.
     """
     project_id = "proj-parity"
     project_dir = _make_project_dir(tmp_path, project_id)
     _setup_project_in_db(mem_conn, project_id, project_dir)
 
-    # Simulate what the hook emits as raw_payload (full file bytes).
-    # Use a fixed-timestamp yaml_block for determinism (T1 requirement).
-    fixed_yaml = textwrap.dedent("""\
+    # Simulate what the independent-reviewer agent wrote before the hook fired.
+    independent_review = "## Independent Review\n\nCode looks good. No blockers.\n"
+
+    # Simulate the yaml_block the hook builds (fixed timestamp for T1).
+    fixed_yaml_block = textwrap.dedent("""\
         ---
         verdict: approved
         evidence_items_checked: 3
@@ -448,17 +498,27 @@ def test_projector_writes_raw_payload_verbatim(mem_conn, tmp_path) -> None:
         ---
     """)
 
-    # Reference: write the "legacy hook result" to a reference path.
+    # Reference: what the legacy hook would have written to disk directly.
+    # Legacy hook: existing + separator + yaml_block.
+    legacy_output = independent_review + _SEPARATOR + fixed_yaml_block
+
     ref_dir = tmp_path / "reference" / "phases" / "build"
     ref_dir.mkdir(parents=True)
     ref_path = ref_dir / "reviewer-report.md"
-    ref_path.write_text(fixed_yaml, encoding="utf-8")
+    ref_path.write_text(legacy_output, encoding="utf-8")
 
-    # Projector replay: pass raw_payload = fixed_yaml (the full file bytes).
-    event = _make_gate_completed_create_event(
-        project_id=project_id, raw_payload=fixed_yaml
+    # Projector path: pre-seed the file (as independent-reviewer wrote it),
+    # then replay the append event with raw_payload = yaml_block only.
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    report_path = phase_dir / "reviewer-report.md"
+    report_path.write_text(independent_review, encoding="utf-8")
+
+    event = _make_gate_completed_append_event(
+        project_id=project_id,
+        existing_content=independent_review,
+        yaml_block=fixed_yaml_block,
     )
-    report_path = project_dir / "phases" / "build" / "reviewer-report.md"
 
     from daemon.projector import project_event
 
@@ -469,15 +529,16 @@ def test_projector_writes_raw_payload_verbatim(mem_conn, tmp_path) -> None:
     proj_content = report_path.read_text(encoding="utf-8")
     ref_content = ref_path.read_text(encoding="utf-8")
 
-    # Byte-identical — the projector writes raw_payload verbatim.
+    # Byte-identical: projector reconstructs the same file the legacy hook wrote.
     assert proj_content == ref_content, (
         "Projector output is not byte-identical to the legacy hook output.\n"
-        f"Projector wrote {len(proj_content)} chars; reference has {len(ref_content)} chars."
+        f"Projector wrote {len(proj_content)} chars; reference has {len(ref_content)} chars.\n"
+        f"Projector: {proj_content!r}\nReference: {ref_content!r}"
     )
 
     # Structural equivalence: same non-empty lines in the same order.
-    proj_lines = [l for l in proj_content.splitlines() if l.strip()]
-    ref_lines = [l for l in ref_content.splitlines() if l.strip()]
+    proj_lines = [line for line in proj_content.splitlines() if line.strip()]
+    ref_lines = [line for line in ref_content.splitlines() if line.strip()]
     assert proj_lines == ref_lines
 
 

--- a/tests/daemon/test_projector_consensus_gate.py
+++ b/tests/daemon/test_projector_consensus_gate.py
@@ -11,7 +11,7 @@ Covers:
   * test_idempotent_replay_gate_completed: replay same gate_completed (create) event twice
     → file unchanged on second apply.
   * test_idempotent_append_replay_no_double_append: replay same gate_completed (append) event
-    twice → no double-append (SHA-256 fingerprint guard, #770).
+    twice → no double-append (substring scan guard: separator+raw_payload already present, #770).
   * test_projector_reconstructs_cumulative_file_from_yaml_block: simulate legacy hook output,
     replay per-section payload via the projector → projector output byte-identical to legacy
     hook output (T1 determinism).
@@ -140,7 +140,6 @@ def _make_gate_completed_append_event(
     project_id: str = "my-proj",
     phase: str = "build",
     eval_id: str = "aabbccdd11223344",
-    existing_content: str,
     yaml_block: str | None = None,
 ) -> dict[str, Any]:
     """Build a wicked.consensus.gate_completed event (append branch).
@@ -318,7 +317,6 @@ def test_gate_completed_appends_to_existing(mem_conn, tmp_path) -> None:
     # Append event carries only the yaml_block (per-section payload, #770).
     event = _make_gate_completed_append_event(
         project_id=project_id,
-        existing_content=existing_content,
     )
     # Expected: existing + separator + yaml_block (byte-identical to legacy hook output).
     expected_full = existing_content + _SEPARATOR + _SAMPLE_YAML_BLOCK
@@ -438,7 +436,6 @@ def test_idempotent_append_replay_no_double_append(mem_conn, tmp_path) -> None:
 
     event = _make_gate_completed_append_event(
         project_id=project_id,
-        existing_content=existing_content,
     )
     expected_after_first = existing_content + _SEPARATOR + _SAMPLE_YAML_BLOCK
 
@@ -450,7 +447,7 @@ def test_idempotent_append_replay_no_double_append(mem_conn, tmp_path) -> None:
             "First append produced unexpected content."
         )
 
-        # Second apply — same event; SHA-256 guard must skip the duplicate.
+        # Second apply — same event; substring scan guard must skip the duplicate.
         _consensus_gate_completed(mem_conn, event)
         after_second = report_path.read_text(encoding="utf-8")
 
@@ -516,7 +513,6 @@ def test_projector_reconstructs_cumulative_file_from_yaml_block(mem_conn, tmp_pa
 
     event = _make_gate_completed_append_event(
         project_id=project_id,
-        existing_content=independent_review,
         yaml_block=fixed_yaml_block,
     )
 

--- a/tests/test_post_tool_site3.py
+++ b/tests/test_post_tool_site3.py
@@ -419,15 +419,21 @@ class TestEvalIdEntryPointMint(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# raw_payload = full file bytes — matches Sites 1+2 contract
+# raw_payload = per-section payload (#770 resolution)
 # ---------------------------------------------------------------------------
 
-class TestRawPayloadFullBytes(unittest.TestCase):
-    """raw_payload must be the full file bytes at time of emit.
+class TestPerSectionPayload(unittest.TestCase):
+    """raw_payload must be the just-written content (per-section shape, #770).
 
-    Matches the Sites 1+2 contract (dispatch_log.py / consensus_gate.py)
-    which emit raw_payload = full bytes for projector byte-for-byte replay.
-    Digest payload was reverted; unbounded-growth concern tracked as #770.
+    - append branch: raw_payload == yaml_block (just the section appended),
+      NOT the cumulative file.  Matches Site 1 per-entry contract.
+    - create branch: raw_payload == yaml_block (which IS the full file on
+      create since the file is fresh) — unchanged from prior shape.
+    - pending branch: raw_payload == pending_content (full template) —
+      unchanged, already correct shape.
+
+    The projector handler reconstructs the cumulative file by reading the
+    existing file and applying the standard separator.
     """
 
     def _capture_emit(
@@ -455,15 +461,18 @@ class TestRawPayloadFullBytes(unittest.TestCase):
 
         return captured
 
-    def test_append_path_raw_payload_equals_file_content(self) -> None:
-        """append branch: raw_payload must equal the full file content after write."""
+    def test_append_path_raw_payload_equals_yaml_block_not_full_file(self) -> None:
+        """append branch: raw_payload must equal yaml_block (just the section),
+        NOT the full cumulative file.  Per-section payload contract (#770).
+        """
         with tempfile.TemporaryDirectory() as tmp:
             phase_dir = _make_phase_dir(Path(tmp), project="rp-append", phase="build")
             report_path = phase_dir / "reviewer-report.md"
 
-            # First write — creates the file.
+            # First write — creates the file (yaml_block = full file on create).
             captured1 = self._capture_emit(phase_dir, "eval00000001")
             self.assertGreater(len(captured1), 0, "emit_event was never called (create)")
+            first_yaml_block = captured1[0]["raw_payload"]
 
             # Second write — appends to the file (triggers append branch).
             captured2 = self._capture_emit(phase_dir, "eval00000002")
@@ -473,14 +482,40 @@ class TestRawPayloadFullBytes(unittest.TestCase):
             append_payload = captured2[-1]
             self.assertIn("raw_payload", append_payload,
                           "append branch must emit raw_payload field")
-            self.assertEqual(
-                append_payload["raw_payload"],
+
+            # raw_payload must be the yaml_block ONLY — NOT the cumulative file.
+            yaml_block = append_payload["raw_payload"]
+            self.assertNotEqual(
+                yaml_block,
                 file_content,
-                "raw_payload must equal full file content after append write",
+                "append branch raw_payload must NOT equal the full cumulative file",
+            )
+            # The cumulative file contains the first section + separator + second section.
+            # The second section (yaml_block) must appear at the END of the file.
+            self.assertTrue(
+                file_content.endswith(yaml_block),
+                "Cumulative file must end with the just-written yaml_block",
+            )
+            # The yaml_block must be a strict substring of the cumulative file.
+            self.assertIn(
+                yaml_block,
+                file_content,
+                "yaml_block must appear in cumulative file",
+            )
+            # The yaml_block must NOT include the first section's content.
+            self.assertNotIn(
+                first_yaml_block,
+                yaml_block,
+                "append branch raw_payload must not contain the first section",
             )
 
     def test_create_path_raw_payload_equals_file_content(self) -> None:
-        """create branch: raw_payload must equal the full file content after write."""
+        """create branch: raw_payload must equal the full file content after write.
+
+        On the create branch yaml_block IS the entire file, so create + append
+        branches share "just-written content" semantics — file content and
+        yaml_block are identical here.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             phase_dir = _make_phase_dir(Path(tmp), project="rp-create", phase="build")
             report_path = phase_dir / "reviewer-report.md"
@@ -495,7 +530,7 @@ class TestRawPayloadFullBytes(unittest.TestCase):
             self.assertEqual(
                 create_payload["raw_payload"],
                 file_content,
-                "raw_payload must equal full file content after create write",
+                "create branch: raw_payload must equal full file content (yaml_block IS the full file)",
             )
 
     def test_pending_path_raw_payload_equals_file_content(self) -> None:


### PR DESCRIPTION
## Summary

- Changes the append-branch `wicked.consensus.gate_completed` event payload from **full cumulative file bytes** to **just the yaml_block that was appended** — matching Site 1's (`wicked.dispatch.log_entry_appended`) per-entry contract. Resolves the architectural tension surfaced in PR #764 Copilot review: bounded payload AND projector replayability both achieved.
- Updates `_consensus_gate_completed` projector handler to perform branch detection on file existence: append mode reads existing + separator + payload; create mode writes payload as fresh file.
- Adds an idempotency guard on the append branch (substring scan for `separator + raw_payload`) because the daemon consumer uses `INSERT OR REPLACE` not `INSERT OR IGNORE` — handlers fire for every event in the batch without prior dedup.

Closes #770. Predecessor: #768 (projector handlers). Architectural decision: `memory/site-3-payload-contract-per-section-events.md`.

## Changes

### `hooks/scripts/post_tool.py`

Line ~1014 (append branch emit):
- **Before**: `"raw_payload": new_content` (full cumulative file after append)
- **After**: `"raw_payload": yaml_block` (just the section that was appended)

Create branch (`raw_payload: yaml_block`) and pending branch (`raw_payload: pending_content`) are **unchanged** — already correct shape.

### `daemon/projector.py::_consensus_gate_completed`

- Adds `_REVIEWER_REPORT_SEPARATOR` module constant (mirrors the in-function string in `post_tool.py`, making the shared contract explicit).
- Replaces the naive `report_path.write_text(str(raw_payload))` with branch detection:
  - File exists + `branch == "append"`: read existing + apply separator + append payload. Substring idempotency guard before writing.
  - Otherwise (create): `phase_dir.mkdir(parents=True, exist_ok=True)` + write payload as fresh file.
- `_consensus_gate_pending` handler is **unchanged**.

### Tests

- `TestRawPayloadFullBytes` renamed to `TestPerSectionPayload`; append-branch test updated to assert `raw_payload == yaml_block` (not cumulative file).
- `_make_gate_completed_append_event` updated: `raw_payload = yaml_block` only (was full cumulative).
- `test_gate_completed_appends_to_existing` updated: now tests that projector reconstructs `existing + separator + yaml_block`.
- `test_projector_writes_raw_payload_verbatim` renamed to `test_projector_reconstructs_cumulative_file_from_yaml_block` — end-to-end byte-identity smoke test.
- **New**: `test_idempotent_append_replay_no_double_append` — applies same append event twice, asserts file unchanged on second apply.

## Test plan

- [x] `python3 -m pytest tests/test_post_tool_site3.py tests/daemon/test_projector_consensus_gate.py` — **38/38 pass** (was 37; +1 new idempotency test)
- [x] Full suite baseline: 52 pre-existing failures unchanged, 2353 pass (was 2352 before our new test)
- [x] Smoke-test: Python inline verification of byte-identity between legacy hook output and projector output
- [x] `/wg-check` quick-mode: PASS (pre-existing Tier-1 allowlist warnings and agent line-count warnings are not introduced by this PR)
- [x] Idempotency: verified consumer uses `INSERT OR REPLACE` (not `INSERT OR IGNORE`) — guard is load-bearing, not dead code

## Idempotency mechanism

**Existing daemon dedupe**: `append_event_log` uses `INSERT OR REPLACE` — does NOT short-circuit before calling the handler. The handler fires for every event in the batch.

**New guard added**: substring scan `if (separator + raw_payload) in existing: skip`. This is the only layer preventing double-appends on replay of the append branch. Create and pending branches are idempotent by nature (same bytes → same file).

## Projector output byte-identity confirmation

Smoke-test confirmed:
- `existing (35 chars) + separator + yaml_block (26 chars)` → `97 chars cumulative`
- Legacy hook path: `new_content = existing + separator + yaml_block` → `write(new_content)` → 97 chars
- Projector path: `write(existing + separator + raw_payload)` where `raw_payload = yaml_block` → 97 chars
- **PASS: byte-identical**

🤖 Generated with [Claude Code](https://claude.com/claude-code)