### PR TITLE
fix(crew): #787 solo_mode bus integration — Site W1 cutover (resolves active drift)

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -1772,6 +1772,154 @@ def _condition_marked_cleared(conn: sqlite3.Connection, event: dict) -> None:
     )
 
 
+def _inline_review_context_recorded(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.crew.inline_review_context_recorded → inline-review-context.md.
+
+    Site W1 of bus-cutover wave-2 (#787).  Gated on
+    ``WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT`` via
+    ``_bus_as_truth_enabled("INLINE_REVIEW_CONTEXT")``.
+
+    Solo-mode (``scripts/crew/solo_mode.py``) writes three artifacts
+    when the inline-HITL path runs: gate-result.json,
+    conditions-manifest.json (CONDITIONAL only), and inline-review-context.md.
+    The first two are already covered by ``wicked.gate.decided`` via the
+    payload-aware ``_PROJECTION_RESOLVERS["wicked.gate.decided"]`` resolver.
+    This handler covers the third.
+
+    Payload contract (from ``solo_mode._emit_inline_review_context``):
+      project_id, phase, gate_name, bullets (list[str]), raw_response,
+      gate_result_ref (str path).  The handler reconstructs the same
+      markdown shape that ``solo_mode._write_inline_review_context``
+      produces so projector and direct-write paths produce
+      byte-identical output (modulo timestamps when the event includes
+      ``recorded_at``).
+
+    Idempotency: content-hash on the rendered markdown.  Atomic write
+    via temp+rename.  project_dir resolved via db.get_project; absent
+    row or NULL directory → warn and skip.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("INLINE_REVIEW_CONTEXT")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    gate_name, ok = _require(payload, "gate_name", et)
+    if not ok:
+        return
+
+    bullets = payload.get("bullets") or []
+    raw_response = payload.get("raw_response") or ""
+    gate_result_ref = payload.get("gate_result_ref") or "gate-result.json"
+    recorded_at = payload.get("recorded_at")
+
+    # Resolve project_dir.
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.crew.inline_review_context_recorded — "
+            "project %r has no directory in DB; skipping",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    target = project_dir / "phases" / str(phase) / "inline-review-context.md"
+
+    # Render the markdown — mirrors solo_mode._write_inline_review_context.
+    if recorded_at is None:
+        from datetime import datetime, timezone
+        recorded_at = datetime.now(timezone.utc).isoformat().replace(
+            "+00:00", "Z",
+        )
+
+    lines = [
+        f"# Inline Gate Review: {gate_name} ({phase})",
+        "",
+        f"**Timestamp**: {recorded_at}",
+        f"**Gate**: {gate_name}",
+        f"**Phase**: {phase}",
+        "",
+        "## Evidence Summary",
+        "",
+    ]
+    for b in bullets:
+        lines.append(f"- {b}")
+    lines += [
+        "",
+        "## User Response",
+        "",
+        f"> {str(raw_response).strip()}",
+        "",
+        "## Artifact Reference",
+        "",
+        f"Gate result: `{gate_result_ref}`",
+        "",
+    ]
+
+    candidate_bytes = "\n".join(lines).encode("utf-8")
+
+    # Content-hash idempotency.
+    import hashlib
+    try:
+        if target.exists():
+            existing_bytes = target.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: inline-review-context — content hash matches "
+                    "existing %s; skipping rewrite", target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: inline-review-context — could not read %s for "
+            "idempotency check: %s; proceeding to write", target, exc,
+        )
+
+    # Atomic write.
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(target)
+    except OSError as exc:
+        logger.warning(
+            "projector: inline-review-context — could not write %s: %s",
+            target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.crew.inline_review_context_recorded "
+        "project_id=%r phase=%r gate_name=%r path=%s",
+        project_id, phase, gate_name, target,
+    )
+
+
 def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.gate.blocked → no-op disk handler (PR-1 inert).
 
@@ -1897,6 +2045,15 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # multiple files — see _PROJECTION_MAP shape change in
     # reconcile_v2.py).
     "wicked.condition.marked_cleared": _condition_marked_cleared,
+    # Site W1 of bus-cutover wave-2 (#787): solo_mode inline-HITL
+    # evidence record.  ``wicked.crew.inline_review_context_recorded`` is
+    # fired by ``solo_mode.dispatch_human_inline()`` BEFORE the legacy
+    # disk write at phases/{phase}/inline-review-context.md.  Solo-mode
+    # also fires ``wicked.gate.decided`` in the same flow which the
+    # existing gate.decided handler maps to gate-result.json (+
+    # conditions-manifest.json on CONDITIONAL) — this handler covers the
+    # third artifact.  Gated on WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT.
+    "wicked.crew.inline_review_context_recorded": _inline_review_context_recorded,
 }
 
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -93,6 +93,19 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.condition",
         "description": "Condition verification flipped to verified=True via mark_cleared() (Site 5 cutover)",
     },
+    # Site W1 of bus-cutover wave-2 (#787): solo_mode inline-HITL
+    # evidence record.  Emitted from solo_mode.dispatch_human_inline()
+    # BEFORE the disk write at phases/{phase}/inline-review-context.md.
+    # Solo-mode also fires wicked.gate.decided for the same gate which
+    # carries the verdict + conditions; this event is for the markdown
+    # evidence file specifically (separate artifact, separate event).
+    # chain_id format: {project}.{phase}.gate (one inline-review-context
+    # per gate per phase, no per-condition split).
+    "wicked.crew.inline_review_context_recorded": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.solo_mode",
+        "description": "Inline-HITL gate review evidence recorded by solo_mode (Site W1 cutover)",
+    },
     # Jam domain — jam.py
     "wicked.session.started": {
         "domain": "wicked-garden",
@@ -319,12 +332,13 @@ def _is_disabled() -> bool:
 # ---------------------------------------------------------------------------
 
 _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
-    "DISPATCH_LOG",        # Site 1 — dispatch-log.jsonl (PR #751)
-    "CONSENSUS_REPORT",    # Site 2 — consensus-report.json (PR #758)
-    "CONSENSUS_EVIDENCE",  # Site 2 — consensus-evidence.json (PR #758)
-    "REVIEWER_REPORT",     # Site 3 — reviewer-report.md (PR #776)
-    "GATE_RESULT",         # Site 4 — gate-result.json (PR #782 + #784)
-    "CONDITIONS_MANIFEST", # Site 5 — conditions-manifest.json (this PR)
+    "DISPATCH_LOG",          # Site 1 — dispatch-log.jsonl (PR #751)
+    "CONSENSUS_REPORT",      # Site 2 — consensus-report.json (PR #758)
+    "CONSENSUS_EVIDENCE",    # Site 2 — consensus-evidence.json (PR #758)
+    "REVIEWER_REPORT",       # Site 3 — reviewer-report.md (PR #776)
+    "GATE_RESULT",           # Site 4 — gate-result.json (PR #782 + #784)
+    "CONDITIONS_MANIFEST",   # Site 5 — conditions-manifest.json (PR #785)
+    "INLINE_REVIEW_CONTEXT", # Site W1 — inline-review-context.md (#787, this PR)
 })
 
 

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -154,13 +154,27 @@ _PROJECTION_RESOLVERS: Dict[str, Callable[[Dict[str, Any], str, Path], "list[Pat
     "wicked.consensus.gate_pending": _resolve_single_file(
         "phases/{phase}/reviewer-report.md"
     ),
-    # Site 5 (this PR) — condition verification flip.
+    # Site 5 (PR #785) — condition verification flip.
     # ``wicked.condition.marked_cleared`` updates the manifest AND writes a
     # resolution sidecar.  Sidecar paths vary per condition_id and are
     # transient (the manifest is the source of truth; ``recover()``
     # re-derives sidecars on demand) so they are NOT tracked here.
     "wicked.condition.marked_cleared": _resolve_single_file(
         "phases/{phase}/conditions-manifest.json"
+    ),
+    # Site W1 (#787) — solo_mode inline-HITL evidence record.
+    # ``wicked.crew.inline_review_context_recorded`` materialises the
+    # markdown evidence file at phases/{phase}/inline-review-context.md.
+    # Solo-mode also fires ``wicked.gate.decided`` for the same gate, which
+    # the existing gate.decided resolver maps to gate-result.json (+
+    # conditions-manifest.json on CONDITIONAL).  This is a SECOND, distinct
+    # event because the inline-review-context.md is a different artifact
+    # written from the same flow — separate file, separate semantics
+    # (evidence/audit), so a separate event is the right shape (per
+    # ``memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md``:
+    # don't dodge the structural answer; new artifact = new event).
+    "wicked.crew.inline_review_context_recorded": _resolve_single_file(
+        "phases/{phase}/inline-review-context.md"
     ),
 }
 
@@ -210,7 +224,8 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
     "consensus-evidence.json":  "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
     "reviewer-report.md":       "REVIEWER_REPORT",     # Site 3
     "gate-result.json":         "GATE_RESULT",         # Site 4 — active (PR #782 + #780 default-ON)
-    "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — active (this PR default-ON)
+    "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — active (PR #785 default-ON)
+    "inline-review-context.md": "INLINE_REVIEW_CONTEXT", # Site W1 (#787) — solo_mode evidence record
 }
 
 # ---------------------------------------------------------------------------
@@ -289,12 +304,19 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # ``data["conditions"]`` is non-empty.  Same registry entry — one
     # event, multiple files (the new _PROJECTION_RESOLVERS shape).
     "wicked.gate.decided":                True,
-    # Site 5 (this PR) — _condition_marked_cleared materialises the
+    # Site 5 (PR #785) — _condition_marked_cleared materialises the
     # verification flip on conditions-manifest.json + writes the resolution
     # sidecar.  Wired into conditions_manifest.mark_cleared() as a
     # bus emit; projector handler in daemon/projector.py replays the
     # same atomic two-step write order.
     "wicked.condition.marked_cleared":    True,
+    # Site W1 (#787) — _inline_review_context_recorded materialises the
+    # solo_mode evidence markdown at phases/{phase}/inline-review-context.md.
+    # Wired into solo_mode.dispatch_human_inline() as a bus emit BEFORE the
+    # legacy direct write; projector handler in daemon/projector.py
+    # rebuilds the markdown deterministically from the event payload so the
+    # projection and direct-write paths produce byte-identical output.
+    "wicked.crew.inline_review_context_recorded": True,
     # Site 5 — no event handler mapping yet
     # (conditions-manifest.json has no event type in _PROJECTION_RESOLVERS)
 }

--- a/scripts/crew/solo_mode.py
+++ b/scripts/crew/solo_mode.py
@@ -610,12 +610,92 @@ def dispatch_human_inline(
         }
 
     # -----------------------------------------------------------------------
-    # Write gate-result.json
+    # Site W1 (#787) bus-cutover: emit BEFORE the legacy disk writes so the
+    # projector handlers can materialise the same files when the
+    # WG_BUS_AS_TRUTH_* flags are on.  Without these emits, the direct
+    # writes below would surface as ``projection-without-event`` drift in
+    # reconcile_v2 (Sites 4 + 5 went default-ON in PRs #784/#785).  The
+    # legacy writes still run for crash-recovery safety; the projector's
+    # content-hash idempotency makes its replay a no-op when bytes match.
+    # Fail-open: any emit failure must NOT block the disk writes.
     # -----------------------------------------------------------------------
     gate_result_ref = (
         str(project_dir / "phases" / phase / "gate-result.json")
         if project_dir else "gate-result.json"
     )
+    project_id_str = (
+        getattr(state, "name", None) if state is not None else None
+    )
+    chain_id_str = (
+        getattr(state, "chain_id", None) if state is not None else None
+    )
+    if chain_id_str is None and project_id_str:
+        # Synthesize a phase-level chain_id when state lacks one — keeps
+        # the projector handler's chain_id-based phase extraction working
+        # for callers that bootstrap solo-mode without a full ProjectState.
+        chain_id_str = f"{project_id_str}.{phase}.gate"
+
+    # Build the gate_result dict that the projector will use to materialise
+    # gate-result.json + (CONDITIONAL) conditions-manifest.json.  Same shape
+    # as ``_write_gate_result`` builds below — this is the source of truth
+    # the legacy direct writes mirror.
+    bus_gate_data: Dict[str, Any] = {
+        "verdict": parsed["verdict"],
+        "result": parsed["verdict"],
+        "reviewer": REVIEWER_NAME,
+        "recorded_at": _utc_now(),
+        "score": parsed["score"],
+        "reason": parsed.get("reason", ""),
+        "phase": phase,
+        "gate": gate_name,
+        "conditions": parsed.get("conditions") or [],
+        "dispatch_mode": DISPATCH_MODE,
+        "mode": DISPATCH_MODE,
+    }
+
+    if project_dir is not None and project_id_str:
+        try:
+            from _bus import emit_event  # type: ignore[import]
+            # wicked.gate.decided — covers gate-result.json + (CONDITIONAL)
+            # conditions-manifest.json via the existing payload-aware
+            # resolver in reconcile_v2._PROJECTION_RESOLVERS.
+            emit_event(
+                "wicked.gate.decided",
+                {
+                    "project_id": project_id_str,
+                    "phase": phase,
+                    "result": parsed["verdict"],
+                    "score": parsed["score"],
+                    "reviewer": REVIEWER_NAME,
+                    "data": bus_gate_data,
+                },
+                chain_id=chain_id_str,
+            )
+            # wicked.crew.inline_review_context_recorded — covers
+            # inline-review-context.md (Site W1, this PR).  Carries the
+            # same fields the projector handler needs to render the
+            # markdown deterministically.
+            emit_event(
+                "wicked.crew.inline_review_context_recorded",
+                {
+                    "project_id": project_id_str,
+                    "phase": phase,
+                    "gate_name": gate_name,
+                    "bullets": list(bullets),
+                    "raw_response": raw_response,
+                    "gate_result_ref": gate_result_ref,
+                    "recorded_at": bus_gate_data["recorded_at"],
+                },
+                chain_id=chain_id_str,
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable — disk writes still run below
+
+    # -----------------------------------------------------------------------
+    # Write gate-result.json (legacy direct write — preserved during
+    # cutover for crash-recovery safety; projector idempotency means its
+    # replay is a no-op when the bus-projected bytes match).
+    # -----------------------------------------------------------------------
     if project_dir is not None:
         _write_gate_result(project_dir, phase, gate_name, parsed, context_ref=None)
 

--- a/tests/crew/test_solo_mode_hitl.py
+++ b/tests/crew/test_solo_mode_hitl.py
@@ -635,6 +635,119 @@ class TestDispatchHumanInlineArtifacts(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Site W1 (#787) — bus emit wiring before disk writes
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchHumanInlineBusEmit(unittest.TestCase):
+    """Site W1 of bus-cutover wave-2: dispatch_human_inline must emit
+    wicked.gate.decided + wicked.crew.inline_review_context_recorded
+    BEFORE the legacy disk writes (#787).  Without these emits the
+    direct writes would surface as projection-without-event drift in
+    reconcile_v2 since Sites 4+5 went default-ON.
+    """
+
+    def _capture_emits(self, state, verdict_response: str, tmpdir: str) -> list:
+        """Run dispatch with a mock emit_event; return captured calls."""
+        captured: list = []
+
+        def _fake_emit(event_type, payload, *, chain_id=None):
+            captured.append({
+                "event_type": event_type,
+                "payload": payload,
+                "chain_id": chain_id,
+            })
+
+        with patch("solo_mode._is_interactive", return_value=True), \
+             patch("phase_manager.get_project_dir", return_value=Path(tmpdir)), \
+             patch("dispatch_log.append"), \
+             patch("_bus.emit_event", _fake_emit):
+            dispatch_human_inline(
+                state, "build", "code-quality", _minimal_gate_policy(),
+                _input_fn=lambda _="": verdict_response,
+                _print_fn=lambda _: None,
+            )
+        return captured
+
+    def test_approve_emits_gate_decided_and_inline_context(self):
+        """APPROVE verdict → both events fire with chain_id including phase."""
+        state = _make_state(name="proj-emit-approve")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            captured = self._capture_emits(state, "APPROVE", tmpdir)
+
+        types = [e["event_type"] for e in captured]
+        self.assertIn("wicked.gate.decided", types)
+        self.assertIn("wicked.crew.inline_review_context_recorded", types)
+
+        gate_emit = next(e for e in captured if e["event_type"] == "wicked.gate.decided")
+        self.assertEqual(gate_emit["payload"]["project_id"], "proj-emit-approve")
+        self.assertEqual(gate_emit["payload"]["phase"], "build")
+        self.assertEqual(gate_emit["payload"]["result"], "APPROVE")
+        self.assertEqual(gate_emit["payload"]["reviewer"], REVIEWER_NAME)
+        # Critical: payload carries the full data dict for the projector's
+        # payload-aware resolver to materialise gate-result.json (and
+        # conditions-manifest.json on CONDITIONAL).
+        self.assertIn("data", gate_emit["payload"])
+        self.assertEqual(gate_emit["payload"]["data"]["verdict"], "APPROVE")
+        self.assertEqual(gate_emit["payload"]["data"]["dispatch_mode"], DISPATCH_MODE)
+
+        ctx_emit = next(
+            e for e in captured
+            if e["event_type"] == "wicked.crew.inline_review_context_recorded"
+        )
+        self.assertEqual(ctx_emit["payload"]["gate_name"], "code-quality")
+        self.assertEqual(ctx_emit["payload"]["raw_response"], "APPROVE")
+        self.assertIn("bullets", ctx_emit["payload"])
+        self.assertIn("gate_result_ref", ctx_emit["payload"])
+
+    def test_conditional_emits_gate_decided_with_conditions_in_data(self):
+        """CONDITIONAL verdict carries conditions in data so the projector
+        resolver fans out to materialise conditions-manifest.json."""
+        state = _make_state(name="proj-emit-cond")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            captured = self._capture_emits(
+                state,
+                # The CONDITIONAL parser flow: this minimum input keeps the
+                # conditions list populated by the human-inline parser.
+                "CONDITIONAL: missing test coverage on the new helper",
+                tmpdir,
+            )
+
+        gate_emit = next(
+            e for e in captured if e["event_type"] == "wicked.gate.decided"
+        )
+        self.assertEqual(gate_emit["payload"]["data"]["verdict"], "CONDITIONAL")
+
+    def test_bus_emit_failure_does_not_block_disk_writes(self):
+        """A bus-emit failure must NOT block the legacy disk writes
+        (fail-open per Decision #8)."""
+        state = _make_state(name="proj-emit-fail")
+
+        def _raising_emit(event_type, payload, *, chain_id=None):
+            raise RuntimeError("simulated bus failure")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proj_dir = Path(tmpdir)
+            with patch("solo_mode._is_interactive", return_value=True), \
+                 patch("phase_manager.get_project_dir", return_value=proj_dir), \
+                 patch("dispatch_log.append"), \
+                 patch("_bus.emit_event", _raising_emit):
+                result = dispatch_human_inline(
+                    state, "build", "code-quality", _minimal_gate_policy(),
+                    _input_fn=lambda _="": "APPROVE",
+                    _print_fn=lambda _: None,
+                )
+
+            # Verdict still computed.
+            self.assertEqual(result["verdict"], "APPROVE")
+            # Disk writes still completed.
+            gr_path = proj_dir / "phases" / "build" / "gate-result.json"
+            ctx_path = proj_dir / "phases" / "build" / "inline-review-context.md"
+            self.assertTrue(gr_path.exists())
+            self.assertTrue(ctx_path.exists())
+
+
+# ---------------------------------------------------------------------------
 # Blocker 1 (#662): rigor upgraded to full mid-flight → council fallback
 # ---------------------------------------------------------------------------
 

--- a/tests/daemon/test_projector_inline_review_context.py
+++ b/tests/daemon/test_projector_inline_review_context.py
@@ -1,0 +1,203 @@
+"""tests/daemon/test_projector_inline_review_context.py — Site W1 (#787)
+projector tests for ``inline-review-context.md`` materialised from
+``wicked.crew.inline_review_context_recorded`` events fired by
+``solo_mode.dispatch_human_inline()``.
+
+Covers:
+  * Handler registered in ``_HANDLERS``.
+  * Flag-off contract (no write).
+  * Missing-payload-fields contract (no write, debug log).
+  * Happy path: full payload → markdown materialised with the same
+    shape ``solo_mode._write_inline_review_context`` produces.
+  * Content-hash idempotency on replay.
+  * Project-row absent / NULL-directory edge cases.
+  * Resolver mapping: event_type ↔ inline-review-context.md.
+
+T1: deterministic — fixed-string ``recorded_at`` in payload.
+T2: no sleep-based sync.
+T3: isolated — each test gets its own tmp_path + in-memory DB.
+T6: provenance: #787 Site W1 wave-2 cutover.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+_FIXED_RECORDED_AT = "2026-05-03T18:00:00Z"
+
+
+def _setup_project_in_db(conn, project_id: str, project_dir: Path) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+def _make_event(
+    *,
+    project_id: str = "my-proj",
+    phase: str = "build",
+    gate_name: str = "build-quality",
+    bullets: "list[str] | None" = None,
+    raw_response: str = "Looks fine — APPROVE",
+    gate_result_ref: str = "phases/build/gate-result.json",
+    recorded_at: "str | None" = _FIXED_RECORDED_AT,
+) -> dict:
+    if bullets is None:
+        bullets = ["Tests passing", "No security findings"]
+    payload: dict = {
+        "project_id": project_id,
+        "phase": phase,
+        "gate_name": gate_name,
+        "bullets": bullets,
+        "raw_response": raw_response,
+        "gate_result_ref": gate_result_ref,
+    }
+    if recorded_at is not None:
+        payload["recorded_at"] = recorded_at
+    return {
+        "event_id": 1,
+        "event_type": "wicked.crew.inline_review_context_recorded",
+        "chain_id": f"{project_id}.{phase}.gate",
+        "created_at": 1_700_000_001,
+        "payload": payload,
+    }
+
+
+def test_handler_is_registered() -> None:
+    from daemon.projector import _HANDLERS, _inline_review_context_recorded
+
+    assert "wicked.crew.inline_review_context_recorded" in _HANDLERS
+    assert (
+        _HANDLERS["wicked.crew.inline_review_context_recorded"]
+        is _inline_review_context_recorded
+    )
+
+
+def test_flag_off_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _inline_review_context_recorded
+
+    project_dir = tmp_path / "proj-flagoff"
+    _setup_project_in_db(mem_conn, "proj-flagoff", project_dir)
+    target = project_dir / "phases" / "build" / "inline-review-context.md"
+
+    event = _make_event(project_id="proj-flagoff")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off"}):
+        _inline_review_context_recorded(mem_conn, event)
+
+    assert not target.exists()
+
+
+def test_missing_required_fields_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _inline_review_context_recorded
+
+    project_dir = tmp_path / "proj-missing"
+    _setup_project_in_db(mem_conn, "proj-missing", project_dir)
+    target = project_dir / "phases" / "build" / "inline-review-context.md"
+
+    event = _make_event(project_id="proj-missing")
+    # Drop required field gate_name.
+    del event["payload"]["gate_name"]
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "on"}):
+        _inline_review_context_recorded(mem_conn, event)
+
+    assert not target.exists()
+
+
+def test_happy_path_materialises_markdown(mem_conn, tmp_path) -> None:
+    from daemon.projector import _inline_review_context_recorded
+
+    project_dir = tmp_path / "proj-happy"
+    _setup_project_in_db(mem_conn, "proj-happy", project_dir)
+    target = project_dir / "phases" / "build" / "inline-review-context.md"
+
+    event = _make_event(
+        project_id="proj-happy",
+        bullets=["Tests passing", "Security clean"],
+        raw_response="APPROVE",
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "on"}):
+        _inline_review_context_recorded(mem_conn, event)
+
+    assert target.exists()
+    body = target.read_text(encoding="utf-8")
+    # Spot-check headings + content the projector should always emit.
+    assert "# Inline Gate Review: build-quality (build)" in body
+    assert f"**Timestamp**: {_FIXED_RECORDED_AT}" in body
+    assert "**Gate**: build-quality" in body
+    assert "**Phase**: build" in body
+    assert "## Evidence Summary" in body
+    assert "- Tests passing" in body
+    assert "- Security clean" in body
+    assert "## User Response" in body
+    assert "> APPROVE" in body
+    assert "## Artifact Reference" in body
+    assert "Gate result: `phases/build/gate-result.json`" in body
+
+
+def test_replay_skips_rewrite_via_content_hash(mem_conn, tmp_path) -> None:
+    from daemon.projector import _inline_review_context_recorded
+
+    project_dir = tmp_path / "proj-replay"
+    _setup_project_in_db(mem_conn, "proj-replay", project_dir)
+    target = project_dir / "phases" / "build" / "inline-review-context.md"
+
+    event = _make_event(project_id="proj-replay")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "on"}):
+        _inline_review_context_recorded(mem_conn, event)
+        first_mtime = target.stat().st_mtime_ns
+        first_bytes = target.read_bytes()
+        _inline_review_context_recorded(mem_conn, event)
+        second_mtime = target.stat().st_mtime_ns
+        second_bytes = target.read_bytes()
+
+    assert first_bytes == second_bytes
+    assert first_mtime == second_mtime, (
+        "replay must short-circuit before atomic rename — identical mtime "
+        "confirms content-hash guard fired"
+    )
+
+
+def test_missing_project_row_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _inline_review_context_recorded
+
+    project_dir = tmp_path / "proj-no-db"
+    target = project_dir / "phases" / "build" / "inline-review-context.md"
+    # Intentionally do NOT register project in DB.
+
+    event = _make_event(project_id="proj-no-db")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "on"}):
+        _inline_review_context_recorded(mem_conn, event)
+
+    assert not target.exists()
+
+
+def test_resolver_returns_inline_review_context() -> None:
+    """_PROJECTION_RESOLVERS maps the event to inline-review-context.md."""
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"),
+        "wicked.crew.inline_review_context_recorded",
+        "proj.build.gate",
+        {"project_id": "proj", "phase": "build", "gate_name": "g"},
+    )
+    names = {p.name for p in paths}
+    assert names == {"inline-review-context.md"}

--- a/tests/test_bus_emit_health.py
+++ b/tests/test_bus_emit_health.py
@@ -516,15 +516,16 @@ class TestFlagFlipDefaultState(unittest.TestCase):
             self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_default_on_frozenset_contains_all_shipped_sites(self) -> None:
-        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 6 shipped site tokens
-        after Sites 1-5 (#746) all cut over."""
+        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 7 shipped site
+        tokens: Sites 1-5 (#746) + Site W1 (#787 solo_mode cutover)."""
         expected = frozenset({
-            "DISPATCH_LOG",        # Site 1
-            "CONSENSUS_REPORT",    # Site 2 (flag A)
-            "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
-            "REVIEWER_REPORT",     # Site 3
-            "GATE_RESULT",         # Site 4 (PR #784)
-            "CONDITIONS_MANIFEST", # Site 5 (this PR)
+            "DISPATCH_LOG",          # Site 1
+            "CONSENSUS_REPORT",      # Site 2 (flag A)
+            "CONSENSUS_EVIDENCE",    # Site 2 (flag B — independent)
+            "REVIEWER_REPORT",       # Site 3
+            "GATE_RESULT",           # Site 4 (PR #784)
+            "CONDITIONS_MANIFEST",   # Site 5 (PR #785)
+            "INLINE_REVIEW_CONTEXT", # Site W1 (#787, this PR)
         })
         self.assertEqual(_bus._BUS_AS_TRUTH_DEFAULT_ON, expected)
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -790,12 +790,13 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
     def test_all_flags_off_returns_empty_set(self) -> None:
         """With all WG_BUS_AS_TRUTH_* flags explicitly ``"off"``, active names is empty."""
         env_clear = {
-            "WG_BUS_AS_TRUTH_DISPATCH_LOG":        "off",
-            "WG_BUS_AS_TRUTH_CONSENSUS_REPORT":    "off",
-            "WG_BUS_AS_TRUTH_CONSENSUS_EVIDENCE":  "off",
-            "WG_BUS_AS_TRUTH_REVIEWER_REPORT":     "off",
-            "WG_BUS_AS_TRUTH_GATE_RESULT":         "off",
-            "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "off",
+            "WG_BUS_AS_TRUTH_DISPATCH_LOG":          "off",
+            "WG_BUS_AS_TRUTH_CONSENSUS_REPORT":      "off",
+            "WG_BUS_AS_TRUTH_CONSENSUS_EVIDENCE":    "off",
+            "WG_BUS_AS_TRUTH_REVIEWER_REPORT":       "off",
+            "WG_BUS_AS_TRUTH_GATE_RESULT":           "off",
+            "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST":   "off",
+            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#787)
         }
         with patch.dict(os.environ, env_clear):
             result = reconcile_v2._active_projection_names()
@@ -805,22 +806,18 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
     def test_site3_flag_on_returns_reviewer_report_only(self) -> None:
         """With only REVIEWER_REPORT flag ON, active names is {'reviewer-report.md'}.
 
-        Note (#769 fold): the handler-presence gate uses per-event-type keys.
-        This test patches _PROJECTION_HANDLERS_AVAILABLE to mark both
-        gate_completed and gate_pending as True (simulating Site 3 handler
-        present) so the flag-gate behaviour is testable in isolation.  The
-        handler-gate behaviour is covered separately in TestHandlerPresenceGate.
+        PR #781 flipped the Site 3 registry entries True natively;
+        no handler-presence patching required.
         """
         env = {
-            "WG_BUS_AS_TRUTH_DISPATCH_LOG":        "off",
-            "WG_BUS_AS_TRUTH_CONSENSUS_REPORT":    "off",
-            "WG_BUS_AS_TRUTH_CONSENSUS_EVIDENCE":  "off",
-            "WG_BUS_AS_TRUTH_REVIEWER_REPORT":     "on",
-            "WG_BUS_AS_TRUTH_GATE_RESULT":         "off",
-            "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST": "off",
+            "WG_BUS_AS_TRUTH_DISPATCH_LOG":          "off",
+            "WG_BUS_AS_TRUTH_CONSENSUS_REPORT":      "off",
+            "WG_BUS_AS_TRUTH_CONSENSUS_EVIDENCE":    "off",
+            "WG_BUS_AS_TRUTH_REVIEWER_REPORT":       "on",
+            "WG_BUS_AS_TRUTH_GATE_RESULT":           "off",
+            "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST":   "off",
+            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#787)
         }
-        # PR #781 flipped the Site 3 registry entries True natively;
-        # no handler-presence patching required.
         with patch.dict(os.environ, env):
             result = reconcile_v2._active_projection_names()
         self.assertEqual(result, frozenset({"reviewer-report.md"}))


### PR DESCRIPTION
## Summary

Resolves #787 — solo_mode.py was producing \`projection-without-event\` drift on every inline-HITL gate review since Sites 4+5 went default-ON in PRs #784/#785. This PR wires the bus emits and ships Site W1 of wave-2 in one shot.

Closes #787.

## Two changes (both load-bearing for the fix)

### 1. solo_mode emits \`wicked.gate.decided\` BEFORE its disk writes

\`solo_mode.dispatch_human_inline()\` now fires \`wicked.gate.decided\` with the full \`gate_result\` dict under \`payload[\"data\"]\` — same shape as \`phase_manager.approve_phase\`. The existing payload-aware resolver in \`reconcile_v2._PROJECTION_RESOLVERS\` picks up both \`gate-result.json\` AND (CONDITIONAL only) \`conditions-manifest.json\` from this single emit. \`chain_id\` synthesised as \`{project}.{phase}.gate\` when \`state\` lacks one.

### 2. New event for the third artifact (\`inline-review-context.md\`)

The third solo-mode artifact needed its own event because it's a distinct artifact with distinct semantics (markdown evidence record). Per the workaround-vs-fix lesson: don't bend the existing event; new artifact = new event.

- **Event**: \`wicked.crew.inline_review_context_recorded\` (subdomain: \`crew.solo_mode\`)
- **Resolver** in \`reconcile_v2._PROJECTION_RESOLVERS\`
- **Handler** \`_inline_review_context_recorded\` in \`daemon/projector.py\` — re-renders the markdown deterministically from the event payload, so projector and direct-write paths produce byte-identical output
- **Flag** \`WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT\` in \`PROJECTION_FILE_FLAGS\`, default-ON in \`_BUS_AS_TRUTH_DEFAULT_ON\`

## Tests

- **NEW**: \`tests/daemon/test_projector_inline_review_context.py\` (7 tests)
  - Handler registration, flag-off, missing-fields, happy path, idempotency, project-row absent, resolver mapping
- **NEW**: \`TestDispatchHumanInlineBusEmit\` class in \`tests/crew/test_solo_mode_hitl.py\` (3 tests)
  - APPROVE → both events fire with correct payload shape
  - CONDITIONAL → \`gate.decided\` carries verdict in \`data\` dict
  - Bus emit failure → disk writes still complete (fail-open per Decision #8)
- **Updated**: \`tests/test_reconcile_v2.py\` — all-flags-off + Site-3-only-on tests now include the new \`INLINE_REVIEW_CONTEXT\` flag in env control sets.
- **Updated**: \`tests/test_bus_emit_health.py\` — \`test_default_on_frozenset_contains_all_shipped_sites\` expects 7 tokens.

## Test plan

- [x] \`tests/daemon/test_projector_inline_review_context.py\` — 7/7 pass
- [x] \`tests/crew/test_solo_mode_hitl.py::TestDispatchHumanInlineBusEmit\` — 3/3 pass
- [x] \`tests/test_reconcile_v2.py\` — full pass (registry + env-control updates)
- [x] \`tests/test_bus_emit_health.py\` — full pass (default-ON expectation updated)
- [x] \`tests/daemon/test_projector_gate_result.py\`, \`test_projector_conditions_manifest.py\`, \`test_projector_consensus_gate.py\`, \`test_projector_dispatch_log.py\`, \`test_projector_consensus.py\` — all pass
- [x] All other \`tests/crew/\` tests — pass
- [x] **Full suite**: 2463 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs, stub audit on \`_stack_signals.py\` — same set on \`origin/main\`)

## Operator-visible impact

**Before**: every solo-mode inline-HITL approval produced \`projection-without-event\` drift on \`gate-result.json\` and (CONDITIONAL) \`conditions-manifest.json\`. Reconciler reported drift on every gate.

**After**: solo_mode emits the same events as \`phase_manager.approve_phase\`; projector materialises the same files via the bus path; reconciler sees zero drift. The legacy direct writes still run (defense-in-depth during cutover; content-hash idempotency makes the projector replay a no-op when bytes match).

## Refs

- Issue #787 — bug report with repro
- Wave-2 plan: \`docs/v9/wave-2-cutover-plan.md\` §W1 (PR #786)
- Sites 4 + 5 cutover: PRs #782, #784, #785
- Design lessons: \`memory/ship-inert-and-activate-later-is-a-contradiction-bundle-instead.md\`, \`memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)