### PR TITLE
feat(crew): wave-2 Tranche B — JSONL append cutovers W6+W7+W8+W10a bundled (#746)

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -1920,6 +1920,361 @@ def _inline_review_context_recorded(conn: sqlite3.Connection, event: dict) -> No
     )
 
 
+# --- Wave-2 Tranche B (#746): JSONL append-stream projectors ----------------
+#
+# Each handler below mirrors the JSONL-append shape from wave-1 Site 1
+# (dispatch-log).  The source module's _atomic_append (or open("a"))
+# writes one line; this handler replays the same line from raw_payload
+# into the same path.  Idempotency: line-presence check (the projector
+# must skip when the exact line is already present, since the daemon
+# consumer doesn't dedupe before calling handlers).
+#
+# Common boilerplate is factored into ``_jsonl_append_projection`` —
+# each handler resolves its file path + flag token + payload key and
+# delegates the actual append + idempotency.
+
+
+def _jsonl_append_projection(
+    conn: sqlite3.Connection,
+    event: dict,
+    *,
+    flag_token: str,
+    relative_template: str,
+    handler_name: str,
+) -> None:
+    """Shared body for wave-2 Tranche B JSONL-append projectors.
+
+    Args:
+        conn: daemon DB connection.
+        event: bus event with payload carrying ``project_id``, ``phase``,
+            and ``raw_payload`` (the JSONL line bytes, terminator-less).
+        flag_token: WG_BUS_AS_TRUTH_<token> gate.
+        relative_template: ``phases/{phase}/<basename>`` template.
+        handler_name: short name used in log lines (e.g.
+            ``"wicked.amendment.appended"``).
+
+    Behaviour:
+        * flag-off → no-op.
+        * Missing required payload fields → debug log, no-op.
+        * project_id has no DB row / NULL directory → warn, skip.
+        * Idempotency: if the exact raw_payload line is already in the
+          file, skip the append (replay short-circuit).
+        * Append uses ``open("a") + fsync`` mirroring the source modules.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled(flag_token)
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: %s — project %r has no directory in DB; skipping",
+            handler_name, project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    target = project_dir / relative_template.replace("{phase}", str(phase))
+
+    line = str(raw_payload)
+    if not line.endswith("\n"):
+        line = line + "\n"
+
+    # Idempotency: skip if the exact line is already in the file.  Required
+    # because the daemon consumer doesn't dedupe before calling handlers
+    # (append_event_log uses INSERT OR REPLACE — handler fires per event
+    # in the batch).
+    try:
+        if target.exists():
+            existing = target.read_text(encoding="utf-8")
+            if line in existing:
+                logger.debug(
+                    "projector: %s — line already present in %s; skipping",
+                    handler_name, target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: %s — could not read %s for idempotency check: %s; "
+            "proceeding to append",
+            handler_name, target, exc,
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            try:
+                import os
+                os.fsync(fh.fileno())
+            except OSError:
+                pass  # fail-open: fsync unsupported on this FS
+    except OSError as exc:
+        logger.warning(
+            "projector: %s — append failed at %s: %s",
+            handler_name, target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied %s project_id=%r phase=%r path=%s",
+        handler_name, project_id, phase, target,
+    )
+
+
+def _amendment_appended(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.amendment.appended → phases/{phase}/amendments.jsonl.
+
+    Site W6 of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_AMENDMENTS``.  Replays the raw_payload JSONL line
+    from ``amendments.append()`` into the same file.
+    """
+    _jsonl_append_projection(
+        conn, event,
+        flag_token="AMENDMENTS",
+        relative_template="phases/{phase}/amendments.jsonl",
+        handler_name="wicked.amendment.appended",
+    )
+
+
+def _reeval_addendum_appended(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.reeval.addendum_appended → BOTH per-phase + project-root logs.
+
+    Site W7 of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_REEVAL_ADDENDUM``.  ``reeval_addendum.append()``
+    writes BOTH ``phases/{phase}/reeval-log.jsonl`` AND
+    ``process-plan.addendum.jsonl`` per call; this handler replays
+    BOTH writes in the same order for crash-safety parity.
+
+    Both writes use the shared ``_jsonl_append_projection`` helper but
+    with different relative paths.  The per-phase log is templated;
+    the project-root log is fixed.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("REEVAL_ADDENDUM")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.reeval.addendum_appended — project %r has no "
+            "directory in DB; skipping",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    line = str(raw_payload)
+    if not line.endswith("\n"):
+        line = line + "\n"
+
+    targets = [
+        project_dir / "phases" / str(phase) / "reeval-log.jsonl",
+        project_dir / "process-plan.addendum.jsonl",
+    ]
+
+    import os
+    for target in targets:
+        # Idempotency per file — each is independent.
+        try:
+            if target.exists():
+                existing = target.read_text(encoding="utf-8")
+                if line in existing:
+                    logger.debug(
+                        "projector: wicked.reeval.addendum_appended — line "
+                        "already present in %s; skipping",
+                        target,
+                    )
+                    continue
+        except OSError as exc:
+            logger.warning(
+                "projector: wicked.reeval.addendum_appended — could not read "
+                "%s for idempotency check: %s; proceeding to append",
+                target, exc,
+            )
+
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+                fh.flush()
+                try:
+                    os.fsync(fh.fileno())
+                except OSError:
+                    pass  # fail-open: fsync unsupported on this FS
+        except OSError as exc:
+            logger.warning(
+                "projector: wicked.reeval.addendum_appended — append failed "
+                "at %s: %s",
+                target, exc,
+            )
+            # Continue to the next target — best-effort dual-write mirrors
+            # the source module's separate _atomic_append calls.
+
+    logger.debug(
+        "projector: applied wicked.reeval.addendum_appended "
+        "project_id=%r phase=%r targets=%d",
+        project_id, phase, len(targets),
+    )
+
+
+def _convergence_transition_recorded(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.convergence.transition_recorded → convergence-log.jsonl.
+
+    Site W8 of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_CONVERGENCE``.  Replays the raw_payload JSONL line
+    from ``convergence.record_transition()`` into the same file.
+    """
+    _jsonl_append_projection(
+        conn, event,
+        flag_token="CONVERGENCE",
+        relative_template="phases/{phase}/convergence-log.jsonl",
+        handler_name="wicked.convergence.transition_recorded",
+    )
+
+
+def _semantic_gap_recorded(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.review.semantic_gap_recorded → phases/review/semantic-gap-report.json.
+
+    Site W10a of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_SEMANTIC_GAP``.  This is a JSON file (not JSONL)
+    that the source rewrites in full per call — so the projector does
+    a content-hash idempotency check + atomic write rather than
+    line-append.  The path is fixed at ``phases/review/semantic-gap-report.json``
+    (the source always writes here regardless of the gate's actual phase).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("SEMANTIC_GAP")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.review.semantic_gap_recorded — project %r "
+            "has no directory in DB; skipping",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    target = project_dir / "phases" / "review" / "semantic-gap-report.json"
+    candidate_bytes = str(raw_payload).encode("utf-8")
+
+    import hashlib
+    try:
+        if target.exists():
+            existing_bytes = target.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: semantic-gap-report — content hash matches "
+                    "existing %s; skipping rewrite", target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: semantic-gap-report — could not read %s for "
+            "idempotency check: %s; proceeding to write",
+            target, exc,
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(target)
+    except OSError as exc:
+        logger.warning(
+            "projector: semantic-gap-report — write failed at %s: %s",
+            target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.review.semantic_gap_recorded "
+        "project_id=%r path=%s",
+        project_id, target,
+    )
+
+
 def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.gate.blocked → no-op disk handler (PR-1 inert).
 
@@ -2054,6 +2409,14 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     # conditions-manifest.json on CONDITIONAL) — this handler covers the
     # third artifact.  Gated on WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT.
     "wicked.crew.inline_review_context_recorded": _inline_review_context_recorded,
+    # Wave-2 Tranche B (#746): JSONL append-stream cutovers.
+    # Each handler mirrors the source module's append (or full-write
+    # for semantic-gap) into the same path.  Gated per-handler on its
+    # own WG_BUS_AS_TRUTH_<TOKEN> flag.
+    "wicked.amendment.appended":              _amendment_appended,
+    "wicked.reeval.addendum_appended":        _reeval_addendum_appended,
+    "wicked.convergence.transition_recorded": _convergence_transition_recorded,
+    "wicked.review.semantic_gap_recorded":    _semantic_gap_recorded,
 }
 
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -131,6 +131,30 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "platform.log_retention",
         "description": "Log file rotated by log_retention.rotate_if_needed (audit marker)",
     },
+    # Wave-2 Tranche B (#746): JSONL append-stream cutovers.
+    # Each event mirrors a JSONL append into a per-phase log file; the
+    # projector handler replays the append from raw_payload.  Same shape
+    # as wave-1 Site 1 (dispatch-log) but for four additional logs.
+    "wicked.amendment.appended": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.amendment",
+        "description": "Phase amendment appended to amendments.jsonl (Site W6 cutover)",
+    },
+    "wicked.reeval.addendum_appended": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.reeval",
+        "description": "Re-eval addendum appended to per-phase + project-root JSONL logs (Site W7 cutover; dual-file projection)",
+    },
+    "wicked.convergence.transition_recorded": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.convergence",
+        "description": "Convergence-log transition recorded for an artifact (Site W8 cutover)",
+    },
+    "wicked.review.semantic_gap_recorded": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.review",
+        "description": "Semantic-gap report persisted at review phase (Site W10a cutover)",
+    },
     # Jam domain — jam.py
     "wicked.session.started": {
         "domain": "wicked-garden",
@@ -303,6 +327,16 @@ _PAYLOAD_ALLOW_OVERRIDES: Dict[str, frozenset] = {
     # raw_payload so the projector can reproduce the file byte-for-byte.
     "wicked.consensus.gate_completed": frozenset({"raw_payload"}),
     "wicked.consensus.gate_pending": frozenset({"raw_payload"}),
+    # Wave-2 Tranche B (#746): JSONL append-stream cutovers carry the
+    # canonical JSONL line via `raw_payload` so the projector can replay
+    # the append byte-for-byte.  Same pattern as Site 1 dispatch-log.
+    # Each per-event audit note: the line bytes describe an append-only
+    # log entry (already validated by the source module's _validate_*
+    # call), so payload inspection is bounded by the schema check upstream.
+    "wicked.amendment.appended": frozenset({"raw_payload"}),
+    "wicked.reeval.addendum_appended": frozenset({"raw_payload"}),
+    "wicked.convergence.transition_recorded": frozenset({"raw_payload"}),
+    "wicked.review.semantic_gap_recorded": frozenset({"raw_payload"}),
 }
 
 # ---------------------------------------------------------------------------
@@ -363,7 +397,12 @@ _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
     "REVIEWER_REPORT",       # Site 3 — reviewer-report.md (PR #776)
     "GATE_RESULT",           # Site 4 — gate-result.json (PR #782 + #784)
     "CONDITIONS_MANIFEST",   # Site 5 — conditions-manifest.json (PR #785)
-    "INLINE_REVIEW_CONTEXT", # Site W1 — inline-review-context.md (#787, this PR)
+    "INLINE_REVIEW_CONTEXT", # Site W1 — inline-review-context.md (PR #788)
+    # Wave-2 Tranche B (this PR):
+    "AMENDMENTS",            # Site W6 — amendments.jsonl
+    "REEVAL_ADDENDUM",       # Site W7 — reeval-log.jsonl + process-plan.addendum.jsonl
+    "CONVERGENCE",           # Site W8 — convergence-log.jsonl
+    "SEMANTIC_GAP",          # Site W10a — semantic-gap-report.json
 })
 
 

--- a/scripts/crew/amendments.py
+++ b/scripts/crew/amendments.py
@@ -239,6 +239,36 @@ def append(
     # Append with newline terminator. JSONL is append-only by contract;
     # callers MUST NOT rewrite earlier lines.
     line = json.dumps(record, sort_keys=False) + "\n"
+
+    # Wave-2 Tranche B emit (#746 W6): fire BEFORE the disk append so
+    # the projector handler can replay the same line.  phase_dir shape
+    # is {project_dir}/phases/{phase}, so project_id = phase_dir.parent.parent.name
+    # and phase = phase_dir.name.  Fail-open: bus unavailable must NOT
+    # block the append.
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        from _bus import emit_event  # type: ignore[import]
+        project_id_str = phase_dir.parent.parent.name
+        phase_str = phase_dir.name
+        emit_event(
+            "wicked.amendment.appended",
+            {
+                "project_id": project_id_str,
+                "phase": phase_str,
+                "amendment_id": amendment_id,
+                "trigger": trigger,
+                "scope_version": scope_version,
+                "raw_payload": line,
+            },
+            chain_id=f"{project_id_str}.{phase_str}.{amendment_id}",
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — append below still runs
+
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(line)
         fh.flush()

--- a/scripts/crew/convergence.py
+++ b/scripts/crew/convergence.py
@@ -281,6 +281,35 @@ def record_transition(
         },
     }
 
+    # Wave-2 Tranche B emit (#746 W8): fire BEFORE the disk append so
+    # the projector handler can replay the same line.  chain_id includes
+    # artifact_id for per-artifact uniqueness (per
+    # memory/bus-chain-id-must-include-uniqueness-segment-gotcha.md).
+    # Fail-open: bus unavailable must NOT block the append.
+    line = json.dumps(entry, sort_keys=False) + "\n"
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        from _bus import emit_event  # type: ignore[import]
+        project_id_str = project_dir.name
+        emit_event(
+            "wicked.convergence.transition_recorded",
+            {
+                "project_id": project_id_str,
+                "phase": phase,
+                "artifact_id": artifact_id,
+                "from_state": current,
+                "to_state": to_state,
+                "raw_payload": line,
+            },
+            chain_id=f"{project_id_str}.{phase}.{artifact_id}",
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — append below still runs
+
     _append_log(_log_path(project_dir, phase), entry)
     return entry
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -2573,9 +2573,37 @@ def _check_semantic_alignment_gate(
         out_dir = project_dir / "phases" / "review"
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / "semantic-gap-report.json"
-        out_path.write_text(
-            json.dumps(semantic_review.report_to_dict(report), indent=2)
+        report_bytes = json.dumps(
+            semantic_review.report_to_dict(report), indent=2,
         )
+        # Wave-2 Tranche B emit (#746 W10a): fire BEFORE the disk
+        # write so the projector handler can replay the same bytes.
+        # The semantic-gap report lives at a fixed phase ("review")
+        # regardless of which phase triggered the alignment check.
+        # chain_id format: {project}.review.semantic-gap.{report.score}
+        # — score is sufficient discriminator since each report is a
+        # full snapshot (not append-only); reports with the same score
+        # would be byte-identical anyway, content-hash idempotency in
+        # the handler short-circuits the rewrite.  Fail-open: bus
+        # unavailable must NOT block the disk write.
+        try:
+            from _bus import emit_event  # type: ignore[import]
+            project_id_str = project_dir.name
+            emit_event(
+                "wicked.review.semantic_gap_recorded",
+                {
+                    "project_id": project_id_str,
+                    "phase": "review",
+                    "verdict": report.verdict,
+                    "score": report.score,
+                    "raw_payload": report_bytes,
+                },
+                chain_id=f"{project_id_str}.review.semantic-gap-{report.score}",
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable — direct write below still runs
+
+        out_path.write_text(report_bytes)
     except OSError as exc:
         logger.warning(
             "[semantic-alignment] could not persist gap report: %s", exc,

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -176,6 +176,31 @@ _PROJECTION_RESOLVERS: Dict[str, Callable[[Dict[str, Any], str, Path], "list[Pat
     "wicked.crew.inline_review_context_recorded": _resolve_single_file(
         "phases/{phase}/inline-review-context.md"
     ),
+    # Wave-2 Tranche B (this PR) — JSONL append-stream cutovers.
+    # Each event mirrors a JSONL append into a per-phase log file.  The
+    # projector handler appends the raw_payload line to the same file
+    # (mirroring the source module's _atomic_append).  Same shape as
+    # wave-1 Site 1 (dispatch-log) but for four additional logs.
+    "wicked.amendment.appended": _resolve_single_file(
+        "phases/{phase}/amendments.jsonl"
+    ),
+    # W7 is dual-file: the same event materialises BOTH the per-phase
+    # reeval-log.jsonl AND the project-root process-plan.addendum.jsonl.
+    # Custom resolver because the project-root path doesn't include
+    # the phase segment.
+    "wicked.reeval.addendum_appended": lambda payload, phase, project_dir: [
+        project_dir / "phases" / phase / "reeval-log.jsonl",
+        project_dir / "process-plan.addendum.jsonl",
+    ],
+    "wicked.convergence.transition_recorded": _resolve_single_file(
+        "phases/{phase}/convergence-log.jsonl"
+    ),
+    # W10a — semantic-gap report lives at a fixed path under phases/review/
+    # (not parameterised by the event's phase).  Use a custom resolver
+    # that ignores the phase argument and pins to "review".
+    "wicked.review.semantic_gap_recorded": lambda payload, phase, project_dir: [
+        project_dir / "phases" / "review" / "semantic-gap-report.json",
+    ],
 }
 
 
@@ -223,9 +248,14 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
     "consensus-report.json":    "CONSENSUS_REPORT",    # Site 2 (flag A)
     "consensus-evidence.json":  "CONSENSUS_EVIDENCE",  # Site 2 (flag B — independent)
     "reviewer-report.md":       "REVIEWER_REPORT",     # Site 3
-    "gate-result.json":         "GATE_RESULT",         # Site 4 — active (PR #782 + #780 default-ON)
-    "conditions-manifest.json": "CONDITIONS_MANIFEST", # Site 5 — active (PR #785 default-ON)
-    "inline-review-context.md": "INLINE_REVIEW_CONTEXT", # Site W1 (#787) — solo_mode evidence record
+    "gate-result.json":            "GATE_RESULT",           # Site 4 — active (PR #782 + #780 default-ON)
+    "conditions-manifest.json":    "CONDITIONS_MANIFEST",   # Site 5 — active (PR #785 default-ON)
+    "inline-review-context.md":    "INLINE_REVIEW_CONTEXT", # Site W1 (PR #788) — solo_mode evidence record
+    # Wave-2 Tranche B (this PR) — active default-ON:
+    "amendments.jsonl":            "AMENDMENTS",            # Site W6 — phase amendments JSONL
+    "reeval-log.jsonl":            "REEVAL_ADDENDUM",       # Site W7 — re-eval per-phase log (project-root mirror also produced from same event)
+    "convergence-log.jsonl":       "CONVERGENCE",           # Site W8 — artifact convergence log
+    "semantic-gap-report.json":    "SEMANTIC_GAP",          # Site W10a — semantic alignment report
 }
 
 # ---------------------------------------------------------------------------
@@ -317,6 +347,13 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     # rebuilds the markdown deterministically from the event payload so the
     # projection and direct-write paths produce byte-identical output.
     "wicked.crew.inline_review_context_recorded": True,
+    # Wave-2 Tranche B (this PR) — JSONL append cutovers.  Each handler
+    # appends the raw_payload line to the matching file (or, for W7,
+    # to BOTH the per-phase log and the project-root mirror).
+    "wicked.amendment.appended":               True,
+    "wicked.reeval.addendum_appended":         True,
+    "wicked.convergence.transition_recorded":  True,
+    "wicked.review.semantic_gap_recorded":     True,
     # Site 5 — no event handler mapping yet
     # (conditions-manifest.json has no event type in _PROJECTION_RESOLVERS)
 }

--- a/scripts/crew/reeval_addendum.py
+++ b/scripts/crew/reeval_addendum.py
@@ -240,6 +240,37 @@ def append(
     per_phase = _per_phase_log_path(project_dir, phase)
     project_log = _project_addendum_path(project_dir)
 
+    # Wave-2 Tranche B emit (#746 W7): fire BEFORE the dual append so
+    # the projector handler can replay BOTH writes (per-phase + project-
+    # root) in the same order for crash-safety parity.  chain_id uses
+    # the record's chain_id when present (per the schema, every addendum
+    # carries its own chain_id), else falls back to {project}.{phase}.{ts}.
+    # Fail-open: bus unavailable must NOT block the disk appends.
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        from _bus import emit_event  # type: ignore[import]
+        project_id_str = project_dir.name
+        record_chain = record.get("chain_id")
+        if not record_chain:
+            ts = record.get("recorded_at") or record.get("timestamp") or ""
+            ts_compact = "".join(ch for ch in ts if ch.isdigit())[:14] or "noid"
+            record_chain = f"{project_id_str}.{phase}.reeval-{ts_compact}"
+        emit_event(
+            "wicked.reeval.addendum_appended",
+            {
+                "project_id": project_id_str,
+                "phase": phase,
+                "raw_payload": line + "\n",  # _atomic_append adds the newline
+            },
+            chain_id=str(record_chain),
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — atomic appends below still run
+
     _atomic_append(per_phase, line)
     _atomic_append(project_log, line)
 

--- a/tests/daemon/test_projector_tranche_b.py
+++ b/tests/daemon/test_projector_tranche_b.py
@@ -1,0 +1,406 @@
+"""tests/daemon/test_projector_tranche_b.py — Wave-2 Tranche B projector
+handler tests for the four JSONL append-stream cutovers (#746).
+
+Sites covered:
+  * W6 ``wicked.amendment.appended``         → amendments.jsonl (per-phase)
+  * W7 ``wicked.reeval.addendum_appended``   → reeval-log.jsonl + process-plan.addendum.jsonl (DUAL FILE)
+  * W8 ``wicked.convergence.transition_recorded`` → convergence-log.jsonl
+  * W10a ``wicked.review.semantic_gap_recorded``  → semantic-gap-report.json (full-file rewrite)
+
+Common contract for the three append-stream handlers (W6/W7/W8):
+  * Flag-off → no-op
+  * Missing required payload fields (project_id, phase, raw_payload) → no-op
+  * Project row absent / NULL directory → warn + no-op
+  * Idempotency: line-presence check (replay short-circuit)
+  * Append uses ``open("a") + fsync`` with newline normalisation
+
+W10a is full-file rewrite (not append) so it uses content-hash idempotency
++ atomic temp+rename, same shape as Site 5's gate-result handler.
+
+T1: deterministic.  T3: isolated tmp_path + in-memory DB.  T6: provenance #746 wave-2 B.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+def _setup_project(conn, project_id: str, project_dir: Path) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+def _make_event(
+    *,
+    event_type: str,
+    project_id: str,
+    phase: str,
+    raw_payload: str,
+    extras: "dict | None" = None,
+    chain_id: "str | None" = None,
+) -> dict:
+    payload = {
+        "project_id": project_id,
+        "phase": phase,
+        "raw_payload": raw_payload,
+    }
+    if extras:
+        payload.update(extras)
+    return {
+        "event_id": 1,
+        "event_type": event_type,
+        "chain_id": chain_id or f"{project_id}.{phase}.x",
+        "created_at": 1_700_000_001,
+        "payload": payload,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration — all four handlers in _HANDLERS
+# ---------------------------------------------------------------------------
+
+
+def test_all_tranche_b_handlers_registered() -> None:
+    from daemon.projector import (
+        _HANDLERS,
+        _amendment_appended,
+        _reeval_addendum_appended,
+        _convergence_transition_recorded,
+        _semantic_gap_recorded,
+    )
+
+    assert _HANDLERS["wicked.amendment.appended"] is _amendment_appended
+    assert _HANDLERS["wicked.reeval.addendum_appended"] is _reeval_addendum_appended
+    assert _HANDLERS["wicked.convergence.transition_recorded"] is _convergence_transition_recorded
+    assert _HANDLERS["wicked.review.semantic_gap_recorded"] is _semantic_gap_recorded
+
+
+# ---------------------------------------------------------------------------
+# W6 — amendments.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_amendment_flag_off_no_append(mem_conn, tmp_path) -> None:
+    from daemon.projector import _amendment_appended
+
+    project_dir = tmp_path / "proj-amend-off"
+    _setup_project(mem_conn, "proj-amend-off", project_dir)
+    target = project_dir / "phases" / "build" / "amendments.jsonl"
+
+    event = _make_event(
+        event_type="wicked.amendment.appended",
+        project_id="proj-amend-off",
+        phase="build",
+        raw_payload='{"amendment_id": "AMD-x", "summary": "x"}',
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_AMENDMENTS": "off"}):
+        _amendment_appended(mem_conn, event)
+
+    assert not target.exists()
+
+
+def test_amendment_happy_path_appends_line(mem_conn, tmp_path) -> None:
+    from daemon.projector import _amendment_appended
+
+    project_dir = tmp_path / "proj-amend-on"
+    _setup_project(mem_conn, "proj-amend-on", project_dir)
+    target = project_dir / "phases" / "build" / "amendments.jsonl"
+
+    line = '{"amendment_id": "AMD-test-001", "summary": "test"}'
+    event = _make_event(
+        event_type="wicked.amendment.appended",
+        project_id="proj-amend-on",
+        phase="build",
+        raw_payload=line,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_AMENDMENTS": "on"}):
+        _amendment_appended(mem_conn, event)
+
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert content == line + "\n"
+
+
+def test_amendment_replay_idempotent(mem_conn, tmp_path) -> None:
+    from daemon.projector import _amendment_appended
+
+    project_dir = tmp_path / "proj-amend-replay"
+    _setup_project(mem_conn, "proj-amend-replay", project_dir)
+    target = project_dir / "phases" / "build" / "amendments.jsonl"
+
+    line = '{"amendment_id": "AMD-x", "summary": "x"}'
+    event = _make_event(
+        event_type="wicked.amendment.appended",
+        project_id="proj-amend-replay",
+        phase="build",
+        raw_payload=line,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_AMENDMENTS": "on"}):
+        _amendment_appended(mem_conn, event)
+        first = target.read_text(encoding="utf-8")
+        _amendment_appended(mem_conn, event)
+        second = target.read_text(encoding="utf-8")
+
+    assert first == second, "replay must short-circuit (line already present)"
+
+
+# ---------------------------------------------------------------------------
+# W7 — reeval-log.jsonl + process-plan.addendum.jsonl (DUAL FILE)
+# ---------------------------------------------------------------------------
+
+
+def test_reeval_addendum_writes_both_files(mem_conn, tmp_path) -> None:
+    from daemon.projector import _reeval_addendum_appended
+
+    project_dir = tmp_path / "proj-reeval"
+    _setup_project(mem_conn, "proj-reeval", project_dir)
+    per_phase = project_dir / "phases" / "design" / "reeval-log.jsonl"
+    project_log = project_dir / "process-plan.addendum.jsonl"
+
+    line = '{"chain_id": "proj.design.reeval-1", "trigger": "re-eval"}'
+    event = _make_event(
+        event_type="wicked.reeval.addendum_appended",
+        project_id="proj-reeval",
+        phase="design",
+        raw_payload=line,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REEVAL_ADDENDUM": "on"}):
+        _reeval_addendum_appended(mem_conn, event)
+
+    assert per_phase.exists()
+    assert project_log.exists()
+    expected_line = line + "\n"
+    assert per_phase.read_text(encoding="utf-8") == expected_line
+    assert project_log.read_text(encoding="utf-8") == expected_line
+
+
+def test_reeval_addendum_replay_idempotent_per_file(mem_conn, tmp_path) -> None:
+    """Replay must not double-append in EITHER file."""
+    from daemon.projector import _reeval_addendum_appended
+
+    project_dir = tmp_path / "proj-reeval-replay"
+    _setup_project(mem_conn, "proj-reeval-replay", project_dir)
+    per_phase = project_dir / "phases" / "design" / "reeval-log.jsonl"
+    project_log = project_dir / "process-plan.addendum.jsonl"
+
+    line = '{"chain_id": "p.design.r-1", "trigger": "re-eval"}'
+    event = _make_event(
+        event_type="wicked.reeval.addendum_appended",
+        project_id="proj-reeval-replay",
+        phase="design",
+        raw_payload=line,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REEVAL_ADDENDUM": "on"}):
+        _reeval_addendum_appended(mem_conn, event)
+        _reeval_addendum_appended(mem_conn, event)
+
+    assert per_phase.read_text(encoding="utf-8") == line + "\n"
+    assert project_log.read_text(encoding="utf-8") == line + "\n"
+
+
+def test_reeval_addendum_flag_off_no_writes(mem_conn, tmp_path) -> None:
+    from daemon.projector import _reeval_addendum_appended
+
+    project_dir = tmp_path / "proj-reeval-off"
+    _setup_project(mem_conn, "proj-reeval-off", project_dir)
+
+    event = _make_event(
+        event_type="wicked.reeval.addendum_appended",
+        project_id="proj-reeval-off",
+        phase="design",
+        raw_payload='{"trigger": "x"}',
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_REEVAL_ADDENDUM": "off"}):
+        _reeval_addendum_appended(mem_conn, event)
+
+    assert not (project_dir / "phases" / "design" / "reeval-log.jsonl").exists()
+    assert not (project_dir / "process-plan.addendum.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# W8 — convergence-log.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_convergence_happy_path_appends(mem_conn, tmp_path) -> None:
+    from daemon.projector import _convergence_transition_recorded
+
+    project_dir = tmp_path / "proj-conv"
+    _setup_project(mem_conn, "proj-conv", project_dir)
+    target = project_dir / "phases" / "build" / "convergence-log.jsonl"
+
+    line = '{"artifact_id": "A-1", "from_state": "Designed", "to_state": "Built"}'
+    event = _make_event(
+        event_type="wicked.convergence.transition_recorded",
+        project_id="proj-conv",
+        phase="build",
+        raw_payload=line,
+        extras={"artifact_id": "A-1"},
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONVERGENCE": "on"}):
+        _convergence_transition_recorded(mem_conn, event)
+
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == line + "\n"
+
+
+def test_convergence_flag_off_no_append(mem_conn, tmp_path) -> None:
+    from daemon.projector import _convergence_transition_recorded
+
+    project_dir = tmp_path / "proj-conv-off"
+    _setup_project(mem_conn, "proj-conv-off", project_dir)
+    target = project_dir / "phases" / "build" / "convergence-log.jsonl"
+
+    event = _make_event(
+        event_type="wicked.convergence.transition_recorded",
+        project_id="proj-conv-off",
+        phase="build",
+        raw_payload='{"artifact_id": "A-1"}',
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_CONVERGENCE": "off"}):
+        _convergence_transition_recorded(mem_conn, event)
+
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# W10a — semantic-gap-report.json (full-file rewrite, content-hash idempotency)
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_gap_writes_to_review_phase_regardless_of_event_phase(
+    mem_conn, tmp_path,
+) -> None:
+    """Semantic-gap report always lands at phases/review/, not the event's phase."""
+    from daemon.projector import _semantic_gap_recorded
+
+    project_dir = tmp_path / "proj-sg"
+    _setup_project(mem_conn, "proj-sg", project_dir)
+    target = project_dir / "phases" / "review" / "semantic-gap-report.json"
+
+    body = json.dumps({"verdict": "ALIGNED", "score": 0.95}, indent=2)
+    # NOTE: event "phase" is "build" but the projector pins to "review".
+    event = _make_event(
+        event_type="wicked.review.semantic_gap_recorded",
+        project_id="proj-sg",
+        phase="build",
+        raw_payload=body,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SEMANTIC_GAP": "on"}):
+        _semantic_gap_recorded(mem_conn, event)
+
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == body
+
+
+def test_semantic_gap_replay_short_circuits_via_content_hash(
+    mem_conn, tmp_path,
+) -> None:
+    from daemon.projector import _semantic_gap_recorded
+
+    project_dir = tmp_path / "proj-sg-replay"
+    _setup_project(mem_conn, "proj-sg-replay", project_dir)
+    target = project_dir / "phases" / "review" / "semantic-gap-report.json"
+
+    body = json.dumps({"verdict": "DIVERGENT", "score": 0.6})
+    event = _make_event(
+        event_type="wicked.review.semantic_gap_recorded",
+        project_id="proj-sg-replay",
+        phase="review",
+        raw_payload=body,
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SEMANTIC_GAP": "on"}):
+        _semantic_gap_recorded(mem_conn, event)
+        first_mtime = target.stat().st_mtime_ns
+        _semantic_gap_recorded(mem_conn, event)
+        second_mtime = target.stat().st_mtime_ns
+
+    assert first_mtime == second_mtime, (
+        "replay must skip atomic-rename when content-hash matches"
+    )
+
+
+def test_semantic_gap_flag_off_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _semantic_gap_recorded
+
+    project_dir = tmp_path / "proj-sg-off"
+    _setup_project(mem_conn, "proj-sg-off", project_dir)
+    target = project_dir / "phases" / "review" / "semantic-gap-report.json"
+
+    event = _make_event(
+        event_type="wicked.review.semantic_gap_recorded",
+        project_id="proj-sg-off",
+        phase="review",
+        raw_payload='{}',
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SEMANTIC_GAP": "off"}):
+        _semantic_gap_recorded(mem_conn, event)
+
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Resolvers — projection paths match the handlers' targets
+# ---------------------------------------------------------------------------
+
+
+def test_amendment_resolver_returns_amendments_jsonl() -> None:
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"),
+        "wicked.amendment.appended",
+        "proj.build.AMD-x",
+        {"project_id": "proj", "phase": "build"},
+    )
+    assert {p.name for p in paths} == {"amendments.jsonl"}
+
+
+def test_reeval_addendum_resolver_returns_dual_paths() -> None:
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"),
+        "wicked.reeval.addendum_appended",
+        "proj.design.reeval-1",
+        {"project_id": "proj", "phase": "design"},
+    )
+    names = sorted(str(p).split("proj/")[-1] for p in paths)
+    assert names == [
+        "phases/design/reeval-log.jsonl",
+        "process-plan.addendum.jsonl",
+    ]
+
+
+def test_semantic_gap_resolver_pins_to_review_phase() -> None:
+    """Resolver returns phases/review/semantic-gap-report.json regardless
+    of the chain_id's phase segment."""
+    import reconcile_v2  # type: ignore[import]
+
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/proj"),
+        "wicked.review.semantic_gap_recorded",
+        "proj.build.semantic-gap-x",  # event-phase is "build" — projector pins "review"
+        {"project_id": "proj", "phase": "build"},
+    )
+    assert len(paths) == 1
+    assert str(paths[0]).endswith("phases/review/semantic-gap-report.json")

--- a/tests/test_bus_emit_health.py
+++ b/tests/test_bus_emit_health.py
@@ -516,8 +516,9 @@ class TestFlagFlipDefaultState(unittest.TestCase):
             self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_default_on_frozenset_contains_all_shipped_sites(self) -> None:
-        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 7 shipped site
-        tokens: Sites 1-5 (#746) + Site W1 (#787 solo_mode cutover)."""
+        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 11 shipped
+        tokens: wave-1 Sites 1-5, Site W1 (#788), and wave-2 Tranche B
+        (W6/W7/W8/W10a)."""
         expected = frozenset({
             "DISPATCH_LOG",          # Site 1
             "CONSENSUS_REPORT",      # Site 2 (flag A)
@@ -525,7 +526,12 @@ class TestFlagFlipDefaultState(unittest.TestCase):
             "REVIEWER_REPORT",       # Site 3
             "GATE_RESULT",           # Site 4 (PR #784)
             "CONDITIONS_MANIFEST",   # Site 5 (PR #785)
-            "INLINE_REVIEW_CONTEXT", # Site W1 (#787, this PR)
+            "INLINE_REVIEW_CONTEXT", # Site W1 (PR #788)
+            # Wave-2 Tranche B (this PR):
+            "AMENDMENTS",            # Site W6 — amendments.jsonl
+            "REEVAL_ADDENDUM",       # Site W7 — reeval-log + project addendum
+            "CONVERGENCE",           # Site W8 — convergence-log.jsonl
+            "SEMANTIC_GAP",          # Site W10a — semantic-gap-report.json
         })
         self.assertEqual(_bus._BUS_AS_TRUTH_DEFAULT_ON, expected)
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -796,7 +796,12 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
             "WG_BUS_AS_TRUTH_REVIEWER_REPORT":       "off",
             "WG_BUS_AS_TRUTH_GATE_RESULT":           "off",
             "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST":   "off",
-            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#787)
+            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#788)
+            # Wave-2 Tranche B (this PR):
+            "WG_BUS_AS_TRUTH_AMENDMENTS":            "off",
+            "WG_BUS_AS_TRUTH_REEVAL_ADDENDUM":       "off",
+            "WG_BUS_AS_TRUTH_CONVERGENCE":           "off",
+            "WG_BUS_AS_TRUTH_SEMANTIC_GAP":          "off",
         }
         with patch.dict(os.environ, env_clear):
             result = reconcile_v2._active_projection_names()
@@ -816,7 +821,12 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
             "WG_BUS_AS_TRUTH_REVIEWER_REPORT":       "on",
             "WG_BUS_AS_TRUTH_GATE_RESULT":           "off",
             "WG_BUS_AS_TRUTH_CONDITIONS_MANIFEST":   "off",
-            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#787)
+            "WG_BUS_AS_TRUTH_INLINE_REVIEW_CONTEXT": "off",  # Site W1 (#788)
+            # Wave-2 Tranche B (this PR):
+            "WG_BUS_AS_TRUTH_AMENDMENTS":            "off",
+            "WG_BUS_AS_TRUTH_REEVAL_ADDENDUM":       "off",
+            "WG_BUS_AS_TRUTH_CONVERGENCE":           "off",
+            "WG_BUS_AS_TRUTH_SEMANTIC_GAP":          "off",
         }
         with patch.dict(os.environ, env):
             result = reconcile_v2._active_projection_names()


### PR DESCRIPTION
## Summary

Bundles all four wave-2 Tranche B sites into ONE PR per the bundle-vs-defer lesson. Each is a complete cutover; bundling delivers four finished products in one merge.

## Sites cut over

| Site | File(s) | Event | Flag |
|------|---------|-------|------|
| **W6** | \`phases/{phase}/amendments.jsonl\` | \`wicked.amendment.appended\` | \`AMENDMENTS\` |
| **W7** | \`phases/{phase}/reeval-log.jsonl\` + \`process-plan.addendum.jsonl\` | \`wicked.reeval.addendum_appended\` | \`REEVAL_ADDENDUM\` |
| **W8** | \`phases/{phase}/convergence-log.jsonl\` | \`wicked.convergence.transition_recorded\` | \`CONVERGENCE\` |
| **W10a** | \`phases/review/semantic-gap-report.json\` | \`wicked.review.semantic_gap_recorded\` | \`SEMANTIC_GAP\` |

All four flags **default-ON** in main after merge. Operators opt out per-site with \`WG_BUS_AS_TRUTH_<TOKEN>=off\`.

## Projector handlers

Three handlers (W6/W7/W8) follow the JSONL append pattern: replay the \`raw_payload\` line into the same path with line-presence idempotency (skip when the exact line already exists). Common boilerplate factored into \`_jsonl_append_projection\` helper.

**W7 dual-file**: the source's \`reeval_addendum.append()\` writes BOTH the per-phase log AND the project-root mirror per call; the projector handler replays BOTH writes in the same order with per-file idempotency.

**W10a full-file rewrite**: \`semantic-gap-report.json\` is overwritten in full per call (not appended); content-hash idempotency + atomic temp+rename, same shape as Site 5's gate-result handler.

## Resolvers — payload-aware multi-path

W6/W8/W10a use single-file resolvers. **W7** uses a custom dual-path resolver (per-phase + project-root). **W10a** uses a custom resolver that pins to \`phases/review/\` regardless of the event's chain_id phase segment.

## Source emit wiring

Each emit fires BEFORE the legacy disk write/append, fail-open per Decision #8:

- \`amendments.append()\`: chain_id \`{project}.{phase}.{amendment_id}\`
- \`reeval_addendum.append()\`: chain_id from the record (or synthesised from timestamp)
- \`convergence.record_transition()\`: chain_id \`{project}.{phase}.{artifact_id}\`
- semantic-gap (\`phase_manager.py:2575\`): chain_id includes \`report.score\`

## Tests

- **NEW**: \`tests/daemon/test_projector_tranche_b.py\` (15 tests)
  - Registration, per-site flag-off, happy paths, idempotent replay, dual-file invariants, content-hash short-circuit, resolver mappings
- **Updated**: \`tests/test_reconcile_v2.py\` — env-control tests include 4 new Tranche B flags
- **Updated**: \`tests/test_bus_emit_health.py\` — default-ON frozenset expects 11 tokens

## Test plan

- [x] \`tests/daemon/test_projector_tranche_b.py\` — 15/15 pass
- [x] \`tests/test_reconcile_v2.py\`, \`tests/test_bus_emit_health.py\` — full pass
- [x] All other daemon/crew/hooks tests — pass
- [x] **Full suite**: 2489 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs, stub audit on \`_stack_signals.py\` — same set on \`origin/main\`)

## Bus-cutover state after this merge

| Wave | Sites | Status |
|------|-------|--------|
| Wave 1 | 1-5 | ✅ default-ON |
| W1 | solo_mode | ✅ default-ON (PR #788) |
| Tranche A | W2/W3/W4 + W10 exempts | ✅ exempts + summary emits (PR #789) |
| Tranche B | W6/W7/W8/W10a | ✅ default-ON (this PR) |

**Remaining**: Tranche C (W5 hitl_judge, W9a/W9b subagent_lifecycle refactor + cutover, W10b status.md SKIPPED) per \`docs/v9/wave-2-cutover-plan.md\` §3.

## Refs

- Wave-2 plan: \`docs/v9/wave-2-cutover-plan.md\` (PR #786)
- Per-site W6/W7/W8/W10a sections (lines 247-459)
- Design lessons: \`memory/ship-inert-and-activate-later-is-a-contradiction-bundle-instead.md\`, \`memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)