### PR TITLE
feat(crew): wave-2 Tranche A — summary emits for migration/maintenance + W10 exempt markers (#746)

### DIFF
--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -106,6 +106,31 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.solo_mode",
         "description": "Inline-HITL gate review evidence recorded by solo_mode (Site W1 cutover)",
     },
+    # Wave-2 Tranche A summary emits — these are AUDIT MARKERS, not file
+    # projection events.  The corresponding scripts (adopt_legacy.py,
+    # migrate_qe_evaluator_name.py, log_retention.py) are EXEMPT from
+    # full bus-cutover per docs/v9/wave-2-cutover-plan.md §W2/W3/W4: the
+    # writes themselves are migration/maintenance side-effects (one-shot
+    # transformations or rotation) that don't fit the projector replay
+    # model.  These summary emits give the audit log a marker so future
+    # forensics can identify projects that went through legacy adoption
+    # / qe-evaluator rename / log rotation.  No projector handlers; no
+    # entries in _PROJECTION_RESOLVERS.
+    "wicked.crew.legacy_adopted": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.migration",
+        "description": "Legacy beta.3 → v6.0 project migration applied via adopt_legacy.py (audit marker)",
+    },
+    "wicked.crew.qe_evaluator_migrated": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.migration",
+        "description": "qe-evaluator → gate-adjudicator rename applied via migrate_qe_evaluator_name.py (audit marker)",
+    },
+    "wicked.log.rotated": {
+        "domain": "wicked-garden",
+        "subdomain": "platform.log_retention",
+        "description": "Log file rotated by log_retention.rotate_if_needed (audit marker)",
+    },
     # Jam domain — jam.py
     "wicked.session.started": {
         "domain": "wicked-garden",

--- a/scripts/crew/adopt_legacy.py
+++ b/scripts/crew/adopt_legacy.py
@@ -254,6 +254,15 @@ def apply_transformations(
     """Apply (or preview) transformations for each detected marker.
 
     Returns list of human-readable outcome lines.
+
+    Bus-cutover wave-2 Site W2 (#746): EXEMPT from full bus-cutover
+    per docs/v9/wave-2-cutover-plan.md §W2.  This is a one-shot
+    operator-invoked migration; the bus-as-truth contract applies to
+    runtime state, not migration tooling.  An audit-marker summary
+    event ``wicked.crew.legacy_adopted`` fires AFTER the
+    transformations land (only when not dry-run AND markers were
+    applied) so future forensics can identify projects that went
+    through the legacy adoption path.
     """
     outcomes: List[str] = []
     for marker in markers:
@@ -271,6 +280,32 @@ def apply_transformations(
             outcomes.append(
                 _transform_legacy_bypass(project_dir, file_path, dry_run)
             )
+
+    # Wave-2 Tranche A audit-marker emit (#746 W2).  Only fires on
+    # actual application (not dry-run) AND when markers were processed.
+    # Fail-open: bus unavailable must NOT fail the migration.
+    if not dry_run and outcomes:
+        try:
+            import sys as _sys
+            from pathlib import Path as _Path
+            _scripts_root = str(_Path(__file__).resolve().parents[1])
+            if _scripts_root not in _sys.path:
+                _sys.path.insert(0, _scripts_root)
+            from _bus import emit_event  # type: ignore[import]
+            project_id = project_dir.name
+            emit_event(
+                "wicked.crew.legacy_adopted",
+                {
+                    "project_id": project_id,
+                    "marker_count": len(markers),
+                    "outcome_count": len(outcomes),
+                    "markers_applied": list(markers),
+                },
+                chain_id=f"{project_id}.root",
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable — migration disk writes already completed
+
     return outcomes
 
 

--- a/scripts/crew/log_retention.py
+++ b/scripts/crew/log_retention.py
@@ -207,6 +207,38 @@ def rotate_if_needed(
         )
         return None
 
+    # Wave-2 Tranche A audit-marker emit (#746 W3).  log_retention is
+    # EXEMPT from full bus-cutover per docs/v9/wave-2-cutover-plan.md
+    # §W3 — rotation is a maintenance side-effect that doesn't change
+    # any source of truth (the reconciler reads active logs, not
+    # archives).  This optional summary marker gives operators a
+    # forensics anchor: "did the log rotate before or after the bug?"
+    # Fail-open: bus unavailable must NOT fail rotation (the disk
+    # operations have already completed by this point).
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        from _bus import emit_event  # type: ignore[import]
+        # chain_id is best-effort: log files don't carry a project
+        # identifier inherently.  Use the parent-directory name as a
+        # weak grouping key so per-project rotations are distinguishable.
+        rotation_scope = path.parent.parent.name or "unknown-scope"
+        emit_event(
+            "wicked.log.rotated",
+            {
+                "log_path": str(path),
+                "archive_path": str(dest),
+                "size_bytes": size,
+                "threshold_bytes": threshold,
+            },
+            chain_id=f"{rotation_scope}.root",
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — rotation disk operations already completed
+
     return dest
 
 

--- a/scripts/crew/migrate_qe_evaluator_name.py
+++ b/scripts/crew/migrate_qe_evaluator_name.py
@@ -269,6 +269,44 @@ def _scan_and_migrate(
         f"{errors} error(s)."
     )
 
+    # Wave-2 Tranche A audit-marker emit (#746 W4).  Same shape as
+    # adopt_legacy.py's wicked.crew.legacy_adopted: this script is
+    # EXEMPT from full bus-cutover (one-shot operator migration), but
+    # emits a summary marker so future forensics can identify projects
+    # that went through the qe-evaluator → gate-adjudicator rename.
+    # Only fires on actual application (not dry-run) AND when migrations
+    # happened.  Fail-open: bus unavailable must NOT fail the migration.
+    if not dry_run and migrated > 0:
+        try:
+            import sys as _sys
+            from pathlib import Path as _Path
+            _scripts_root = str(_Path(__file__).resolve().parents[1])
+            if _scripts_root not in _sys.path:
+                _sys.path.insert(0, _scripts_root)
+            from _bus import emit_event  # type: ignore[import]
+            # Scope identifier for chain_id: when targeting a single
+            # project_dir, use its basename; when scanning a projects_root,
+            # use the root's basename + "all-projects" sentinel so the
+            # marker is distinguishable from a single-project run.
+            scope_id = (
+                project_dir.name if project_dir is not None
+                else f"{(projects_root.name if projects_root else 'unknown')}-all-projects"
+            )
+            emit_event(
+                "wicked.crew.qe_evaluator_migrated",
+                {
+                    "project_id": scope_id,
+                    "scope": "single-project" if project_dir else "all-projects",
+                    "scanned": scanned,
+                    "migrated": migrated,
+                    "skipped": skipped,
+                    "errors": errors,
+                },
+                chain_id=f"{scope_id}.root",
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable — migration disk writes already completed
+
     return 1 if errors else 0
 
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -1597,6 +1597,11 @@ def ensure_reviewer_context(
             f"Prior-phase gate findings live in "
             f"`phases/*/gate-result.json`.\n"
         )
+        # Bus-cutover wave-2 EXEMPT (#746 W10 site 1, per
+        # docs/v9/wave-2-cutover-plan.md §W10): reviewer-context.md is a
+        # PLACEHOLDER stub that the executor overwrites with real content
+        # before review.  Drift means the executor sees an empty stub
+        # and writes over it; harmless.  Not a projection target.
         context_path.write_text(stub, encoding="utf-8")
     except OSError:
         return None
@@ -4349,6 +4354,12 @@ def adopt_clarify_from_memo(
             "> " + excerpt.replace("\n", "\n> ") + excerpt_suffix,
             "",
         ]
+        # Bus-cutover wave-2 EXEMPT (#746 W10 site 4, per
+        # docs/v9/wave-2-cutover-plan.md §W10): adopted-from-design-memo
+        # pointer file is a pure operator-convenience artifact; the
+        # authoritative source is the memo it points to.  Not a
+        # projection target — projecting it would just duplicate the
+        # memo path.
         (phase_dir / fname).write_text(
             "\n".join(frontmatter_lines) + "\n".join(body),
             encoding="utf-8",
@@ -5287,6 +5298,12 @@ def cutover_action(project: str, target_mode: str) -> Dict[str, Any]:
     phases_dir = project_dir / "phases"
     phases_dir.mkdir(parents=True, exist_ok=True)
     marker_path = phases_dir / ".cutover-to-mode-3.json"
+    # Bus-cutover wave-2 EXEMPT (#746 W10 site 5, per
+    # docs/v9/wave-2-cutover-plan.md §W10): mode-3 cutover marker is a
+    # one-shot operator forensics artifact (writes once per project, never
+    # rewritten).  Not a projection target — the marker's whole purpose
+    # is "this happened at this time"; replaying it would lie about
+    # when it happened.
     try:
         marker_path.write_text(json.dumps({
             "timestamp": get_utc_timestamp(),

--- a/tests/crew/test_wave_2_tranche_a_summary_emits.py
+++ b/tests/crew/test_wave_2_tranche_a_summary_emits.py
@@ -1,0 +1,346 @@
+"""tests/crew/test_wave_2_tranche_a_summary_emits.py — Wave-2 Tranche A
+audit-marker summary emits (#746 W2/W3/W4).
+
+Each of the three migration/maintenance scripts is EXEMPT from full
+bus-cutover (per docs/v9/wave-2-cutover-plan.md §W2/W3/W4) but emits
+a summary marker after successful operation so future forensics can
+identify projects that went through legacy adoption / qe-evaluator
+rename / log rotation.
+
+Covers:
+  * adopt_legacy.apply_transformations → wicked.crew.legacy_adopted
+    (fires on actual application, not dry-run, only when markers
+    were processed; fail-open on bus error)
+  * migrate_qe_evaluator_name._scan_and_migrate →
+    wicked.crew.qe_evaluator_migrated (fires when migrated > 0 and
+    not dry-run; fail-open on bus error)
+  * log_retention.rotate_if_needed → wicked.log.rotated (fires when
+    rotation actually happened — file was over threshold; fail-open
+    on bus error)
+
+T1: deterministic — no wall-clock-dependent assertions.
+T3: isolated — each test gets its own tmp_path.
+T6: provenance: #746 wave-2 Tranche A.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+# ---------------------------------------------------------------------------
+# adopt_legacy.apply_transformations → wicked.crew.legacy_adopted
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_legacy_emits_summary_after_apply(tmp_path) -> None:
+    """apply_transformations(dry_run=False) with markers → fires emit."""
+    import adopt_legacy  # type: ignore[import]
+
+    project_dir = tmp_path / "legacy-proj"
+    project_dir.mkdir()
+    # Minimum project.json with NO phase_plan_mode key — that triggers
+    # the missing-phase_plan_mode marker.
+    (project_dir / "project.json").write_text(
+        json.dumps({"id": "legacy-proj", "name": "legacy-proj"}),
+    )
+
+    captured: list = []
+
+    def _fake_emit(event_type, payload, *, chain_id=None):
+        captured.append({
+            "event_type": event_type,
+            "payload": payload,
+            "chain_id": chain_id,
+        })
+
+    with patch("_bus.emit_event", _fake_emit):
+        outcomes = adopt_legacy.apply_transformations(
+            project_dir, ["missing-phase_plan_mode"], dry_run=False,
+        )
+
+    assert outcomes, "transformation must produce at least one outcome line"
+    assert len(captured) == 1, f"exactly one summary emit expected, got {captured}"
+    emit = captured[0]
+    assert emit["event_type"] == "wicked.crew.legacy_adopted"
+    assert emit["payload"]["project_id"] == "legacy-proj"
+    assert emit["payload"]["marker_count"] == 1
+    assert emit["payload"]["outcome_count"] == 1
+    assert emit["payload"]["markers_applied"] == ["missing-phase_plan_mode"]
+    assert emit["chain_id"] == "legacy-proj.root"
+
+
+def test_adopt_legacy_does_not_emit_on_dry_run(tmp_path) -> None:
+    """dry_run=True must NOT fire the summary emit (no real change happened)."""
+    import adopt_legacy  # type: ignore[import]
+
+    project_dir = tmp_path / "legacy-proj-dry"
+    project_dir.mkdir()
+    (project_dir / "project.json").write_text(
+        json.dumps({"id": "legacy-proj-dry"}),
+    )
+
+    captured: list = []
+
+    def _fake_emit(event_type, payload, *, chain_id=None):
+        captured.append(event_type)
+
+    with patch("_bus.emit_event", _fake_emit):
+        adopt_legacy.apply_transformations(
+            project_dir, ["missing-phase_plan_mode"], dry_run=True,
+        )
+
+    assert captured == [], "dry_run must not emit — no actual change happened"
+
+
+def test_adopt_legacy_does_not_emit_when_no_markers(tmp_path) -> None:
+    """No markers → no transformations → no emit."""
+    import adopt_legacy  # type: ignore[import]
+
+    project_dir = tmp_path / "legacy-proj-clean"
+    project_dir.mkdir()
+
+    captured: list = []
+
+    with patch("_bus.emit_event", lambda et, p, **kw: captured.append(et)):
+        outcomes = adopt_legacy.apply_transformations(
+            project_dir, [], dry_run=False,
+        )
+
+    assert outcomes == []
+    assert captured == []
+
+
+def test_adopt_legacy_emit_failure_does_not_break_migration(tmp_path) -> None:
+    """A bus-emit failure must NOT raise out of apply_transformations."""
+    import adopt_legacy  # type: ignore[import]
+
+    project_dir = tmp_path / "legacy-proj-busfail"
+    project_dir.mkdir()
+    (project_dir / "project.json").write_text(
+        json.dumps({"id": "legacy-proj-busfail"}),
+    )
+
+    def _raising_emit(event_type, payload, *, chain_id=None):
+        raise RuntimeError("simulated bus failure")
+
+    with patch("_bus.emit_event", _raising_emit):
+        # Must not raise.
+        outcomes = adopt_legacy.apply_transformations(
+            project_dir, ["missing-phase_plan_mode"], dry_run=False,
+        )
+
+    # Migration outcomes still produced — fail-open invariant.
+    assert outcomes
+    # And the disk transformation actually landed.
+    parsed = json.loads((project_dir / "project.json").read_text(encoding="utf-8"))
+    assert parsed.get("phase_plan_mode") == "facilitator"
+
+
+# ---------------------------------------------------------------------------
+# migrate_qe_evaluator_name._scan_and_migrate → wicked.crew.qe_evaluator_migrated
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_jsonl(project_dir: Path, phase: str = "design") -> Path:
+    """Seed a single phases/{phase}/reeval-log.jsonl with a legacy entry."""
+    phase_dir = project_dir / "phases" / phase
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    p = phase_dir / "reeval-log.jsonl"
+    p.write_text(
+        json.dumps({"reviewer": "qe-evaluator", "verdict": "APPROVE"}) + "\n",
+    )
+    return p
+
+
+def test_migrate_qe_evaluator_emits_summary_when_migrations_happen(tmp_path) -> None:
+    """_scan_and_migrate(project_dir, dry_run=False) with at least one
+    legacy file → fires wicked.crew.qe_evaluator_migrated."""
+    import migrate_qe_evaluator_name as mig  # type: ignore[import]
+
+    project_dir = tmp_path / "migrate-proj"
+    project_dir.mkdir()
+    _seed_legacy_jsonl(project_dir)
+
+    captured: list = []
+
+    def _fake_emit(event_type, payload, *, chain_id=None):
+        captured.append({
+            "event_type": event_type,
+            "payload": payload,
+            "chain_id": chain_id,
+        })
+
+    with patch("_bus.emit_event", _fake_emit):
+        rc = mig._scan_and_migrate(
+            projects_root=None, project_dir=project_dir, dry_run=False,
+        )
+
+    assert rc == 0
+    assert len(captured) == 1
+    emit = captured[0]
+    assert emit["event_type"] == "wicked.crew.qe_evaluator_migrated"
+    assert emit["payload"]["project_id"] == "migrate-proj"
+    assert emit["payload"]["scope"] == "single-project"
+    assert emit["payload"]["migrated"] >= 1
+    assert emit["payload"]["errors"] == 0
+    assert emit["chain_id"] == "migrate-proj.root"
+
+
+def test_migrate_qe_evaluator_does_not_emit_on_dry_run(tmp_path) -> None:
+    """dry_run=True must NOT fire the summary emit."""
+    import migrate_qe_evaluator_name as mig  # type: ignore[import]
+
+    project_dir = tmp_path / "migrate-proj-dry"
+    project_dir.mkdir()
+    _seed_legacy_jsonl(project_dir)
+
+    captured: list = []
+
+    with patch("_bus.emit_event", lambda et, p, **kw: captured.append(et)):
+        mig._scan_and_migrate(
+            projects_root=None, project_dir=project_dir, dry_run=True,
+        )
+
+    assert captured == []
+
+
+def test_migrate_qe_evaluator_does_not_emit_when_zero_migrated(tmp_path) -> None:
+    """No legacy entries to migrate → no emit (skipped count != migrated)."""
+    import migrate_qe_evaluator_name as mig  # type: ignore[import]
+
+    project_dir = tmp_path / "migrate-proj-clean"
+    project_dir.mkdir()
+    # File exists but has no legacy entries.
+    phase_dir = project_dir / "phases" / "design"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "reeval-log.jsonl").write_text(
+        json.dumps({"reviewer": "gate-adjudicator"}) + "\n",
+    )
+
+    captured: list = []
+
+    with patch("_bus.emit_event", lambda et, p, **kw: captured.append(et)):
+        mig._scan_and_migrate(
+            projects_root=None, project_dir=project_dir, dry_run=False,
+        )
+
+    assert captured == [], (
+        "no legacy entries → no migration → no emit "
+        "(audit marker only fires when something changed)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# log_retention.rotate_if_needed → wicked.log.rotated
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_if_needed_emits_summary_when_rotation_fires(tmp_path) -> None:
+    """rotate_if_needed with file over threshold → fires wicked.log.rotated."""
+    import log_retention  # type: ignore[import]
+
+    # Path shape mirrors production: <project_dir>/phases/<phase>/<log>
+    log_dir = tmp_path / "proj" / "phases" / "build"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "dispatch-log.jsonl"
+    # Write enough bytes to trigger rotation at a small explicit threshold.
+    log_path.write_text("x" * 1024, encoding="utf-8")
+
+    captured: list = []
+
+    def _fake_emit(event_type, payload, *, chain_id=None):
+        captured.append({
+            "event_type": event_type,
+            "payload": payload,
+            "chain_id": chain_id,
+        })
+
+    with patch("_bus.emit_event", _fake_emit):
+        archive = log_retention.rotate_if_needed(
+            log_path, max_size_bytes=512,
+        )
+
+    assert archive is not None and archive.exists()
+    assert len(captured) == 1
+    emit = captured[0]
+    assert emit["event_type"] == "wicked.log.rotated"
+    assert emit["payload"]["log_path"] == str(log_path)
+    assert emit["payload"]["archive_path"] == str(archive)
+    assert emit["payload"]["size_bytes"] == 1024
+    assert emit["payload"]["threshold_bytes"] == 512
+    # Truncate happened.
+    assert log_path.read_text(encoding="utf-8") == ""
+
+
+def test_rotate_if_needed_does_not_emit_when_below_threshold(tmp_path) -> None:
+    """File below threshold → no rotation → no emit."""
+    import log_retention  # type: ignore[import]
+
+    log_dir = tmp_path / "proj" / "phases" / "build"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "dispatch-log.jsonl"
+    log_path.write_text("small", encoding="utf-8")
+
+    captured: list = []
+
+    with patch("_bus.emit_event", lambda et, p, **kw: captured.append(et)):
+        result = log_retention.rotate_if_needed(
+            log_path, max_size_bytes=10_000,
+        )
+
+    assert result is None
+    assert captured == []
+
+
+def test_rotate_if_needed_emit_failure_does_not_break_rotation(tmp_path) -> None:
+    """A bus-emit failure must NOT undo the rotation."""
+    import log_retention  # type: ignore[import]
+
+    log_dir = tmp_path / "proj" / "phases" / "build"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "dispatch-log.jsonl"
+    log_path.write_text("x" * 1024, encoding="utf-8")
+
+    def _raising_emit(event_type, payload, *, chain_id=None):
+        raise RuntimeError("simulated bus failure")
+
+    with patch("_bus.emit_event", _raising_emit):
+        archive = log_retention.rotate_if_needed(log_path, max_size_bytes=512)
+
+    # Rotation completed despite emit failure.
+    assert archive is not None and archive.exists()
+    assert log_path.read_text(encoding="utf-8") == ""
+
+
+# ---------------------------------------------------------------------------
+# Bus event catalog — confirm all three Tranche A summary events registered
+# ---------------------------------------------------------------------------
+
+
+def test_all_tranche_a_events_in_catalog() -> None:
+    """All three summary events must be in BUS_EVENT_MAP for the lint."""
+    import _bus  # type: ignore[import]
+
+    expected = {
+        "wicked.crew.legacy_adopted",
+        "wicked.crew.qe_evaluator_migrated",
+        "wicked.log.rotated",
+    }
+    for evt in expected:
+        assert evt in _bus.BUS_EVENT_MAP, (
+            f"{evt} missing from _bus.BUS_EVENT_MAP — emits will fail "
+            f"the bus_emit_lint and downstream consumers cannot subscribe"
+        )


### PR DESCRIPTION
## Summary

First wave-2 cutover landing. Per \`docs/v9/wave-2-cutover-plan.md\` §Tranche A: parallel-safe sites that are EXEMPT from full bus-cutover (their writes are migration/maintenance side-effects that don't fit the projector replay model). Each gets a SUMMARY emit so future forensics can identify projects that went through the operation; the writes themselves proceed direct.

## Three new audit-marker events

| Event | Source | When |
|-------|--------|------|
| \`wicked.crew.legacy_adopted\` | \`adopt_legacy.apply_transformations()\` | After successful beta.3→v6.0 migration (not dry-run; markers applied) |
| \`wicked.crew.qe_evaluator_migrated\` | \`migrate_qe_evaluator_name._scan_and_migrate()\` | After successful qe-evaluator → gate-adjudicator rename (not dry-run; migrated > 0) |
| \`wicked.log.rotated\` | \`log_retention.rotate_if_needed()\` | After successful rotation (file was over threshold) |

All three are audit-only — **no projector handlers, not in \`_PROJECTION_RESOLVERS\`, not in \`_PROJECTION_HANDLERS_AVAILABLE\`**. They're forensics anchors, not file-projection events.

## Three W10 exempt-marker comments

Per wave-2 plan §W10, three of the five \`phase_manager.py\` write sites originally listed in the staging plan §3 are exempt from cutover. Each got a comment explaining the exempt status with a pointer to the plan section:

- **Line 1600**: \`reviewer-context.md\` placeholder stub (overwritten by executor — drift is harmless)
- **Line 4343**: adopted-from-design-memo pointer (operator convenience; authoritative source is the memo)
- **Line 5282**: mode-3 cutover marker (one-shot forensics artifact; replay would lie about timing)

The remaining two W10 sites (semantic-gap report at 2571 and \`status.md\` SKIPPED at 4159) are future work — W10a and W10b in Tranches B/C.

## Fail-open invariant

Every emit is wrapped in \`try/except\`. A bus-emit failure must NOT fail the underlying migration / rotation operation (Decision #8). The disk operations have already completed by the time the emit fires; the emit is purely an audit marker.

## Tests

NEW: \`tests/crew/test_wave_2_tranche_a_summary_emits.py\` (11 tests)

- **adopt_legacy**: emits on real apply with markers; does NOT emit on dry_run; does NOT emit when no markers; emit failure does not break migration
- **migrate_qe_evaluator_name**: emits when migrations happen; does NOT emit on dry_run; does NOT emit when zero migrated (already-clean files)
- **log_retention**: emits on actual rotation; does NOT emit when below threshold; emit failure does not undo rotation
- **catalog**: all three event names present in \`BUS_EVENT_MAP\`

## Test plan

- [x] \`tests/crew/test_wave_2_tranche_a_summary_emits.py\` — 11/11 pass
- [x] \`tests/crew/test_adopt_legacy.py\`, \`test_migrate_qe_evaluator_name.py\`, \`test_log_retention.py\` — full pass (no regressions from the emit additions)
- [x] **Full suite**: 2474 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs, stub audit on \`_stack_signals.py\` — same set on \`origin/main\`)

## What's next

- **Tranche B** (sequential JSONL appends): W6 amendments, W8 convergence, W7 reeval_addendum, W10a semantic-gap. Four releases per the wave-2 plan §3.
- **Tranche C** (overlapping/refactor sites): W5 hitl_judge, W9a/W9b subagent_lifecycle refactor + cutover, W10b status.md SKIPPED.
- W1 was the highest-criticality wave-2 site (solo_mode) — already landed in PR #788 (#787 fix) ahead of wave-2 sequencing because it was an active drift bug.

## Refs

- Wave-2 plan: \`docs/v9/wave-2-cutover-plan.md\` (PR #786)
  - W2/W3/W4 per-site sections (lines 119-202)
  - W10 exempt rationale (lines 419-441)
- Site W1 fix landed separately: PR #788 (closes #787)

🤖 Generated with [Claude Code](https://claude.com/claude-code)