### PR TITLE
fix(crew): #767 wire projector cursor into reconcile_v2 lag math

### DIFF
--- a/scripts/crew/reconcile_v2.py
+++ b/scripts/crew/reconcile_v2.py
@@ -709,6 +709,61 @@ def _event_log_total(conn: sqlite3.Connection) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Projector cursor (#767) — last event_id the daemon's bus subscriber acked
+# into the projector.  Reads the existing ``cursor`` table maintained by the
+# daemon's subscriber loop; we only need read access (reconcile_v2 is a
+# read-only diagnostic per the module docstring's hard constraints).
+#
+# Schema (daemon/db.py:101-106):
+#   cursor (
+#     bus_source    TEXT PRIMARY KEY,
+#     cursor_id     TEXT NOT NULL,
+#     last_event_id INTEGER NOT NULL DEFAULT 0,
+#     acked_at      INTEGER NOT NULL
+#   )
+#
+# Default bus source is ``wicked-bus`` (see daemon/db.py::_BUS_SOURCE_DEFAULT).
+# When the cursor row is absent the daemon hasn't subscribed yet — we treat
+# that as projector_health == "unreachable" because we can't tell if it's
+# caught up or just silent.
+# ---------------------------------------------------------------------------
+
+# Bus source name the daemon's subscriber registers under.  Mirrors
+# ``daemon.db._BUS_SOURCE_DEFAULT`` — kept as a separate constant rather than
+# importing daemon.db to avoid a hard cross-package dependency from a
+# scripts/crew/ module on a daemon/ module (the staging plan keeps the
+# diagnostic decoupled from the daemon's import graph).
+_PROJECTOR_BUS_SOURCE = "wicked-bus"
+
+
+def _get_projector_last_applied_seq(conn: sqlite3.Connection) -> Optional[int]:
+    """Return the projector's last-applied event_id from the cursor table.
+
+    Returns None when:
+      * The cursor table doesn't exist (DB schema mismatch / not initialised)
+      * The cursor row for ``wicked-bus`` is absent (subscriber never registered)
+      * Any sqlite error occurs (fail-open per the module's hard constraints)
+
+    The daemon's bus subscriber upserts this row on every successful event
+    apply (see daemon/db.py::set_cursor); reading it here gives us the
+    projector's progress without taking a write lock.
+    """
+    try:
+        row = conn.execute(
+            "SELECT last_event_id FROM cursor WHERE bus_source = ?",
+            (_PROJECTOR_BUS_SOURCE,),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Projection-file discovery
 # ---------------------------------------------------------------------------
 
@@ -810,6 +865,8 @@ def _collect_projection_files(project_dir: Path) -> List[Path]:
 def _detect_projection_stale(
     events: List[Dict[str, Any]],
     project_dir: Path,
+    *,
+    projection_last_applied_seq: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Events in projection_status='pending' with no materialised file.
 
@@ -834,22 +891,24 @@ def _detect_projection_stale(
         )
         for proj_path in proj_paths:
             if not proj_path.exists():
-                # projection_last_applied_seq: the event_id at which the projector
-                # last successfully processed an event.  This cursor is not yet
-                # tracked in the daemon DB schema (no projector_state table /
-                # sidecar).  Emit null per staging plan §5 schema compliance
-                # until the cursor is wired in (PR #764 follow-up TODO in
-                # _build_report_header).
+                # projection_last_applied_seq + lag_events (#767):
+                # cursor wired in.  When the caller passes the cursor's
+                # last_event_id, populate per-entry; otherwise fall back to
+                # null (cursor row absent or DB unreachable — fail-open).
+                ev_seq = ev["event_id"]
+                per_entry_lag: Optional[int] = None
+                if projection_last_applied_seq is not None:
+                    per_entry_lag = max(0, ev_seq - projection_last_applied_seq)
                 drift.append({
                     "type": DRIFT_PROJECTION_STALE,
                     "projection": str(proj_path.relative_to(project_dir)),
-                    "event_seq": ev["event_id"],
+                    "event_seq": ev_seq,
                     "event_type": ev["event_type"],
                     "chain_id": ev.get("chain_id"),
-                    "projection_last_applied_seq": None,  # cursor pending — see TODO
-                    "lag_events": None,                   # derived from cursor
+                    "projection_last_applied_seq": projection_last_applied_seq,
+                    "lag_events": per_entry_lag,
                     "reason": (
-                        f"event_seq {ev['event_id']} ({ev['event_type']!r}) "
+                        f"event_seq {ev_seq} ({ev['event_type']!r}) "
                         f"is pending but projection has not been materialised"
                     ),
                 })
@@ -1042,9 +1101,14 @@ def reconcile_project(
         else:
             errors.append("projector DB unavailable (file missing or schema absent)")
 
+    # Fetch cursor + events while we still hold the connection (#767).
+    # The cursor read is fail-open — drift detection still runs even when
+    # the cursor row is absent (per-entry lag fields just stay null).
+    last_applied_seq: Optional[int] = None
     try:
         if db_conn is not None:
             events = _query_events_for_project(db_conn, project_slug)
+            last_applied_seq = _get_projector_last_applied_seq(db_conn)
     except sqlite3.Error as exc:
         errors.append(f"event_log query failed: {exc}")
     finally:
@@ -1056,7 +1120,10 @@ def reconcile_project(
 
     drift: List[Dict[str, Any]] = []
     if project_dir.is_dir():
-        drift.extend(_detect_projection_stale(events, project_dir))
+        drift.extend(_detect_projection_stale(
+            events, project_dir,
+            projection_last_applied_seq=last_applied_seq,
+        ))
         drift.extend(_detect_event_without_projection(events, project_dir))
         drift.extend(_detect_projection_without_event(events, project_dir))
     else:
@@ -1142,41 +1209,53 @@ def _build_report_header(
     conn: Optional[sqlite3.Connection],
     command_invoked: str,
 ) -> Dict[str, Any]:
-    """Build the §5 header block for the full report."""
+    """Build the §5 header block for the full report.
+
+    Lag math (#767 wired the projector cursor — was placeholder in PR #764):
+      ``lag_events = head_seq - projection_last_applied_seq`` when both
+      values are available; ``null`` when the cursor row is absent (daemon
+      hasn't registered yet) or the DB is unreachable.
+
+    projector_health enum is ``{ok, lagging, unreachable}``:
+      * ``unreachable`` — DB connection absent OR cursor row missing
+        (cannot answer "is it caught up?" either way).
+      * ``lagging``     — lag_events > _LAG_EVENTS_THRESHOLD.
+      * ``ok``          — lag_events <= _LAG_EVENTS_THRESHOLD (catches the
+                          subscriber-stalled-at-head edge: lag == 0 is ok).
+    """
     head_seq = 0
     total_seq = 0
+    last_applied_seq: Optional[int] = None
     if conn is not None:
         # DB access failure here just means the header reports zeros for
         # head/total; the report is still valid and fail-open is correct.
         with contextlib.suppress(sqlite3.Error):
             head_seq = _event_log_head(conn)
             total_seq = _event_log_total(conn)
+            last_applied_seq = _get_projector_last_applied_seq(conn)
 
-    # Lag math — Path A (follow-up issue filed for Path B cursor wiring).
-    #
-    # The correct lag formula is:
-    #   head_seq - projection_last_applied_seq
-    # where projection_last_applied_seq is the event_id the projector last
-    # successfully processed.  That cursor is NOT currently tracked in the
-    # daemon DB schema — there is no projector_state table or sidecar file.
-    #
-    # The previous formula (total_seq - head_seq) was permanently false:
-    # MAX(event_id) >= COUNT(*) in any retained DB, so the condition
-    # `total_seq > head_seq` could never be true and lag was always 0.
-    #
-    # Until the projector cursor is wired in, we emit null for lag_events
-    # rather than a misleading zero.
-    #
-    # TODO: wire projection_last_applied_seq from the projector and replace
-    # the null with the real lag.  Filed as follow-up issue #767.
-    lag_events: Optional[int] = None  # cursor unavailable — see TODO above
+    # Lag math (#767): cursor wired in.  Compute when both values are real;
+    # leave null when the cursor row is absent so consumers can distinguish
+    # "definitely caught up" from "we don't know yet".
+    lag_events: Optional[int] = None
+    if last_applied_seq is not None:
+        # head_seq always >= last_applied_seq under normal operation; clamp
+        # to 0 in the event of clock skew or a cursor that somehow leads
+        # the head (e.g. partial DB rebuild).  Negative lag is meaningless.
+        lag_events = max(0, head_seq - last_applied_seq)
 
     if conn is None:
+        # No DB → cannot answer; report unreachable.
         projector_health = "unreachable"
+    elif last_applied_seq is None:
+        # DB present but cursor row missing — subscriber hasn't registered.
+        # Per schema enum, surface this as "unreachable" rather than "ok"
+        # because consumers should treat "no cursor" as "no signal".
+        projector_health = "unreachable"
+    elif lag_events is not None and lag_events > _LAG_EVENTS_THRESHOLD:
+        projector_health = "lagging"
     else:
-        # Cursor absent — consumer cannot act on the cursor either way.
-        # Schema enum is {ok, lagging, unreachable}; "unknown" is not valid.
-        projector_health = "unreachable"
+        projector_health = "ok"
 
     return {
         "captured_at": datetime.now(timezone.utc).isoformat(),
@@ -1185,6 +1264,7 @@ def _build_report_header(
         "event_log_total_seq": total_seq,
         "lag_events": lag_events,
         "projector_health": projector_health,
+        "projection_last_applied_seq": last_applied_seq,
     }
 
 

--- a/tests/test_reconcile_v2.py
+++ b/tests/test_reconcile_v2.py
@@ -1524,5 +1524,282 @@ class TestReconcileV2FlagPredicate(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Issue #767 — projector cursor wiring
+# ---------------------------------------------------------------------------
+
+
+def _init_db_with_cursor_table(db_path: Path) -> None:
+    """Create event_log + cursor schema (mirrors daemon/db.py)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS event_log (
+            event_id            INTEGER PRIMARY KEY,
+            event_type          TEXT NOT NULL,
+            chain_id            TEXT,
+            payload_json        TEXT NOT NULL DEFAULT '{}',
+            projection_status   TEXT NOT NULL DEFAULT 'applied',
+            error_message       TEXT,
+            ingested_at         INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS cursor (
+            bus_source      TEXT PRIMARY KEY,
+            cursor_id       TEXT NOT NULL,
+            last_event_id   INTEGER NOT NULL DEFAULT 0,
+            acked_at        INTEGER NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _set_cursor(db_path: Path, last_event_id: int) -> None:
+    """Upsert a cursor row mimicking the daemon subscriber."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO cursor (bus_source, cursor_id, last_event_id, acked_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(bus_source) DO UPDATE SET
+            last_event_id = excluded.last_event_id,
+            acked_at      = excluded.acked_at
+        """,
+        ("wicked-bus", "test-cursor", last_event_id, int(time.time())),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestProjectorCursorWiring(unittest.TestCase):
+    """Issue #767 — projector cursor wired into lag math.
+
+    Acceptance criteria from the issue:
+      * Cursor read populates lag_events = head_seq - last_event_id
+      * lag_events > _LAG_EVENTS_THRESHOLD → projector_health = "lagging"
+      * lag_events <= threshold → projector_health = "ok"
+      * Per-entry projection-stale records carry actual cursor value
+      * Cursor absent / DB unreachable → null fields preserved (fail-open)
+    """
+
+    def test_get_projector_last_applied_seq_returns_value_when_cursor_present(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-cursor-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+            _set_cursor(db_path, last_event_id=42)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                result = reconcile_v2._get_projector_last_applied_seq(conn)
+            finally:
+                conn.close()
+
+        self.assertEqual(result, 42)
+
+    def test_get_projector_last_applied_seq_returns_none_when_cursor_absent(self) -> None:
+        """Cursor table exists but has no row for wicked-bus → None."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-no-cursor-row-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                result = reconcile_v2._get_projector_last_applied_seq(conn)
+            finally:
+                conn.close()
+
+        self.assertIsNone(result)
+
+    def test_get_projector_last_applied_seq_returns_none_when_cursor_table_missing(self) -> None:
+        """Cursor table doesn't exist → sqlite.Error → None (fail-open)."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-no-table-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_event_log_schema(db_path)  # only event_log, no cursor table
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                result = reconcile_v2._get_projector_last_applied_seq(conn)
+            finally:
+                conn.close()
+
+        self.assertIsNone(result)
+
+    def test_header_lag_events_zero_when_cursor_at_head(self) -> None:
+        """Cursor caught up to head → lag = 0 → projector_health = ok."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-caught-up-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+            _insert_event_row(
+                db_path,
+                event_id=10,
+                event_type="wicked.gate.decided",
+                chain_id="p.build.gate",
+            )
+            _set_cursor(db_path, last_event_id=10)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reconcile_v2.main(["--all", "--json", "--daemon-db", str(db_path)])
+
+        payload = json.loads(buf.getvalue())
+        header = payload["header"]
+        self.assertEqual(header["lag_events"], 0)
+        self.assertEqual(header["projector_health"], "ok")
+        self.assertEqual(header["projection_last_applied_seq"], 10)
+
+    def test_header_lag_events_lagging_when_cursor_behind(self) -> None:
+        """Cursor far behind head → lag > threshold → projector_health = lagging."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-lagging-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+            # Seed events spanning past the lag threshold (default 10).
+            for ev_id in range(1, 25):
+                _insert_event_row(
+                    db_path,
+                    event_id=ev_id,
+                    event_type="wicked.gate.decided",
+                    chain_id=f"p.build.gate-{ev_id}",
+                )
+            # Cursor at 5 → lag = 24 - 5 = 19 (> 10 threshold)
+            _set_cursor(db_path, last_event_id=5)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reconcile_v2.main(["--all", "--json", "--daemon-db", str(db_path)])
+
+        payload = json.loads(buf.getvalue())
+        header = payload["header"]
+        self.assertEqual(header["lag_events"], 19)
+        self.assertEqual(header["projector_health"], "lagging")
+        self.assertEqual(header["projection_last_applied_seq"], 5)
+
+    def test_header_lag_events_ok_when_cursor_within_threshold(self) -> None:
+        """Cursor a few events behind head → lag <= threshold → ok."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-ok-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+            for ev_id in range(1, 16):
+                _insert_event_row(
+                    db_path,
+                    event_id=ev_id,
+                    event_type="wicked.gate.decided",
+                    chain_id=f"p.build.gate-{ev_id}",
+                )
+            # Cursor at 7 → lag = 15 - 7 = 8 (<= 10 threshold)
+            _set_cursor(db_path, last_event_id=7)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reconcile_v2.main(["--all", "--json", "--daemon-db", str(db_path)])
+
+        payload = json.loads(buf.getvalue())
+        header = payload["header"]
+        self.assertEqual(header["lag_events"], 8)
+        self.assertEqual(header["projector_health"], "ok")
+
+    def test_header_lag_events_clamped_to_zero_when_cursor_leads_head(self) -> None:
+        """Defensive: if cursor > head (shouldn't happen normally), clamp lag to 0
+        rather than emitting a misleading negative."""
+        with tempfile.TemporaryDirectory(prefix="wg-rv2-clamp-") as tmp:
+            db_path = Path(tmp) / "test.db"
+            _init_db_with_cursor_table(db_path)
+            _insert_event_row(
+                db_path,
+                event_id=10,
+                event_type="wicked.gate.decided",
+                chain_id="p.build.gate",
+            )
+            # Cursor at 99 (ahead of head=10) — partial DB rebuild scenario.
+            _set_cursor(db_path, last_event_id=99)
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reconcile_v2.main(["--all", "--json", "--daemon-db", str(db_path)])
+
+        payload = json.loads(buf.getvalue())
+        header = payload["header"]
+        self.assertEqual(
+            header["lag_events"], 0,
+            "negative lag must be clamped to 0, not emitted as misleading "
+            f"negative or unbounded large value (got {header['lag_events']!r})",
+        )
+        self.assertEqual(header["projector_health"], "ok")
+
+
+class TestProjectionStaleEntryCarriesCursorFields(_ReconcileV2Fixture):
+    """Issue #767 — per-entry projection-stale records carry the actual
+    projection_last_applied_seq and lag_events when cursor is wired.
+
+    Inherits ``_ReconcileV2Fixture`` for the patched ``_projects_root`` —
+    extends the fixture's event_log-only schema with the cursor table.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Extend the fixture DB with the cursor table.  The fixture's
+        # _init_event_log_schema only created event_log; we need both
+        # for cursor wiring tests.
+        conn = sqlite3.connect(str(self.db_path))
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS cursor (
+                bus_source      TEXT PRIMARY KEY,
+                cursor_id       TEXT NOT NULL,
+                last_event_id   INTEGER NOT NULL DEFAULT 0,
+                acked_at        INTEGER NOT NULL
+            );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def _seed_cursor(self, last_event_id: int) -> None:
+        _set_cursor(self.db_path, last_event_id=last_event_id)
+
+    def test_stale_entry_carries_cursor_value(self) -> None:
+        """Per-entry projection_last_applied_seq matches the cursor's last_event_id."""
+        # Make the project dir under the patched projects_root.
+        project_dir = self.projects_root / "stale-pe-proj"
+        (project_dir / "phases" / "build").mkdir(parents=True, exist_ok=True)
+
+        _insert_event_row(
+            self.db_path,
+            event_id=42,
+            event_type="wicked.gate.decided",
+            chain_id="stale-pe-proj.build.gate",
+            projection_status="pending",
+        )
+        self._seed_cursor(last_event_id=20)
+
+        conn = self._conn()
+        try:
+            result = reconcile_v2.reconcile_project(
+                "stale-pe-proj", _daemon_conn=conn,
+            )
+        finally:
+            conn.close()
+
+        stale_entries = [
+            d for d in result["drift"]
+            if d["type"] == reconcile_v2.DRIFT_PROJECTION_STALE
+        ]
+        self.assertGreater(
+            len(stale_entries), 0,
+            f"Expected projection-stale drift; got drift={result['drift']!r}",
+        )
+        for entry in stale_entries:
+            self.assertEqual(
+                entry["projection_last_applied_seq"], 20,
+                "per-entry cursor must reflect the actual cursor row",
+            )
+            # event_seq=42, cursor=20 → lag=22 for this entry
+            self.assertEqual(
+                entry["lag_events"], 22,
+                f"lag = event_seq - cursor; got {entry['lag_events']!r}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The projector cursor was already maintained by the daemon's bus subscriber in the existing \`cursor\` table (\`daemon/db.py:101\`); reconcile_v2 just wasn't reading it. **No new schema, no new write path — just a read.**

Closes #767.

## Before

\`_build_report_header()\` and per-entry projection-stale records emitted:
- \`projection_last_applied_seq: null\`
- \`lag_events: null\`
- \`projector_health: \"unreachable\"\` (when DB was reachable but cursor was treated as absent)

## After

| State | \`lag_events\` | \`projector_health\` |
|-------|--------------|----------------------|
| DB connection absent | \`null\` | \`unreachable\` |
| Cursor row missing | \`null\` | \`unreachable\` |
| Cursor at head (lag=0) | \`0\` | \`ok\` |
| Cursor lagging ≤ threshold | \`N\` | \`ok\` |
| Cursor lagging > threshold (default 10) | \`N\` | \`lagging\` |
| Cursor leads head (defensive) | \`0\` (clamped) | \`ok\` |

Per-entry projection-stale records now carry \`projection_last_applied_seq\` and \`lag_events = max(0, event_seq - cursor)\` so each stale event reports its own distance from the projector's progress.

## Implementation

- **NEW** \`_get_projector_last_applied_seq(conn)\` — inline SQL read against the cursor table for the \`wicked-bus\` source. No \`daemon.db\` import (keeps reconcile_v2 decoupled from daemon's import graph per ADR \`docs/v9/adr-reconcile-v2.md\`). Fail-open on sqlite.Error / missing row / schema mismatch (returns None).
- **\`_build_report_header()\`** — computes lag math, sets projector_health enum, exposes \`projection_last_applied_seq\` in header.
- **\`_detect_projection_stale()\`** — accepts new keyword \`projection_last_applied_seq\`, threads it into per-entry fields.
- **\`reconcile_project()\`** — fetches cursor once via the helper, passes to detector.
- Removed \`# TODO\` comments referencing #767.

## Tests

- **NEW**: \`TestProjectorCursorWiring\` (7 tests) — helper read paths (cursor present / row absent / table missing), header lag-state matrix (caught-up / under-threshold / lagging / cursor-leads-head clamp).
- **NEW**: \`TestProjectionStaleEntryCarriesCursorFields\` (1 test) — per-entry cursor + lag_events match.
- **Existing**: \`TestHeaderLagFieldsNullCursor\` + \`TestProjectionStaleEntrySchema\` still pass — when the cursor table is absent (the existing fixture DB only has event_log), the cursor read returns None and the null-fallback path is preserved.

## Test plan

- [x] \`tests/test_reconcile_v2.py\` — 68/68 pass (8 new + 60 existing)
- [x] **Full suite**: 2514 pass / 10 pre-existing unrelated failures (delivery drift, command alias stubs, stub audit on \`_stack_signals.py\` — same set on \`origin/main\`)

## Why this was simple

The cursor infrastructure was already there. The daemon subscriber calls \`daemon.db.set_cursor()\` on every successful event apply (Site 1, PR #751). PR #764 added the lag fields to the schema but didn't wire the read because the assumption at the time was \"no cursor exists\". Investigation now showed the cursor DOES exist; this PR is ~60 lines of read code against existing schema.

## Refs

- Schema: \`daemon/db.py:101\` (cursor table); \`:973\` (get_cursor); \`:984\` (set_cursor)
- Bus source default: \`daemon/db.py:28\` (\`_BUS_SOURCE_DEFAULT = \"wicked-bus\"\`)
- ADR: \`docs/v9/adr-reconcile-v2.md\` §5 (post-cutover JSON schema spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)