### PR TITLE
fix(crew): #781 Site 3 follow-up — flip _PROJECTION_HANDLERS_AVAILABLE for gate_completed/pending

### DIFF
--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -154,9 +154,9 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
 #   wicked.consensus.report_created     → _consensus_report_created [line 950] ✓ PRESENT
 #   wicked.consensus.evidence_recorded  → _consensus_evidence_recorded [line 951] ✓ PRESENT
 #   wicked.consensus.gate_completed     → _consensus_gate_completed (PR #773) ✓ PRESENT
-#                                          (registry flip is the subject of a follow-up issue)
+#                                          (registry flip landed in PR #781 / this commit)
 #   wicked.consensus.gate_pending       → _consensus_gate_pending (PR #773) ✓ PRESENT
-#                                          (registry flip is the subject of a follow-up issue)
+#                                          (registry flip landed in PR #781 / this commit)
 #   wicked.gate.decided                 → _gate_decided handles DB rows; disk projection
 #                                          fans out to _gate_decided_disk (PR-1 / #778)  ✓ PRESENT
 #                                          (emit at phase_manager.py:3931 carries the full
@@ -178,10 +178,14 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # Site 2 — _consensus_report_created / _consensus_evidence_recorded landed in PR #758
     "wicked.consensus.report_created":    True,
     "wicked.consensus.evidence_recorded": True,
-    # Site 3 — both gate_completed and gate_pending map to reviewer-report.md;
-    # neither handler is registered yet (pending #768)
-    "wicked.consensus.gate_completed":    False,
-    "wicked.consensus.gate_pending":      False,
+    # Site 3 — _consensus_gate_completed + _consensus_gate_pending landed
+    # in PR #773 (closing #768).  This registry was never updated at the
+    # time, leaving reviewer-report.md silently excluded from the drift
+    # detector even though Site 3 had shipped end-to-end with flag-on by
+    # default in PR #777.  Discovered during PR #782 (Site 4) and fixed
+    # here (#781).
+    "wicked.consensus.gate_completed":    True,
+    "wicked.consensus.gate_pending":      True,
     # Site 4 — _gate_decided_disk fan-out (from existing _gate_decided)
     # landed in PR-1 (#778) and the emit at phase_manager.py:3931 was
     # widened in the same PR to carry the full gate_result dict under

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -552,8 +552,11 @@ class TestGatePendingMapsToReviewerReport(_ReconcileV2Fixture):
         Note (#769 fold): the handler-presence gate now filters per event type.
         This test patches gate_pending as True (handler present) so the detector
         runs and reports the missing projection.  Without patching, gate_pending
-        handler is False (pending #768) and the detector correctly skips it —
-        that negative case is covered in TestHandlerGateInDetectorFunctions.
+        handler is False and the detector correctly skips it — that
+        negative case is covered in TestHandlerGateInDetectorFunctions.
+
+        PR #781 flipped the gate_completed/pending registry entries True
+        natively, so no patching is required to exercise this path.
         """
         _make_project_dir(self.workspace, "pending-missing-proj")
         _insert_event_row(
@@ -564,11 +567,7 @@ class TestGatePendingMapsToReviewerReport(_ReconcileV2Fixture):
             projection_status="applied",
         )
         conn = self._conn()
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.consensus.gate_pending"] = True   # simulate handler present
-        registry["wicked.consensus.gate_completed"] = True
-        with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-            result = reconcile_v2.reconcile_project("pending-missing-proj", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("pending-missing-proj", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]
@@ -813,13 +812,10 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
             "WG_BUS_AS_TRUTH_GATE_RESULT":         "off",
             "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "off",
         }
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        # Simulate Site 3 handler present — both event types that map to reviewer-report.md
-        registry["wicked.consensus.gate_completed"] = True
-        registry["wicked.consensus.gate_pending"] = True
+        # PR #781 flipped the Site 3 registry entries True natively;
+        # no handler-presence patching required.
         with patch.dict(os.environ, env):
-            with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-                result = reconcile_v2._active_projection_names()
+            result = reconcile_v2._active_projection_names()
         self.assertEqual(result, frozenset({"reviewer-report.md"}))
 
 
@@ -874,11 +870,9 @@ class TestProjWithoutEventFlagGating(_ReconcileV2Fixture):
     def test_reviewer_report_with_site3_flag_on_and_no_event_reports_drift(self) -> None:
         """Site 3 flag ON + reviewer-report.md but no matching event → drift fires.
 
-        Note (#769 fold): the handler-presence gate uses per-event-type keys.
-        This test patches both gate_completed and gate_pending as True so we can
-        verify the flag-gate + drift-detection path without the handler-gate
-        vetoing the file first.  The handler-gate behaviour (handler absent →
-        file excluded even when flag is on) is covered in
+        PR #781 flipped the Site 3 registry entries True natively, so the
+        handler-presence gate no longer vetoes the file.  The
+        handler-absent → file-excluded behaviour stays covered in
         TestHandlerPresenceGate.test_active_projection_names_excludes_files_with_no_handler.
         """
         project_dir = _make_project_dir(self.workspace, "s3-flag-on-orphan")
@@ -887,13 +881,8 @@ class TestProjWithoutEventFlagGating(_ReconcileV2Fixture):
         # No event rows.
         conn = self._conn()
         env = {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        # Simulate Site 3 handler present — both event types that map to reviewer-report.md
-        registry["wicked.consensus.gate_completed"] = True
-        registry["wicked.consensus.gate_pending"] = True
         with patch.dict(os.environ, env):
-            with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-                result = reconcile_v2.reconcile_project("s3-flag-on-orphan", _daemon_conn=conn)
+            result = reconcile_v2.reconcile_project("s3-flag-on-orphan", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]
@@ -1403,14 +1392,10 @@ class TestHandlerGateInDetectorFunctions(_ReconcileV2Fixture):
             projection_status="applied",
         )
         conn = self._conn()
-        # Registry with gate_completed handler explicitly present.
-        registry = dict(reconcile_v2._PROJECTION_HANDLERS_AVAILABLE)
-        registry["wicked.consensus.gate_completed"] = True
-        registry["wicked.consensus.gate_pending"] = True
+        # PR #781 flipped both handler-presence entries True natively.
         env = {"WG_BUS_AS_TRUTH_REVIEWER_REPORT": "on"}
         with patch.dict(os.environ, env):
-            with patch.object(reconcile_v2, "_PROJECTION_HANDLERS_AVAILABLE", registry):
-                result = reconcile_v2.reconcile_project("handler-present-proj", _daemon_conn=conn)
+            result = reconcile_v2.reconcile_project("handler-present-proj", _daemon_conn=conn)
         conn.close()
 
         drift_types = [d["type"] for d in result["drift"]]


### PR DESCRIPTION
## Summary

2-line registry flip + comment update + 4 test-patch cleanups. Closes #781.

Site 3 projector handlers landed in PR #773 closing #768, and Site 3 was flag-flipped default-ON in PR #777 — but \`scripts/crew/reconcile_v2.py:165-166\` still had both registry entries marked False with a stale \`pending #768\` comment. The drift detector was therefore silently skipping \`reviewer-report.md\` even though Site 3 had been shipping end-to-end.

Discovered during PR #782 (Site 4 prep) when verifying handler-presence gate state before flipping Site 4 entries. Filed as standalone follow-up per #772 lesson #4 (bundling hides seams).

## Diff (25 insertions / 36 deletions across 2 files)

### \`scripts/crew/reconcile_v2.py\`
- Flip \`wicked.consensus.gate_completed\` and \`wicked.consensus.gate_pending\` registry entries to \`True\`.
- Update the audit-comment block (lines 156-159) to remove \`pending #768\` and reference this PR.

### \`tests/test_reconcile_v2.py\`
- Remove 4 redundant \`registry[\"wicked.consensus.gate_*\"] = True\` patch sites (production registry is True natively now). Same cleanup pattern PR #782 used for the Site 4 entries.
- Negative-case patches (handler-absent at lines 1230-1231 / 1296-1297 / 1373-1374 / 1440-1441) stay unchanged — they still need to override the now-True production value to False.

## Test plan

- [x] \`tests/test_reconcile_v2.py\` — all pass
- [x] \`tests/daemon/test_projector_consensus_gate.py\` — pass (no patch dependency)
- [x] \`tests/daemon/test_projector_gate_result.py\` — pass
- [x] \`tests/crew/test_synthetic_drift.py\` — pass
- [x] \`tests/crew/test_resume_projector.py\` — pass

114 passing, 7 unrelated skips.

## Why this wasn't bundled into PR #782

Per #772 lesson #4: bundling hides seams. Site 3 cleanup is independent of Site 4 (different sites, different flags, different registry entries). Keeping it separate gives the cleanup its own audit trail and makes the change reviewable in isolation.

## Refs

- PR #773 (#768) — Site 3 projector handlers (the work this should have shipped alongside)
- PR #774 (#769) — handler-presence gate that introduced this dict
- PR #777 (#746) — Site 3 flag-flip default-ON
- PR #782 (#778) — Site 4 prep, where this was discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)