### PR TITLE
feat(crew): wave-2 Tranche C — W5 + W9a/W9b + W10b bundled (#746) — bus-cutover COMPLETE

### DIFF
--- a/agents/crew/independent-reviewer.md
+++ b/agents/crew/independent-reviewer.md
@@ -101,7 +101,7 @@ If `evidence_items_checked` == 0 and complexity >= 5: add a finding (but do not 
 
 ### 6. Check Specialist Engagement
 
-Read `{phase_dir}/specialist-engagement.json` if it exists.
+Read `{phase_dir}/specialist-engagement.jsonl` if it exists (one JSON object per line; refactored from JSON-array to JSONL in Site W9a wave-2 cutover).  For pre-W9a projects, fall back to the legacy `{phase_dir}/specialist-engagement.json` (single JSON array).
 Count the number of entries (each entry = one specialist engagement).
 
 If specialist engagement count == 0 and complexity >= 5:

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -226,6 +226,126 @@ def _phase_transitioned(conn: sqlite3.Connection, event: dict) -> None:
         "projector: applied %s project_id=%r %r -> %r", et, project_id, phase_from, phase_to
     )
 
+    # Site W10b fan-out (#746): when the transition is SKIPPED, ALSO
+    # materialise phases/{phase_from}/status.md from the same event.
+    # Gated on WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS.  Wrapped in
+    # try/except so a status-md write failure NEVER taints the DB-row
+    # work above (Decision #8).
+    try:
+        if str(_opt(payload, "gate_result", "")).upper() == "SKIPPED":
+            _phase_skipped_status_md(conn, event)
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        logger.exception(
+            "projector: _phase_skipped_status_md fan-out raised — "
+            "DB-row projection preserved; status.md may not have been written"
+        )
+
+
+def _phase_skipped_status_md(conn: sqlite3.Connection, event: dict) -> None:
+    """Materialise phases/{phase}/status.md for a SKIPPED phase transition.
+
+    Site W10b of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS``.  Mirrors the markdown
+    shape that ``phase_manager.skip_phase`` writes at line 4188 so
+    projection and direct-write paths produce byte-identical output.
+
+    Payload contract (from skip_phase emit):
+      project_id, phase_from (the phase being skipped),
+      gate_result == "SKIPPED" (the SKIPPED sentinel),
+      approver, skip_reason, skipped_at.
+
+    Idempotency: content-hash short-circuit on rewrite.
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("SKIPPED_PHASE_STATUS")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    project_id = payload.get("project_id")
+    phase_from = payload.get("phase_from")
+    if not project_id or not phase_from:
+        return
+
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: status.md SKIPPED — project %r has no directory in DB; "
+            "skipping",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    target = project_dir / "phases" / str(phase_from) / "status.md"
+
+    approver = payload.get("approver", "auto")
+    skip_reason = payload.get("skip_reason", "")
+    skipped_at = payload.get("skipped_at", "")
+
+    body = (
+        f"---\n"
+        f"phase: {phase_from}\n"
+        f"status: skipped\n"
+        f"skipped_at: {skipped_at}\n"
+        f"approved_by: {approver}\n"
+        f"---\n\n"
+        f"# {str(phase_from).replace('-', ' ').title()} Phase — Skipped\n\n"
+        f"**Reason**: {skip_reason or 'Not applicable for this project scope'}\n\n"
+        f"**Approved by**: {approver}\n"
+    )
+    candidate_bytes = body.encode("utf-8")
+
+    import hashlib
+    try:
+        if target.exists():
+            existing_bytes = target.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: status.md SKIPPED — content hash matches "
+                    "existing %s; skipping rewrite", target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: status.md SKIPPED — could not read %s for "
+            "idempotency check: %s; proceeding to write", target, exc,
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(target)
+    except OSError as exc:
+        logger.warning(
+            "projector: status.md SKIPPED — write failed at %s: %s",
+            target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied status.md SKIPPED projection "
+        "project_id=%r phase=%r path=%s",
+        project_id, phase_from, target,
+    )
+
 
 def _phase_auto_advanced(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.phase.auto_advanced — phase-approved audit event.
@@ -2275,6 +2395,158 @@ def _semantic_gap_recorded(conn: sqlite3.Connection, event: dict) -> None:
     )
 
 
+# --- Wave-2 Tranche C (#746): W5 + W9b -------------------------------------
+
+
+# Whitelist of HITL evidence filenames the projector will materialise.
+# Caller-supplied filenames outside this set are rejected to defend
+# against path-traversal via payload (e.g. "../../etc/passwd").  See
+# wave-2 plan §W5 lines 233-239 for the threat model.
+_HITL_FILENAME_WHITELIST: frozenset = frozenset({
+    "hitl-decision.json",
+    "council-decision.json",
+    "hitl-challenge-decision.json",
+    "hitl-clarify-decision.json",
+    "hitl-council-decision.json",
+})
+
+
+def _hitl_decision_recorded(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.hitl.decision_recorded → phases/{phase}/{filename}.
+
+    Site W5 of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_HITL_DECISION``.  Replays the raw_payload bytes
+    (the JSON-serialised JudgeDecision) into the same path
+    ``hitl_judge.write_hitl_decision_evidence`` writes to.
+
+    Filename safety: payload["filename"] is caller-supplied (the three
+    integration points pass different names — clarify-halt vs council
+    vs challenge).  The handler validates the name against
+    ``_HITL_FILENAME_WHITELIST`` before writing.  Anything outside the
+    whitelist is rejected with a warning — defends against
+    path-traversal vectors via crafted payloads.
+
+    Idempotency: content-hash short-circuit (full-file rewrite, not append).
+    """
+    global _BUS_IMPORT_WARNED
+    try:
+        from _bus import _bus_as_truth_enabled  # type: ignore[import]
+        flag_on = _bus_as_truth_enabled("HITL_DECISION")
+    except ImportError as exc:
+        if not _BUS_IMPORT_WARNED:
+            logger.warning(
+                "projector: _bus import failed — treating WG_BUS_AS_TRUTH_* "
+                "flags as off: %s", exc,
+            )
+            _BUS_IMPORT_WARNED = True
+        flag_on = False
+    except Exception:  # noqa: BLE001 — keep fail-open
+        flag_on = False
+
+    if not flag_on:
+        return
+
+    payload = event.get("payload", {})
+    et = event.get("event_type", "")
+
+    project_id, ok = _require(payload, "project_id", et)
+    if not ok:
+        return
+    phase, ok = _require(payload, "phase", et)
+    if not ok:
+        return
+    filename, ok = _require(payload, "filename", et)
+    if not ok:
+        return
+    raw_payload, ok = _require(payload, "raw_payload", et)
+    if not ok:
+        return
+
+    # Filename whitelist defense — reject anything outside the known set.
+    # This is the load-bearing security check; caller-supplied filenames
+    # could otherwise traverse out of phases/{phase}/ via "../" or write
+    # to arbitrary basenames.
+    if str(filename) not in _HITL_FILENAME_WHITELIST:
+        logger.warning(
+            "projector: wicked.hitl.decision_recorded — filename %r is "
+            "not in the whitelist; refusing to write (defends against "
+            "path-traversal via payload)",
+            filename,
+        )
+        return
+
+    project_row = db.get_project(conn, str(project_id))
+    if project_row is None or not project_row.get("directory"):
+        logger.warning(
+            "projector: wicked.hitl.decision_recorded — project %r has no "
+            "directory in DB; skipping",
+            project_id,
+        )
+        return
+
+    project_dir = Path(project_row["directory"])
+    target = project_dir / "phases" / str(phase) / str(filename)
+    candidate_bytes = str(raw_payload).encode("utf-8")
+
+    import hashlib
+    try:
+        if target.exists():
+            existing_bytes = target.read_bytes()
+            if (
+                hashlib.sha256(existing_bytes).digest()
+                == hashlib.sha256(candidate_bytes).digest()
+            ):
+                logger.debug(
+                    "projector: hitl decision — content hash matches "
+                    "existing %s; skipping rewrite", target,
+                )
+                return
+    except OSError as exc:
+        logger.warning(
+            "projector: hitl decision — could not read %s for idempotency "
+            "check: %s; proceeding to write", target, exc,
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(candidate_bytes)
+        tmp.replace(target)
+    except OSError as exc:
+        logger.warning(
+            "projector: hitl decision — write failed at %s: %s",
+            target, exc,
+        )
+        return
+
+    logger.debug(
+        "projector: applied wicked.hitl.decision_recorded "
+        "project_id=%r phase=%r filename=%r",
+        project_id, phase, filename,
+    )
+
+
+def _subagent_engaged(conn: sqlite3.Connection, event: dict) -> None:
+    """Project wicked.subagent.engaged → phases/{phase}/specialist-engagement.jsonl.
+
+    Site W9b of bus-cutover wave-2 (#746).  Gated on
+    ``WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT``.  Replays the raw_payload
+    JSONL line from ``subagent_lifecycle._record_specialist_engagement``
+    into the same file.
+
+    The W9a precursor (in this same PR) refactored the source from
+    ``specialist-engagement.json`` (JSON array, read-modify-write) to
+    ``specialist-engagement.jsonl`` (append-only).  This handler uses
+    the standard JSONL append pattern.
+    """
+    _jsonl_append_projection(
+        conn, event,
+        flag_token="SUBAGENT_ENGAGEMENT",
+        relative_template="phases/{phase}/specialist-engagement.jsonl",
+        handler_name="wicked.subagent.engaged",
+    )
+
+
 def _gate_blocked(conn: sqlite3.Connection, event: dict) -> None:
     """Project wicked.gate.blocked → no-op disk handler (PR-1 inert).
 
@@ -2417,6 +2689,15 @@ _HANDLERS: dict[str, Callable[[sqlite3.Connection, dict], None]] = {
     "wicked.reeval.addendum_appended":        _reeval_addendum_appended,
     "wicked.convergence.transition_recorded": _convergence_transition_recorded,
     "wicked.review.semantic_gap_recorded":    _semantic_gap_recorded,
+    # Wave-2 Tranche C (#746):
+    # W5 hitl pause-decision evidence (payload-aware-on-filename with whitelist).
+    # W9b specialist engagement (JSONL append after W9a JSON→JSONL refactor
+    # in this same PR).
+    # W10b status.md SKIPPED is NOT a separate event — it fans out from
+    # the existing _phase_transitioned handler when payload signals
+    # gate_result=="SKIPPED" (gated on WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS).
+    "wicked.hitl.decision_recorded":          _hitl_decision_recorded,
+    "wicked.subagent.engaged":                _subagent_engaged,
 }
 
 

--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -984,15 +984,37 @@ def _check_specialist_engagement(phase_dir: Path, phase_name: str, phases_config
     if not required or complexity < 5:
         return ""
 
-    engagement_path = phase_dir / "specialist-engagement.json"
-    if not engagement_path.exists():
-        engaged_domains: set = set()
-    else:
-        entries = _safe_read_json(engagement_path)
+    # Site W9 of bus-cutover wave-2 (#746): the engagement file
+    # was refactored from JSON-array (read-modify-write) to JSONL
+    # (append-only) in W9a.  Read the JSONL form preferentially; fall
+    # back to the legacy .json form for production projects that
+    # haven't yet had their first post-W9a engagement recorded.  The
+    # next engagement append starts the .jsonl file fresh; both readers
+    # eventually converge on JSONL as projects exercise the hook.
+    engaged_domains: set = set()
+    engagement_jsonl = phase_dir / "specialist-engagement.jsonl"
+    engagement_json = phase_dir / "specialist-engagement.json"
+    if engagement_jsonl.exists():
+        try:
+            for line in engagement_jsonl.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(entry, dict):
+                    engaged_domains.add(entry.get("domain", ""))
+        except OSError:
+            pass  # fail-open: file unreadable → treat as no engagement
+    elif engagement_json.exists():
+        # Legacy backward-compat read for pre-W9a projects.
+        entries = _safe_read_json(engagement_json)
         if isinstance(entries, list):
-            engaged_domains = {e.get("domain", "") for e in entries if isinstance(e, dict)}
-        else:
-            engaged_domains = set()
+            engaged_domains = {
+                e.get("domain", "") for e in entries if isinstance(e, dict)
+            }
 
     missing = [s for s in required if s not in engaged_domains]
     if missing:

--- a/hooks/scripts/subagent_lifecycle.py
+++ b/hooks/scripts/subagent_lifecycle.py
@@ -214,11 +214,25 @@ def _record_specialist_engagement(domain: str, agent_name: str) -> None:
     """Append a specialist engagement entry to the active phase directory.
 
     Writes to:
-        {project_dir}/phases/{current_phase}/specialist-engagement.json
+        {project_dir}/phases/{current_phase}/specialist-engagement.jsonl
 
-    The file is a JSON array. If it does not exist it is created; if it
-    exists the new entry is appended.  All errors are silently swallowed so
-    the hook never blocks on I/O failures.
+    Site W9 of bus-cutover wave-2 (#746):
+      * W9a refactor (this PR): switched from JSON array (read-modify-write)
+        to JSONL (append-only).  The append-only form aligns with the
+        bus-as-truth premise — events are append-only, so the on-disk
+        projection should be too.  Read-modify-write the JSON array
+        contradicted that premise and was a pre-bus design choice.
+      * W9b cutover (this PR): fires ``wicked.subagent.engaged`` BEFORE
+        the JSONL append so the projector handler can replay the same
+        line.  Gated on WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT.
+
+    Backward compatibility: legacy ``specialist-engagement.json`` files
+    in production projects are handled by the reader (see
+    ``hooks/scripts/pre_tool.py``) — JSONL preferred, .json fallback on
+    miss.  No migration tool needed; the next engagement append starts
+    the JSONL file fresh.
+
+    All errors are silently swallowed so the hook never blocks on I/O failures.
     """
     try:
         from _session import SessionState
@@ -258,27 +272,52 @@ def _record_specialist_engagement(domain: str, agent_name: str) -> None:
         base = get_local_path("wicked-crew", "projects")
         phase_dir = base / project_id / "phases" / current_phase
         phase_dir.mkdir(parents=True, exist_ok=True)
-        engagement_file = phase_dir / "specialist-engagement.json"
+        engagement_file = phase_dir / "specialist-engagement.jsonl"
 
-        # Load existing entries or start fresh
-        entries: list = []
-        if engagement_file.exists():
-            try:
-                entries = json.loads(engagement_file.read_text(encoding="utf-8"))
-                if not isinstance(entries, list):
-                    entries = []
-            except Exception:
-                entries = []
-
-        entries.append({
+        entry = {
             "domain": domain,
             "agent": agent_name,
             "completed_at": _now_iso(),
-        })
+        }
+        line = json.dumps(entry, sort_keys=False) + "\n"
 
-        tmp_path = engagement_file.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
-        os.replace(tmp_path, engagement_file)
+        # W9b emit BEFORE the disk append so the projector can replay the
+        # same line.  chain_id includes the agent_name + completed_at so
+        # multiple engagements in the same phase are uniquely identifiable
+        # downstream (per memory/bus-chain-id-must-include-uniqueness-segment-gotcha).
+        # Fail-open: bus unavailable must NOT block the append.
+        try:
+            import sys as _sys
+            from pathlib import Path as _Path
+            _scripts_root = str(_Path(__file__).resolve().parents[2] / "scripts")
+            if _scripts_root not in _sys.path:
+                _sys.path.insert(0, _scripts_root)
+            from _bus import emit_event  # type: ignore[import]
+            ts_compact = "".join(ch for ch in entry["completed_at"] if ch.isdigit())[:14] or "noid"
+            emit_event(
+                "wicked.subagent.engaged",
+                {
+                    "project_id": project_id,
+                    "phase": current_phase,
+                    "domain": domain,
+                    "agent": agent_name,
+                    "raw_payload": line,
+                },
+                chain_id=f"{project_id}.{current_phase}.{agent_name}-{ts_compact}",
+            )
+        except Exception:  # noqa: BLE001 — fail-open per Decision #8
+            pass  # bus unavailable — append below still runs
+
+        # JSONL append-only write (W9a refactor).  Mirrors the
+        # _jsonl_append_projection helper in daemon/projector.py for
+        # crash semantics: open("a") + flush + best-effort fsync.
+        with open(engagement_file, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass  # fail-open: fsync unsupported on this FS
 
     except Exception as exc:
         print(f"[wicked-garden] specialist engagement record error: {exc}", file=sys.stderr)

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -155,6 +155,17 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.review",
         "description": "Semantic-gap report persisted at review phase (Site W10a cutover)",
     },
+    # Wave-2 Tranche C (#746):
+    "wicked.hitl.decision_recorded": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.hitl",
+        "description": "HITL pause-decision evidence recorded by hitl_judge.write_hitl_decision_evidence (Site W5 cutover)",
+    },
+    "wicked.subagent.engaged": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.subagent",
+        "description": "Specialist subagent engagement recorded by subagent_lifecycle (Site W9b cutover)",
+    },
     # Jam domain — jam.py
     "wicked.session.started": {
         "domain": "wicked-garden",
@@ -337,6 +348,13 @@ _PAYLOAD_ALLOW_OVERRIDES: Dict[str, frozenset] = {
     "wicked.reeval.addendum_appended": frozenset({"raw_payload"}),
     "wicked.convergence.transition_recorded": frozenset({"raw_payload"}),
     "wicked.review.semantic_gap_recorded": frozenset({"raw_payload"}),
+    # Wave-2 Tranche C (#746): hitl + subagent_engagement carry the
+    # canonical bytes via raw_payload so the projector can reproduce
+    # the file byte-for-byte.  hitl additionally carries `filename`
+    # (caller-supplied evidence file name) — the projector validates it
+    # against a whitelist before writing to phases/{phase}/{filename}.
+    "wicked.hitl.decision_recorded": frozenset({"raw_payload", "filename"}),
+    "wicked.subagent.engaged": frozenset({"raw_payload"}),
 }
 
 # ---------------------------------------------------------------------------
@@ -391,18 +409,22 @@ def _is_disabled() -> bool:
 # ---------------------------------------------------------------------------
 
 _BUS_AS_TRUTH_DEFAULT_ON: frozenset = frozenset({
-    "DISPATCH_LOG",          # Site 1 — dispatch-log.jsonl (PR #751)
-    "CONSENSUS_REPORT",      # Site 2 — consensus-report.json (PR #758)
-    "CONSENSUS_EVIDENCE",    # Site 2 — consensus-evidence.json (PR #758)
-    "REVIEWER_REPORT",       # Site 3 — reviewer-report.md (PR #776)
-    "GATE_RESULT",           # Site 4 — gate-result.json (PR #782 + #784)
-    "CONDITIONS_MANIFEST",   # Site 5 — conditions-manifest.json (PR #785)
-    "INLINE_REVIEW_CONTEXT", # Site W1 — inline-review-context.md (PR #788)
-    # Wave-2 Tranche B (this PR):
-    "AMENDMENTS",            # Site W6 — amendments.jsonl
-    "REEVAL_ADDENDUM",       # Site W7 — reeval-log.jsonl + process-plan.addendum.jsonl
-    "CONVERGENCE",           # Site W8 — convergence-log.jsonl
-    "SEMANTIC_GAP",          # Site W10a — semantic-gap-report.json
+    "DISPATCH_LOG",            # Site 1 — dispatch-log.jsonl (PR #751)
+    "CONSENSUS_REPORT",        # Site 2 — consensus-report.json (PR #758)
+    "CONSENSUS_EVIDENCE",      # Site 2 — consensus-evidence.json (PR #758)
+    "REVIEWER_REPORT",         # Site 3 — reviewer-report.md (PR #776)
+    "GATE_RESULT",             # Site 4 — gate-result.json (PR #782 + #784)
+    "CONDITIONS_MANIFEST",     # Site 5 — conditions-manifest.json (PR #785)
+    "INLINE_REVIEW_CONTEXT",   # Site W1 — inline-review-context.md (PR #788)
+    # Wave-2 Tranche B (PR #790):
+    "AMENDMENTS",              # Site W6
+    "REEVAL_ADDENDUM",         # Site W7
+    "CONVERGENCE",             # Site W8
+    "SEMANTIC_GAP",            # Site W10a
+    # Wave-2 Tranche C (this PR):
+    "HITL_DECISION",           # Site W5 — phases/{phase}/hitl-*.json + council-*.json
+    "SUBAGENT_ENGAGEMENT",     # Site W9b — phases/{phase}/specialist-engagement.jsonl
+    "SKIPPED_PHASE_STATUS",    # Site W10b — phases/{phase}/status.md (SKIPPED only)
 })
 
 

--- a/scripts/crew/hitl_judge.py
+++ b/scripts/crew/hitl_judge.py
@@ -610,8 +610,39 @@ def write_hitl_decision_evidence(
     target_dir = project_dir / "phases" / phase
     target_dir.mkdir(parents=True, exist_ok=True)
     target_path = target_dir / filename
-    target_path.write_text(
-        json.dumps(decision.to_dict(), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+
+    # Site W5 of bus-cutover wave-2 (#746): emit BEFORE the disk write
+    # so the projector handler can replay the same bytes.  chain_id
+    # uses {project}.{phase}.{filename-stem} for per-evidence-file
+    # uniqueness (different decisions land in different files within
+    # the same phase: hitl-decision.json vs hitl-council-decision.json
+    # vs hitl-challenge-decision.json).  Fail-open: bus unavailable
+    # must NOT block the disk write — evidence loss must be visible.
+    body_bytes = json.dumps(decision.to_dict(), indent=2, sort_keys=True)
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        from _bus import emit_event  # type: ignore[import]
+        project_id_str = project_dir.name
+        # filename stem (strip .json) for chain_id discriminator
+        filename_stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+        emit_event(
+            "wicked.hitl.decision_recorded",
+            {
+                "project_id": project_id_str,
+                "phase": phase,
+                "filename": filename,
+                "raw_payload": body_bytes,
+                "pause": decision.pause,
+                "rule_id": decision.rule_id,
+            },
+            chain_id=f"{project_id_str}.{phase}.{filename_stem}",
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — direct write below still runs
+
+    target_path.write_text(body_bytes, encoding="utf-8")
     return target_path

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -4198,6 +4198,36 @@ def skip_phase(state: ProjectState, phase: str, reason: str = "", approved_by: s
         f"**Reason**: {reason or 'Not applicable for this project scope'}\n\n"
         f"**Approved by**: {approved_by}\n"
     )
+
+    # Site W10b of bus-cutover wave-2 (#746): emit
+    # ``wicked.phase.transitioned`` with ``gate_result="SKIPPED"`` BEFORE
+    # the disk write so the projector handler can fan out to
+    # status.md materialisation (gated on
+    # WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS).  The wave-2 plan W10b
+    # initially assumed the existing event covered SKIPPED transitions;
+    # verification showed skip_phase did not previously emit at all
+    # (only approve_phase did at line ~4055).  Adding the emit here
+    # closes that gap and keeps the bus-as-truth invariant for SKIPPED
+    # transitions on par with APPROVE/CONDITIONAL/REJECT.
+    # Fail-open: bus unavailable must NOT block the disk write.
+    try:
+        from _bus import emit_event
+        emit_event(
+            "wicked.phase.transitioned",
+            {
+                "project_id": state.name,
+                "phase_from": phase,
+                "phase_to": None,  # skip does not advance to a next phase
+                "approver": approved_by,
+                "gate_result": "SKIPPED",  # sentinel for the W10b fan-out
+                "skip_reason": reason or "",
+                "skipped_at": phase_state.completed_at,
+            },
+            chain_id=getattr(state, "chain_id", None),
+        )
+    except Exception:  # noqa: BLE001 — fail-open per Decision #8
+        pass  # bus unavailable — direct write below still runs
+
     status_file.write_text(status_content)
 
     return state

--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -201,6 +201,45 @@ _PROJECTION_RESOLVERS: Dict[str, Callable[[Dict[str, Any], str, Path], "list[Pat
     "wicked.review.semantic_gap_recorded": lambda payload, phase, project_dir: [
         project_dir / "phases" / "review" / "semantic-gap-report.json",
     ],
+    # Wave-2 Tranche C (this PR) — payload-aware-on-filename + JSONL.
+    # W5 hitl: caller supplies the filename (different evidence files
+    # for clarify-halt vs council-synthesis vs challenge-charter).
+    # The resolver whitelists known filenames to defend against
+    # path-traversal via payload — anything outside the whitelist
+    # returns an empty list (no projection target → drift detector
+    # skips, projector handler refuses to write).
+    "wicked.hitl.decision_recorded": lambda payload, phase, project_dir: (
+        [project_dir / "phases" / phase / payload["filename"]]
+        if (
+            isinstance(payload, dict)
+            and isinstance(payload.get("filename"), str)
+            and payload["filename"] in {
+                "hitl-decision.json",
+                "council-decision.json",
+                "hitl-challenge-decision.json",
+                "hitl-clarify-decision.json",
+                "hitl-council-decision.json",
+            }
+        )
+        else []
+    ),
+    # W9b subagent engagement — single-file resolver to JSONL form.
+    # Note: W9a (precursor in this same PR) renamed the source from
+    # ``specialist-engagement.json`` (JSON array, RMW) to
+    # ``specialist-engagement.jsonl`` (append-only JSONL).  The reader
+    # in hooks/scripts/pre_tool.py reads JSONL preferentially with a
+    # one-shot legacy fallback to the .json form.
+    "wicked.subagent.engaged": _resolve_single_file(
+        "phases/{phase}/specialist-engagement.jsonl"
+    ),
+    # W10b — status.md SKIPPED projection is NOT a separate event.
+    # The existing ``wicked.phase.transitioned`` event covers it; the
+    # projector handler ``_phase_transitioned`` is extended to fan out
+    # to a status.md write when payload signals a SKIPPED transition
+    # (gate_result == "SKIPPED").  No entry needed in this resolver
+    # map — the status.md fan-out happens INSIDE the existing
+    # _phase_transitioned handler, gated on
+    # WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS.
 }
 
 
@@ -256,6 +295,22 @@ PROJECTION_FILE_FLAGS: Dict[str, str] = {
     "reeval-log.jsonl":            "REEVAL_ADDENDUM",       # Site W7 — re-eval per-phase log (project-root mirror also produced from same event)
     "convergence-log.jsonl":       "CONVERGENCE",           # Site W8 — artifact convergence log
     "semantic-gap-report.json":    "SEMANTIC_GAP",          # Site W10a — semantic alignment report
+    # Wave-2 Tranche C (this PR) — active default-ON:
+    # W5 hitl_judge writes to filename specified by caller; the resolver
+    # validates against a whitelist of known evidence filenames.  All
+    # five share the HITL_DECISION flag.
+    "hitl-decision.json":              "HITL_DECISION",          # Site W5 — clarify-halt
+    "council-decision.json":           "HITL_DECISION",          # Site W5 — council synthesis
+    "hitl-challenge-decision.json":    "HITL_DECISION",          # Site W5 — challenge dispatch
+    "hitl-clarify-decision.json":      "HITL_DECISION",          # Site W5 — alternate clarify-halt name
+    "hitl-council-decision.json":      "HITL_DECISION",          # Site W5 — alternate council name
+    "specialist-engagement.jsonl":     "SUBAGENT_ENGAGEMENT",    # Site W9 — refactored from .json (W9a) + cutover (W9b)
+    # NOTE: status.md is intentionally NOT in this map.  Several
+    # phase_manager code paths write status.md (SKIPPED, gate-override
+    # audit, etc.); only the SKIPPED path is bus-projected via
+    # _phase_transitioned's payload-aware fan-out (W10b).  Tracking
+    # status.md as a projection target would surface the override-audit
+    # writes as projection-without-event drift.
 }
 
 # ---------------------------------------------------------------------------
@@ -354,6 +409,9 @@ _PROJECTION_HANDLERS_AVAILABLE: Dict[str, bool] = {
     "wicked.reeval.addendum_appended":         True,
     "wicked.convergence.transition_recorded":  True,
     "wicked.review.semantic_gap_recorded":     True,
+    # Wave-2 Tranche C (this PR) — handlers shipped below.
+    "wicked.hitl.decision_recorded":           True,
+    "wicked.subagent.engaged":                 True,
     # Site 5 — no event handler mapping yet
     # (conditions-manifest.json has no event type in _PROJECTION_RESOLVERS)
 }

--- a/tests/daemon/test_projector_tranche_c.py
+++ b/tests/daemon/test_projector_tranche_c.py
@@ -1,0 +1,451 @@
+"""tests/daemon/test_projector_tranche_c.py — Wave-2 Tranche C projector
+handler tests (#746).
+
+Sites covered:
+  * W5  ``wicked.hitl.decision_recorded``    → phases/{phase}/{filename}
+        (filename validated against whitelist)
+  * W9b ``wicked.subagent.engaged``          → phases/{phase}/specialist-engagement.jsonl
+  * W10b ``wicked.phase.transitioned`` (SKIPPED) fan-out
+        → phases/{phase}/status.md (NEW behaviour, not a new event)
+
+T1: deterministic.  T3: isolated tmp_path + in-memory DB.  T6: provenance #746 wave-2 C.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+_SCRIPTS_CREW = _REPO_ROOT / "scripts" / "crew"
+
+for p in (_REPO_ROOT, _SCRIPTS, _SCRIPTS_CREW):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+def _setup_project(conn, project_id: str, project_dir: Path) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_tranche_c_handlers_registered() -> None:
+    from daemon.projector import (
+        _HANDLERS,
+        _hitl_decision_recorded,
+        _subagent_engaged,
+    )
+    assert _HANDLERS["wicked.hitl.decision_recorded"] is _hitl_decision_recorded
+    assert _HANDLERS["wicked.subagent.engaged"] is _subagent_engaged
+
+
+# ---------------------------------------------------------------------------
+# W5 — hitl.decision_recorded
+# ---------------------------------------------------------------------------
+
+
+def _hitl_event(
+    *,
+    project_id: str,
+    phase: str = "clarify",
+    filename: str = "hitl-decision.json",
+    body: str = '{"pause": false}',
+) -> dict:
+    return {
+        "event_id": 1,
+        "event_type": "wicked.hitl.decision_recorded",
+        "chain_id": f"{project_id}.{phase}.x",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": project_id,
+            "phase": phase,
+            "filename": filename,
+            "raw_payload": body,
+        },
+    }
+
+
+def test_hitl_flag_off_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _hitl_decision_recorded
+    project_dir = tmp_path / "p-hitl-off"
+    _setup_project(mem_conn, "p-hitl-off", project_dir)
+    target = project_dir / "phases" / "clarify" / "hitl-decision.json"
+
+    event = _hitl_event(project_id="p-hitl-off")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_HITL_DECISION": "off"}):
+        _hitl_decision_recorded(mem_conn, event)
+    assert not target.exists()
+
+
+def test_hitl_happy_path_writes_file(mem_conn, tmp_path) -> None:
+    from daemon.projector import _hitl_decision_recorded
+    project_dir = tmp_path / "p-hitl-on"
+    _setup_project(mem_conn, "p-hitl-on", project_dir)
+    target = project_dir / "phases" / "clarify" / "hitl-decision.json"
+
+    body = json.dumps({"pause": True, "rule_id": "council.split"})
+    event = _hitl_event(project_id="p-hitl-on", body=body)
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_HITL_DECISION": "on"}):
+        _hitl_decision_recorded(mem_conn, event)
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == body
+
+
+def test_hitl_council_filename_writes_to_council_phase(mem_conn, tmp_path) -> None:
+    """council-decision.json is in the whitelist; council phase is the actual phase."""
+    from daemon.projector import _hitl_decision_recorded
+    project_dir = tmp_path / "p-hitl-council"
+    _setup_project(mem_conn, "p-hitl-council", project_dir)
+    target = project_dir / "phases" / "council" / "council-decision.json"
+
+    event = _hitl_event(
+        project_id="p-hitl-council",
+        phase="council",
+        filename="council-decision.json",
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_HITL_DECISION": "on"}):
+        _hitl_decision_recorded(mem_conn, event)
+    assert target.exists()
+
+
+def test_hitl_filename_traversal_rejected(mem_conn, tmp_path) -> None:
+    """Filenames outside the whitelist (incl. path-traversal attempts) are rejected."""
+    from daemon.projector import _hitl_decision_recorded
+    project_dir = tmp_path / "p-hitl-traverse"
+    _setup_project(mem_conn, "p-hitl-traverse", project_dir)
+
+    # Attempt 1: path-traversal up the tree
+    event_traverse = _hitl_event(
+        project_id="p-hitl-traverse",
+        filename="../../../etc/passwd",
+    )
+    # Attempt 2: arbitrary unknown filename
+    event_unknown = _hitl_event(
+        project_id="p-hitl-traverse",
+        filename="arbitrary-name.json",
+    )
+
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_HITL_DECISION": "on"}):
+        _hitl_decision_recorded(mem_conn, event_traverse)
+        _hitl_decision_recorded(mem_conn, event_unknown)
+
+    # Nothing materialised — projector refused both names.
+    assert not (project_dir / "phases" / "clarify" / "arbitrary-name.json").exists()
+    # The traversal target obviously shouldn't exist either.
+    assert not Path("/etc/passwd-projected-by-evil").exists()  # never possible
+    # Confirm the only legitimate targets were untouched.
+    assert not (project_dir / "phases" / "clarify" / "hitl-decision.json").exists()
+
+
+def test_hitl_replay_short_circuits_via_content_hash(mem_conn, tmp_path) -> None:
+    from daemon.projector import _hitl_decision_recorded
+    project_dir = tmp_path / "p-hitl-replay"
+    _setup_project(mem_conn, "p-hitl-replay", project_dir)
+    target = project_dir / "phases" / "clarify" / "hitl-decision.json"
+
+    event = _hitl_event(project_id="p-hitl-replay")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_HITL_DECISION": "on"}):
+        _hitl_decision_recorded(mem_conn, event)
+        first_mtime = target.stat().st_mtime_ns
+        _hitl_decision_recorded(mem_conn, event)
+        second_mtime = target.stat().st_mtime_ns
+    assert first_mtime == second_mtime
+
+
+def test_hitl_resolver_rejects_unknown_filename() -> None:
+    """The resolver returns an empty list for filenames outside the whitelist —
+    the drift detector then ignores the projection target entirely (defense in
+    depth alongside the handler-side whitelist check)."""
+    import reconcile_v2  # type: ignore[import]
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/p"),
+        "wicked.hitl.decision_recorded",
+        "p.clarify.x",
+        {"project_id": "p", "phase": "clarify", "filename": "../etc/passwd"},
+    )
+    assert paths == []
+
+
+def test_hitl_resolver_returns_phase_filename_for_whitelisted() -> None:
+    import reconcile_v2  # type: ignore[import]
+    paths = reconcile_v2._materialize_projection_paths(
+        Path("/tmp/p"),
+        "wicked.hitl.decision_recorded",
+        "p.clarify.x",
+        {"project_id": "p", "phase": "clarify", "filename": "hitl-decision.json"},
+    )
+    assert len(paths) == 1
+    assert str(paths[0]).endswith("phases/clarify/hitl-decision.json")
+
+
+# ---------------------------------------------------------------------------
+# W9b — subagent.engaged → specialist-engagement.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_engaged_appends_jsonl(mem_conn, tmp_path) -> None:
+    from daemon.projector import _subagent_engaged
+    project_dir = tmp_path / "p-sub"
+    _setup_project(mem_conn, "p-sub", project_dir)
+    target = project_dir / "phases" / "build" / "specialist-engagement.jsonl"
+
+    line = '{"domain": "engineering", "agent": "senior-engineer"}'
+    event = {
+        "event_id": 1,
+        "event_type": "wicked.subagent.engaged",
+        "chain_id": "p-sub.build.engineering",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": "p-sub",
+            "phase": "build",
+            "raw_payload": line,
+        },
+    }
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT": "on"}):
+        _subagent_engaged(mem_conn, event)
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == line + "\n"
+
+
+def test_subagent_engaged_replay_idempotent(mem_conn, tmp_path) -> None:
+    from daemon.projector import _subagent_engaged
+    project_dir = tmp_path / "p-sub-replay"
+    _setup_project(mem_conn, "p-sub-replay", project_dir)
+    target = project_dir / "phases" / "build" / "specialist-engagement.jsonl"
+
+    line = '{"domain": "engineering", "agent": "senior-engineer"}'
+    event = {
+        "event_id": 1,
+        "event_type": "wicked.subagent.engaged",
+        "chain_id": "p-sub-replay.build.x",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": "p-sub-replay",
+            "phase": "build",
+            "raw_payload": line,
+        },
+    }
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT": "on"}):
+        _subagent_engaged(mem_conn, event)
+        _subagent_engaged(mem_conn, event)
+    assert target.read_text(encoding="utf-8") == line + "\n"
+
+
+def test_subagent_engaged_flag_off_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _subagent_engaged
+    project_dir = tmp_path / "p-sub-off"
+    _setup_project(mem_conn, "p-sub-off", project_dir)
+    target = project_dir / "phases" / "build" / "specialist-engagement.jsonl"
+
+    event = {
+        "event_id": 1,
+        "event_type": "wicked.subagent.engaged",
+        "chain_id": "p-sub-off.build.x",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": "p-sub-off",
+            "phase": "build",
+            "raw_payload": '{"domain": "engineering"}',
+        },
+    }
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT": "off"}):
+        _subagent_engaged(mem_conn, event)
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# W10b — _phase_transitioned fan-out to status.md on SKIPPED
+# ---------------------------------------------------------------------------
+
+
+def _phase_transitioned_skipped_event(
+    *,
+    project_id: str,
+    phase_from: str = "operate",
+    approver: str = "auto",
+    reason: str = "Out of scope",
+    skipped_at: str = "2026-05-03T18:00:00Z",
+) -> dict:
+    return {
+        "event_id": 1,
+        "event_type": "wicked.phase.transitioned",
+        "chain_id": f"{project_id}.{phase_from}",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": project_id,
+            "phase_from": phase_from,
+            "phase_to": None,
+            "approver": approver,
+            "gate_result": "SKIPPED",
+            "skip_reason": reason,
+            "skipped_at": skipped_at,
+        },
+    }
+
+
+def test_skipped_phase_status_md_flag_off_no_write(mem_conn, tmp_path) -> None:
+    from daemon.projector import _phase_transitioned
+    project_dir = tmp_path / "p-skip-off"
+    _setup_project(mem_conn, "p-skip-off", project_dir)
+    target = project_dir / "phases" / "operate" / "status.md"
+
+    event = _phase_transitioned_skipped_event(project_id="p-skip-off")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "off"}):
+        _phase_transitioned(mem_conn, event)
+    assert not target.exists()
+
+
+def test_skipped_phase_status_md_happy_path(mem_conn, tmp_path) -> None:
+    from daemon.projector import _phase_transitioned
+    project_dir = tmp_path / "p-skip-on"
+    _setup_project(mem_conn, "p-skip-on", project_dir)
+    target = project_dir / "phases" / "operate" / "status.md"
+
+    event = _phase_transitioned_skipped_event(
+        project_id="p-skip-on",
+        approver="user-explicit",
+        reason="Out of scope for this project",
+    )
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "on"}):
+        _phase_transitioned(mem_conn, event)
+
+    assert target.exists()
+    body = target.read_text(encoding="utf-8")
+    assert "phase: operate" in body
+    assert "status: skipped" in body
+    assert "approved_by: user-explicit" in body
+    assert "**Reason**: Out of scope for this project" in body
+
+
+def test_phase_transitioned_non_skipped_does_not_write_status_md(
+    mem_conn, tmp_path,
+) -> None:
+    """Non-SKIPPED transitions (APPROVE/CONDITIONAL/REJECT) must NOT
+    trigger the status.md fan-out — that is the W10b invariant."""
+    from daemon.projector import _phase_transitioned
+    project_dir = tmp_path / "p-skip-not"
+    _setup_project(mem_conn, "p-skip-not", project_dir)
+    target = project_dir / "phases" / "build" / "status.md"
+
+    event = {
+        "event_id": 1,
+        "event_type": "wicked.phase.transitioned",
+        "chain_id": "p-skip-not.build",
+        "created_at": 1_700_000_001,
+        "payload": {
+            "project_id": "p-skip-not",
+            "phase_from": "build",
+            "phase_to": "test",
+            "approver": "user",
+            "gate_result": "APPROVE",
+        },
+    }
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "on"}):
+        _phase_transitioned(mem_conn, event)
+    assert not target.exists(), (
+        "APPROVE transition must NOT trigger status.md fan-out — "
+        "fan-out is gated on gate_result=='SKIPPED'"
+    )
+
+
+def test_skipped_replay_short_circuits_via_content_hash(mem_conn, tmp_path) -> None:
+    from daemon.projector import _phase_transitioned
+    project_dir = tmp_path / "p-skip-replay"
+    _setup_project(mem_conn, "p-skip-replay", project_dir)
+    target = project_dir / "phases" / "operate" / "status.md"
+
+    event = _phase_transitioned_skipped_event(project_id="p-skip-replay")
+    with patch.dict(os.environ, {"WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "on"}):
+        _phase_transitioned(mem_conn, event)
+        first_mtime = target.stat().st_mtime_ns
+        _phase_transitioned(mem_conn, event)
+        second_mtime = target.stat().st_mtime_ns
+    assert first_mtime == second_mtime
+
+
+# ---------------------------------------------------------------------------
+# Source-side emit wirings (round-trip behaviour, no daemon needed)
+# ---------------------------------------------------------------------------
+
+
+def test_hitl_judge_emits_before_disk_write(tmp_path) -> None:
+    """write_hitl_decision_evidence emits wicked.hitl.decision_recorded
+    BEFORE writing the JSON file."""
+    from hitl_judge import write_hitl_decision_evidence, JudgeDecision  # type: ignore[import]
+
+    project_dir = tmp_path / "proj-hitl-emit"
+    project_dir.mkdir()
+
+    captured: list = []
+
+    def _fake_emit(event_type, payload, *, chain_id=None):
+        captured.append({
+            "event_type": event_type,
+            "payload": payload,
+            "chain_id": chain_id,
+        })
+
+    decision = JudgeDecision(
+        pause=True, reason="split-verdict",
+        rule_id="council.split-verdict",
+        signals={"margin": 0},
+    )
+
+    with patch("_bus.emit_event", _fake_emit):
+        path = write_hitl_decision_evidence(
+            project_dir, "council", "council-decision.json", decision,
+        )
+
+    assert path.exists()
+    assert len(captured) == 1
+    emit = captured[0]
+    assert emit["event_type"] == "wicked.hitl.decision_recorded"
+    assert emit["payload"]["project_id"] == "proj-hitl-emit"
+    assert emit["payload"]["phase"] == "council"
+    assert emit["payload"]["filename"] == "council-decision.json"
+    assert emit["payload"]["pause"] is True
+    assert emit["payload"]["rule_id"] == "council.split-verdict"
+    assert "raw_payload" in emit["payload"]
+    assert emit["chain_id"] == "proj-hitl-emit.council.council-decision"
+
+
+def test_hitl_judge_emit_failure_does_not_block_write(tmp_path) -> None:
+    """A bus-emit failure must NOT block the disk write (evidence loss
+    must be visible — Decision #8 fail-open)."""
+    from hitl_judge import write_hitl_decision_evidence, JudgeDecision  # type: ignore[import]
+
+    project_dir = tmp_path / "proj-hitl-fail"
+    project_dir.mkdir()
+
+    def _raising_emit(event_type, payload, *, chain_id=None):
+        raise RuntimeError("simulated bus failure")
+
+    decision = JudgeDecision(
+        pause=False, reason="ok", rule_id="ok", signals={},
+    )
+
+    with patch("_bus.emit_event", _raising_emit):
+        path = write_hitl_decision_evidence(
+            project_dir, "clarify", "hitl-decision.json", decision,
+        )
+
+    # Disk write happened despite emit failure.
+    assert path.exists()
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    assert parsed["pause"] is False

--- a/tests/test_bus_emit_health.py
+++ b/tests/test_bus_emit_health.py
@@ -516,22 +516,27 @@ class TestFlagFlipDefaultState(unittest.TestCase):
             self.assertFalse(_bus._bus_as_truth_enabled("NEVER_SHIPPED_TOKEN"))
 
     def test_default_on_frozenset_contains_all_shipped_sites(self) -> None:
-        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 11 shipped
-        tokens: wave-1 Sites 1-5, Site W1 (#788), and wave-2 Tranche B
-        (W6/W7/W8/W10a)."""
+        """_BUS_AS_TRUTH_DEFAULT_ON must contain exactly the 14 shipped
+        tokens: wave-1 Sites 1-5, Site W1 (PR #788), wave-2 Tranche B
+        (W6/W7/W8/W10a, PR #790), and wave-2 Tranche C (W5/W9b/W10b,
+        this PR)."""
         expected = frozenset({
-            "DISPATCH_LOG",          # Site 1
-            "CONSENSUS_REPORT",      # Site 2 (flag A)
-            "CONSENSUS_EVIDENCE",    # Site 2 (flag B — independent)
-            "REVIEWER_REPORT",       # Site 3
-            "GATE_RESULT",           # Site 4 (PR #784)
-            "CONDITIONS_MANIFEST",   # Site 5 (PR #785)
-            "INLINE_REVIEW_CONTEXT", # Site W1 (PR #788)
-            # Wave-2 Tranche B (this PR):
-            "AMENDMENTS",            # Site W6 — amendments.jsonl
-            "REEVAL_ADDENDUM",       # Site W7 — reeval-log + project addendum
-            "CONVERGENCE",           # Site W8 — convergence-log.jsonl
-            "SEMANTIC_GAP",          # Site W10a — semantic-gap-report.json
+            "DISPATCH_LOG",            # Site 1
+            "CONSENSUS_REPORT",        # Site 2 (flag A)
+            "CONSENSUS_EVIDENCE",      # Site 2 (flag B — independent)
+            "REVIEWER_REPORT",         # Site 3
+            "GATE_RESULT",             # Site 4 (PR #784)
+            "CONDITIONS_MANIFEST",     # Site 5 (PR #785)
+            "INLINE_REVIEW_CONTEXT",   # Site W1 (PR #788)
+            # Wave-2 Tranche B (PR #790):
+            "AMENDMENTS",              # W6
+            "REEVAL_ADDENDUM",         # W7
+            "CONVERGENCE",             # W8
+            "SEMANTIC_GAP",            # W10a
+            # Wave-2 Tranche C (this PR):
+            "HITL_DECISION",           # W5
+            "SUBAGENT_ENGAGEMENT",     # W9b (W9a JSON→JSONL refactor in same PR)
+            "SKIPPED_PHASE_STATUS",    # W10b
         })
         self.assertEqual(_bus._BUS_AS_TRUTH_DEFAULT_ON, expected)
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -802,6 +802,10 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
             "WG_BUS_AS_TRUTH_REEVAL_ADDENDUM":       "off",
             "WG_BUS_AS_TRUTH_CONVERGENCE":           "off",
             "WG_BUS_AS_TRUTH_SEMANTIC_GAP":          "off",
+            # Wave-2 Tranche C (this PR):
+            "WG_BUS_AS_TRUTH_HITL_DECISION":         "off",
+            "WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT":   "off",
+            "WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "off",
         }
         with patch.dict(os.environ, env_clear):
             result = reconcile_v2._active_projection_names()
@@ -827,6 +831,10 @@ class TestActiveProjNamesAllFlagsOff(unittest.TestCase):
             "WG_BUS_AS_TRUTH_REEVAL_ADDENDUM":       "off",
             "WG_BUS_AS_TRUTH_CONVERGENCE":           "off",
             "WG_BUS_AS_TRUTH_SEMANTIC_GAP":          "off",
+            # Wave-2 Tranche C (this PR):
+            "WG_BUS_AS_TRUTH_HITL_DECISION":         "off",
+            "WG_BUS_AS_TRUTH_SUBAGENT_ENGAGEMENT":   "off",
+            "WG_BUS_AS_TRUTH_SKIPPED_PHASE_STATUS": "off",
         }
         with patch.dict(os.environ, env):
             result = reconcile_v2._active_projection_names()


### PR DESCRIPTION
## Summary

**Final tranche of the bus-cutover.** Bundles W5 (hitl), W9a precursor (JSON→JSONL refactor) + W9b cutover (subagent engagement), and W10b (SKIPPED phase status.md) into ONE PR per the bundle-vs-defer lesson.

After this merges: **all planned bus-cutover sites are shipped**. 14 default-ON tokens. Zero remaining planned cutover work.

## Sites

| Site | Artifact | Event | Flag |
|------|----------|-------|------|
| **W5** | \`phases/{phase}/{hitl,council}-*-decision.json\` | \`wicked.hitl.decision_recorded\` | \`HITL_DECISION\` |
| **W9b** | \`phases/{phase}/specialist-engagement.jsonl\` | \`wicked.subagent.engaged\` | \`SUBAGENT_ENGAGEMENT\` |
| **W10b** | \`phases/{phase}/status.md\` (SKIPPED only) | \`wicked.phase.transitioned\` (existing event, fan-out) | \`SKIPPED_PHASE_STATUS\` |

## W9a precursor — JSON-array → JSONL refactor

\`subagent_lifecycle._record_specialist_engagement\` switched from read-modify-write JSON-array to append-only JSONL. The JSON-array shape contradicted bus-as-truth (events are append-only; the projection should be too).

**Backward compatibility**: \`pre_tool.py\` reads JSONL preferentially with a fallback to the legacy \`.json\` for production projects that haven't yet had a post-W9a engagement recorded. No migration tool needed.

Doc updated: \`agents/crew/independent-reviewer.md\` references the JSONL filename with the legacy fallback.

## W5 — payload-aware-on-filename resolver with whitelist

\`hitl_judge.write_hitl_decision_evidence(filename=...)\` is caller-supplied. Both the resolver AND the projector handler validate against \`_HITL_FILENAME_WHITELIST\` to defend against path-traversal via crafted payloads. Filenames outside the whitelist are rejected (resolver returns empty list; handler refuses to write).

5 entries added to \`PROJECTION_FILE_FLAGS\` (one per known filename), all sharing the \`HITL_DECISION\` flag.

## W10b — extends existing \`wicked.phase.transitioned\`

Initial wave-2 plan assumed the existing event covered SKIPPED. **Verification showed \`skip_phase\` did not previously emit at all** (only \`approve_phase\` did). Added the emit inside \`skip_phase\` with \`gate_result=\"SKIPPED\"\` as the sentinel, and extended \`_phase_transitioned\` to fan out to a new \`_phase_skipped_status_md\` helper when payload signals SKIPPED.

\`status.md\` is intentionally NOT in \`PROJECTION_FILE_FLAGS\` — other code paths (gate-override audit) write it too, and tracking would surface those as projection-without-event drift.

## Tests

- **NEW**: \`tests/daemon/test_projector_tranche_c.py\` (17 tests)
  - Registration, flag-off, happy paths, idempotent replay, traversal rejection, content-hash short-circuits, resolver whitelist behaviour, NON-SKIPPED transitions don't trigger fan-out, source-side emit wiring (hitl_judge emits before write; emit failure does not block write)
- **Updated**: \`tests/test_reconcile_v2.py\` — env-control tests include 3 new flags
- **Updated**: \`tests/test_bus_emit_health.py\` — default-ON frozenset expects 14 tokens

## Test plan

- [x] \`tests/daemon/test_projector_tranche_c.py\` — 17/17 pass
- [x] \`tests/test_reconcile_v2.py\`, \`tests/test_bus_emit_health.py\` — full pass
- [x] All other daemon/crew/hooks tests — pass
- [x] **Full suite**: 2506 pass / 10 pre-existing unrelated failures

## Bus-cutover state after this merge

| Wave | Sites | Status |
|------|-------|--------|
| Wave 1 | 1-5 (gate path) | ✅ default-ON |
| W1 | solo_mode | ✅ default-ON (PR #788) |
| Tranche A | W2/W3/W4 + W10 exempts | ✅ exempts + summary emits (PR #789) |
| Tranche B | W6/W7/W8/W10a | ✅ default-ON (PR #790) |
| **Tranche C** | **W5/W9a/W9b/W10b** | ✅ **default-ON (this PR)** |

**All planned bus-cutover work is complete.** The remaining direct-write paths (Sites 1-5) stay during a soak window per the staging plan §4 "two releases of zero drift" rule before deletion.

## Refs

- Wave-2 plan: \`docs/v9/wave-2-cutover-plan.md\` (PR #786)
- Design lessons: \`memory/ship-inert-and-activate-later-is-a-contradiction-bundle-instead.md\`, \`memory/workaround-vs-fix-stop-shaping-plans-around-bad-design.md\`, \`memory/staging-plan-write-site-count-grep-before-trusting.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)