### PR TITLE
feat(crew): Scope A — delete legacy direct-writes for 3 bus-cutover sites (#746)

### DIFF
--- a/hooks/scripts/subagent_lifecycle.py
+++ b/hooks/scripts/subagent_lifecycle.py
@@ -306,18 +306,7 @@ def _record_specialist_engagement(domain: str, agent_name: str) -> None:
                 chain_id=f"{project_id}.{current_phase}.{agent_name}-{ts_compact}",
             )
         except Exception:  # noqa: BLE001 — fail-open per Decision #8
-            pass  # bus unavailable — append below still runs
-
-        # JSONL append-only write (W9a refactor).  Mirrors the
-        # _jsonl_append_projection helper in daemon/projector.py for
-        # crash semantics: open("a") + flush + best-effort fsync.
-        with open(engagement_file, "a", encoding="utf-8") as fh:
-            fh.write(line)
-            fh.flush()
-            try:
-                os.fsync(fh.fileno())
-            except OSError:
-                pass  # fail-open: fsync unsupported on this FS
+            pass  # bus unavailable — projector handler replays on reconnect
 
     except Exception as exc:
         print(f"[wicked-garden] specialist engagement record error: {exc}", file=sys.stderr)

--- a/scripts/crew/hitl_judge.py
+++ b/scripts/crew/hitl_judge.py
@@ -642,7 +642,6 @@ def write_hitl_decision_evidence(
             chain_id=f"{project_id_str}.{phase}.{filename_stem}",
         )
     except Exception:  # noqa: BLE001 — fail-open per Decision #8
-        pass  # bus unavailable — direct write below still runs
+        pass  # bus unavailable — projector handler replays on reconnect
 
-    target_path.write_text(body_bytes, encoding="utf-8")
     return target_path

--- a/scripts/crew/solo_mode.py
+++ b/scripts/crew/solo_mode.py
@@ -340,62 +340,6 @@ def _write_conditions_manifest(
 
 
 # ---------------------------------------------------------------------------
-# Inline-review-context writer
-# ---------------------------------------------------------------------------
-
-
-def _write_inline_review_context(
-    project_dir: Path,
-    phase: str,
-    gate_name: str,
-    bullets: List[str],
-    raw_response: str,
-    gate_result_ref: str,
-) -> Optional[Path]:
-    """Write ``inline-review-context.md`` alongside gate-result.json.
-
-    Contains: evidence summary, user's raw response, timestamp, gate-result ref.
-    """
-    phase_dir = project_dir / "phases" / phase
-    phase_dir.mkdir(parents=True, exist_ok=True)
-    ctx_path = phase_dir / "inline-review-context.md"
-
-    lines = [
-        f"# Inline Gate Review: {gate_name} ({phase})",
-        "",
-        f"**Timestamp**: {_utc_now()}",
-        f"**Gate**: {gate_name}",
-        f"**Phase**: {phase}",
-        "",
-        "## Evidence Summary",
-        "",
-    ]
-    for b in bullets:
-        lines.append(f"- {b}")
-    lines += [
-        "",
-        "## User Response",
-        "",
-        f"> {raw_response.strip()}",
-        "",
-        "## Artifact Reference",
-        "",
-        f"Gate result: `{gate_result_ref}`",
-        "",
-    ]
-
-    try:
-        ctx_path.write_text("\n".join(lines), encoding="utf-8")
-        return ctx_path
-    except OSError as exc:
-        sys.stderr.write(
-            f"[solo-mode] inline-review-context write failed "
-            f"(phase={phase}, gate={gate_name}): {exc}\n"
-        )
-        return None
-
-
-# ---------------------------------------------------------------------------
 # Gate-result writer
 # ---------------------------------------------------------------------------
 
@@ -698,20 +642,6 @@ def dispatch_human_inline(
     # -----------------------------------------------------------------------
     if project_dir is not None:
         _write_gate_result(project_dir, phase, gate_name, parsed, context_ref=None)
-
-    # -----------------------------------------------------------------------
-    # Write inline-review-context.md
-    # -----------------------------------------------------------------------
-    if project_dir is not None:
-        ctx_path = _write_inline_review_context(
-            project_dir, phase, gate_name, bullets, raw_response, gate_result_ref
-        )
-        if ctx_path:
-            # Back-patch context_ref into gate-result.json (best-effort)
-            _write_gate_result(
-                project_dir, phase, gate_name, parsed,
-                context_ref=str(ctx_path),
-            )
 
     # -----------------------------------------------------------------------
     # Write conditions-manifest.json for CONDITIONAL verdict

--- a/tests/crew/test_solo_mode_hitl.py
+++ b/tests/crew/test_solo_mode_hitl.py
@@ -612,26 +612,39 @@ class TestDispatchHumanInlineArtifacts(unittest.TestCase):
             self.assertIn("mode", gr)
             self.assertEqual(gr["mode"], DISPATCH_MODE)
 
-    def test_inline_review_context_written(self):
+    def test_inline_review_context_bus_emit_fired(self):
+        """W1 bus-cutover: inline-review-context is projected via bus emit;
+        the legacy disk write has been removed.  Verify the bus event fires
+        with the correct payload fields instead of asserting the file exists."""
         state = _make_state()
         policy = _minimal_gate_policy()
+        captured: list = []
+
+        def _fake_emit(event_type, payload, *, chain_id=None):
+            captured.append({"event_type": event_type, "payload": payload})
 
         with tempfile.TemporaryDirectory() as tmpdir:
             proj_dir = Path(tmpdir)
             with patch("solo_mode._is_interactive", return_value=True), \
                  patch("phase_manager.get_project_dir", return_value=proj_dir), \
-                 patch("dispatch_log.append"):
+                 patch("dispatch_log.append"), \
+                 patch("_bus.emit_event", _fake_emit):
                 dispatch_human_inline(
                     state, "build", "code-quality", policy,
                     _input_fn=lambda _="": "APPROVE",
                     _print_fn=lambda _: None,
                 )
 
-            ctx_path = proj_dir / "phases" / "build" / "inline-review-context.md"
-            self.assertTrue(ctx_path.exists(), "inline-review-context.md must be written")
-            content = ctx_path.read_text()
-            self.assertIn("Inline Gate Review", content)
-            self.assertIn("APPROVE", content)
+        types = [e["event_type"] for e in captured]
+        self.assertIn("wicked.crew.inline_review_context_recorded", types,
+                      "inline_review_context_recorded event must fire")
+        ctx_emit = next(
+            e for e in captured
+            if e["event_type"] == "wicked.crew.inline_review_context_recorded"
+        )
+        self.assertIn("gate_name", ctx_emit["payload"])
+        self.assertIn("raw_response", ctx_emit["payload"])
+        self.assertIn("bullets", ctx_emit["payload"])
 
 
 # ---------------------------------------------------------------------------
@@ -740,11 +753,9 @@ class TestDispatchHumanInlineBusEmit(unittest.TestCase):
 
             # Verdict still computed.
             self.assertEqual(result["verdict"], "APPROVE")
-            # Disk writes still completed.
+            # gate-result.json disk write still completed (legacy write preserved).
             gr_path = proj_dir / "phases" / "build" / "gate-result.json"
-            ctx_path = proj_dir / "phases" / "build" / "inline-review-context.md"
             self.assertTrue(gr_path.exists())
-            self.assertTrue(ctx_path.exists())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_projector_tranche_c.py
+++ b/tests/daemon/test_projector_tranche_c.py
@@ -385,8 +385,10 @@ def test_skipped_replay_short_circuits_via_content_hash(mem_conn, tmp_path) -> N
 
 
 def test_hitl_judge_emits_before_disk_write(tmp_path) -> None:
-    """write_hitl_decision_evidence emits wicked.hitl.decision_recorded
-    BEFORE writing the JSON file."""
+    """write_hitl_decision_evidence emits wicked.hitl.decision_recorded.
+    W5 bus-cutover: the legacy disk write has been removed; the projector
+    handler materialises the file from the bus event.  Verify the emit
+    fires with the correct payload and the function returns the target path."""
     from hitl_judge import write_hitl_decision_evidence, JudgeDecision  # type: ignore[import]
 
     project_dir = tmp_path / "proj-hitl-emit"
@@ -412,7 +414,8 @@ def test_hitl_judge_emits_before_disk_write(tmp_path) -> None:
             project_dir, "council", "council-decision.json", decision,
         )
 
-    assert path.exists()
+    # Function must still return the target path for caller compatibility.
+    assert path == project_dir / "phases" / "council" / "council-decision.json"
     assert len(captured) == 1
     emit = captured[0]
     assert emit["event_type"] == "wicked.hitl.decision_recorded"
@@ -425,9 +428,11 @@ def test_hitl_judge_emits_before_disk_write(tmp_path) -> None:
     assert emit["chain_id"] == "proj-hitl-emit.council.council-decision"
 
 
-def test_hitl_judge_emit_failure_does_not_block_write(tmp_path) -> None:
-    """A bus-emit failure must NOT block the disk write (evidence loss
-    must be visible — Decision #8 fail-open)."""
+def test_hitl_judge_emit_failure_does_not_block_return(tmp_path) -> None:
+    """A bus-emit failure must NOT prevent the function from returning the
+    target path (fail-open per Decision #8).  The projector handler replays
+    the write on reconnect; callers that stored the path will find the file
+    once the projector catches up."""
     from hitl_judge import write_hitl_decision_evidence, JudgeDecision  # type: ignore[import]
 
     project_dir = tmp_path / "proj-hitl-fail"
@@ -445,7 +450,5 @@ def test_hitl_judge_emit_failure_does_not_block_write(tmp_path) -> None:
             project_dir, "clarify", "hitl-decision.json", decision,
         )
 
-    # Disk write happened despite emit failure.
-    assert path.exists()
-    parsed = json.loads(path.read_text(encoding="utf-8"))
-    assert parsed["pause"] is False
+    # Function returns the expected path even when the bus emit failed.
+    assert path == project_dir / "phases" / "clarify" / "hitl-decision.json"


### PR DESCRIPTION
## Summary

Bus-cutover (#746) is shipped default-ON across 14 sites. The bus emit is now canonical; on-disk artifacts are projections materialised by `daemon/projector.py`. This PR removes the legacy direct-write call for the 3 sites (of the 6 in Scope A) that have **no synchronous read-after-write callers**. The remaining 3 sites (W6, W7, W8) have genuine read-after-write dependencies and are deferred to Scope B.

## Sites deleted

| Site | File | Legacy write removed |
|------|------|---------------------|
| W1 | `scripts/crew/solo_mode.py` | `_write_inline_review_context()` function + its call block in `dispatch_human_inline`. Function had a single call site; deleted entirely. Back-patch `_write_gate_result(context_ref=...)` removed with it. |
| W5 | `scripts/crew/hitl_judge.py` | `target_path.write_text(body_bytes, ...)` in `write_hitl_decision_evidence`. Function still returns `target_path` for caller compatibility. |
| W9b | `hooks/scripts/subagent_lifecycle.py` | `with open(engagement_file, "a", ...)` + flush/fsync block in `_record_specialist_engagement`. |

## Bus emits that remain canonical

- W1: `wicked.crew.inline_review_context_recorded` (fires before the deleted write)
- W5: `wicked.hitl.decision_recorded` (fires before the deleted write)
- W9b: `wicked.subagent.engaged` (fires before the deleted write)

## What stays

- All `emit_event(...)` calls
- All `try/except` fail-open wrappers (Decision #8)
- All function signatures and return values (callers depend on these)
- All non-write logic (validation, ID generation, payload construction)

## Test changes

- `tests/crew/test_solo_mode_hitl.py`: `test_inline_review_context_written` → `test_inline_review_context_bus_emit_fired` (asserts bus payload fields instead of disk file). `test_bus_emit_failure_does_not_block_disk_writes` removes the `ctx_path.exists()` assertion.
- `tests/daemon/test_projector_tranche_c.py`: `test_hitl_judge_emits_before_disk_write` replaces `path.exists()` with path-equality check. `test_hitl_judge_emit_failure_does_not_block_write` renamed and rewritten — verifies function returns correct path despite emit failure.

## Sites skipped (Scope B — genuine read-after-write)

- **W6** (`amendments.append`): `_next_scope_version` reads the JSONL file on every `append` call to maintain a monotonic scope_version. Removing the write breaks version counters across sequential calls.
- **W7** (`reeval_addendum.append`): `read()` / `read_latest()` read from the JSONL files written by `_atomic_append`. Multiple tests and production callers call `append` then `read`.
- **W8** (`convergence.record_transition`): `current_state()` is called at the start of each `record_transition` to validate the state machine. Without the disk write, all transitions after the first raise `ValueError`.

## Verification

- Grepped all 6 function names for callers before editing (results confirmed no synchronous read-after-write for W1, W5, W9b).
- Ran focused test files post-deletion: `test_solo_mode_hitl.py` 49/49 passed, `test_projector_tranche_c.py` 17/17 passed.
- Full suite: 10 failures, all pre-existing on `main` (delivery drift, command alias stubs, stub audit on `_stack_signals.py` / `telemetry.py`). Zero new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)