### PR TITLE
feat(crew): #780 Site 4 flag flip — GATE_RESULT default-ON + scenario footer

### DIFF
--- a/scenarios/crew/bus-cutover-gate-result-security-floor.md
+++ b/scenarios/crew/bus-cutover-gate-result-security-floor.md
@@ -1159,3 +1159,30 @@ Specific invariants that must hold post-cutover:
 - `gate-ingest-audit.jsonl` still accumulates entries for every rejected projection; both `unauthorized_dispatch` and `unauthorized_dispatch_accepted_legacy` tag paths exist (Case 4).
 - Bypass levers still work at projection time via the same envvar semantics (Case 5).
 - `WG_GATE_RESULT_STRICT_AFTER` auto-expire logic is envvar-driven and has no cutover dependency (Case 6).
+
+---
+
+## Post-cutover status (2026-05-03 — PR #780 default-flipped GATE_RESULT)
+
+After PR #782 landed `_gate_decided_disk` in the projector and PR #780
+flipped `WG_BUS_AS_TRUTH_GATE_RESULT` to default-ON, the projection path
+is the active write path in fresh checkouts. The legacy direct write at
+`phase_manager.py:3676` still runs (write-then-emit shape — see PR #782's
+fold for the rationale); the projector's content-hash idempotency makes
+the second write a no-op.
+
+This scenario therefore exercises **both paths** in the default
+configuration:
+- The direct write at `phase_manager.py:3676` produces the file first.
+- The projector handler `_gate_decided_disk` runs the security floor
+  (`validate_gate_result` covering schema + sanitizer per AC-9 §5.4
+  embedded composition; `check_orphan`; `append_audit_entry`) and
+  short-circuits via content-hash equality when the bytes match.
+- `_load_gate_result()` reads the file and re-runs the security floor at
+  read time.
+
+To exercise the legacy path in isolation, operators can opt out via
+`WG_BUS_AS_TRUTH_GATE_RESULT=off` (literal "on"/"off" only — see PR #777
+for the normalization contract). The scenario's case-by-case assertions
+remain valid in either configuration because each Case targets a public
+module surface, not a specific call site.

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -301,10 +301,9 @@ def _is_disabled() -> bool:
 
 # ---------------------------------------------------------------------------
 # Default-ON set for _bus_as_truth_enabled — shipped cutover sites whose
-# flag falls through to the default map.  Only sites 1-3 have shipped; the
-# remaining tokens (GATE_RESULT, CONDITIONS_MANIFEST) default OFF until their
-# cutovers land.  Keep this frozenset in sync with PROJECTION_FILE_FLAGS in
-# scripts/crew/reconcile_v2.py.
+# flag falls through to the default map.  Sites 1-4 have shipped; only
+# CONDITIONS_MANIFEST defaults OFF until Site 5 lands.  Keep this frozenset
+# in sync with PROJECTION_FILE_FLAGS in scripts/crew/reconcile_v2.py.
 # ---------------------------------------------------------------------------
 
 _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
@@ -312,6 +311,7 @@ _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
     "CONSENSUS_REPORT",   # Site 2 — consensus-report.json (PR #758)
     "CONSENSUS_EVIDENCE", # Site 2 — consensus-evidence.json (PR #758)
     "REVIEWER_REPORT",    # Site 3 — reviewer-report.md (PR #776)
+    "GATE_RESULT",        # Site 4 — gate-result.json (PR #782 + this PR)
 })
 
 

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -125,7 +125,7 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
     "consensus-report.json":    "CONSENSUS_REPORT",    # Site 2 (flag A)
     "consensus-evidence.json":  "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
     "reviewer-report.md":       "REVIEWER_REPORT",     # Site 3
-    "gate-result.json":         "GATE_RESULT",         # Site 4 — placeholder
+    "gate-result.json":         "GATE_RESULT",         # Site 4 — active (PR #782 + #780 default-ON)
     "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — placeholder
 }
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -1466,10 +1466,16 @@ class TestReconcileV2FlagPredicate(unittest.TestCase):
             self.assertFalse(reconcile_v2._flag_on("DISPATCH_LOG"))
 
     def test_unshipped_site_default_off_when_unset(self) -> None:
-        """Unshipped token (GATE_RESULT) is OFF via default map when unset."""
+        """Unshipped token (CONDITIONS_MANIFEST, Site 5) is OFF via default
+        map when unset.
+
+        GATE_RESULT (Site 4) was previously the unshipped reference here;
+        PR #780 flipped it default-ON when Site 4 cutover completed, so
+        CONDITIONS_MANIFEST is now the only remaining unshipped token.
+        """
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("WG_BUS_AS_TRUTH_GATE_RESULT", None)
-            self.assertFalse(reconcile_v2._flag_on("GATE_RESULT"))
+            os.environ.pop("WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST", None)
+            self.assertFalse(reconcile_v2._flag_on("CONDITIONS_MANIFEST"))
 
     def test_active_projection_names_includes_dispatch_log_by_default(self) -> None:
         """Without any env var, DISPATCH_LOG is default-ON → dispatch-log.jsonl


### PR DESCRIPTION
## Summary

**Final step of Site 4 cutover.** After PR #782 landed the projector handlers + emit-payload widening (closes #778) and PR #783 fixed the Site 3 registry follow-up (closes #781), \`gate-result.json\` is fully cut over via the bus. This PR flips the default-ON flag so fresh checkouts get bus-as-truth projection without an explicit env var.

Closes #780. **Site 4 is fully shipped after this merges.**

## Diff (41 insertions / 8 deletions across 4 files)

### \`scripts/_bus.py\`
- Add \`GATE_RESULT\` to \`_BUS_AS_TRUTH_DEFAULT_ON\` frozenset.
- Update comment from \"Sites 1-3 have shipped\" to \"Sites 1-4 have shipped; only CONDITIONS_MANIFEST defaults OFF until Site 5 lands.\"

### \`scripts/crew/reconcile_v2.py\`
- \`PROJECTION_FILE_FLAGS\` comment for \`gate-result.json\` switches from \`# Site 4 — placeholder\` to \`# Site 4 — active (PR #782 + #780 default-ON)\`.

### \`tests/test_reconcile_v2.py\`
- \`test_unshipped_site_default_off_when_unset\` now references \`CONDITIONS_MANIFEST\` (Site 5). \`GATE_RESULT\` (Site 4) is no longer unshipped — same test-update pattern PR #777 used when flipping Sites 1-3.

### \`scenarios/crew/bus-cutover-gate-result-security-floor.md\`
- Footer documents post-cutover state. Both paths run by default:
  - Direct write at \`phase_manager.py:3676\` produces the file first.
  - Projector handler \`_gate_decided_disk\` runs the security floor and short-circuits via content-hash equality.
  - \`_load_gate_result()\` reads + re-runs the security floor at read time.
- Existing Cases remain valid in either configuration because they target public module surfaces.
- Documents \`WG_BUS_AS_TRUTH_GATE_RESULT=off\` opt-out for operators wanting the legacy direct-write-only path.

## Operator opt-out

\`WG_BUS_AS_TRUTH_GATE_RESULT=off\` — literal \`on\`/\`off\` only, case/whitespace normalised. See PR #777 for the contract.

## Test plan

- [x] \`tests/test_reconcile_v2.py\` — pass
- [x] \`tests/daemon/test_projector_gate_result.py\` — pass
- [x] \`tests/daemon/test_projector_consensus_gate.py\` — pass
- [x] \`tests/daemon/test_projector_dispatch_log.py\` — pass
- [x] \`tests/crew/test_synthetic_drift.py\`, \`test_resume_projector.py\` — pass
- [x] \`tests/crew/test_phase_manager.py\`, \`test_consensus_gate.py\`, \`test_gate_enforcement.py\` — pass
- [x] \`tests/daemon/test_hook_dispatch.py\`, \`test_hook_subscription_schema.py\`, \`test_unknown_event.py\`, \`test_parity.py\` — pass
- [x] \`tests/hooks/test_bus_emit_lint.py\` — pass

**361 passing, 7 unrelated skips, zero regressions.**

## Site 4 stack — now complete

- ✅ **#782** — handlers + payload widening + registry flip (cutover)
- ✅ **#783** — Site 3 registry follow-up (#781)
- 🟡 **#784** — this PR (flag flip + scenario footer)

After this merges, the only remaining bus-cutover work is **Site 5** (\`conditions-manifest.json\`), then the docs rewrite.

## Refs

- Council decision: \`memory/site-4-gate-result-cutover-write-site-and-pr-sequence-decision.md\`
- AC-9 §5.4 composition: \`memory/gate-result-security-floor-composition-and-audit-tags.md\`
- Bundle-vs-defer lesson: \`memory/ship-inert-and-activate-later-is-a-contradiction-bundle-instead.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)