### PR TITLE
feat(crew): #746 Site 5 cutover — conditions-manifest.json end-to-end (bus-cutover COMPLETE for planned sites)

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -1435,6 +1435,342 @@ def _gate_decided_disk(conn: sqlite3.Connection, event: dict) -> None:
         project_id, phase, data.get("result") or data.get("verdict"), target,
     )
 
+    # Site 5 fan-out (#746): when the verdict is CONDITIONAL and the
+    # payload carries a non-empty conditions list, ALSO materialise
+    # conditions-manifest.json from the same event.  One event, multiple
+    # files — the new _PROJECTION_MAP shape (Dict[str, FrozenSet[str]])
+    # makes this explicit.  Wrapped in try/except so a manifest-write
+    # failure NEVER taints the gate-result.json projection above.
+    try:
+        _conditions_manifest_from_gate_decided(
+            conn, project_dir, str(phase), data
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        logger.exception(
+            "projector: _conditions_manifest_from_gate_decided fan-out "
+            "raised — gate-result.json projection preserved; "
+            "conditions-manifest.json may not have been written"
+        )
+
+
+def _conditions_manifest_from_gate_decided(
+    conn: sqlite3.Connection,
+    project_dir: Path,
+    phase: str,
+    gate_data: dict,
+) -> None:
+    """Materialise conditions-manifest.json from a wicked.gate.decided event.
+
+    Site 5 of the bus-cutover staging plan (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST`` (separate flag from
+    ``WG_BUS_AS_TRUTH_GATE_RESULT`` so operators can opt out of one
+    cutover without disabling the other).
+
+    Short-circuits when:
+      * Flag is off.
+      * Verdict is not CONDITIONAL.
+      * ``gate_data["conditions"]`` is missing or empty.
+
+    Mirrors the legacy ``phase_manager._write_conditions_manifest()``
+    shape exactly (same condition_id format, same field set) so the
+    direct-write and projector paths produce byte-identical output.
+    Content-hash idempotency on rewrite, atomic temp+rename write —
+    same pattern as ``_gate_decided_disk``'s gate-result.json materialisation.
+
+    project_dir is supplied by the caller (already resolved from db).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("CONDITIONS_MANIFEST")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    verdict = gate_data.get("result") or gate_data.get("verdict")
+    if verdict != "CONDITIONAL":
+        # Only CONDITIONAL verdicts produce a conditions manifest.
+        # APPROVE / REJECT have no conditions to materialise.
+        return
+
+    conditions_in = gate_data.get("conditions") or []
+    if not conditions_in:
+        # CONDITIONAL with empty conditions list is a degenerate case;
+        # don't materialise an empty manifest (would be misleading).
+        logger.debug(
+            "projector: conditions-manifest projection — verdict CONDITIONAL "
+            "but conditions list is empty; skipping write (phase=%r)", phase,
+        )
+        return
+
+    # Mirror phase_manager._write_conditions_manifest's shape exactly so
+    # direct-write and projector paths produce byte-identical output.
+    # CONDITION-{i+1} ids and the same field set (description, verified=
+    # False, resolution=None, verified_at=None).
+    import json
+    import hashlib
+    from datetime import datetime, timezone
+
+    def _utc_iso() -> str:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    manifest = {
+        "source_gate": phase,
+        "created_at": gate_data.get("recorded_at") or _utc_iso(),
+        "conditions": [
+            {
+                "id": f"CONDITION-{i + 1}",
+                "description": c.get("description", c.get("condition", str(c)))
+                if isinstance(c, dict) else str(c),
+                "verified": False,
+                "resolution": None,
+                "verified_at": None,
+            }
+            for i, c in enumerate(conditions_in)
+        ],
+    }
+
+    manifest_path = project_dir / "phases" / phase / "conditions-manifest.json"
+    candidate_bytes = json.dumps(manifest, indent=2).encode("utf-8")
+
+    # Content-hash idempotency: skip when existing bytes match.
+    try:
+        if manifest_path.exists():
+            existing_bytes = manifest_path.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: conditions-manifest projection — content hash "
+                    "matches existing %s; skipping rewrite", manifest_path,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: conditions-manifest projection — could not read "
+            "existing %s for idempotency check: %s; proceeding to write",
+            manifest_path, exc,
+        )
+
+    # Atomic write.
+    try:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(manifest_path)
+    except OSError as exc:
+        logger.warning(
+            "projector: conditions-manifest projection — could not write %s: %s",
+            manifest_path, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied conditions-manifest projection from "
+        "wicked.gate.decided phase=%r conditions=%d path=%s",
+        phase, len(conditions_in), manifest_path,
+    )
+
+
+def _condition_marked_cleared(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.condition.marked_cleared → resolution sidecar + manifest flip.
+
+    Site 5 of the bus-cutover staging plan (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST`` via
+    ``_bus_as_truth_enabled("CONDITIONS_MANIFEST")``.
+
+    Replays the same atomic two-step write order as
+    ``conditions_manifest.mark_cleared()``:
+      1. Write resolution sidecar (.resolution.json) with fsync.
+      2. Mutate manifest in memory (flip verified=True, set resolution
+         + verified_at fields).
+      3. Atomically replace conditions-manifest.json.
+
+    A crash between steps 1 and 3 leaves the sidecar on disk; the
+    existing ``conditions_manifest.recover()`` reconciles such orphans
+    by re-running step 3 from the sidecar's contents.
+
+    Idempotency: when the manifest already shows the condition as
+    verified with the matching resolution_ref, the handler skips both
+    writes (no-op replay).  This is correct because the legacy direct
+    write at ``conditions_manifest.mark_cleared()`` is also still
+    running today (bus + direct-write coexist via this idempotency
+    until the legacy path is removed in a future cleanup).
+
+    project_dir resolved via db.get_project; absent row or NULL
+    directory → warn and skip (mirrors Site 3 / 4 contract).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("CONDITIONS_MANIFEST")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    condition_id, ok = _require(payload, "condition_id", et)
+    if not ok:
+        return
+    resolution_ref, ok = _require(payload, "resolution_ref", et)
+    if not ok:
+        return
+
+    note = payload.get("note")
+    verified_at = payload.get("verified_at")
+
+    # Resolve project_dir from the DB.
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — project %r has no "
+            "directory in DB; skipping (project must be projected via "
+            "wicked.project.created before Site 5 handlers can write files)",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    manifest_path = project_dir / "phases" / str(phase) / "conditions-manifest.json"
+
+    if not manifest_path.exists():
+        # No manifest to update — handler is a no-op rather than an error.
+        # The manifest is created by the gate.decided CONDITIONAL fan-out
+        # above; if it's absent, the gate.decided event hasn't been
+        # processed yet.  Replay will catch up when both events flow.
+        logger.debug(
+            "projector: wicked.condition.marked_cleared — manifest not yet "
+            "materialised at %s; skipping (gate.decided likely pending)",
+            manifest_path,
+        )
+        return
+
+    # Lazy import: re-uses the production helper for the atomic write
+    # ordering so a single source of truth governs the sidecar+manifest
+    # crash semantics.
+    import json
+    try:
+        from conditions_manifest import (  # type: ignore[import]
+            atomic_write_json,
+            _resolution_sidecar_path,
+            _find_condition_index,
+            _utc_now_iso,
+        )
+    except ImportError as exc:
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — conditions_manifest "
+            "module unavailable: %s; skipping projection",
+            exc,
+        )
+        return
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — manifest unreadable "
+            "at %s: %s; skipping projection",
+            manifest_path, exc,
+        )
+        return
+
+    try:
+        idx = _find_condition_index(manifest, str(condition_id))
+    except ValueError:
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — condition %r not "
+            "found in manifest %s; skipping (sidecar not orphaned because "
+            "we never wrote one)",
+            condition_id, manifest_path,
+        )
+        return
+
+    # Idempotency: if already cleared with the same resolution, skip both writes.
+    condition = manifest["conditions"][idx]
+    if (
+        condition.get("verified") is True
+        and condition.get("resolution") == resolution_ref
+    ):
+        logger.debug(
+            "projector: wicked.condition.marked_cleared — condition %r already "
+            "cleared with matching resolution_ref; skipping replay",
+            condition_id,
+        )
+        return
+
+    timestamp = str(verified_at) if verified_at else _utc_now_iso()
+    sidecar = {
+        "condition_id": str(condition_id),
+        "resolution_ref": str(resolution_ref),
+        "note": note,
+        "written_at": timestamp,
+    }
+
+    # Step 1: sidecar lands first (mirror mark_cleared crash-safety order).
+    sidecar_path = _resolution_sidecar_path(manifest_path, str(condition_id))
+    try:
+        atomic_write_json(sidecar_path, sidecar)
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — sidecar write "
+            "failed at %s: %s; skipping manifest flip",
+            sidecar_path, exc,
+        )
+        return
+
+    # Step 2: mutate manifest in memory.
+    condition["verified"] = True
+    condition["resolution"] = str(resolution_ref)
+    condition["verified_at"] = timestamp
+    if note is not None:
+        condition["resolution_note"] = note
+
+    # Step 3: atomic manifest replace.
+    try:
+        atomic_write_json(manifest_path, manifest)
+    except OSError as exc:
+        logger.warning(
+            "projector: wicked.condition.marked_cleared — manifest flip "
+            "failed at %s: %s; sidecar persisted, recover() will reconcile",
+            manifest_path, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.condition.marked_cleared "
+        "project_id=%r phase=%r condition_id=%r path=%s",
+        project_id, phase, condition_id, manifest_path,
+    )
+
 
 def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.gate.blocked → no-op disk handler (PR-1 inert).
@@ -1550,6 +1886,17 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # full ``data`` payload, so flag-on triggers an early debug-return until
     # PR-2 (#779) widens the emit shape.
     "wicked.gate.blocked": _gate_blocked,
+    # Site 5 of bus-cutover (#746): conditions-manifest.json file projection.
+    # ``wicked.condition.marked_cleared`` is fired by
+    # ``conditions_manifest.mark_cleared()`` BEFORE its disk writes; the
+    # projector handler ``_condition_marked_cleared`` replays the same
+    # atomic two-step write order (sidecar → manifest flip).  Gated on
+    # ``WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST`` inside the handler.
+    # The gate.decided handler also fans out to write the INITIAL
+    # conditions-manifest.json on CONDITIONAL verdicts (one event,
+    # multiple files — see _PROJECTION_MAP shape change in
+    # reconcile_v2.py).
+    "wicked.condition.marked_cleared": _condition_marked_cleared,
 }
 
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -81,6 +81,18 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.condition",
         "description": "Mechanical CONDITIONAL finding resolved via crew:resolve skill (verdict unchanged)",
     },
+    # Site 5 of bus-cutover (#746): condition verification flip.
+    # Emitted from conditions_manifest.mark_cleared() BEFORE the disk
+    # writes (sidecar + manifest).  The projector handler
+    # _condition_marked_cleared in daemon/projector.py replays the same
+    # atomic two-step write order: sidecar first, then manifest flip.
+    # chain_id MUST include condition_id for per-condition idempotency
+    # (see ``memory/bus-chain-id-must-include-uniqueness-segment-gotcha.md``).
+    "wicked.condition.marked_cleared": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.condition",
+        "description": "Condition verification flipped to verified=True via mark_cleared() (Site 5 cutover)",
+    },
     # Jam domain — jam.py
     "wicked.session.started": {
         "domain": "wicked-garden",
@@ -301,17 +313,18 @@ def _is_disabled() -> bool:
 
 # ---------------------------------------------------------------------------
 # Default-ON set for _bus_as_truth_enabled — shipped cutover sites whose
-# flag falls through to the default map.  Sites 1-4 have shipped; only
-# CONDITIONS_MANIFEST defaults OFF until Site 5 lands.  Keep this frozenset
-# in sync with PROJECTION_FILE_FLAGS in scripts/crew/reconcile_v2.py.
+# flag falls through to the default map.  All five planned sites (1-5) have
+# shipped.  Keep this frozenset in sync with PROJECTION_FILE_FLAGS in
+# scripts/crew/reconcile_v2.py.
 # ---------------------------------------------------------------------------
 
 _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
-    "DISPATCH_LOG",       # Site 1 — dispatch-log.jsonl (PR #751)
-    "CONSENSUS_REPORT",   # Site 2 — consensus-report.json (PR #758)
-    "CONSENSUS_EVIDENCE", # Site 2 — consensus-evidence.json (PR #758)
-    "REVIEWER_REPORT",    # Site 3 — reviewer-report.md (PR #776)
-    "GATE_RESULT",        # Site 4 — gate-result.json (PR #782 + this PR)
+    "DISPATCH_LOG",        # Site 1 — dispatch-log.jsonl (PR #751)
+    "CONSENSUS_REPORT",    # Site 2 — consensus-report.json (PR #758)
+    "CONSENSUS_EVIDENCE",  # Site 2 — consensus-evidence.json (PR #758)
+    "REVIEWER_REPORT",     # Site 3 — reviewer-report.md (PR #776)
+    "GATE_RESULT",         # Site 4 — gate-result.json (PR #782 + #784)
+    "CONDITIONS_MANIFEST", # Site 5 — conditions-manifest.json (this PR)
 })
 
 

--- a/scripts/crew/conditions_manifest.py
+++ b/scripts/crew/conditions_manifest.py
@@ -227,6 +227,42 @@ def mark_cleared(
         "written_at": timestamp,
     }
 
+    # Site 5 of bus-cutover (#746): emit BEFORE the disk writes so the
+    # projector handler can replay the same two-step ordering when
+    # WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST=on.  The legacy direct writes
+    # below still run for crash-recovery compatibility; the projector's
+    # content-hash idempotency makes its replay a no-op when the bytes
+    # match.  Fail-open: an emit failure must NOT block the disk writes
+    # (the manifest correctness is the load-bearing invariant).
+    #
+    # chain_id MUST include condition_id per
+    # ``memory/bus-chain-id-must-include-uniqueness-segment-gotcha.md`` —
+    # without it, a phase-level chain_id would let consumers silently
+    # skip every clear after the first in the same phase.
+    project_id, phase = _project_id_and_phase_from_manifest_path(manifest_path)
+    if project_id is not None and phase is not None:
+        try:
+            import sys as _sys
+            from pathlib import Path as _Path
+            _scripts_root = str(_Path(__file__).resolve().parents[1])
+            if _scripts_root not in _sys.path:
+                _sys.path.insert(0, _scripts_root)
+            from _bus import emit_event  # type: ignore[import]
+            emit_event(
+                "wicked.condition.marked_cleared",
+                {
+                    "project_id": project_id,
+                    "phase": phase,
+                    "condition_id": condition_id,
+                    "resolution_ref": resolution_ref,
+                    "note": note,
+                    "verified_at": timestamp,
+                },
+                chain_id=f"{project_id}.{phase}.{condition_id}",
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable / import failed — disk writes still run below
+
     # Step 1: resolution sidecar lands first. A crash after this point
     # leaves a "claim" on disk that recovery can act on.
     sidecar_path = _resolution_sidecar_path(manifest_path, condition_id)
@@ -244,6 +280,29 @@ def mark_cleared(
     atomic_write_json(manifest_path, manifest)
 
     return manifest
+
+
+def _project_id_and_phase_from_manifest_path(
+    manifest_path: Path,
+) -> "tuple[Optional[str], Optional[str]]":
+    """Extract (project_id, phase) from a conditions-manifest.json path.
+
+    Path shape: ``{project_dir}/phases/{phase}/conditions-manifest.json``.
+    The project_id is the basename of project_dir (matches the convention
+    used elsewhere in scripts/crew/).  Returns (None, None) when the path
+    doesn't match the expected shape — caller should fail-open and skip
+    the bus emit rather than guess.
+    """
+    parts = manifest_path.parts
+    # We need ".../phases/{phase}/conditions-manifest.json" suffix.
+    if len(parts) < 4 or parts[-1] != "conditions-manifest.json" or parts[-3] != "phases":
+        return None, None
+    phase = parts[-2]
+    # project_dir is the parent of "phases/" — i.e. parts[:-3]
+    project_dir = Path(*parts[:-3]) if parts[:-3] else None
+    if project_dir is None:
+        return None, None
+    return project_dir.name, phase
 
 
 def recover(

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -74,34 +74,118 @@ _LAG_EVENTS_THRESHOLD = 10
 # These are the primary bus-truth artifacts after cutover Site 3.
 # ---------------------------------------------------------------------------
 
-_PROJECTION_MAP: Dict[str, str] = {
-    # Phase gate decisions
-    # Only ``wicked.gate.decided`` materialises gate-result.json.  ``wicked.
-    # gate.blocked`` is a sentinel signalling REJECT state that's already
-    # encoded in the file from the preceding ``wicked.gate.decided`` emit;
-    # it is intentionally NOT in this map so the drift detector treats it
-    # as non-materialising.  Without this exclusion, an event_log row with
-    # only gate.blocked + an on-disk gate-result.json would silently pass
-    # the projection-without-event check (false negative — Copilot finding
-    # on PR #782).  ``_gate_blocked`` stays registered in
-    # daemon/projector.py._HANDLERS for completeness; it just doesn't
-    # claim to produce a file.
-    "wicked.gate.decided": "phases/{phase}/gate-result.json",
-    # Dispatch log entries (Site 1)
-    "wicked.dispatch.log_entry_appended": "phases/{phase}/dispatch-log.jsonl",
+# ---------------------------------------------------------------------------
+# Per-event projection resolvers — function shape lets each event express
+# CONDITIONAL file production based on payload, not just static mapping.
+#
+# Rationale (Site 5 / #746): ``wicked.gate.decided`` ALWAYS materialises
+# gate-result.json but CONDITIONALLY materialises conditions-manifest.json
+# (only when verdict is CONDITIONAL with a non-empty conditions list).
+# A static ``Dict[str, FrozenSet[str]]`` cannot model this — it would
+# either over-claim (drift on every APPROVE event missing the manifest)
+# or under-claim (silent on the conditional case).  The resolver-function
+# shape models the conditional production directly: each function inspects
+# the payload and yields the paths the event is expected to produce, given
+# the actual verdict.  See
+# ``memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md`` for
+# the structural-fix-vs-workaround rationale.
+#
+# Resolver signature:
+#   (payload: Dict, phase: str, project_dir: Path) -> Iterable[Path]
+# ---------------------------------------------------------------------------
+
+
+def _resolve_gate_decided(
+    payload: Dict[str, Any], phase: str, project_dir: Path,
+) -> "list[Path]":
+    """``wicked.gate.decided`` — gate-result.json always; conditions-manifest.json
+    only on CONDITIONAL verdicts with a non-empty conditions list."""
+    paths: "list[Path]" = [
+        project_dir / "phases" / phase / "gate-result.json",
+    ]
+    data = payload.get("data") or {}
+    verdict = data.get("result") or data.get("verdict")
+    conditions = data.get("conditions") or []
+    if verdict == "CONDITIONAL" and conditions:
+        paths.append(
+            project_dir / "phases" / phase / "conditions-manifest.json"
+        )
+    return paths
+
+
+def _resolve_single_file(template: str):
+    """Build a resolver for events that always produce exactly one file."""
+    def _resolver(
+        payload: Dict[str, Any], phase: str, project_dir: Path,
+    ) -> "list[Path]":
+        return [project_dir / template.replace("{phase}", phase)]
+    _resolver.__name__ = f"_resolve_{template.replace('/', '_').replace('.', '_')}"
+    return _resolver
+
+
+_PROJECTION_RESOLVERS: Dict[str, Callable[[Dict[str, Any], str, Path], "list[Path]"]] = {
+    # Phase gate decisions — payload-aware (gate-result.json + maybe manifest).
+    "wicked.gate.decided": _resolve_gate_decided,
+    # ``wicked.gate.blocked`` is a REJECT-state sentinel that does not
+    # materialise a file (gate-result.json is already produced by the
+    # preceding gate.decided emit).  Intentionally NOT in this dict so the
+    # drift detector treats it as non-materialising.  Without this
+    # exclusion, an event_log row with only gate.blocked + an on-disk
+    # gate-result.json would silently pass projection-without-event
+    # detection (false negative — Copilot finding on PR #782).
+    # ``_gate_blocked`` stays registered in ``daemon/projector.py._HANDLERS``
+    # for completeness; it just doesn't claim to produce a file.
+    #
+    # Dispatch log (Site 1)
+    "wicked.dispatch.log_entry_appended": _resolve_single_file(
+        "phases/{phase}/dispatch-log.jsonl"
+    ),
     # Consensus artifacts (Site 2)
-    "wicked.consensus.report_created": "phases/{phase}/consensus-report.json",
-    "wicked.consensus.evidence_recorded": "phases/{phase}/consensus-evidence.json",
-    # Reviewer report (Site 3 — this PR).
-    # Both gate_completed (approved/rejected path) and gate_pending (deferred
-    # verdict path) materialise the same reviewer-report.md file.  The drift
-    # detector supports N event-types → 1 file; both entries are legal because
-    # _collect_projection_files returns each path once, and
-    # _detect_projection_without_event builds a set of resolved paths from
-    # ALL known events — so a file covered by either event is not flagged.
-    "wicked.consensus.gate_completed": "phases/{phase}/reviewer-report.md",
-    "wicked.consensus.gate_pending": "phases/{phase}/reviewer-report.md",
+    "wicked.consensus.report_created": _resolve_single_file(
+        "phases/{phase}/consensus-report.json"
+    ),
+    "wicked.consensus.evidence_recorded": _resolve_single_file(
+        "phases/{phase}/consensus-evidence.json"
+    ),
+    # Reviewer report (Site 3) — both event types produce the same file.
+    "wicked.consensus.gate_completed": _resolve_single_file(
+        "phases/{phase}/reviewer-report.md"
+    ),
+    "wicked.consensus.gate_pending": _resolve_single_file(
+        "phases/{phase}/reviewer-report.md"
+    ),
+    # Site 5 (this PR) — condition verification flip.
+    # ``wicked.condition.marked_cleared`` updates the manifest AND writes a
+    # resolution sidecar.  Sidecar paths vary per condition_id and are
+    # transient (the manifest is the source of truth; ``recover()``
+    # re-derives sidecars on demand) so they are NOT tracked here.
+    "wicked.condition.marked_cleared": _resolve_single_file(
+        "phases/{phase}/conditions-manifest.json"
+    ),
 }
+
+
+# Compatibility view: many call sites and tests refer to "the projection
+# map" by event_type → file basenames.  This view derives the static set
+# of basenames each event MAY produce (ignoring conditional production)
+# from the resolvers above by calling each with an empty payload AND a
+# CONDITIONAL+conditions stub.  Used by ``_handler_available_for_file``
+# and similar discovery code that needs "could this event ever produce
+# file F?" semantics.
+def _all_possible_basenames_for(event_type: str) -> FrozenSet[str]:
+    resolver = _PROJECTION_RESOLVERS.get(event_type)
+    if resolver is None:
+        return frozenset()
+    # Stub payload that triggers any conditional branches in the resolver.
+    stub_payload = {
+        "data": {
+            "result": "CONDITIONAL",
+            "verdict": "CONDITIONAL",
+            "conditions": [{"description": "stub"}],
+        },
+    }
+    paths = resolver(stub_payload, "_stub_phase_", Path("/__stub_root__"))
+    return frozenset(p.name for p in paths)
 
 # ---------------------------------------------------------------------------
 # Per-FILE projection flag mapping — used by _active_projection_names() to
@@ -126,7 +210,7 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
     "consensus-evidence.json":  "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
     "reviewer-report.md":       "REVIEWER_REPORT",     # Site 3
     "gate-result.json":         "GATE_RESULT",         # Site 4 — active (PR #782 + #780 default-ON)
-    "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — placeholder
+    "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — active (this PR default-ON)
 }
 
 # ---------------------------------------------------------------------------
@@ -164,9 +248,13 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
 #                                          materialises gate-result.json when flag-on)
 #   wicked.gate.blocked                 → _gate_blocked (PR-1 / #778) — registered in
 #                                          _HANDLERS for completeness but REMOVED from
-#                                          _PROJECTION_MAP (above) because it doesn't
+#                                          _PROJECTION_RESOLVERS (above) because it doesn't
 #                                          materialise a file.  Therefore not keyed in
 #                                          this registry either.
+#   wicked.condition.marked_cleared     → _condition_marked_cleared (Site 5 / this PR) ✓ PRESENT
+#                                          (writes resolution sidecar + flips manifest entry
+#                                          to verified=True; same atomic two-step ordering
+#                                          as conditions_manifest.mark_cleared())
 #
 # Update this dict when a new handler lands in daemon/projector.py.
 # Never mark True speculatively — read the file and verify first.
@@ -193,29 +281,40 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # WG_BUS_AS_TRUTH_GATE_RESULT=on; flipping the registry True here
     # tells the drift detector to scan gate-result.json.
     # ``wicked.gate.blocked`` is intentionally absent from this registry
-    # because it was removed from _PROJECTION_MAP above — it doesn't
+    # because it was removed from _PROJECTION_RESOLVERS above — it doesn't
     # materialise a file and the detector doesn't gate on it.
+    #
+    # Site 5 (this PR) extends ``_gate_decided_disk`` to ALSO materialise
+    # ``conditions-manifest.json`` when the verdict is CONDITIONAL and
+    # ``data["conditions"]`` is non-empty.  Same registry entry — one
+    # event, multiple files (the new _PROJECTION_RESOLVERS shape).
     "wicked.gate.decided":                True,
+    # Site 5 (this PR) — _condition_marked_cleared materialises the
+    # verification flip on conditions-manifest.json + writes the resolution
+    # sidecar.  Wired into conditions_manifest.mark_cleared() as a
+    # bus emit; projector handler in daemon/projector.py replays the
+    # same atomic two-step write order.
+    "wicked.condition.marked_cleared":    True,
     # Site 5 — no event handler mapping yet
-    # (conditions-manifest.json has no event type in _PROJECTION_MAP)
+    # (conditions-manifest.json has no event type in _PROJECTION_RESOLVERS)
 }
 
 
 def _handler_available_for_file(name: str) -> bool:
     """Return True iff ALL event types that materialise *name* have a handler.
 
-    Resolves the event types that map to *name* by scanning _PROJECTION_MAP
+    Resolves the event types that map to *name* by scanning _PROJECTION_RESOLVERS
     in reverse.  Returns True only when handlers exist for ALL mapping event
     types (conservative: if any event type lacks a handler the file is treated
     as unprojectable until ALL handlers land).
 
-    A file with no event types in _PROJECTION_MAP (e.g. conditions-manifest.json
+    A file with no event types in _PROJECTION_RESOLVERS (e.g. conditions-manifest.json
     at Site 5 before its event type is added) returns False — defaulting to
     safe exclusion.
     """
     event_types_for_file = [
-        et for et, template in _PROJECTION_MAP.items()
-        if Path(template).name == name
+        et for et in _PROJECTION_RESOLVERS
+        if name in _all_possible_basenames_for(et)
     ]
     if not event_types_for_file:
         return False
@@ -436,8 +535,14 @@ def _query_events_for_project(
 ) -> List[Dict[str, Any]]:
     """Return event_log rows whose chain_id starts with ``{project_slug}.``.
 
-    Rows are ordered by event_id ascending.  We fetch only the columns
-    reconcile_v2 needs to avoid surprises when the daemon schema evolves.
+    Rows are ordered by event_id ascending.  Site 5 (#746) added
+    ``payload_json`` to the SELECT so payload-aware projection resolvers
+    can decide which files an event is expected to produce based on
+    payload contents (e.g. ``wicked.gate.decided`` only requires
+    conditions-manifest.json on CONDITIONAL verdicts).  Each returned
+    row carries a parsed ``payload`` dict; rows with malformed JSON
+    silently fall back to ``{}`` so a single bad event doesn't taint
+    the rest of the scan.
     """
     # LIKE escape: project_slug may contain underscores which LIKE treats
     # as single-char wildcards.  Use ESCAPE clause to be safe.
@@ -445,16 +550,27 @@ def _query_events_for_project(
     try:
         rows = conn.execute(
             """
-            SELECT event_id, event_type, chain_id, projection_status, error_message, ingested_at
+            SELECT event_id, event_type, chain_id, payload_json,
+                   projection_status, error_message, ingested_at
             FROM   event_log
             WHERE  chain_id LIKE ? ESCAPE '\\'
             ORDER  BY event_id ASC
             """,
             (f"{escaped}.%",),
         ).fetchall()
-        return [dict(r) for r in rows]
     except sqlite3.Error:
         return []
+
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        d = dict(r)
+        raw = d.pop("payload_json", None)
+        try:
+            d["payload"] = json.loads(raw) if raw else {}
+        except (TypeError, ValueError):
+            d["payload"] = {}
+        out.append(d)
+    return out
 
 
 def _event_log_head(conn: sqlite3.Connection) -> int:
@@ -494,24 +610,39 @@ def _list_known_project_slugs() -> List[str]:
         return []
 
 
-def _materialize_projection_path(
-    project_dir: Path, event_type: str, chain_id: Optional[str]
-) -> Optional[Path]:
-    """Return the expected on-disk path for an event type + chain_id pair.
+def _materialize_projection_paths(
+    project_dir: Path,
+    event_type: str,
+    chain_id: Optional[str],
+    payload: Optional[Dict[str, Any]] = None,
+) -> List[Path]:
+    """Return the expected on-disk paths for an event, given its payload.
 
-    Returns None when the event type is not in _PROJECTION_MAP or the
-    chain_id does not carry enough information to resolve the path.
+    Per Site 5 (#746): an event may CONDITIONALLY produce files based on
+    payload contents (e.g. ``wicked.gate.decided`` produces
+    conditions-manifest.json only when verdict is CONDITIONAL with a
+    non-empty conditions list).  The resolver function in
+    ``_PROJECTION_RESOLVERS`` inspects the payload and yields the paths
+    the event is expected to produce.
+
+    Returns an empty list when the event type has no resolver, the
+    chain_id doesn't carry a phase segment, or the payload doesn't
+    trigger any conditional branches.
+
+    The ``payload`` parameter defaults to ``None`` (treated as ``{}``) so
+    legacy call sites that don't have the payload handy still get the
+    "always-produces" subset of projections — the conditional branches
+    just won't fire without payload data.
     """
-    template = _PROJECTION_MAP.get(event_type)
-    if template is None:
-        return None
+    resolver = _PROJECTION_RESOLVERS.get(event_type)
+    if resolver is None:
+        return []
 
     phase = _phase_from_chain_id(chain_id)
     if phase is None:
-        return None
+        return []
 
-    rel = template.replace("{phase}", phase)
-    return project_dir / rel
+    return list(resolver(payload or {}, phase, project_dir))
 
 
 def _collect_projection_files(project_dir: Path) -> List[Path]:
@@ -581,30 +712,30 @@ def _detect_projection_stale(
         # Skip events whose handler has not yet landed in daemon/projector.py.
         if not _PROJECTION_HANDLERS_AVAILABLE.get(ev["event_type"], False):
             continue
-        proj_path = _materialize_projection_path(
-            project_dir, ev["event_type"], ev.get("chain_id")
+        proj_paths = _materialize_projection_paths(
+            project_dir, ev["event_type"], ev.get("chain_id"), ev.get("payload"),
         )
-        if proj_path is None:
-            continue
-        if not proj_path.exists():
-            # projection_last_applied_seq: the event_id at which the projector
-            # last successfully processed an event.  This cursor is not yet
-            # tracked in the daemon DB schema (no projector_state table / sidecar).
-            # Emit null per staging plan §5 schema compliance until the cursor is
-            # wired in (see PR #764 follow-up TODO in _build_report_header).
-            drift.append({
-                "type": DRIFT_PROJECTION_STALE,
-                "projection": str(proj_path.relative_to(project_dir)),
-                "event_seq": ev["event_id"],
-                "event_type": ev["event_type"],
-                "chain_id": ev.get("chain_id"),
-                "projection_last_applied_seq": None,  # cursor pending — see TODO
-                "lag_events": None,                   # derived from cursor — unavailable
-                "reason": (
-                    f"event_seq {ev['event_id']} ({ev['event_type']!r}) "
-                    f"is pending but projection has not been materialised"
-                ),
-            })
+        for proj_path in proj_paths:
+            if not proj_path.exists():
+                # projection_last_applied_seq: the event_id at which the projector
+                # last successfully processed an event.  This cursor is not yet
+                # tracked in the daemon DB schema (no projector_state table /
+                # sidecar).  Emit null per staging plan §5 schema compliance
+                # until the cursor is wired in (PR #764 follow-up TODO in
+                # _build_report_header).
+                drift.append({
+                    "type": DRIFT_PROJECTION_STALE,
+                    "projection": str(proj_path.relative_to(project_dir)),
+                    "event_seq": ev["event_id"],
+                    "event_type": ev["event_type"],
+                    "chain_id": ev.get("chain_id"),
+                    "projection_last_applied_seq": None,  # cursor pending — see TODO
+                    "lag_events": None,                   # derived from cursor
+                    "reason": (
+                        f"event_seq {ev['event_id']} ({ev['event_type']!r}) "
+                        f"is pending but projection has not been materialised"
+                    ),
+                })
     return drift
 
 
@@ -629,31 +760,30 @@ def _detect_event_without_projection(
         # Skip events whose handler has not yet landed in daemon/projector.py.
         if not _PROJECTION_HANDLERS_AVAILABLE.get(ev["event_type"], False):
             continue
-        # Only check events we can map to a projection path.
-        proj_path = _materialize_projection_path(
-            project_dir, ev["event_type"], ev.get("chain_id")
+        # Only check events we can map to projection paths.
+        proj_paths = _materialize_projection_paths(
+            project_dir, ev["event_type"], ev.get("chain_id"), ev.get("payload"),
         )
-        if proj_path is None:
-            continue
-        # Projection absent on disk → drift regardless of projection_status.
-        if not proj_path.exists():
-            # Skip pending events — those are covered by projection_stale.
-            if ev.get("projection_status") == "pending":
-                continue
-            drift.append({
-                "type": DRIFT_EVENT_WITHOUT_PROJECTION,
-                "event_seq": ev["event_id"],
-                "event_type": ev["event_type"],
-                "chain_id": ev.get("chain_id"),
-                "expected_projection": str(proj_path.relative_to(project_dir)),
-                "projection_status": ev.get("projection_status"),
-                "error_message": ev.get("error_message"),
-                "reason": (
-                    f"event_seq {ev['event_id']} ({ev['event_type']!r}) "
-                    f"has no materialised projection at "
-                    f"{proj_path.relative_to(project_dir)}"
-                ),
-            })
+        for proj_path in proj_paths:
+            # Projection absent on disk → drift regardless of projection_status.
+            if not proj_path.exists():
+                # Skip pending events — those are covered by projection_stale.
+                if ev.get("projection_status") == "pending":
+                    continue
+                drift.append({
+                    "type": DRIFT_EVENT_WITHOUT_PROJECTION,
+                    "event_seq": ev["event_id"],
+                    "event_type": ev["event_type"],
+                    "chain_id": ev.get("chain_id"),
+                    "expected_projection": str(proj_path.relative_to(project_dir)),
+                    "projection_status": ev.get("projection_status"),
+                    "error_message": ev.get("error_message"),
+                    "reason": (
+                        f"event_seq {ev['event_id']} ({ev['event_type']!r}) "
+                        f"has no materialised projection at "
+                        f"{proj_path.relative_to(project_dir)}"
+                    ),
+                })
     return drift
 
 
@@ -668,13 +798,16 @@ def _detect_projection_without_event(
     direct-write bypassing the bus, or lint was off).
     """
     # Build a set of expected-projection paths from the known events so we
-    # can quickly test each on-disk file against it.
+    # can quickly test each on-disk file against it.  Per Site 5 (#746):
+    # an event may produce multiple files, and may produce them
+    # CONDITIONALLY based on payload (e.g. gate.decided produces
+    # conditions-manifest.json only on CONDITIONAL verdicts).  Pass
+    # ev["payload"] so the resolver can make those conditional decisions.
     event_projection_paths: set = set()
     for ev in events:
-        p = _materialize_projection_path(
-            project_dir, ev["event_type"], ev.get("chain_id")
-        )
-        if p is not None:
+        for p in _materialize_projection_paths(
+            project_dir, ev["event_type"], ev.get("chain_id"), ev.get("payload"),
+        ):
             event_projection_paths.add(p.resolve())
 
     drift: List[Dict[str, Any]] = []

--- a/tests/daemon/test_projector_conditions_manifest.py
+++ b/tests/daemon/test_projector_conditions_manifest.py
@@ -1,0 +1,621 @@
+"""tests/daemon/test_projector_conditions_manifest.py — Site 5 bus-cutover
+projector tests for ``conditions-manifest.json`` (#746).
+
+Covers:
+  * ``_conditions_manifest_from_gate_decided`` fan-out from
+    ``_gate_decided_disk``: flag off → no write; non-CONDITIONAL verdicts
+    → no write; CONDITIONAL with empty conditions → no write;
+    CONDITIONAL with conditions → manifest materialised; content-hash
+    idempotency on replay.
+  * Fan-out fail-open: a manifest-write failure does NOT taint the
+    gate-result.json projection that ran successfully before it.
+  * ``_condition_marked_cleared`` handler: flag off; missing payload
+    fields; absent manifest; condition not in manifest; idempotent
+    skip when already cleared with matching resolution; happy path
+    (sidecar written + manifest flipped to verified=True).
+  * Resolver-driven projection paths: ``_materialize_projection_paths``
+    correctly returns gate-result + manifest for CONDITIONAL gate.decided
+    events and only gate-result for APPROVE/REJECT.
+
+T1: deterministic — fixed-epoch timestamps; no wall-clock-dependent assertions.
+T2: no sleep-based sync.
+T3: isolated — each test gets its own tmp_path + in-memory DB.
+T4: one concern per test.
+T5: descriptive names.
+T6: provenance: #746 Site 5 cutover.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure daemon/ and scripts/ are importable from the repo root.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = 1_700_000_001
+
+
+def _setup_project_in_db(conn, project_id: str, project_dir: Path) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+def _make_project_dir(tmp_path: Path, project_id: str = "my-proj") -> Path:
+    return tmp_path / project_id
+
+
+def _conditional_gate_data(
+    *,
+    verdict: str = "CONDITIONAL",
+    conditions: "list[dict] | None" = None,
+    reviewer: str = "test-reviewer",
+    score: float = 0.55,
+    recorded_at: str = "2026-05-03T12:00:00Z",
+    phase: str = "build",
+    gate: str = "build-quality",
+) -> dict:
+    """Build a gate_result dict with conditions for the CONDITIONAL branch."""
+    if conditions is None:
+        conditions = [
+            {"description": "Add unit tests for module X"},
+            {"description": "Document the new public API"},
+        ]
+    return {
+        "verdict": verdict,
+        "result": verdict,
+        "reviewer": reviewer,
+        "score": score,
+        "recorded_at": recorded_at,
+        "phase": phase,
+        "gate": gate,
+        "conditions": conditions,
+    }
+
+
+def _make_gate_decided_event(
+    *,
+    event_id: int = 1,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    data: "dict | None" = None,
+) -> dict:
+    payload: dict = {
+        "project_id": project_id,
+        "phase": phase,
+        "result": (data or {}).get("result", "CONDITIONAL"),
+        "score": (data or {}).get("score", 0.55),
+        "reviewer": (data or {}).get("reviewer", "test-reviewer"),
+    }
+    if data is not None:
+        payload["data"] = data
+    else:
+        payload["data"] = _conditional_gate_data(phase=phase)
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.gate.decided",
+        "chain_id": f"{project_id}.{phase}.gate",
+        "created_at": _FIXED_TS + event_id,
+        "payload": payload,
+    }
+
+
+def _make_marked_cleared_event(
+    *,
+    event_id: int = 1,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    condition_id: str = "CONDITION-1",
+    resolution_ref: str = "commits/abc123",
+    note: "str | None" = "fixed in PR #999",
+) -> dict:
+    return {
+        "event_id": event_id,
+        "event_type": "wicked.condition.marked_cleared",
+        "chain_id": f"{project_id}.{phase}.{condition_id}",
+        "created_at": _FIXED_TS + event_id,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "condition_id": condition_id,
+            "resolution_ref": resolution_ref,
+            "note": note,
+            "verified_at": "2026-05-03T13:00:00Z",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _PROJECTION_RESOLVERS — payload-aware projection-path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_gate_decided_approve_returns_only_gate_result() -> None:
+    """APPROVE verdict → conditions-manifest.json must NOT be expected."""
+    import reconcile_v2  # type: ignore[import]
+
+    payload = {"data": {"result": "APPROVE", "conditions": []}}
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"), "wicked.gate.decided", "proj.build.gate", payload,
+    )
+    names = {p.name for p in paths}
+    assert names == {"gate-result.json"}, (
+        "APPROVE verdict must not require conditions-manifest.json — "
+        f"resolver returned: {names}"
+    )
+
+
+def test_resolver_gate_decided_reject_returns_only_gate_result() -> None:
+    """REJECT verdict → conditions-manifest.json must NOT be expected."""
+    import reconcile_v2  # type: ignore[import]
+
+    payload = {"data": {"result": "REJECT", "conditions": []}}
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"), "wicked.gate.decided", "proj.build.gate", payload,
+    )
+    names = {p.name for p in paths}
+    assert names == {"gate-result.json"}
+
+
+def test_resolver_gate_decided_conditional_with_conditions_returns_both() -> None:
+    """CONDITIONAL + non-empty conditions → both files expected."""
+    import reconcile_v2  # type: ignore[import]
+
+    payload = {
+        "data": {
+            "result": "CONDITIONAL",
+            "conditions": [{"description": "fix X"}],
+        },
+    }
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"), "wicked.gate.decided", "proj.build.gate", payload,
+    )
+    names = {p.name for p in paths}
+    assert names == {"gate-result.json", "conditions-manifest.json"}
+
+
+def test_resolver_gate_decided_conditional_empty_conditions_returns_only_gate_result() -> None:
+    """CONDITIONAL but empty conditions list → only gate-result expected.
+
+    Degenerate case — the projector wouldn't write a manifest with no
+    conditions, so it's not a tracked projection.
+    """
+    import reconcile_v2  # type: ignore[import]
+
+    payload = {"data": {"result": "CONDITIONAL", "conditions": []}}
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"), "wicked.gate.decided", "proj.build.gate", payload,
+    )
+    names = {p.name for p in paths}
+    assert names == {"gate-result.json"}
+
+
+def test_resolver_gate_decided_no_payload_returns_only_gate_result() -> None:
+    """Legacy / payload-less call → only the always-produced file."""
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"), "wicked.gate.decided", "proj.build.gate", None,
+    )
+    names = {p.name for p in paths}
+    assert names == {"gate-result.json"}
+
+
+def test_resolver_marked_cleared_returns_conditions_manifest() -> None:
+    """wicked.condition.marked_cleared maps to conditions-manifest.json."""
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"),
+        "wicked.condition.marked_cleared",
+        "proj.build.CONDITION-1",
+        {"project_id": "proj", "phase": "build", "condition_id": "CONDITION-1"},
+    )
+    names = {p.name for p in paths}
+    assert names == {"conditions-manifest.json"}
+
+
+# ---------------------------------------------------------------------------
+# _conditions_manifest_from_gate_decided fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_conditions_manifest_not_written(mem_conn, tmp_path) -> None:
+    """flag-off → no conditions-manifest.json produced even on CONDITIONAL."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-cm-flagoff"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    manifest_target = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "off",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not manifest_target.exists(), (
+        "CONDITIONS_MANIFEST flag off must suppress manifest projection "
+        "even when GATE_RESULT is on"
+    )
+
+
+def test_flag_on_approve_verdict_no_manifest_written(mem_conn, tmp_path) -> None:
+    """APPROVE verdict → no manifest write regardless of flag state."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-cm-approve"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    manifest_target = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+
+    approve_data = _conditional_gate_data(verdict="APPROVE", conditions=[])
+    event = _make_gate_decided_event(project_id=project_id, data=approve_data)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not manifest_target.exists()
+
+
+def test_flag_on_conditional_empty_conditions_no_manifest(mem_conn, tmp_path) -> None:
+    """CONDITIONAL but empty conditions list → no manifest (degenerate case)."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-cm-empty"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    manifest_target = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+
+    cond_data = _conditional_gate_data(verdict="CONDITIONAL", conditions=[])
+    event = _make_gate_decided_event(project_id=project_id, data=cond_data)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+
+    assert not manifest_target.exists()
+
+
+def test_flag_on_conditional_with_conditions_writes_manifest(mem_conn, tmp_path) -> None:
+    """Happy path: CONDITIONAL + conditions → manifest written with correct shape."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-cm-happy"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    manifest_target = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+
+    assert manifest_target.exists(), "CONDITIONAL with conditions must write manifest"
+    parsed = json.loads(manifest_target.read_text(encoding="utf-8"))
+    assert parsed["source_gate"] == "build"
+    assert len(parsed["conditions"]) == 2
+    assert parsed["conditions"][0]["id"] == "CONDITION-1"
+    assert parsed["conditions"][0]["verified"] is False
+    assert parsed["conditions"][0]["description"] == "Add unit tests for module X"
+    assert parsed["conditions"][1]["id"] == "CONDITION-2"
+
+
+def test_conditions_manifest_idempotent_on_replay(mem_conn, tmp_path) -> None:
+    """Replay same event → mtime + bytes unchanged (content-hash short-circuit)."""
+    from daemon.projector import _gate_decided_disk
+
+    project_id = "proj-cm-replay"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    manifest_target = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+
+    event = _make_gate_decided_event(project_id=project_id)
+    with patch.dict(os.environ, {
+        "WG_BUS_AS_TRUTH_GATE_RESULT": "on",
+        "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on",
+        "WG_GATE_RESULT_DISPATCH_CHECK": "off",
+    }):
+        _gate_decided_disk(mem_conn, event)
+        first_mtime = manifest_target.stat().st_mtime_ns
+        first_bytes = manifest_target.read_bytes()
+        _gate_decided_disk(mem_conn, event)
+        second_mtime = manifest_target.stat().st_mtime_ns
+        second_bytes = manifest_target.read_bytes()
+
+    assert first_bytes == second_bytes
+    assert first_mtime == second_mtime, (
+        "replay must short-circuit before write — identical mtime confirms "
+        "the content-hash guard fired"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _condition_marked_cleared handler
+# ---------------------------------------------------------------------------
+
+
+def test_marked_cleared_handler_is_registered() -> None:
+    """wicked.condition.marked_cleared MUST be in _HANDLERS for Site 5."""
+    from daemon.projector import _HANDLERS, _condition_marked_cleared
+
+    assert "wicked.condition.marked_cleared" in _HANDLERS
+    assert _HANDLERS["wicked.condition.marked_cleared"] is _condition_marked_cleared
+
+
+def test_marked_cleared_flag_off_noop(mem_conn, tmp_path) -> None:
+    """flag-off → handler returns immediately."""
+    from daemon.projector import _condition_marked_cleared
+
+    project_id = "proj-mc-flagoff"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    manifest_path.write_text(json.dumps({
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": False, "resolution": None,
+             "verified_at": None, "description": "x"},
+        ],
+    }))
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_marked_cleared_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "off"}):
+        _condition_marked_cleared(mem_conn, event)
+
+    parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert parsed["conditions"][0]["verified"] is False, (
+        "flag-off handler must not mutate the manifest"
+    )
+
+
+def test_marked_cleared_absent_manifest_noop(mem_conn, tmp_path) -> None:
+    """No manifest on disk → handler logs at debug and returns (gate.decided
+    materialisation likely pending; replay catches up)."""
+    from daemon.projector import _condition_marked_cleared
+
+    project_id = "proj-mc-noman"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_marked_cleared_event(project_id=project_id)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on"}):
+        _condition_marked_cleared(mem_conn, event)
+
+    manifest_path = (
+        project_dir / "phases" / "build" / "conditions-manifest.json"
+    )
+    assert not manifest_path.exists()
+
+
+def test_marked_cleared_unknown_condition_id_noop(mem_conn, tmp_path) -> None:
+    """Manifest exists but the condition_id isn't in it → warn + skip."""
+    from daemon.projector import _condition_marked_cleared
+
+    project_id = "proj-mc-unknown"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    original_manifest = {
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": False, "resolution": None,
+             "verified_at": None, "description": "x"},
+        ],
+    }
+    manifest_path.write_text(json.dumps(original_manifest))
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_marked_cleared_event(
+        project_id=project_id, condition_id="CONDITION-99",
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on"}):
+        _condition_marked_cleared(mem_conn, event)
+
+    parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert parsed == original_manifest, "unknown condition_id must not mutate manifest"
+
+
+def test_marked_cleared_happy_path_writes_sidecar_and_flips_manifest(
+    mem_conn, tmp_path,
+) -> None:
+    """Happy path: sidecar written, manifest flipped to verified=True."""
+    from daemon.projector import _condition_marked_cleared
+
+    project_id = "proj-mc-happy"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    manifest_path.write_text(json.dumps({
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": False, "resolution": None,
+             "verified_at": None, "description": "x"},
+        ],
+    }))
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+
+    event = _make_marked_cleared_event(
+        project_id=project_id,
+        resolution_ref="commits/abc123",
+        note="fix",
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on"}):
+        _condition_marked_cleared(mem_conn, event)
+
+    parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert parsed["conditions"][0]["verified"] is True
+    assert parsed["conditions"][0]["resolution"] == "commits/abc123"
+    assert parsed["conditions"][0]["verified_at"] == "2026-05-03T13:00:00Z"
+    assert parsed["conditions"][0]["resolution_note"] == "fix"
+
+    sidecar_path = phase_dir / "conditions-manifest.CONDITION-1.resolution.json"
+    assert sidecar_path.exists(), "sidecar must land before manifest flip (crash safety)"
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    assert sidecar["condition_id"] == "CONDITION-1"
+    assert sidecar["resolution_ref"] == "commits/abc123"
+
+
+def test_marked_cleared_idempotent_when_already_cleared(mem_conn, tmp_path) -> None:
+    """Replay with the same resolution_ref on an already-cleared condition →
+    no rewrite (mtime unchanged)."""
+    from daemon.projector import _condition_marked_cleared
+
+    project_id = "proj-mc-idempotent"
+    project_dir = _make_project_dir(tmp_path, project_id)
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    # Pre-cleared manifest with the same resolution_ref the event will carry.
+    manifest_path.write_text(json.dumps({
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": True,
+             "resolution": "commits/abc123",
+             "verified_at": "2026-05-03T12:00:00Z", "description": "x"},
+        ],
+    }))
+    _setup_project_in_db(mem_conn, project_id, project_dir)
+    sidecar_path = phase_dir / "conditions-manifest.CONDITION-1.resolution.json"
+
+    event = _make_marked_cleared_event(
+        project_id=project_id,
+        resolution_ref="commits/abc123",
+    )
+
+    first_manifest_mtime = manifest_path.stat().st_mtime_ns
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "on"}):
+        _condition_marked_cleared(mem_conn, event)
+    second_manifest_mtime = manifest_path.stat().st_mtime_ns
+
+    assert first_manifest_mtime == second_manifest_mtime, (
+        "idempotent replay must short-circuit before sidecar+manifest writes"
+    )
+    assert not sidecar_path.exists(), (
+        "idempotent replay must not write a sidecar"
+    )
+
+
+# ---------------------------------------------------------------------------
+# mark_cleared() emit wiring
+# ---------------------------------------------------------------------------
+
+
+def test_mark_cleared_emits_event_with_condition_chain_id(tmp_path) -> None:
+    """conditions_manifest.mark_cleared() must fire wicked.condition.marked_cleared
+    with chain_id including condition_id (per-condition uniqueness gotcha)."""
+    import conditions_manifest  # type: ignore[import]
+
+    project_dir = tmp_path / "proj-emit"
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    manifest_path.write_text(json.dumps({
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": False, "resolution": None,
+             "verified_at": None, "description": "x"},
+        ],
+    }))
+
+    captured: "list[dict]" = []
+
+    def _fake_emit(event_type: str, payload: dict, *, chain_id=None):
+        captured.append({"event_type": event_type, "payload": payload, "chain_id": chain_id})
+
+    with patch("_bus.emit_event", _fake_emit):
+        conditions_manifest.mark_cleared(
+            manifest_path, "CONDITION-1", "commits/abc123", note="fix",
+        )
+
+    assert len(captured) == 1
+    emit = captured[0]
+    assert emit["event_type"] == "wicked.condition.marked_cleared"
+    assert emit["payload"]["project_id"] == "proj-emit"
+    assert emit["payload"]["phase"] == "build"
+    assert emit["payload"]["condition_id"] == "CONDITION-1"
+    assert emit["payload"]["resolution_ref"] == "commits/abc123"
+    assert emit["chain_id"] == "proj-emit.build.CONDITION-1", (
+        "chain_id must include condition_id (per-condition uniqueness gotcha)"
+    )
+
+
+def test_mark_cleared_disk_writes_run_when_emit_fails(tmp_path) -> None:
+    """A bus-emit failure must NOT block the legacy disk writes (fail-open)."""
+    import conditions_manifest  # type: ignore[import]
+
+    project_dir = tmp_path / "proj-emit-fail"
+    phase_dir = project_dir / "phases" / "build"
+    phase_dir.mkdir(parents=True)
+    manifest_path = phase_dir / "conditions-manifest.json"
+    manifest_path.write_text(json.dumps({
+        "source_gate": "build",
+        "conditions": [
+            {"id": "CONDITION-1", "verified": False, "resolution": None,
+             "verified_at": None, "description": "x"},
+        ],
+    }))
+
+    def _raising_emit(event_type, payload, *, chain_id=None):
+        raise RuntimeError("simulated bus failure")
+
+    with patch("_bus.emit_event", _raising_emit):
+        conditions_manifest.mark_cleared(
+            manifest_path, "CONDITION-1", "commits/xyz789",
+        )
+
+    # Disk writes must still have completed.
+    parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert parsed["conditions"][0]["verified"] is True
+    assert parsed["conditions"][0]["resolution"] == "commits/xyz789"
+    sidecar = phase_dir / "conditions-manifest.CONDITION-1.resolution.json"
+    assert sidecar.exists()

--- a/tests/test_bus_emit_health.py
+++ b/tests/test_bus_emit_health.py
@@ -453,15 +453,26 @@ class TestFlagFlipDefaultState(unittest.TestCase):
             self.assertTrue(_bus._bus_as_truth_enabled("DISPATCH_LOG"))
 
     def test_unshipped_site_default_off_when_unset(self) -> None:
-        """GATE_RESULT (unshipped) returns False when env var is unset."""
+        """A token NOT in _BUS_AS_TRUTH_DEFAULT_ON returns False when env var unset.
+
+        After Site 5 (#746), all five planned cutover tokens (DISPATCH_LOG,
+        CONSENSUS_REPORT, CONSENSUS_EVIDENCE, REVIEWER_REPORT, GATE_RESULT,
+        CONDITIONS_MANIFEST) are in the default-ON set — there are no
+        unshipped tokens left.  This test guards the safety property: any
+        FUTURE token (e.g. a hypothetical Site 6 placeholder, or a token
+        used in tests) defaults OFF when unset, so an env-var typo never
+        silently flips bus-as-truth on for something we didn't intend to
+        ship.  Originally referenced GATE_RESULT (Site 4); flipped to a
+        hypothetical token in PR for Site 5.
+        """
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("WG_BUS_AS_TRUTH_GATE_RESULT", None)
-            self.assertFalse(_bus._bus_as_truth_enabled("GATE_RESULT"))
+            os.environ.pop("WG_BUS_AS_TRUTH_NEVER_SHIPPED_TOKEN", None)
+            self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_explicit_on_overrides_default_for_unshipped_site(self) -> None:
         """Explicit ``"on"`` returns True even for an unshipped (default-OFF) site."""
-        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "on"}):
-            self.assertTrue(_bus._bus_as_truth_enabled("GATE_RESULT"))
+        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_NEVER_SHIPPED_TOKEN": "on"}):
+            self.assertTrue(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_explicit_off_overrides_default_for_shipped_site(self) -> None:
         """Explicit ``"off"`` returns False even for a shipped (default-ON) site."""
@@ -493,24 +504,27 @@ class TestFlagFlipDefaultState(unittest.TestCase):
 
     def test_dry_run_for_unshipped_site_returns_false(self) -> None:
         """``"dry-run"`` for an unshipped site falls through to default-OFF."""
-        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "dry-run"}):
-            self.assertFalse(_bus._bus_as_truth_enabled("GATE_RESULT"))
+        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_NEVER_SHIPPED_TOKEN": "dry-run"}):
+            self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_1_for_unshipped_site_returns_false(self) -> None:
         """``"1"`` for an unshipped site falls through to default-OFF (Finding #4).
 
         Pre-fold: shipped ``"1"`` → True (truthy), unshipped ``"1"`` → False.
         Post-fold: both go through the same fall-through path for consistency."""
-        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_GATE_RESULT": "1"}):
-            self.assertFalse(_bus._bus_as_truth_enabled("GATE_RESULT"))
+        with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_NEVER_SHIPPED_TOKEN": "1"}):
+            self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_default_on_frozenset_contains_all_shipped_sites(self) -> None:
-        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 4 shipped site tokens."""
+        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 6 shipped site tokens
+        after Sites 1-5 (#746) all cut over."""
         expected = frozenset({
-            "DISPATCH_LOG",
-            "CONSENSUS_REPORT",
-            "CONSENSUS_EVIDENCE",
-            "REVIEWER_REPORT",
+            "DISPATCH_LOG",        # Site 1
+            "CONSENSUS_REPORT",    # Site 2 (flag A)
+            "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
+            "REVIEWER_REPORT",     # Site 3
+            "GATE_RESULT",         # Site 4 (PR #784)
+            "CONDITIONS_MANIFEST", # Site 5 (this PR)
         })
         self.assertEqual(_bus._BUS_AS_TRUTH_DEFAULT_ON, expected)
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -578,39 +578,46 @@ class TestGatePendingMapsToReviewerReport(_ReconcileV2Fixture):
 # Finding #2 — conditions-manifest.json excluded during pre-Site-5 coexistence
 # ---------------------------------------------------------------------------
 
-class TestConditionsManifestExcludedPreSite5(_ReconcileV2Fixture):
-    """Regression: conditions-manifest.json must NOT trigger projection-without-event
-    before Site 5 ships.  Every existing CONDITIONAL phase would fire false drift
-    otherwise.
-
-    TODO (Site 5): when WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST ships, re-add
-    conditions-manifest.json to _collect_projection_files + _PROJECTION_MAP and
-    flip this test to assert drift IS detected when the file has no event.
+class TestConditionsManifestPostSite5(_ReconcileV2Fixture):
+    """Site 5 cutover (#746): conditions-manifest.json IS now a tracked
+    projection.  An on-disk manifest with no producing event in event_log
+    must fire ``projection-without-event`` drift (the TODO from the
+    original ``TestConditionsManifestExcludedPreSite5`` class is now done).
     """
 
-    def test_conditions_manifest_without_event_does_not_report_drift(self) -> None:
-        """Pre-Site-5 coexistence: conditions-manifest.json is not a tracked
-        projection and must produce zero drift even when no event exists for it."""
-        project_dir = _make_project_dir(self.workspace, "cond-manifest-proj")
+    def test_conditions_manifest_without_event_reports_drift(self) -> None:
+        """Post-Site-5: conditions-manifest.json on disk with NO producing
+        event in event_log → projection-without-event drift fires.
+
+        The expected producers post-Site-5 are:
+        - ``wicked.gate.decided`` with verdict CONDITIONAL + non-empty
+          conditions list (initial creation), OR
+        - ``wicked.condition.marked_cleared`` (subsequent verification flips).
+
+        With neither in event_log, the file is an orphan.
+        """
+        project_dir = _make_project_dir(self.workspace, "cond-orphan-proj")
         phase_dir = _make_phase_dir(project_dir, "design")
         _write_file(
             phase_dir / "conditions-manifest.json",
             '{"conditions": []}',
         )
-        # No event rows inserted — simulating pre-Site-5 state.
+        # No event rows inserted — orphan file scenario.
         conn = self._conn()
-        result = reconcile_v2.reconcile_project("cond-manifest-proj", _daemon_conn=conn)
+        result = reconcile_v2.reconcile_project("cond-orphan-proj", _daemon_conn=conn)
         conn.close()
 
         pwe = [
             d for d in result["drift"]
             if d["type"] == reconcile_v2.DRIFT_PROJECTION_WITHOUT_EVENT
         ]
-        self.assertEqual(
-            pwe,
-            [],
-            "conditions-manifest.json should not trigger projection-without-event "
-            "before Site 5 cuts over.",
+        self.assertTrue(
+            any(
+                d["projection"] == "phases/design/conditions-manifest.json"
+                for d in pwe
+            ),
+            "conditions-manifest.json with no producing event must fire "
+            f"projection-without-event drift. Got: {pwe}",
         )
 
 
@@ -1465,17 +1472,21 @@ class TestReconcileV2FlagPredicate(unittest.TestCase):
         with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "off"}):
             self.assertFalse(reconcile_v2._flag_on("DISPATCH_LOG"))
 
-    def test_unshipped_site_default_off_when_unset(self) -> None:
-        """Unshipped token (CONDITIONS_MANIFEST, Site 5) is OFF via default
-        map when unset.
+    def test_unknown_token_default_off_when_unset(self) -> None:
+        """Tokens NOT in ``_BUS_AS_TRUTH_DEFAULT_ON`` default OFF when unset.
 
-        GATE_RESULT (Site 4) was previously the unshipped reference here;
-        PR #780 flipped it default-ON when Site 4 cutover completed, so
-        CONDITIONS_MANIFEST is now the only remaining unshipped token.
+        After Site 5 (this PR), all five planned cutover tokens
+        (DISPATCH_LOG, CONSENSUS_REPORT, CONSENSUS_EVIDENCE,
+        REVIEWER_REPORT, GATE_RESULT, CONDITIONS_MANIFEST) are in the
+        default-ON set — there are no unshipped tokens left.  This test
+        guards the safety property: any FUTURE token (e.g. a hypothetical
+        Site 6 placeholder, or a token used in tests) defaults OFF when
+        unset, so an env-var typo never silently flips bus-as-truth on
+        for something we didn't intend to ship.
         """
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST", None)
-            self.assertFalse(reconcile_v2._flag_on("CONDITIONS_MANIFEST"))
+            os.environ.pop("WG_BUS_AS_TRUTH_NEVER_SHIPPED_TOKEN", None)
+            self.assertFalse(reconcile_v2._flag_on("NEVER_SHIPPED_TOKEN"))
 
     def test_active_projection_names_includes_dispatch_log_by_default(self) -> None:
         """Without any env var, DISPATCH_LOG is default-ON → dispatch-log.jsonl


### PR DESCRIPTION
## Summary

**Final cutover of the bus-cutover staging plan (#746).** Bundles 5a + 5b into one PR per the structural design lesson captured in \`memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md\` — no precursor PR, no flag-flip split. Default-ON from the start.

After this merges, all five planned cutover sites are shipped and bus-as-truth is the default for every projection file: \`dispatch-log.jsonl\`, \`consensus-{report,evidence}.json\`, \`reviewer-report.md\`, \`gate-result.json\`, \`conditions-manifest.json\`.

## Structural fix: \`_PROJECTION_MAP\` → \`_PROJECTION_RESOLVERS\`

The old \`Dict[str, str]\` map can't model "wicked.gate.decided produces gate-result.json **always** but conditions-manifest.json only on **CONDITIONAL** verdicts." A static map either over-claims (drift on every APPROVE event missing the manifest) or under-claims (silent on the conditional case). Replaced with \`Dict[str, Callable]\` where each resolver function inspects the payload and yields the paths the event is expected to produce.

\`\`\`
Resolver signature:
  (payload: Dict, phase: str, project_dir: Path) -> List[Path]
\`\`\`

\`_query_events_for_project\` now SELECTs \`payload_json\` and parses it into \`ev["payload"]\` so detector callers pass it through to the resolvers.

## New event type: \`wicked.condition.marked_cleared\`

Added to \`scripts/_bus.py\` event catalog. Fired from \`conditions_manifest.mark_cleared()\` BEFORE the legacy disk writes (sidecar + manifest flip) with chain_id \`{project}.{phase}.{condition_id}\` per the per-condition-uniqueness gotcha. Fail-open: bus-emit failure does NOT block the disk writes.

## New projector handlers

- **\`_conditions_manifest_from_gate_decided\`** — fan-out from \`_gate_decided_disk\`'s tail. On CONDITIONAL verdicts with non-empty conditions, materialises \`conditions-manifest.json\` with the same shape as legacy \`_write_conditions_manifest\` (CONDITION-{i+1} ids, \`verified=False\`, \`resolution=None\`). Content-hash idempotency on rewrite, atomic temp+rename. Wrapped in try/except so a manifest failure does NOT taint the gate-result projection.

- **\`_condition_marked_cleared\`** — full handler for the new event type. Replays \`mark_cleared()\`'s atomic two-step write order (sidecar first, then manifest flip). Idempotency: skip both writes when condition is already cleared with matching \`resolution_ref\`. Re-uses \`conditions_manifest.atomic_write_json\` and \`_resolution_sidecar_path\` so projector and direct-write paths share a single source of truth for crash semantics.

## Default-ON

\`CONDITIONS_MANIFEST\` added to \`_BUS_AS_TRUTH_DEFAULT_ON\` frozenset. \`PROJECTION_FILE_FLAGS\` comment for \`conditions-manifest.json\` flips from \`placeholder\` to \`active\`.

## Tests

- **NEW**: \`tests/daemon/test_projector_conditions_manifest.py\` (19 tests)
  - Resolver-driven projection paths (APPROVE/REJECT/CONDITIONAL/empty cases)
  - Fan-out gating + happy path + idempotency
  - \`_condition_marked_cleared\`: registration, flag-off, absent manifest, unknown condition_id, idempotent skip when already cleared, happy path
  - \`mark_cleared()\` emit wiring (chain_id includes condition_id; fail-open)
- Updated: \`tests/test_reconcile_v2.py\` — \`TestConditionsManifestExcludedPreSite5\` renamed to \`TestConditionsManifestPostSite5\` and inverted (orphan manifest NOW fires drift; original TODO is done).
- Updated: \`tests/test_bus_emit_health.py\` — 4 stale tests referencing \`GATE_RESULT\` as "unshipped" updated to use a hypothetical never-shipped token (these should have been fixed in PR #784; absorbed here since they share the same default-ON contract). \`test_default_on_frozenset_contains_all_shipped_sites\` now expects all 6 tokens.

## Test plan

- [x] \`tests/daemon/test_projector_conditions_manifest.py\` — 19/19 pass
- [x] \`tests/test_reconcile_v2.py\` — full pass (resolver refactor, payload-aware drift)
- [x] \`tests/test_bus_emit_health.py\` — full pass (4 stale tests fixed)
- [x] \`tests/daemon/test_projector_gate_result.py\` — pass (Site 4 unaffected)
- [x] \`tests/daemon/test_projector_consensus_gate.py\`, \`test_projector_dispatch_log.py\`, \`test_projector_consensus.py\` — pass
- [x] \`tests/crew/test_synthetic_drift.py\`, \`test_resume_projector.py\`, \`test_phase_manager.py\`, \`test_consensus_gate.py\`, \`test_gate_enforcement.py\` — pass
- [x] \`tests/daemon/test_hook_dispatch.py\`, \`test_unknown_event.py\`, \`test_parity.py\` — pass
- [x] \`tests/hooks/test_bus_emit_lint.py\` — pass
- [x] **Full suite**: 2453 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs, stub audit on \`_stack_signals.py\` — same set on \`origin/main\`).

## Bus-cutover complete (planned sites)

| Site | File | Status |
|------|------|--------|
| 1 | dispatch-log.jsonl | ✅ PR #751 + flag flip |
| 2 | consensus-report.json + consensus-evidence.json | ✅ PR #758 + flag flip |
| 3 | reviewer-report.md | ✅ PR #773 + #777 + #781 |
| 4 | gate-result.json | ✅ PR #782 + #784 |
| 5 | conditions-manifest.json | ✅ this PR |

**Wave 2** (deferred per staging plan §4): solo-mode, legacy adoption, log retention, migration scripts, HITL judge persistence, re-eval logs, convergence log, subagent engagement, phase context + semantic-gap report. These stay on direct-write paths until the five core sites have flipped and one full release of zero drift confirms the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)