### PR TITLE
feat(crew): #746 Site 4 cutover — projector handlers + payload widening (closes #778, supersedes #779)

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -1449,15 +1449,16 @@ def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
     state from the ``_gate_decided_disk`` projection (PR-2 onward).  No
     additional disk mutation is needed under the current contract.
 
-    Why register at all then?  ``reconcile_v2._handler_available_for_file``
-    is conservative: ALL event types in ``_PROJECTION_MAP`` for a given
-    file must have registered handlers before that file becomes
-    scan-active in the drift detector.  ``wicked.gate.blocked`` is mapped
-    to ``gate-result.json`` (``reconcile_v2.py:80``), so without this
-    registration the file stays excluded from drift detection even after
-    ``_gate_decided_disk`` lands.  The Site 3 precedent (#774 fold) made
-    this gating per-event-type, which forces this kind of dummy
-    registration when one event lacks meaningful disk work.
+    Why register at all then?  ``wicked.gate.blocked`` IS a real bus
+    event the daemon must consume — leaving it out of ``_HANDLERS`` would
+    surface every blocked emit as ``unknown event_type`` in the
+    projector log.  The registration here is for event handling, NOT
+    file materialisation: ``wicked.gate.blocked`` was REMOVED from
+    ``reconcile_v2._PROJECTION_MAP`` (PR #782 fold for Copilot finding
+    on PR-1) so the drift detector doesn't treat it as a file-producing
+    event.  Without the map removal, an event_log row with only
+    gate.blocked + an on-disk gate-result.json would silently pass the
+    projection-without-event check (false negative).
 
     Future-compat: structured to be the place where REJECT-only metadata
     (e.g., a ``blocking_reason`` annotation distinct from the gate verdict)

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -312,6 +312,19 @@ def _gate_decided(conn: sqlite3.Connection, event: dict) -> None:
         "projector: applied wicked.gate.decided project_id=%r phase=%r result=%r",
         project_id, phase, result,
     )
+    # Site 4 of bus-cutover (#746, #778) fan-out: disk projection for
+    # gate-result.json.  DB-row work above always runs; disk projection runs
+    # only when WG_BUS_AS_TRUTH_GATE_RESULT=on and the payload carries the
+    # full gate_result dict (PR-2 / #779 widens the emit).  Wrapped in
+    # try/except so disk failures NEVER break the DB-row projection
+    # (Decision #6 idempotency, Decision #8 never-raise).
+    try:
+        _gate_decided_disk(conn, event)
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        logger.exception(
+            "projector: _gate_decided_disk fan-out raised — DB-row "
+            "projection preserved; disk projection skipped"
+        )
 
 
 def _rework_triggered(conn: sqlite3.Connection, event: dict) -> None:
@@ -1173,6 +1186,317 @@ def _ac_evidence_linked(conn: sqlite3.Connection, event: dict) -> None:
     )
 
 
+# --- Site 4 of bus-cutover (#746, #778): gate-result.json disk projection --
+#
+# Two handlers, both gated on WG_BUS_AS_TRUTH_GATE_RESULT via
+# ``_bus_as_truth_enabled("GATE_RESULT")``:
+#
+#   * ``_gate_decided_disk``  — invoked from the tail of the existing
+#     ``_gate_decided`` (DB-row handler).  Materialises gate-result.json
+#     from the full gate_result dict carried in ``event["payload"]["data"]``.
+#     PR-2 (#779) widens the emit to carry that key; until then this
+#     handler is inert (early-returns with a debug log).
+#
+#   * ``_gate_blocked``       — registered fresh for ``wicked.gate.blocked``.
+#     INERT no-op in PR-1: the file is already in REJECT state from the
+#     wicked.gate.decided projection that fires immediately before
+#     wicked.gate.blocked in approve_phase's REJECT branch.  Registered
+#     so reconcile_v2._handler_available_for_file's conservative
+#     "ALL event types must have handlers" rule passes for gate-result.json.
+#
+# Security floor on the projection path mirrors phase_manager._load_gate_result
+# composition (AC-9 §5.4):
+#   1. validate_gate_result(data)              — schema + sanitizer (embedded)
+#   2. check_orphan(data, project_dir, phase)  — soft-window or strict reject
+#   3. append_audit_entry(...)                 — every reject path
+#
+# Idempotency: content-hash on the full serialized JSON.  When the file
+# already matches the new payload byte-for-byte, the write is skipped.
+
+def _gate_decided_disk(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.gate.decided → phases/{phase}/gate-result.json on disk.
+
+    Site 4 of the bus-cutover staging plan (#746, #778).  Behaviour gated
+    on ``WG_BUS_AS_TRUTH_GATE_RESULT`` via
+    ``_bus_as_truth_enabled("GATE_RESULT")``:
+
+      * flag-off (default): no-op.
+      * flag-on: validate the full gate_result dict from the event payload,
+        run the AC-9 §5.4 security floor (schema + sanitizer via
+        ``validate_gate_result``, dispatch-log orphan check via
+        ``check_orphan``, audit log on every reject path), then write
+        ``gate-result.json`` with content-hash idempotency.
+
+    Payload contract (PR-2 / #779 ships the emit widening):
+      ``payload["data"]`` — the full gate_result dict that
+      ``phase_manager._persist_gate_result`` would otherwise write.
+      When absent (current 5-field emit at phase_manager.py:3931),
+      the handler logs at debug level and returns inertly.
+
+    Idempotency guard: content-hash on the canonical JSON serialization.
+    The daemon consumer does not deduplicate before calling handlers
+    (``append_event_log`` uses INSERT OR REPLACE), so without this guard
+    every replay would rewrite the file.
+
+    project_dir resolved via ``db.get_project(conn, project_id).directory``.
+    Absent row or NULL directory → warn and skip (mirrors Site 3).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("GATE_RESULT")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off (will not re-warn this process): %s",
+                exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+
+    # Payload contract: the full gate_result dict ships under "data".
+    # Until PR-2 (#779) widens the emit, this key is absent and the
+    # handler returns inertly — flag-on can be enabled safely.
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        logger.debug(
+            "projector: wicked.gate.decided disk projection — payload lacks "
+            "'data' dict (project_id=%r phase=%r); inert until #779 ships "
+            "emit-payload widening",
+            project_id, phase,
+        )
+        return
+
+    # Resolve project_dir from the DB.
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.gate.decided disk projection — project %r has "
+            "no directory in DB; skipping file write (project must be "
+            "projected via wicked.project.created before Site 4 handlers can "
+            "write files)",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    phase_dir = project_dir / "phases" / str(phase)
+    target = phase_dir / "gate-result.json"
+
+    # Lazy imports — security floor modules + stdlib helpers only loaded
+    # when the projection actually fires.  Keeps the import-time cost of
+    # the projector module low for callers that never opt into Site 4.
+    import json
+    import hashlib
+    try:
+        from gate_result_schema import (
+            GateResultAuthorizationError,
+            GateResultSchemaError,
+            validate_gate_result,
+        )
+        from gate_ingest_audit import append_audit_entry
+        from dispatch_log import check_orphan, _get_strict_after_date
+    except ImportError as exc:
+        logger.warning(
+            "projector: wicked.gate.decided disk projection — security "
+            "floor modules unavailable: %s; skipping write to avoid "
+            "shipping unvalidated bytes",
+            exc,
+        )
+        return
+
+    # Serialize candidate bytes once: used for hash compare, audit
+    # raw_bytes, and the actual write.  Keeps the canonical form
+    # consistent across all three.
+    candidate_bytes = json.dumps(
+        data, indent=2, sort_keys=True
+    ).encode("utf-8")
+
+    # Schema + sanitizer (sanitizer is embedded inside validate_gate_result
+    # per AC-9 §5.4 composition; one call covers both).  Raise on either
+    # → audit + skip write.  Surface the schema/content distinction in the
+    # audit event tag so downstream tooling can triage.
+    try:
+        validate_gate_result(data)
+    except GateResultSchemaError as exc:
+        event_tag = (
+            "sanitization_violation" if exc.violation_class == "content"
+            else "schema_violation"
+        )
+        append_audit_entry(
+            project_dir, str(phase),
+            event=event_tag,
+            reason=exc.reason,
+            offending_field=exc.offending_field,
+            offending_value=exc.offending_value_excerpt,
+            raw_bytes=candidate_bytes,
+        )
+        logger.warning(
+            "projector: wicked.gate.decided disk projection — schema/"
+            "sanitizer violation (project_id=%r phase=%r): %s; audit "
+            "entry written, file NOT updated",
+            project_id, phase, exc.reason,
+        )
+        return
+
+    # Orphan detection — soft-window allows fall-through with audit;
+    # strict mode rejects the write.  Mirrors the composition in
+    # ``phase_manager._load_gate_result`` byte-for-byte so the projection
+    # path enforces the same security contract as direct writes.
+    try:
+        check_orphan(data, project_dir, str(phase))
+    except GateResultAuthorizationError as exc:
+        today = datetime.now(timezone.utc).date()
+        if today >= _get_strict_after_date():
+            append_audit_entry(
+                project_dir, str(phase),
+                event="unauthorized_dispatch",
+                reason=exc.reason,
+                offending_field=exc.offending_field,
+                offending_value=exc.offending_value_excerpt,
+                raw_bytes=candidate_bytes,
+            )
+            logger.warning(
+                "projector: wicked.gate.decided disk projection — "
+                "strict-mode orphan reject (project_id=%r phase=%r); "
+                "audit entry written, file NOT updated",
+                project_id, phase,
+            )
+            return
+        # Soft window — audit as accepted_legacy and fall through to write.
+        append_audit_entry(
+            project_dir, str(phase),
+            event="unauthorized_dispatch_accepted_legacy",
+            reason=exc.reason,
+            offending_field=exc.offending_field,
+            offending_value=exc.offending_value_excerpt,
+            raw_bytes=candidate_bytes,
+        )
+
+    # Content-hash idempotency: skip rewrite when existing bytes match.
+    # Required because the daemon consumer does not dedupe before calling
+    # handlers (append_event_log uses INSERT OR REPLACE — handler fires
+    # for every event in the batch).  This is the ONLY layer preventing
+    # gratuitous re-writes on replay.
+    try:
+        if target.exists():
+            existing_bytes = target.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: wicked.gate.decided disk projection — "
+                    "content hash matches existing %s; skipping rewrite",
+                    target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.gate.decided disk projection — could not "
+            "read existing %s for idempotency check: %s; proceeding to write",
+            target, exc,
+        )
+
+    # Atomic write: temp file + rename.  Rename is atomic on POSIX;
+    # readers either see the old bytes or the new bytes, never partial.
+    try:
+        phase_dir.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(target)
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.gate.decided disk projection — could not "
+            "write %s: %s",
+            target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.gate.decided disk projection "
+        "project_id=%r phase=%r verdict=%r path=%s",
+        project_id, phase, data.get("result") or data.get("verdict"), target,
+    )
+
+
+def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.gate.blocked → no-op disk handler (PR-1 inert).
+
+    Site 4 of the bus-cutover staging plan (#746, #778).  Behaviour gated
+    on ``WG_BUS_AS_TRUTH_GATE_RESULT`` via
+    ``_bus_as_truth_enabled("GATE_RESULT")``.
+
+    PR-1 ships this handler INERT.  ``wicked.gate.blocked`` always follows
+    ``wicked.gate.decided`` in ``approve_phase``'s REJECT branch — by the
+    time this handler fires, ``gate-result.json`` is already in REJECT
+    state from the ``_gate_decided_disk`` projection (PR-2 onward).  No
+    additional disk mutation is needed under the current contract.
+
+    Why register at all then?  ``reconcile_v2._handler_available_for_file``
+    is conservative: ALL event types in ``_PROJECTION_MAP`` for a given
+    file must have registered handlers before that file becomes
+    scan-active in the drift detector.  ``wicked.gate.blocked`` is mapped
+    to ``gate-result.json`` (``reconcile_v2.py:80``), so without this
+    registration the file stays excluded from drift detection even after
+    ``_gate_decided_disk`` lands.  The Site 3 precedent (#774 fold) made
+    this gating per-event-type, which forces this kind of dummy
+    registration when one event lacks meaningful disk work.
+
+    Future-compat: structured to be the place where REJECT-only metadata
+    (e.g., a ``blocking_reason`` annotation distinct from the gate verdict)
+    could be appended to the file if such a contract arrives later.  For
+    now: flag-off no-op; flag-on debug log + return.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("GATE_RESULT")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off (will not re-warn this process): %s",
+                exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+    project_id, _ = _require(payload, "project_id", et)
+    phase, _ = _require(payload, "phase", et)
+
+    logger.debug(
+        "projector: wicked.gate.blocked disk projection NO-OP — "
+        "gate-result.json already projected from preceding "
+        "wicked.gate.decided in approve_phase REJECT branch "
+        "(project_id=%r phase=%r)",
+        project_id, phase,
+    )
+
+
 # --- dispatch table --------------------------------------------------------
 
 _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
@@ -1214,6 +1538,17 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # Registered always per Decision #6.
     "wicked.consensus.gate_completed": _consensus_gate_completed,
     "wicked.consensus.gate_pending": _consensus_gate_pending,
+    # Site 4 of bus-cutover (#746, #778): gate-result.json file projection.
+    # ``wicked.gate.decided`` continues to dispatch to ``_gate_decided`` (DB-row
+    # work); the disk projection runs as a try/except fan-out at the tail of
+    # ``_gate_decided``.  ``wicked.gate.blocked`` registers a fresh handler
+    # (``_gate_blocked``) so reconcile_v2's per-event-type handler-presence
+    # gate flips True for both events bound to gate-result.json (#774 fold).
+    # Both gate on WG_BUS_AS_TRUTH_GATE_RESULT inside the handler.  PR-1
+    # ships INERT — the existing emit at phase_manager.py:3931 lacks the
+    # full ``data`` payload, so flag-on triggers an early debug-return until
+    # PR-2 (#779) widens the emit shape.
+    "wicked.gate.blocked": _gate_blocked,
 }
 
 

--- a/docs/v9/bus-cutover-staging-plan.md
+++ b/docs/v9/bus-cutover-staging-plan.md
@@ -285,10 +285,15 @@ production.
 
 #### Site 4: `phases/{phase}/gate-result.json`
 
-- **Site**: `scripts/crew/phase_manager.py:3676` (canonical write) plus
-  CONDITIONAL/REJECT/skip-reeval branches at 2684, 2913, 2939, 2958,
-  2994, 3415 (all 🔗 caller-chain via `approve_phase` →
-  `wicked.gate.decided` at line 3931).
+- **Site**: `scripts/crew/phase_manager.py:3676` is the SOLE write site
+  for `gate-result.json`. Verified by
+  `grep 'gate-result\.json.*write_text\|write_text.*gate-result\.json'
+  scripts/crew/phase_manager.py` — only line 3676 matches. (Earlier
+  drafts of this plan listed lines 2684, 2913, 2939, 2958, 2994, 3415
+  as additional caller-chain writers; that was wrong — those lines
+  write `conditions-manifest.json`, iteration files, status, and
+  reeval-log entries, not `gate-result.json`. Corrected 2026-05-03
+  during Site 4 pre-impl council.)
 - **Current write path**: `_persist_gate_result()` at line 3676 is the
   canonical writer. Mkdir then `write_text()`. Triggered from
   `approve_phase` after the gate verdict is computed.

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -3928,12 +3928,21 @@ def approve_phase(
         try:
             from _bus import emit_event
             gate_decision = gate_result.get("result", "UNKNOWN")
+            # Site 4 of bus-cutover (#746, #778): the payload now carries the
+            # full validated gate_result dict under ``data`` so the projector
+            # handler ``_gate_decided_disk`` can materialise gate-result.json
+            # from the bus event when WG_BUS_AS_TRUTH_GATE_RESULT=on.  The
+            # five top-level fields (project_id, phase, result, score,
+            # reviewer) are kept for downstream consumers that don't need the
+            # full dict.  The defensive ``copy()`` prevents downstream
+            # mutation of the in-memory verdict.
             emit_event("wicked.gate.decided", {
                 "project_id": state.name,
                 "phase": phase,
                 "result": gate_decision,
                 "score": gate_result.get("score"),
                 "reviewer": gate_result.get("reviewer"),
+                "data": dict(gate_result),
             }, chain_id=getattr(state, "chain_id", None))
             if gate_decision == "REJECT":
                 emit_event("wicked.gate.blocked", {

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -76,8 +76,17 @@ _LAG_EVENTS_THRESHOLD = 10
 
 _PROJECTION_MAP: Dict[str, str] = {
     # Phase gate decisions
+    # Only ``wicked.gate.decided`` materialises gate-result.json.  ``wicked.
+    # gate.blocked`` is a sentinel signalling REJECT state that's already
+    # encoded in the file from the preceding ``wicked.gate.decided`` emit;
+    # it is intentionally NOT in this map so the drift detector treats it
+    # as non-materialising.  Without this exclusion, an event_log row with
+    # only gate.blocked + an on-disk gate-result.json would silently pass
+    # the projection-without-event check (false negative — Copilot finding
+    # on PR #782).  ``_gate_blocked`` stays registered in
+    # daemon/projector.py._HANDLERS for completeness; it just doesn't
+    # claim to produce a file.
     "wicked.gate.decided": "phases/{phase}/gate-result.json",
-    "wicked.gate.blocked": "phases/{phase}/gate-result.json",
     # Dispatch log entries (Site 1)
     "wicked.dispatch.log_entry_appended": "phases/{phase}/dispatch-log.jsonl",
     # Consensus artifacts (Site 2)
@@ -150,7 +159,14 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
 #                                          (registry flip is the subject of a follow-up issue)
 #   wicked.gate.decided                 → _gate_decided handles DB rows; disk projection
 #                                          fans out to _gate_decided_disk (PR-1 / #778)  ✓ PRESENT
-#   wicked.gate.blocked                 → _gate_blocked (PR-1 / #778, INERT no-op)  ✓ PRESENT
+#                                          (emit at phase_manager.py:3931 carries the full
+#                                          gate_result dict under payload["data"] — handler
+#                                          materialises gate-result.json when flag-on)
+#   wicked.gate.blocked                 → _gate_blocked (PR-1 / #778) — registered in
+#                                          _HANDLERS for completeness but REMOVED from
+#                                          _PROJECTION_MAP (above) because it doesn't
+#                                          materialise a file.  Therefore not keyed in
+#                                          this registry either.
 #
 # Update this dict when a new handler lands in daemon/projector.py.
 # Never mark True speculatively — read the file and verify first.
@@ -166,16 +182,16 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # neither handler is registered yet (pending #768)
     "wicked.consensus.gate_completed":    False,
     "wicked.consensus.gate_pending":      False,
-    # Site 4 — _gate_decided_disk fan-out (from existing _gate_decided) +
-    # _gate_blocked landed in PR-1 (#778).  Both are gated on
-    # WG_BUS_AS_TRUTH_GATE_RESULT inside the handler.  PR-1 ships INERT
-    # (the existing emit at phase_manager.py:3931 lacks the full ``data``
-    # payload — handler early-returns until PR-2 / #779 widens the emit).
-    # The registry flip happens here in PR-1 so reconcile_v2's drift detector
-    # picks up gate-result.json once the cutover lands; without this flip,
-    # _handler_available_for_file would keep the file excluded.
+    # Site 4 — _gate_decided_disk fan-out (from existing _gate_decided)
+    # landed in PR-1 (#778) and the emit at phase_manager.py:3931 was
+    # widened in the same PR to carry the full gate_result dict under
+    # payload["data"].  The handler is therefore materialising when
+    # WG_BUS_AS_TRUTH_GATE_RESULT=on; flipping the registry True here
+    # tells the drift detector to scan gate-result.json.
+    # ``wicked.gate.blocked`` is intentionally absent from this registry
+    # because it was removed from _PROJECTION_MAP above — it doesn't
+    # materialise a file and the detector doesn't gate on it.
     "wicked.gate.decided":                True,
-    "wicked.gate.blocked":                True,
     # Site 5 — no event handler mapping yet
     # (conditions-manifest.json has no event type in _PROJECTION_MAP)
 }

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -144,11 +144,13 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
 #   wicked.dispatch.log_entry_appended  → _dispatch_log_appended  [line 944]  ✓ PRESENT
 #   wicked.consensus.report_created     → _consensus_report_created [line 950] ✓ PRESENT
 #   wicked.consensus.evidence_recorded  → _consensus_evidence_recorded [line 951] ✓ PRESENT
-#   wicked.consensus.gate_completed     → NO handler registered  ✗ ABSENT (pending #768)
-#   wicked.consensus.gate_pending       → NO handler registered  ✗ ABSENT (pending #768)
-#   wicked.gate.decided                 → _gate_decided handles DB rows but NOT on-disk
-#                                          gate-result.json projection ✗ ABSENT
-#   wicked.gate.blocked                 → NO on-disk projection handler  ✗ ABSENT
+#   wicked.consensus.gate_completed     → _consensus_gate_completed (PR #773) ✓ PRESENT
+#                                          (registry flip is the subject of a follow-up issue)
+#   wicked.consensus.gate_pending       → _consensus_gate_pending (PR #773) ✓ PRESENT
+#                                          (registry flip is the subject of a follow-up issue)
+#   wicked.gate.decided                 → _gate_decided handles DB rows; disk projection
+#                                          fans out to _gate_decided_disk (PR-1 / #778)  ✓ PRESENT
+#   wicked.gate.blocked                 → _gate_blocked (PR-1 / #778, INERT no-op)  ✓ PRESENT
 #
 # Update this dict when a new handler lands in daemon/projector.py.
 # Never mark True speculatively — read the file and verify first.
@@ -164,9 +166,16 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # neither handler is registered yet (pending #768)
     "wicked.consensus.gate_completed":    False,
     "wicked.consensus.gate_pending":      False,
-    # Site 4 — on-disk projection handler not yet shipped
-    "wicked.gate.decided":                False,
-    "wicked.gate.blocked":                False,
+    # Site 4 — _gate_decided_disk fan-out (from existing _gate_decided) +
+    # _gate_blocked landed in PR-1 (#778).  Both are gated on
+    # WG_BUS_AS_TRUTH_GATE_RESULT inside the handler.  PR-1 ships INERT
+    # (the existing emit at phase_manager.py:3931 lacks the full ``data``
+    # payload — handler early-returns until PR-2 / #779 widens the emit).
+    # The registry flip happens here in PR-1 so reconcile_v2's drift detector
+    # picks up gate-result.json once the cutover lands; without this flip,
+    # _handler_available_for_file would keep the file excluded.
+    "wicked.gate.decided":                True,
+    "wicked.gate.blocked":                True,
     # Site 5 — no event handler mapping yet
     # (conditions-manifest.json has no event type in _PROJECTION_MAP)
 }

--- a/tests/daemon/test_projector_gate_result.py
+++ b/tests/daemon/test_projector_gate_result.py
@@ -218,13 +218,15 @@ def test_flag_off_gate_blocked_noop(mem_conn, tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_flag_on_inert_when_payload_lacks_data_key(mem_conn, tmp_path) -> None:
-    """flag-on + payload without ``data`` key (current emit shape) →
-    handler logs at debug and returns; no file written.
+def test_defensive_skip_when_payload_lacks_data_key(mem_conn, tmp_path) -> None:
+    """flag-on + payload without ``data`` key → handler logs at debug
+    and returns; no file written.
 
-    This is the PR-1 invariant: operators can flip the flag on safely
-    BEFORE PR-2 (#779) widens the emit, because the handler is inert
-    until ``data`` arrives in the payload.
+    Defensive check.  Production emit at phase_manager.py:3931 always
+    includes ``data`` after PR #782, but the handler refuses to write
+    when the key is missing (e.g. a malformed external emitter or a
+    legacy event from before the payload widening).  Better to skip
+    than to materialise an incomplete file.
     """
     from daemon.projector import _gate_decided_disk
 

--- a/tests/daemon/test_projector_gate_result.py
+++ b/tests/daemon/test_projector_gate_result.py
@@ -1,0 +1,505 @@
+"""tests/daemon/test_projector_gate_result.py — Projector tests for Site 4
+bus-cutover handlers ``_gate_decided_disk`` (fan-out from ``_gate_decided``)
+and ``_gate_blocked`` (#746, #778).
+
+Covers the PR-1 inert-handler shape:
+  * Registration: ``wicked.gate.blocked`` in ``_HANDLERS``; ``_gate_decided``
+    still maps to its DB-row handler; the fan-out exists at the tail.
+  * Flag-off contract: both handlers no-op when flag off.
+  * Inert under current emit: flag-on + payload missing ``data`` → debug log,
+    no write.  Validates that PR-1 is safe to ship with flag default OFF
+    and remains inert if an operator opts in before #779 widens the emit.
+  * Happy path with synthetic full payload: flag-on + valid ``data`` dict +
+    dispatch-log check disabled → file written with content-hash idempotency.
+  * Security floor invocation: flag-on + invalid ``data`` → audit entry
+    written, file NOT updated.  Distinguishes schema vs sanitizer violations.
+  * Content-hash idempotency: replay with identical payload → no rewrite.
+  * Fan-out fail-open: when ``_gate_decided_disk`` raises, the existing
+    DB-row work in ``_gate_decided`` is preserved.
+  * ``_gate_blocked`` is a flag-gated no-op (PR-1 contract): no file
+    mutation regardless of file state.
+  * Project-directory edge cases: absent project row + NULL directory.
+
+T1: deterministic — fixed-epoch timestamps, no wall-clock reads in assertions.
+T2: no sleep-based sync.
+T3: isolated — each test gets its own tmp_path + in-memory DB via mem_conn.
+T4: one concern per test.
+T5: descriptive names.
+T6: provenance: #746 #778 Site 4 bus-cutover prep.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure daemon/ and scripts/ are importable from the repo root.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — project / phase setup
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = 1_700_000_001
+
+
+def _setup_project_in_db(conn, project_id: str, project_dir: Path) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+def _make_project_dir(tmp_path: Path, project_id: str = "my-proj") -> Path:
+    return tmp_path / project_id
+
+
+def _valid_gate_result(
+    *,
+    verdict: str = "APPROVE",
+    reviewer: str = "test-reviewer",
+    score: float = 0.85,
+    recorded_at: str = "2026-05-03T12:00:00Z",
+    phase: str = "build",
+    gate: str = "build-quality",
+) -> dict[str, Any]:
+    """Build a minimal gate_result dict that passes validate_gate_result."""
+    return {
+        "verdict": verdict,
+        "reviewer": reviewer,
+        "score": score,
+        "recorded_at": recorded_at,
+        "phase": phase,
+        "gate": gate,
+    }
+
+
+def _make_gate_decided_event(
+    *,
+    event_id: int = 1,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    data: dict[str, Any] | None = None,
+    include_data: bool = True,
+) -> dict[str, Any]:
+    """Build a wicked.gate.decided event.
+
+    When include_data=False: payload omits the ``data`` key — exercises the
+    inert path (current 5-field emit at phase_manager.py:3931 before #779).
+    """
+    payload: dict[str, Any] = {
+        "project_id": project_id,
+        "phase": phase,
+        "result": "APPROVE",
+        "score": 0.85,
+        "reviewer": "test-reviewer",
+    }
+    if include_data:
+        payload["data"] = data if data is not None else _valid_gate_result(phase=phase)
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.gate.decided",
+        "chain_id": f"{project_id}.{phase}.gate",
+        "created_at": _FIXED_TS + event_id,
+        "payload": payload,
+    }
+
+
+def _make_gate_blocked_event(
+    *,
+    event_id: int = 2,
+    project_id: str = "my-proj",
+    phase: str = "build",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.gate.blocked",
+        "chain_id": f"{project_id}.{phase}.gate",
+        "created_at": _FIXED_TS + event_id,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "blocking_reason": "REJECT",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_gate_blocked_handler_is_registered_in_dispatch_table() -> None:
+    """wicked.gate.blocked MUST be registered in _HANDLERS for Site 4 prep
+    so reconcile_v2._handler_available_for_file's conservative ALL-event-
+    types-must-have-handlers gate flips True for gate-result.json."""
+    from daemon.projector import _HANDLERS, _gate_blocked
+
+    assert "wicked.gate.blocked" in _HANDLERS, (
+        "wicked.gate.blocked must be registered for #778 Site 4 prep — "
+        "without it, reconcile_v2 keeps gate-result.json excluded from "
+        "drift detection even after the cutover ships."
+    )
+    assert _HANDLERS["wicked.gate.blocked"] is _gate_blocked
+
+
+def test_gate_decided_handler_still_maps_to_db_row_handler() -> None:
+    """wicked.gate.decided continues to dispatch to the existing DB-row
+    handler (_gate_decided).  Disk projection runs as a fan-out at the
+    tail of _gate_decided, NOT as a separate registry entry — _HANDLERS
+    is a strict 1:1 dispatch and we cannot double-register."""
+    from daemon.projector import _HANDLERS, _gate_decided
+
+    assert "wicked.gate.decided" in _HANDLERS
+    assert _HANDLERS["wicked.gate.decided"] is _gate_decided
+
+
+# ---------------------------------------------------------------------------
+# Flag-off contract — both handlers no-op
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_gate_decided_disk_noop_no_file_written(mem_conn, tmp_path) -> None:
+    """flag-off → _gate_decided_disk returns immediately, no file written.
+
+    The DB-row work in _gate_decided still runs (separate concern).  This
+    test verifies only the disk-projection branch.
+    """
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-flagoff"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "off"}):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not target.exists(), "flag-off must not write gate-result.json"
+
+
+def test_flag_off_gate_blocked_noop(mem_conn, tmp_path) -> None:
+    """flag-off → _gate_blocked returns immediately."""
+    from daemon.projector import _gate_blocked
+
+    project_id = "proj-blocked-flagoff"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    event = _make_gate_blocked_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "off"}):
+        _gate_blocked(mem_conn, event)
+
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Inert under current 5-field emit (PR-1 contract)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_on_inert_when_payload_lacks_data_key(mem_conn, tmp_path) -> None:
+    """flag-on + payload without ``data`` key (current emit shape) →
+    handler logs at debug and returns; no file written.
+
+    This is the PR-1 invariant: operators can flip the flag on safely
+    BEFORE PR-2 (#779) widens the emit, because the handler is inert
+    until ``data`` arrives in the payload.
+    """
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-inert"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    # include_data=False → payload missing the 'data' key
+    event = _make_gate_decided_event(project_id=project_id, include_data=False)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not target.exists(), (
+        "flag-on with current 5-field emit must remain inert until #779 — "
+        "an early file write here means the handler trusted an incomplete "
+        "payload and would ship invalid bytes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path with synthetic full payload (forward-compat — exercises #779 shape)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_on_full_payload_writes_file_with_dispatch_check_disabled(
+    mem_conn, tmp_path,
+) -> None:
+    """flag-on + full ``data`` dict + WG_GATE_RESULT_DISPATCH_CHECK=off →
+    file written.  Disabling the orphan check isolates the projection write
+    behaviour from dispatch-log fixture setup, which is exercised separately
+    in tests/crew/test_dispatch_log_*.
+
+    This test exercises the payload shape that PR-2 (#779) will ship.
+    """
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-write"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+
+    assert target.exists(), "expected gate-result.json materialised"
+    parsed = json.loads(target.read_text(encoding="utf-8"))
+    assert parsed["verdict"] == "APPROVE"
+    assert parsed["reviewer"] == "test-reviewer"
+    assert parsed["score"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# Security floor: schema violation surfaces in audit log + skips write
+# ---------------------------------------------------------------------------
+
+
+def test_flag_on_schema_violation_writes_audit_and_skips_write(
+    mem_conn, tmp_path,
+) -> None:
+    """flag-on + invalid ``data`` (missing required ``score``) →
+    schema_violation audit entry written, gate-result.json NOT updated.
+
+    Confirms the AC-9 §5.4 security floor IS invoked from the projection
+    path.  ``score`` is a required field in validate_gate_result; omitting
+    it raises GateResultSchemaError (#650 — score-presence check).
+    """
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-schema-violation"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+    audit_path = (
+        project_dir / "phases" / "build" / "gate-ingest-audit.jsonl"
+    )
+
+    bad_data = _valid_gate_result()
+    del bad_data["score"]   # required by validate_gate_result
+
+    event = _make_gate_decided_event(project_id=project_id, data=bad_data)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not target.exists(), (
+        "schema violation must skip the write — never ship validator-rejected "
+        "bytes to the projection path"
+    )
+    assert audit_path.exists(), "audit entry must be written for every reject"
+    audit_lines = [
+        json.loads(line)
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert any(
+        entry["event"] == "schema_violation" for entry in audit_lines
+    ), f"expected schema_violation in audit; got {audit_lines}"
+
+
+# ---------------------------------------------------------------------------
+# Content-hash idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_replay_same_event_skips_rewrite_via_content_hash(mem_conn, tmp_path) -> None:
+    """Replaying the same event twice → file written once; second call is
+    a no-op via content-hash equality.
+
+    Required because the daemon consumer does not dedupe before calling
+    handlers (append_event_log uses INSERT OR REPLACE — handler fires for
+    every event in the batch).  Without this guard the file would be
+    rewritten on every replay.
+    """
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-replay"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+        first_mtime = target.stat().st_mtime_ns
+        first_bytes = target.read_bytes()
+        # Replay
+        _gate_decided_disk(mem_conn, event)
+        second_mtime = target.stat().st_mtime_ns
+        second_bytes = target.read_bytes()
+
+    assert first_bytes == second_bytes, "replay must not corrupt file content"
+    # Atomic-rename writes always produce a new mtime; the idempotency guard
+    # short-circuits BEFORE the rename, so the mtime stays identical on
+    # replay.  This is the strongest signal the guard fired.
+    assert first_mtime == second_mtime, (
+        "replay must short-circuit before write — identical mtime confirms "
+        "the content-hash guard fired and skipped the atomic-rename path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fan-out from _gate_decided is fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_gate_decided_disk_failure_does_not_break_db_row_projection(
+    mem_conn, tmp_path,
+) -> None:
+    """If _gate_decided_disk raises, the existing DB-row work in
+    _gate_decided must still complete (Decision #6 / Decision #8 — handler
+    must never raise to the dispatcher).
+
+    Simulates a disk failure by patching _gate_decided_disk to raise.
+    The DB-row UPSERT for the phase row should still land.
+    """
+    from daemon.projector import _gate_decided
+
+    project_id = "proj-failopen"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    # Seed a phase row matching the daemon schema (state, not status; no
+    # created_at column).  Using a raw INSERT keeps this test independent
+    # of upsert_phase's evolving signature.
+    mem_conn.execute(
+        "INSERT OR IGNORE INTO phases "
+        "(project_id, phase, state, updated_at) "
+        "VALUES (?, ?, ?, ?)",
+        (project_id, "build", "active", 1_700_000_000),
+    )
+    mem_conn.commit()
+
+    event = _make_gate_decided_event(project_id=project_id)
+
+    with patch(
+        "daemon.projector._gate_decided_disk",
+        side_effect=RuntimeError("simulated disk failure"),
+    ):
+        # Must not raise — the fan-out is wrapped in try/except.
+        _gate_decided(mem_conn, event)
+
+    row = mem_conn.execute(
+        "SELECT gate_verdict, gate_reviewer FROM phases "
+        "WHERE project_id = ? AND phase = ?",
+        (project_id, "build"),
+    ).fetchone()
+    assert row is not None, "DB row must exist after _gate_decided"
+    assert row[0] == "APPROVE", (
+        "DB-row projection must complete even when disk fan-out raises "
+        "(fail-open per Decision #8)"
+    )
+    assert row[1] == "test-reviewer"
+
+
+# ---------------------------------------------------------------------------
+# _gate_blocked is a no-op even when flag is on (PR-1 contract)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_blocked_does_not_mutate_existing_file(mem_conn, tmp_path) -> None:
+    """flag-on + pre-existing gate-result.json → _gate_blocked is a no-op;
+    the file is unchanged.
+
+    PR-1 contract: gate.blocked always follows gate.decided in the REJECT
+    branch.  By the time gate.blocked fires, the file is already in REJECT
+    state from _gate_decided_disk's projection.  No additional disk
+    mutation is needed.
+    """
+    from daemon.projector import _gate_blocked
+
+    project_id = "proj-blocked-noop"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    target = phase_dir / "gate-result.json"
+    pre_existing = '{"verdict": "REJECT"}\n'
+    target.write_text(pre_existing, encoding="utf-8")
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_gate_blocked_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
+        _gate_blocked(mem_conn, event)
+
+    assert target.read_text(encoding="utf-8") == pre_existing, (
+        "PR-1 _gate_blocked must not mutate gate-result.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge: project row missing or directory NULL
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_row_warns_and_skips(mem_conn, tmp_path) -> None:
+    """No project row in DB → handler warns and skips (mirrors Site 3)."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-not-in-db"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    # Intentionally do NOT call _setup_project_in_db.
+    target = project_dir / "phases" / "build" / "gate-result.json"
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not target.exists()
+
+
+def test_null_project_directory_warns_and_skips(mem_conn, tmp_path) -> None:
+    """Project row with NULL directory → handler warns and skips."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-null-dir"
+    mem_conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, None, "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    mem_conn.commit()
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
+        from daemon.projector import _gate_decided_disk
+        _gate_decided_disk(mem_conn, event)
+
+    # Nothing to assert beyond "no exception" — the project_dir is None.
+    # The handler logs a warning and returns; behaviour-wise this matches
+    # the Site 3 contract.

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -200,10 +200,11 @@ class TestProjectionStaleDrift(_ReconcileV2Fixture):
     def test_pending_event_with_no_on_disk_file_is_projection_stale(self) -> None:
         """An event with projection_status=pending and absent on-disk file → drift.
 
-        Note (#769 fold): wicked.gate.decided handler is currently False (Site 4
-        not yet shipped). This test patches it as True to isolate the drift
-        detection logic from the handler-gate; the handler-gate behaviour is
-        tested in TestHandlerGateInDetectorFunctions.
+        Site 4 prep (#778) flipped wicked.gate.decided/blocked to True in the
+        production registry, so no handler-gate patching is required to
+        exercise the drift detection logic for gate-result.json events.
+        Handler-gate behaviour is still tested in
+        TestHandlerGateInDetectorFunctions.
         """
         _make_project_dir(self.workspace, "stale-proj")
         # Gate-decided event pending; NO gate-result.json on disk.
@@ -215,11 +216,7 @@ class TestProjectionStaleDrift(_ReconcileV2Fixture):
             projection_status="pending",
         )
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.gate.decided"] = True   # simulate Site 4 handler present
-        registry["wicked.gate.blocked"] = True
-        with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-            result = reconcile_v2.reconcile_project("stale-proj", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("stale-proj", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]
@@ -228,7 +225,8 @@ class TestProjectionStaleDrift(_ReconcileV2Fixture):
     def test_pending_event_with_file_present_is_not_projection_stale(self) -> None:
         """When the file exists, a pending event is not projection-stale.
 
-        Note (#769 fold): patches wicked.gate.decided as True to isolate drift logic.
+        Site 4 prep (#778) flipped the gate.* registry entries True natively;
+        no handler-gate patching is needed.
         """
         project_dir = _make_project_dir(self.workspace, "not-stale")
         phase_dir = _make_phase_dir(project_dir, "build")
@@ -242,11 +240,7 @@ class TestProjectionStaleDrift(_ReconcileV2Fixture):
             projection_status="pending",
         )
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.gate.decided"] = True
-        registry["wicked.gate.blocked"] = True
-        with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-            result = reconcile_v2.reconcile_project("not-stale", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("not-stale", _daemon_conn=conn)
         conn.close()
 
         stale = [d for d in result["drift"]
@@ -263,8 +257,7 @@ class TestEventWithoutProjectionDrift(_ReconcileV2Fixture):
     def test_applied_event_with_no_file_is_event_without_projection(self) -> None:
         """Applied event but no on-disk projection → event-without-projection drift.
 
-        Note (#769 fold): patches wicked.gate.decided as True to isolate the
-        drift detection logic from the handler-gate.
+        Site 4 prep (#778) flipped the gate.* registry entries True natively.
         """
         _make_project_dir(self.workspace, "ewp-proj")
         _insert_event_row(
@@ -275,11 +268,7 @@ class TestEventWithoutProjectionDrift(_ReconcileV2Fixture):
             projection_status="applied",
         )
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.gate.decided"] = True
-        registry["wicked.gate.blocked"] = True
-        with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-            result = reconcile_v2.reconcile_project("ewp-proj", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("ewp-proj", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]
@@ -337,23 +326,16 @@ class TestProjectionWithoutEventDrift(_ReconcileV2Fixture):
         WG_BUS_AS_TRUTH_GATE_RESULT=on so the file is included in the active
         projection set — otherwise Finding #1 correctly suppresses it.
 
-        Note (#769 fold): the handler-presence gate uses per-event-type keys.
-        This test patches wicked.gate.decided and wicked.gate.blocked as True
-        (simulating that Site 4's handler has landed) so the flag-gate behaviour
-        remains testable in isolation.
+        Site 4 prep (#778) flipped wicked.gate.decided/blocked to True in the
+        production registry, so no handler-gate patching is required.
         """
         project_dir = _make_project_dir(self.workspace, "pwe-proj")
         phase_dir = _make_phase_dir(project_dir, "build")
         _write_file(phase_dir / "gate-result.json")
         # No event rows in DB.
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        # Simulate Site 4 handler present for both event types mapping to gate-result.json
-        registry["wicked.gate.decided"] = True
-        registry["wicked.gate.blocked"] = True
         with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
-            with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-                result = reconcile_v2.reconcile_project("pwe-proj", _daemon_conn=conn)
+            result = reconcile_v2.reconcile_project("pwe-proj", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]
@@ -1041,8 +1023,7 @@ class TestProjectionStaleEntrySchema(_ReconcileV2Fixture):
     def test_projection_stale_entry_has_cursor_fields(self) -> None:
         """projection-stale entry must contain projection_last_applied_seq + lag_events.
 
-        Note (#769 fold): patches wicked.gate.decided as True to isolate the
-        schema-field test from the handler-gate.
+        Site 4 prep (#778) flipped the gate.* registry entries True natively.
         """
         _make_project_dir(self.workspace, "stale-schema-proj")
         _insert_event_row(
@@ -1053,11 +1034,7 @@ class TestProjectionStaleEntrySchema(_ReconcileV2Fixture):
             projection_status="pending",
         )
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.gate.decided"] = True
-        registry["wicked.gate.blocked"] = True
-        with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-            result = reconcile_v2.reconcile_project("stale-schema-proj", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("stale-schema-proj", _daemon_conn=conn)
         conn.close()
 
         stale_entries = [d for d in result["drift"]


### PR DESCRIPTION
## Summary

Complete Site 4 cutover for the bus-cutover (#746). Lays the projector handlers, widens the emit payload at `phase_manager.py:3931` to carry the full `gate_result` dict, and flips the reconcile_v2 registry so the drift detector picks up `gate-result.json`. Flag default OFF.

When this merges, Site 4 is **functionally cut over** — only the default-ON flag flip + scenario extension (#780) remains.

Closes #778. **Supersedes #779** (the original split between prep + cutover collapsed during review fold; see commit `f390e67`).

## Three commits

1. `docs(crew)` (`f4a7c7a`) — staging plan §Site 4 line-number correction (only line 3676 writes the file, not 6 phantom sites).
2. `feat(daemon)` (`4199f37`) — projector handlers + initial registry flip + tests.
3. `fix(crew)` (`f390e67`) — Copilot-fold: widen emit payload + drop `gate.blocked` from `_PROJECTION_MAP`.

## What changed

### `daemon/projector.py`
- New `_gate_decided_disk(conn, event)` — disk projection for `gate-result.json`. Gated on `_bus_as_truth_enabled(\"GATE_RESULT\")`. Reads the full `gate_result` dict from `payload[\"data\"]`, runs the AC-9 §5.4 security floor (`validate_gate_result` covering schema + sanitizer per the embedded-composition gotcha; `check_orphan` for dispatch-log orphan detection; `append_audit_entry` on every reject), then atomic-writes via temp-file + rename. Content-hash sha256 idempotency on rewrite.
- Existing `_gate_decided` extended to fan out to `_gate_decided_disk` at the tail (try/except, fail-open per Decision #8 — disk failures never break DB-row work).
- New `_gate_blocked(conn, event)` — registered in `_HANDLERS` so the daemon consumes the event cleanly (no \"unknown event_type\" log noise), but **does NOT materialise a file**. Removed from `_PROJECTION_MAP` accordingly so the drift detector treats it as non-materialising.

### `scripts/crew/phase_manager.py`
- Emit at line 3931 widened to carry `\"data\": dict(gate_result)`. Existing 5 top-level fields preserved for downstream consumers that don't need the full dict. Defensive `dict(...)` copy prevents mutation of the in-memory verdict.

### `scripts/crew/reconcile_v2.py`
- `_PROJECTION_MAP`: removed `wicked.gate.blocked` (it doesn't materialise a file).
- `_PROJECTION_HANDLERS_AVAILABLE`: `wicked.gate.decided → True` (handler now actually writes when flag-on); `wicked.gate.blocked` removed (no longer keyed since it's not in `_PROJECTION_MAP`).

### `tests/daemon/test_projector_gate_result.py` (NEW, 12 tests)
- Registration, flag-off contract, defensive skip when payload lacks `data` (malformed/legacy events), full-payload happy path with dispatch-check disabled, schema-violation surfaces in audit + skips write, content-hash idempotency on replay, fan-out fail-open, `_gate_blocked` no-op, project-row edge cases.

### `tests/test_reconcile_v2.py`
- Removed 5 patch sites that previously simulated Site 4 handler presence (production registry now True natively).

### `docs/v9/bus-cutover-staging-plan.md`
- Site 4 §: corrected the bogus 6-caller-chain-writers list. Verified by grep — only line 3676 writes `gate-result.json`. (Other listed lines write `conditions-manifest.json`, iteration files, status, reeval-log entries.)

## Both Copilot findings on the prior force-push are folded

- **Finding 1** (registry flip + inert handler = false-positive drift) → fixed by widening the emit so the handler is no longer inert. Registry flip is now correct.
- **Finding 2** (`_gate_blocked` no-op + `_PROJECTION_MAP` membership = false-negative drift) → fixed by removing `wicked.gate.blocked` from `_PROJECTION_MAP`. The handler stays in `_HANDLERS` for daemon consumption.

## Discovered separately (filed as standalone issues)

- **#781** — Site 3's `_PROJECTION_HANDLERS_AVAILABLE` for `gate_completed/pending` was never flipped to True after PR #773 landed handlers. 2-line follow-up.

## Test plan

- [x] `tests/daemon/test_projector_gate_result.py` — 12/12 pass
- [x] `tests/test_reconcile_v2.py` — full pass (no regressions from registry change)
- [x] `tests/daemon/test_projector_consensus_gate.py`, `test_projector_dispatch_log.py`, `test_projector_consensus.py` — pass
- [x] `tests/crew/test_synthetic_drift.py`, `test_resume_projector.py`, `test_phase_manager.py`, `test_consensus_gate.py`, `test_gate_enforcement.py` — pass
- [x] `tests/daemon/test_hook_dispatch.py`, `test_hook_subscription_schema.py`, `test_unknown_event.py`, `test_parity.py` — pass
- [x] `tests/hooks/test_bus_emit_lint.py` — pass
- [x] **Full suite**: 2434 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs — confirmed present on `origin/main` without this branch's changes).

Total relevant: **377 tests across the affected surface**, zero regressions.

## What's left for the cutover

Just **#780** (renamed from PR-3): add `GATE_RESULT` to `_BUS_AS_TRUTH_DEFAULT_ON` + extend the PR #765 security-floor scenario to cover the projection path. Standalone, soak-and-flip step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)