### PR TITLE
docs(meta): post-cutover bus-as-truth section in CLAUDE.md + AGENTS.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -392,6 +392,22 @@ and the unique-value test before their skills will be accepted in the marketplac
 
 `gate-result.json` ingestion runs a layered defense floor: schema validator, content sanitizer (codepoint allow-list + injection patterns), dispatch-log orphan detection, and append-only audit log. This is a **floor** against content drift and trivial prompt-injection — not a wall against local disk-write attackers. Rollback levers: `WG_GATE_RESULT_SCHEMA_VALIDATION=off`, `WG_GATE_RESULT_CONTENT_SANITIZATION=off`, `WG_GATE_RESULT_DISPATCH_CHECK=off` — all auto-expire at `WG_GATE_RESULT_STRICT_AFTER`. Benchmark SLO re-baseline is owned by the `wicked-garden:platform:gate-benchmark-rebaseline` skill.
 
+## Bus-as-truth architecture (v9.x cutover)
+
+Issue #746 cutover is complete (PRs #751 → #791). Bus events are the source of truth for every gate-critical and audit-load-bearing artifact; on-disk files are projections materialized by `daemon/projector.py` handlers. Drift detector (`scripts/crew/reconcile_v2.py`) measures three classes: `projection-stale` (projector lagging), `event-without-projection` (handler missing/failed), `projection-without-event` (direct write bypassing the bus).
+
+**14 default-ON `WG_BUS_AS_TRUTH_*` tokens**: `DISPATCH_LOG`, `CONSENSUS_REPORT`, `CONSENSUS_EVIDENCE`, `REVIEWER_REPORT`, `GATE_RESULT`, `CONDITIONS_MANIFEST`, `INLINE_REVIEW_CONTEXT`, `AMENDMENTS`, `REEVAL_ADDENDUM`, `CONVERGENCE`, `SEMANTIC_GAP`, `HITL_DECISION`, `SUBAGENT_ENGAGEMENT`, `SKIPPED_PHASE_STATUS`. Operators opt out per-site with `WG_BUS_AS_TRUTH_<TOKEN>=off` (literal `on`/`off` only, case/whitespace normalised — see PR #777 for the contract). Source of truth: `scripts/_bus.py::_BUS_AS_TRUTH_DEFAULT_ON`.
+
+**Resolver shape**: `scripts/crew/reconcile_v2.py::_PROJECTION_RESOLVERS` is `Dict[str, Callable[[payload, phase, project_dir], List[Path]]]` — function-per-event, payload-aware. One event can produce zero, one, or many files conditionally on payload. Site 5's `_resolve_gate_decided` produces `gate-result.json` always and `conditions-manifest.json` only on CONDITIONAL verdicts; Tranche B's W7 dual-file resolver produces both per-phase + project-root logs from one event; Tranche C's W5 hitl resolver picks the file from `payload["filename"]` validated against `_HITL_FILENAME_WHITELIST` for path-traversal defense.
+
+**Adding a new bus-projected artifact**: (1) register the event in `scripts/_bus.py::BUS_EVENT_MAP` + `_PAYLOAD_ALLOW_OVERRIDES` carve-out for `raw_payload`; (2) add the projector handler to `daemon/projector.py._HANDLERS` (use `_jsonl_append_projection` for JSONL append patterns); (3) add the resolver to `_PROJECTION_RESOLVERS`; (4) add `_PROJECTION_HANDLERS_AVAILABLE` entry True; (5) add the file to `PROJECTION_FILE_FLAGS` with a new token; (6) add the token to `_BUS_AS_TRUTH_DEFAULT_ON`; (7) wire the source-side emit BEFORE the legacy disk write, fail-open per Decision #8 (bus failure must NOT block the write).
+
+**Audit-marker events** (no projector handler): `wicked.crew.legacy_adopted`, `wicked.crew.qe_evaluator_migrated`, `wicked.log.rotated`. These mark "this happened" without becoming sources of truth — used for forensics on migration/maintenance side-effects.
+
+**Soak phase**: legacy direct-write paths still run during a soak window per `docs/v9/bus-cutover-staging-plan.md` §4 ("two releases of zero drift" rule). Content-hash idempotency in projector handlers makes the duplicate writes byte-for-byte safe. Direct-write deletion is mechanical follow-up work.
+
+**Architecture refs**: `docs/v9/bus-cutover-staging-plan.md` (wave-1 design), `docs/v9/wave-2-cutover-plan.md` (wave-2 per-site analysis + tranche sequencing), `docs/v9/adr-reconcile-v2.md` (why reconcile_v2 co-exists with reconcile.py).
+
 ## wicked-brain
 
 Digital brain: **wicked-garden** | 11,269 indexed items | 11,208 chunks, 23 wiki articles, 15 memories | server port 4243

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,20 @@ External plugins integrate with wicked-garden by following the contract in
 Plugin authors must pass the v9 discovery conventions (`docs/v9/discovery-conventions.md`)
 and the unique-value test before their skills will be accepted in the marketplace.
 
+## Bus-as-truth contract (v9.x cutover)
+
+The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the source of truth** for every gate-critical and audit-load-bearing artifact; on-disk files are projections materialized by `daemon/projector.py`. 14 sites are default-ON. See CLAUDE.md "Bus-as-truth architecture" for the full inventory and resolver shape.
+
+**Rules for agents writing code that produces a tracked artifact**:
+
+1. **Emit BEFORE the disk write.** Pattern: `emit_event("wicked.<domain>.<verb>", payload, chain_id=...)` then `write_text(...)`. Never write first and emit after — the projector replays from the event, so the event must precede the write.
+2. **Fail-open per Decision #8.** Wrap the emit in `try/except`. A bus emit failure must NEVER block the legacy disk write — evidence loss is preferable visible (the disk write succeeds; missing event surfaces as drift).
+3. **chain_id includes a uniqueness segment** when the operation can repeat in a phase. Per `memory/bus-chain-id-must-include-uniqueness-segment-gotcha.md`: phase-level `chain_id` lets `is_processed` dedupe drop subsequent events in the same phase. Include `condition_id`, `artifact_id`, `amendment_id`, etc. as the discriminator.
+4. **Carve out `raw_payload`** in `scripts/_bus.py::_PAYLOAD_ALLOW_OVERRIDES` if the projector needs the canonical bytes (JSONL append handlers always do; full-file rewrite handlers may instead carry structured fields).
+5. **For new artifacts**: follow the 7-step add-a-bus-projected-artifact procedure in CLAUDE.md "Bus-as-truth architecture" — event registration → carve-out → handler → resolver → handler-available → file-flag → default-ON.
+
+**Soak window**: legacy direct-write paths still run alongside the bus path. Don't delete them yet — `docs/v9/bus-cutover-staging-plan.md` §4 requires two releases of zero drift before deletion. Content-hash idempotency in projector handlers makes the duplicate writes safe.
+
 ## Planning & Execution
 
 - When I say "just do it" or "just make the changes", execute immediately without presenting plans for approval. Do not enter plan mode or ask for confirmation unless I explicitly ask for a plan.


### PR DESCRIPTION
## Summary

Adds the missing post-cutover architecture section to both CLAUDE.md (project-internal reference) and AGENTS.md (cross-tool agent contract). Cutover (#746) is complete in main as of PR #791 but neither file documented the new architecture.

## CLAUDE.md

NEW section **\"Bus-as-truth architecture (v9.x cutover)\"** after the existing gate-result security floor section:

- Names the 14 default-ON \`WG_BUS_AS_TRUTH_*\` tokens
- Documents the \`_PROJECTION_RESOLVERS\` shape (\`Dict[str, Callable]\`, payload-aware)
- 7-step procedure for adding a new bus-projected artifact
- Distinguishes audit-marker events (no projector) from projection events
- Notes the soak window contract for direct-write deletion
- Architecture refs to staging plan + wave-2 plan + ADR

## AGENTS.md

NEW section **\"Bus-as-truth contract (v9.x cutover)\"** mirroring CLAUDE.md with agent-facing rules:

1. Emit BEFORE the disk write
2. Fail-open per Decision #8
3. \`chain_id\` includes a uniqueness segment
4. Carve out \`raw_payload\` in \`_PAYLOAD_ALLOW_OVERRIDES\` when needed
5. Follow the 7-step procedure from CLAUDE.md for new artifacts
+ soak window guidance: don't delete legacy direct writes yet

Both files reference each other and stay in sync.

## Related housekeeping (separate \`gh\` actions, no code change in this PR)

Same session pass closed 4 stale follow-up issues + the umbrella cutover tracking issue:

- #746 — umbrella cutover tracking (implementation complete)
- #759 — \`_bus_cutover_handler\` builder, superseded by \`_jsonl_append_projection\` in PRs #790/#791
- #752 — worst-case payload sizing, deferred indefinitely (no signal)
- #772 — lessons retro, incorporated as 5 brain memories
- #761 — eval_id call-graph test, superseded by chain_id discriminator pattern across all 14 sites

**Remaining open follow-up**: #767 (projector cursor wiring for reconcile_v2 lag math) — independent enhancement, real value.

## Test plan

Docs only. Manual review of the two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)