### PR TITLE
feat(crew): #746 Site 1 — delete dispatch-log.jsonl legacy direct-write; emit-only + projector materialises

### DIFF
--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -784,7 +784,14 @@ def _dispatch_log_appended(conn: sqlite3.Connection, event: dict) -> None:
     hmac_value = _opt(payload, "hmac")
     hmac_present_flag = 1 if _opt(payload, "hmac_present") else 0
 
-    conn.execute(
+    # Replay-safety idempotency (PR #800 fix-up): use ``INSERT OR IGNORE``
+    # with a rowcount check so we know whether THIS event was the inserter
+    # or a no-op replay.  The disk-side append is gated on the rowcount —
+    # if SQL ignored (event_id already projected), the disk side MUST also
+    # skip even if rotation moved the original line into ``archive/`` so
+    # the active-file substring check would otherwise miss it.  This is
+    # the only layer that prevents replay duplication post-rotation.
+    cursor = conn.execute(
         """
         INSERT OR IGNORE INTO dispatch_log_entries
             (event_id, project_id, phase, gate, reviewer, dispatch_id,
@@ -807,6 +814,18 @@ def _dispatch_log_appended(conn: sqlite3.Connection, event: dict) -> None:
             str(raw_payload),
         ),
     )
+    sql_inserted = cursor.rowcount == 1
+    if not sql_inserted:
+        # Replay of an already-projected event.  The original disk append
+        # may have rotated to ``archive/``; trying to append again would
+        # duplicate the entry.  Skip the disk side under flag-off too —
+        # logging only at debug level since this is a normal replay path.
+        logger.debug(
+            "projector: wicked.dispatch.log_entry_appended event_id=%r "
+            "already projected (replay); skipping disk projection",
+            event_id,
+        )
+        return
 
     # Site 1 disk projection (PR #800): materialise dispatch-log.jsonl on
     # disk so reconcile_v2's drift detector + check_orphan's read path +

--- a/daemon/projector.py
+++ b/daemon/projector.py
@@ -807,6 +807,51 @@ def _dispatch_log_appended(conn: sqlite3.Connection, event: dict) -> None:
             str(raw_payload),
         ),
     )
+
+    # Site 1 disk projection (PR #800): materialise dispatch-log.jsonl on
+    # disk so reconcile_v2's drift detector + check_orphan's read path +
+    # synthetic_drift contract still hold after the legacy direct-write in
+    # ``dispatch_log.append`` was deleted.  Wrapped in fail-open ``try``
+    # so a disk-write failure NEVER taints the SQL projection above (SQL
+    # row + drift event are still recorded).  Mirrors Site 2's
+    # ``_consensus_disk_write`` shape but reuses the existing
+    # ``_jsonl_append_projection`` helper since dispatch-log.jsonl is an
+    # append-stream artifact (same shape as W6/W7/W8).
+    #
+    # Rotation (#505): pre-#800 ``dispatch_log.append`` called
+    # ``rotate_if_needed`` BEFORE writing — that branch was deleted along
+    # with the direct write.  The projector now owns rotation: cheap
+    # stat() check before the append, fail-open on missing module.
+    try:
+        project_row = db.get_project(conn, str(project_id))
+        if project_row is not None and project_row.get("directory"):
+            target_path = (
+                Path(project_row["directory"]) / "phases" / str(phase)
+                / "dispatch-log.jsonl"
+            )
+            try:
+                from log_retention import rotate_if_needed  # type: ignore[import]
+                rotate_if_needed(target_path)
+            except ImportError:
+                pass  # fail-open: rotation module unavailable in this env
+            except Exception as rot_exc:  # noqa: BLE001 — fail-open
+                logger.warning(
+                    "projector: rotate_if_needed raised: %s; proceeding "
+                    "to append unrotated", rot_exc,
+                )
+
+        _jsonl_append_projection(
+            conn, event,
+            flag_token="DISPATCH_LOG",
+            relative_template="phases/{phase}/dispatch-log.jsonl",
+            handler_name="wicked.dispatch.log_entry_appended",
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-open for disk side-effect
+        logger.warning(
+            "projector: wicked.dispatch.log_entry_appended disk projection "
+            "raised — SQL projection still applied: %s", exc,
+        )
+
     logger.debug(
         "projector: applied wicked.dispatch.log_entry_appended "
         "project_id=%r phase=%r gate=%r event_id=%r",

--- a/scripts/crew/dispatch_log.py
+++ b/scripts/crew/dispatch_log.py
@@ -280,18 +280,33 @@ def append(
     expected_result_path: str = "gate-result.json",
     dispatched_at: Optional[str] = None,
 ) -> None:
-    """Append one dispatch record. Appending happens BEFORE dispatcher
-    invocation so an out-of-band gate-result written by a rogue
-    reviewer fails the orphan check (closes the TOCTOU window per
-    CH-04 — orphan *detection*).
+    """Emit wicked.dispatch.log_entry_appended — projector materialises file.
 
-    #500: the appended record is signed via HMAC-SHA256 over the
-    canonical record bytes under the session-scoped secret. The
-    secret is resolved via :func:`_current_hmac_secret` (auto-generated
-    on first use). The ``hmac`` hex string is stored alongside the
-    record; verifier strips it before re-computing the MAC.
+    Site 1 of the bus-cutover (#746, PR #800).  Bus is the source of truth:
+    this function builds the canonical record + HMAC, emits the bus event,
+    and returns.  The legacy ``path.open("a") + write`` call was deleted in
+    PR #800 — the projector handler ``_dispatch_log_appended`` now both
+    inserts the row into ``dispatch_log_entries`` AND materialises
+    ``phases/{phase}/dispatch-log.jsonl`` via ``_jsonl_append_projection``.
+
+    Appending happens BEFORE dispatcher invocation so an out-of-band
+    gate-result written by a rogue reviewer fails the orphan check
+    (closes the TOCTOU window per CH-04 — orphan *detection*).  Post-#800
+    the orphan check (``check_orphan``) reads from the bus event_log
+    first via ``_event_log_reader``, falling back to the legacy disk
+    path for pre-cutover projects (see ``read_entries`` below).
+
+    #500: the emitted record is signed via HMAC-SHA256 over the
+    canonical record bytes under the session-scoped secret.  The
+    ``hmac`` hex string is included in both the projection table row
+    AND the on-disk JSONL line.  Signing failure is fail-open per
+    AC-7 design — orphan-detection still catches the entry and a
+    missing-hmac path is downgraded to a WARN at verification time.
+
+    Bus failure is fail-open per Decision #8: emit failure must NOT
+    propagate to the caller (so the gate dispatch itself completes;
+    orphan check will WARN downstream when no matching entry is found).
     """
-    path = _resolve_log_path(Path(project_dir), phase)
     record: Dict[str, Any] = {
         "reviewer": reviewer,
         "phase": phase,
@@ -302,91 +317,182 @@ def append(
         "dispatch_id": dispatch_id,
     }
 
-    # #500 — compute + attach HMAC. Signing failure must NOT prevent
-    # append: the orphan check still catches a gate-result with no
+    # #500 — compute + attach HMAC.  Signing failure must NOT prevent
+    # the emit: the orphan check still catches a gate-result with no
     # matching entry, and a missing-hmac path is caught by the
-    # legacy-fallback WARN on load. Fail-open per AC-7 design.
+    # legacy-fallback WARN on load.  Fail-open per AC-7 design.
     try:
         secret = _current_hmac_secret()
         record["hmac"] = _compute_hmac(record, secret)
     except Exception as exc:  # pragma: no cover — defensive
         sys.stderr.write(
             "[wicked-garden:gate-result] dispatch-log HMAC signing failed "
-            f"(phase={phase}, reviewer={reviewer}): {exc}. Entry appended "
+            f"(phase={phase}, reviewer={reviewer}): {exc}. Emit will fire "
             "without HMAC; verifier will downgrade to orphan-detection.\n"
         )
 
-    # #505 — rotate BEFORE writing each record. Cheap stat() check;
-    # failure is non-fatal (rotate_if_needed is fail-open). Lazy import
-    # so dispatch still works if log_retention is missing.
-    try:
-        from log_retention import rotate_if_needed  # type: ignore
-        rotate_if_needed(path)
-    except ImportError:  # pragma: no cover — defensive
-        pass  # fail-open: rotation module unavailable, append continues unbounded
+    # #505 — rotation lives in the projector path now (post-#800 the
+    # source side never writes disk; the projector applies events in
+    # event_id order so rotation is naturally bounded by event_log
+    # retention).  Source-side rotation call removed as dead code under
+    # the emit-only contract.
 
-    write_succeeded = False
+    # Bus emit — projector handler materialises both the SQL row AND
+    # the on-disk JSONL line.  Fail-open: bus failure must NOT block the
+    # caller (gate dispatch must still proceed; orphan-check downstream
+    # surfaces the missing entry).
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fp:
-            fp.write(json.dumps(record, separators=(",", ":")) + "\n")
-        write_succeeded = True
-    except OSError as exc:
-        # Non-fatal: dispatch can still proceed; downstream orphan check
-        # will warn on the missing record.
+        from _bus import emit_event  # type: ignore[import]
+        project_id = project_dir.name
+        # #746 C5 — chain_id MUST include dispatch_id to keep two retry
+        # dispatches from collapsing on the bus dedupe ledger
+        # (`_bus.py:569` is_processed keyed on `(event_type, chain_id)`).
+        # Per brain memory `bus-chain-id-must-include-uniqueness-segment-gotcha`.
+        assert gate, "dispatch_log.append() requires gate"
+        chain_id = f"{project_id}.{phase}.{gate}.{dispatch_id}"
+        emit_event(
+            "wicked.dispatch.log_entry_appended",
+            {
+                "project_id": project_id,
+                "phase": phase,
+                "gate": gate,
+                "reviewer": reviewer,
+                "dispatch_id": dispatch_id,
+                "dispatcher_agent": dispatcher_agent,
+                "expected_result_path": expected_result_path,
+                "dispatched_at": record["dispatched_at"],
+                "hmac": record.get("hmac"),
+                "hmac_present": "hmac" in record,
+                # #746 C4 — ``raw_payload`` is the canonical bytes the
+                # projector replays into ``dispatch_log_entries`` AND the
+                # on-disk JSONL line (post-#800).  Carved out of the bus
+                # deny-list at ``_bus.py:_PAYLOAD_ALLOW_OVERRIDES``.
+                "raw_payload": json.dumps(record, separators=(",", ":")),
+            },
+            chain_id=chain_id,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
         sys.stderr.write(
-            "[wicked-garden:gate-result] dispatch-log append failed "
-            f"(phase={phase}, reviewer={reviewer}): {exc}.\n"
+            "[wicked-garden:gate-result] dispatch-log bus emit failed "
+            f"(phase={phase}, reviewer={reviewer}): {exc}\n"
         )
 
-    # Part C of #734: emit AFTER successful write so the bus-emit lint and
-    # the resume projector can subscribe to dispatch activity. Fail-open —
-    # a missing emit must not break the dispatch flow (orphan-check still
-    # catches missing entries via the file-based path).
-    if write_succeeded:
+
+def _read_event_log_entries(
+    project_dir: Path, phase: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Read dispatch-log records from the bus event_log (Site 1 Scope B).
+
+    Mirrors the W6/W7/W8 helper template (see brain memory
+    ``bus-cutover-read-from-event-log-helper-template``).  Returns the
+    parsed list of dispatch entries (one per
+    ``wicked.dispatch.log_entry_appended`` event in event_id order),
+    or ``None`` when the event_log path is unavailable / the read fails.
+    Caller treats ``None`` as "use disk fallback".
+
+    Each event's ``raw_payload`` is the canonical JSON record the
+    projector also writes to disk, so parsing it produces the same
+    record shape as the legacy ``read_entries`` returned.
+    """
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _scripts_root = str(_Path(__file__).resolve().parents[1])
+        if _scripts_root not in _sys.path:
+            _sys.path.insert(0, _scripts_root)
+        import sqlite3 as _sqlite3
+        from _event_log_reader import _escape_like  # type: ignore
+    except Exception:  # noqa: BLE001 — fail-open
+        return None
+
+    db_env = os.environ.get("WG_DAEMON_DB")
+    if db_env:
+        db_path = Path(db_env)
+    else:
+        db_path = (
+            Path.home()
+            / ".something-wicked"
+            / "wicked-garden-daemon"
+            / "projections.db"
+        )
+    if not db_path.is_file():
+        return None
+
+    project_id = project_dir.name
+    try:
+        conn = _sqlite3.connect(
+            f"file:{db_path}?mode=ro", uri=True, check_same_thread=False
+        )
+    except Exception:  # noqa: BLE001 — fail-open
+        return None
+    try:
         try:
-            from _bus import emit_event  # type: ignore[import]
-            # project_dir is already typed as Path in the signature; no wrap needed.
-            project_id = project_dir.name
-            # #746 C5 — chain_id MUST include dispatch_id to keep two retry
-            # dispatches from collapsing on the bus dedupe ledger
-            # (`_bus.py:569` is_processed keyed on `(event_type, chain_id)`).
-            # Per brain memory `bus-chain-id-must-include-uniqueness-segment-gotcha`.
-            assert gate, "dispatch_log.append() requires gate"
-            chain_id = f"{project_id}.{phase}.{gate}.{dispatch_id}"
-            emit_event(
-                "wicked.dispatch.log_entry_appended",
-                {
-                    "project_id": project_id,
-                    "phase": phase,
-                    "gate": gate,
-                    "reviewer": reviewer,
-                    "dispatch_id": dispatch_id,
-                    "dispatcher_agent": dispatcher_agent,
-                    "expected_result_path": expected_result_path,
-                    "dispatched_at": record["dispatched_at"],
-                    "hmac": record.get("hmac"),
-                    "hmac_present": "hmac" in record,
-                    # #746 C4 — `raw_payload` is the canonical bytes the
-                    # projector replays into `dispatch_log_entries`.  Without
-                    # this the projector cannot reproduce the on-disk JSONL
-                    # line under flag-on (Site 1 dual-write).  Carved out of
-                    # the bus deny-list at `_bus.py:_PAYLOAD_ALLOW_OVERRIDES`.
-                    "raw_payload": json.dumps(record, separators=(",", ":")),
-                },
-                chain_id=chain_id,
-            )
-        except Exception as exc:  # pragma: no cover — defensive
-            sys.stderr.write(
-                "[wicked-garden:gate-result] dispatch-log bus emit failed "
-                f"(phase={phase}, reviewer={reviewer}): {exc}\n"
-            )
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='event_log'"
+            ).fetchone()
+            if row is None:
+                return None
+        except Exception:  # noqa: BLE001 — fail-open
+            return None
+
+        # Phase-scoped query: chain_id format is
+        # ``{project_id}.{phase}.{gate}.{dispatch_id}`` so we filter by the
+        # ``{project}.{phase}.`` prefix.
+        prefix = f"{_escape_like(project_id)}.{_escape_like(phase)}.%"
+        try:
+            rows = conn.execute(
+                """
+                SELECT payload_json
+                FROM   event_log
+                WHERE  chain_id LIKE ? ESCAPE '\\'
+                  AND  event_type = ?
+                ORDER  BY event_id ASC
+                """,
+                (prefix, "wicked.dispatch.log_entry_appended"),
+            ).fetchall()
+        except Exception:  # noqa: BLE001 — fail-open
+            return None
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001 — fail-open
+            pass  # fail open: close failure on read-only conn is non-fatal
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        payload_json = row[0]
+        try:
+            payload = json.loads(payload_json) if payload_json else {}
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        raw = payload.get("raw_payload")
+        if not isinstance(raw, str):
+            continue
+        try:
+            entry = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(entry, dict):
+            out.append(entry)
+    return out
 
 
 def read_entries(project_dir: Path, phase: str) -> List[Dict[str, Any]]:
-    """Read dispatch-log entries for a phase. Malformed lines are
-    skipped with a stderr note; callers see only valid records.
+    """Read dispatch-log entries for a phase.
+
+    Bus-as-truth (#746 PR #800): when the daemon event_log is available,
+    read entries from there as the source of truth.  Falls back to disk
+    JSONL for pre-cutover projects (no daemon DB / no event_log entries).
+    Malformed lines are skipped with a stderr note in either path;
+    callers see only valid records.
     """
+    bus_entries = _read_event_log_entries(Path(project_dir), phase)
+    if bus_entries is not None and bus_entries:
+        return bus_entries
+
     path = _resolve_log_path(Path(project_dir), phase)
     if not path.exists():
         return []

--- a/scripts/crew/dispatch_log.py
+++ b/scripts/crew/dispatch_log.py
@@ -46,7 +46,7 @@ import secrets
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _SCRIPTS_DIR = os.path.dirname(_THIS_DIR)
@@ -189,6 +189,25 @@ def _reset_state_for_tests() -> None:
     _LEGACY_HMAC_WARNED = False
     _STRICT_FLIP_ANNOUNCED = False
     _DEPRECATION_EMITTED.clear()
+    _INPROCESS_CACHE.clear()
+
+
+# In-process cache of dispatch records appended in this Python process
+# (PR #800 fix-up).  Site 1 cutover removed the synchronous source-side
+# disk write, but ``approve_phase`` calls ``check_orphan`` IN THE SAME
+# REQUEST as the synthesis path's ``dispatch_log.append`` call.  The bus
+# emit fires on a background thread (subprocess), so the daemon DB has
+# not seen the entry by the time ``check_orphan`` runs — without this
+# cache, every BLEND-synthesis approve would fail orphan detection.
+#
+# Scope: keyed by (project_id, phase) so test isolation works.  Bounded
+# in practice by the lifetime of one approve_phase call; cleared in tests
+# via ``_reset_state_for_tests``.
+_INPROCESS_CACHE: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+
+
+def _cache_key(project_dir: Path, phase: str) -> Tuple[str, str]:
+    return (Path(project_dir).name, phase)
 
 
 def _resolve_log_path(project_dir: Path, phase: str) -> Path:
@@ -337,6 +356,17 @@ def append(
     # retention).  Source-side rotation call removed as dead code under
     # the emit-only contract.
 
+    # PR #800 fix-up: cache the record in-process BEFORE the bus emit so
+    # the same-process synchronous read-after-write path
+    # (``check_orphan`` in ``_load_gate_result``/
+    # ``_validate_and_orphan_check_gate_data`` runs in the same
+    # ``approve_phase`` request as ``_dispatch_gate_reviewer``) can find
+    # this entry without depending on the async daemon catching up.
+    # ``read_entries`` checks this cache first.
+    _INPROCESS_CACHE.setdefault(_cache_key(project_dir, phase), []).append(
+        dict(record)  # defensive copy — caller MUST NOT mutate the cache
+    )
+
     # Bus emit — projector handler materialises both the SQL row AND
     # the on-disk JSONL line.  Fail-open: bus failure must NOT block the
     # caller (gate dispatch must still proceed; orphan-check downstream
@@ -419,9 +449,17 @@ def _read_event_log_entries(
         return None
 
     project_id = project_dir.name
+    # URI-safe path: ``Path.as_uri()`` percent-encodes spaces, ``#``,
+    # ``?``, etc.  Building the URI by f-string drops paths containing
+    # those characters silently (the read path goes to disk fallback
+    # even though the daemon DB exists).
+    try:
+        db_uri = db_path.as_uri() + "?mode=ro"
+    except (ValueError, OSError):  # absolute-path requirement / encoding
+        return None
     try:
         conn = _sqlite3.connect(
-            f"file:{db_path}?mode=ro", uri=True, check_same_thread=False
+            db_uri, uri=True, check_same_thread=False
         )
     except Exception:  # noqa: BLE001 — fail-open
         return None
@@ -480,19 +518,70 @@ def _read_event_log_entries(
     return out
 
 
+def _bus_as_truth_dispatch_log_on() -> bool:
+    """Resolve WG_BUS_AS_TRUTH_DISPATCH_LOG honoring the explicit-off opt-out.
+
+    Mirrors ``scripts/_bus.py::_bus_as_truth_enabled("DISPATCH_LOG")`` so
+    the read path uses the same flag semantics as the emit + projector
+    paths.  Default-ON (DISPATCH_LOG is in ``_BUS_AS_TRUTH_DEFAULT_ON``);
+    explicit ``"off"`` (case/whitespace normalised) opts out.
+    """
+    raw = os.environ.get("WG_BUS_AS_TRUTH_DISPATCH_LOG", "").strip().lower()
+    if raw == "off":
+        return False
+    return True  # default-ON or explicit "on"
+
+
 def read_entries(project_dir: Path, phase: str) -> List[Dict[str, Any]]:
     """Read dispatch-log entries for a phase.
 
-    Bus-as-truth (#746 PR #800): when the daemon event_log is available,
-    read entries from there as the source of truth.  Falls back to disk
-    JSONL for pre-cutover projects (no daemon DB / no event_log entries).
-    Malformed lines are skipped with a stderr note in either path;
+    Resolution order (PR #800 fix-up — covers same-process read-after-write,
+    cross-process bus visibility, and pre-cutover legacy):
+      1. In-process cache — entries appended by THIS process via
+         ``append`` (synchronous read-after-write, indispensable for the
+         same-request approve_phase → check_orphan path).
+      2. Bus event_log — cross-process source of truth post-cutover.
+      3. Disk JSONL — fallback for pre-cutover projects (no event_log
+         entries) AND when the operator opts out via
+         ``WG_BUS_AS_TRUTH_DISPATCH_LOG=off``.
+
+    Malformed lines are skipped with a stderr note in the disk path;
     callers see only valid records.
     """
-    bus_entries = _read_event_log_entries(Path(project_dir), phase)
-    if bus_entries is not None and bus_entries:
-        return bus_entries
+    cache_key = _cache_key(project_dir, phase)
+    cached = list(_INPROCESS_CACHE.get(cache_key, []))
 
+    # When the operator explicitly opts out, skip the event_log read but
+    # KEEP the in-process cache (same-process synchronous semantics
+    # remain correct even under flag-off — the cache is a process-local
+    # detail, not a "bus-as-truth" decision).
+    flag_on = _bus_as_truth_dispatch_log_on()
+
+    bus_entries: List[Dict[str, Any]] = []
+    if flag_on:
+        bus = _read_event_log_entries(Path(project_dir), phase)
+        if bus is not None:
+            bus_entries = bus
+
+    # If the cache OR bus has anything, treat that as the authoritative
+    # set (cache wins on duplicates because it's the just-written record).
+    if cached or bus_entries:
+        seen_keys = set()
+        merged: List[Dict[str, Any]] = []
+        for entry in cached + bus_entries:
+            # Dedup by (dispatch_id, dispatched_at) — unique within a
+            # (project, phase, gate, retry) cohort per the chain_id contract.
+            key = (
+                entry.get("dispatch_id", ""),
+                entry.get("dispatched_at", ""),
+            )
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            merged.append(entry)
+        return merged
+
+    # Disk fallback — pre-cutover legacy OR explicit opt-out.
     path = _resolve_log_path(Path(project_dir), phase)
     if not path.exists():
         return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,15 @@ def _reset_bus_emit_counters():
         _bus._bus_reset_stats()
     except ImportError:
         pass
+    # Also reset dispatch_log's process-local state (PR #800 fix-up): the
+    # in-process cache that powers synchronous read-after-write must be
+    # cleared between tests or one test's appends bleed into the next
+    # test's read_entries.  Same fail-open contract.
+    try:
+        import dispatch_log  # type: ignore[import]
+        dispatch_log._reset_state_for_tests()
+    except ImportError:
+        pass
     yield
     # Post-test reset is intentionally omitted — the pre-test reset above
     # is sufficient. Post-test would mask counter assertions in teardown.

--- a/tests/crew/test_dispatch_log.py
+++ b/tests/crew/test_dispatch_log.py
@@ -38,17 +38,108 @@ def _make_project(tmp: str, phase: str = "design") -> Path:
     return project
 
 
+def _setup_daemon_db_for_test(tmp_root: Path, project_dir: Path) -> Path:
+    """Create an in-memory daemon DB that emits land in (PR #800).
+
+    Site 1's source-side disk write was deleted in PR #800 — the projector
+    handler is the canonical writer.  Tests that assert round-trip behaviour
+    (``append`` → ``read_entries``) need to run the projector synchronously.
+
+    Builds a real sqlite DB at ``tmp_root/projections.db``, applies the
+    daemon schema, registers the project row, sets ``WG_DAEMON_DB`` so
+    ``read_entries`` queries it, and returns the path so the caller can
+    pass it into ``_simulate_bus_pipeline``.
+    """
+    sys.path.insert(0, str(_REPO_ROOT / "daemon"))
+    import db as daemon_db  # noqa: PLC0415 — local test scaffolding
+
+    db_path = tmp_root / "projections.db"
+    import sqlite3 as _sqlite3  # noqa: PLC0415
+    conn = _sqlite3.connect(str(db_path))
+    daemon_db.init_schema(conn)
+    project_id = project_dir.name
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "design",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+    conn.close()
+
+    os.environ["WG_DAEMON_DB"] = str(db_path)
+    return db_path
+
+
+def _simulate_bus_pipeline(db_path: Path):
+    """Return an emit-replacement that routes events through the projector.
+
+    Inserts a row into ``event_log`` then calls ``_dispatch_log_appended``
+    synchronously — this lets unit tests verify the source→bus→projector
+    chain without a running daemon.  Closes the DB connection between calls
+    so each invocation sees a fresh transaction (mirrors the real daemon's
+    per-event flush).
+
+    ``row_factory = sqlite3.Row`` is set on the per-call connection because
+    ``daemon.db.get_project`` does ``dict(row)`` — that only works under
+    Row-factory mode (mirrors the production daemon's connection setup in
+    ``daemon/runtime.py`` where the daemon assigns ``conn.row_factory``).
+    """
+    import sqlite3 as _sqlite3  # noqa: PLC0415
+    sys.path.insert(0, str(_REPO_ROOT / "daemon"))
+    from projector import _dispatch_log_appended  # noqa: PLC0415
+
+    counter = {"event_id": 0}
+
+    def _emit(event_type, payload, chain_id=None, metadata=None):
+        counter["event_id"] += 1
+        eid = counter["event_id"]
+        conn = _sqlite3.connect(str(db_path))
+        conn.row_factory = _sqlite3.Row
+        try:
+            conn.execute(
+                "INSERT INTO event_log (event_id, event_type, chain_id, "
+                "payload_json, projection_status, ingested_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (eid, event_type, chain_id or "",
+                 json.dumps(payload), "pending", 1_700_000_000 + eid),
+            )
+            conn.commit()
+            event = {
+                "event_id": eid,
+                "event_type": event_type,
+                "chain_id": chain_id,
+                "created_at": 1_700_000_000 + eid,
+                "payload": payload,
+            }
+            _dispatch_log_appended(conn, event)
+            conn.commit()
+        finally:
+            conn.close()
+
+    return _emit
+
+
 class AppendAndRead(unittest.TestCase):
     def test_append_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = _make_project(tmp)
-            append(project, "design", reviewer="security-engineer",
-                   gate="design-quality", dispatch_id="d-1",
-                   dispatched_at="2026-04-19T10:00:00+00:00")
-            entries = read_entries(project, "design")
-            self.assertEqual(len(entries), 1)
-            self.assertEqual(entries[0]["reviewer"], "security-engineer")
-            self.assertEqual(entries[0]["dispatch_id"], "d-1")
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            try:
+                with patch.dict(
+                    os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+                ), patch("_bus.emit_event",
+                         side_effect=_simulate_bus_pipeline(db_path)):
+                    append(project, "design", reviewer="security-engineer",
+                           gate="design-quality", dispatch_id="d-1",
+                           dispatched_at="2026-04-19T10:00:00+00:00")
+                    entries = read_entries(project, "design")
+                self.assertEqual(len(entries), 1)
+                self.assertEqual(entries[0]["reviewer"], "security-engineer")
+                self.assertEqual(entries[0]["dispatch_id"], "d-1")
+            finally:
+                os.environ.pop("WG_DAEMON_DB", None)
 
     def test_read_entries_skips_malformed_lines(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -71,15 +162,23 @@ class AppendAndRead(unittest.TestCase):
     def test_read_latest_picks_newest_dispatched_at(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = _make_project(tmp)
-            append(project, "design", reviewer="r1", gate="g",
-                   dispatch_id="d-old",
-                   dispatched_at="2026-04-19T00:00:00+00:00")
-            append(project, "design", reviewer="r2", gate="g",
-                   dispatch_id="d-new",
-                   dispatched_at="2026-04-19T05:00:00+00:00")
-            latest = read_latest(project, "design", "g")
-            self.assertIsNotNone(latest)
-            self.assertEqual(latest["dispatch_id"], "d-new")
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            try:
+                with patch.dict(
+                    os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+                ), patch("_bus.emit_event",
+                         side_effect=_simulate_bus_pipeline(db_path)):
+                    append(project, "design", reviewer="r1", gate="g",
+                           dispatch_id="d-old",
+                           dispatched_at="2026-04-19T00:00:00+00:00")
+                    append(project, "design", reviewer="r2", gate="g",
+                           dispatch_id="d-new",
+                           dispatched_at="2026-04-19T05:00:00+00:00")
+                    latest = read_latest(project, "design", "g")
+                self.assertIsNotNone(latest)
+                self.assertEqual(latest["dispatch_id"], "d-new")
+            finally:
+                os.environ.pop("WG_DAEMON_DB", None)
 
 
 class CheckOrphanSoftWindow(unittest.TestCase):
@@ -110,18 +209,26 @@ class CheckOrphanSoftWindow(unittest.TestCase):
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(project, "design",
-                   reviewer="security-engineer",
-                   gate="design-quality",
-                   dispatch_id="d-1",
-                   dispatched_at="2026-04-19T09:00:00+00:00")
-            parsed = {
-                "reviewer": "security-engineer",
-                "recorded_at": "2026-04-19T10:00:00+00:00",
-                "gate": "design-quality",
-            }
-            # No raise — the entry matches.
-            check_orphan(parsed, project, "design")
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            try:
+                with patch.dict(
+                    os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+                ), patch("_bus.emit_event",
+                         side_effect=_simulate_bus_pipeline(db_path)):
+                    append(project, "design",
+                           reviewer="security-engineer",
+                           gate="design-quality",
+                           dispatch_id="d-1",
+                           dispatched_at="2026-04-19T09:00:00+00:00")
+                    parsed = {
+                        "reviewer": "security-engineer",
+                        "recorded_at": "2026-04-19T10:00:00+00:00",
+                        "gate": "design-quality",
+                    }
+                    # No raise — the entry matches.
+                    check_orphan(parsed, project, "design")
+            finally:
+                os.environ.pop("WG_DAEMON_DB", None)
 
     def test_dispatched_at_after_recorded_at_fails_match(self):
         with tempfile.TemporaryDirectory() as tmp, patch.dict(
@@ -129,18 +236,26 @@ class CheckOrphanSoftWindow(unittest.TestCase):
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(project, "design",
-                   reviewer="r",
-                   gate="g",
-                   dispatch_id="d-1",
-                   dispatched_at="2026-04-19T12:00:00+00:00")
-            parsed = {
-                "reviewer": "r",
-                "recorded_at": "2026-04-19T10:00:00+00:00",
-                "gate": "g",
-            }
-            with self.assertRaises(GateResultAuthorizationError):
-                check_orphan(parsed, project, "design")
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            try:
+                with patch.dict(
+                    os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+                ), patch("_bus.emit_event",
+                         side_effect=_simulate_bus_pipeline(db_path)):
+                    append(project, "design",
+                           reviewer="r",
+                           gate="g",
+                           dispatch_id="d-1",
+                           dispatched_at="2026-04-19T12:00:00+00:00")
+                    parsed = {
+                        "reviewer": "r",
+                        "recorded_at": "2026-04-19T10:00:00+00:00",
+                        "gate": "g",
+                    }
+                    with self.assertRaises(GateResultAuthorizationError):
+                        check_orphan(parsed, project, "design")
+            finally:
+                os.environ.pop("WG_DAEMON_DB", None)
 
 
 class CheckOrphanStrictWindow(unittest.TestCase):
@@ -172,99 +287,79 @@ class DispatchCheckDisabled(unittest.TestCase):
             check_orphan(parsed, project, "design")
 
 
-class BusCutoverFlagByteIdentity(unittest.TestCase):
-    """Site 1 bus-cutover (#746) Council Condition C2 — flag-off MUST be
-    byte-identical to flag-on at the disk-file level.  The flag gates
-    only the projector handler's write to the new SQLite table; the
-    on-disk JSONL must be the same in both modes (one full release of
-    dual-write before deletion of the disk path)."""
+class BusCutoverFlagSourceContract(unittest.TestCase):
+    """Site 1 bus-cutover (PR #800) — emit-only contract.
 
-    def test_flag_off_and_flag_on_produce_identical_disk_bytes(self):
-        # Disable the bus subprocess so the emit thread is a no-op and
-        # we can compare disk bytes deterministically without depending
-        # on a running wicked-bus binary.
-        with tempfile.TemporaryDirectory() as tmp_off, \
-             tempfile.TemporaryDirectory() as tmp_on, \
-             patch.dict(os.environ, {"WICKED_BUS_DISABLED": "1"}):
-            project_off = _make_project(tmp_off)
-            project_on = _make_project(tmp_on)
+    Pre-PR-#800 the source-side ``dispatch_log.append`` did write-then-emit:
+    the disk JSONL was source of truth, and Council Condition C2 required
+    flag-off and flag-on to produce byte-identical disk bytes (the flag
+    gated only the projector's SQL row).
 
-            # Reset secret so both runs sign with the same key.
-            dispatch_log._reset_state_for_tests()
-            dispatch_log.set_hmac_secret("deterministic-secret-for-byte-identity")
+    PR #800 deleted the source-side disk write — the projector handler is
+    now the canonical disk writer too.  Source-side semantics under both
+    flag-off and explicit-off are identical: the helper emits the bus event
+    (or fails fail-open if the bus is down) and returns without touching
+    disk.  These tests assert the new emit-only contract."""
 
-            common_kwargs = dict(
-                reviewer="security-engineer",
-                gate="design-quality",
-                dispatch_id="d-byte-identity",
-                dispatcher_agent="wicked-garden:crew:phase-manager",
-                expected_result_path="phases/design/gate-result.json",
-                dispatched_at="2026-04-19T10:00:00+00:00",
-            )
-
-            # flag-off path (default — env var unset)
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("WG_BUS_AS_TRUTH_DISPATCH_LOG", None)
-                append(project_off, "design", **common_kwargs)
-            off_bytes = (
-                project_off / "phases" / "design" / "dispatch-log.jsonl"
-            ).read_bytes()
-
-            # flag-on path
-            with patch.dict(
-                os.environ,
-                {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
-            ):
-                append(project_on, "design", **common_kwargs)
-            on_bytes = (
-                project_on / "phases" / "design" / "dispatch-log.jsonl"
-            ).read_bytes()
-
-            self.assertEqual(
-                off_bytes, on_bytes,
-                "Council C2 violation: flag-on disk bytes diverge from "
-                "flag-off bytes. The flag MUST gate ONLY the projector "
-                "table write — the on-disk JSONL is source of truth and "
-                "must be byte-identical across modes."
-            )
-
-    def test_explicit_off_value_is_treated_as_off_per_council_c1(self):
-        """Council C1 — explicit ``"off"`` (and ``"OFF"``, ``" off "``) opts out.
-
-        Pre-fold, ``"dry-run"`` was used here as a proxy for "not on".  After the
-        flag-fold (PR #777) ``"dry-run"`` for a shipped token falls through to the
-        default-ON map → True.  The canonical opt-out is now the literal ``"off"``
-        (case/whitespace normalised).  This test is updated to use ``"off"`` as the
-        opt-out value so it continues to assert the byte-identity (C2) contract."""
-        with tempfile.TemporaryDirectory() as tmp_off, \
-             tempfile.TemporaryDirectory() as tmp_explicit_off, \
-             patch.dict(os.environ, {"WICKED_BUS_DISABLED": "1"}):
-            project_off = _make_project(tmp_off)
-            project_explicit_off = _make_project(tmp_explicit_off)
+    def test_source_side_does_not_write_disk_under_flag_on(self):
+        """Source-side never writes disk post PR-#800 — projector owns it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = _make_project(tmp)
             dispatch_log._reset_state_for_tests()
             dispatch_log.set_hmac_secret("deterministic-secret")
 
-            common_kwargs = dict(
-                reviewer="r", gate="g", dispatch_id="d-dry",
-                dispatched_at="2026-04-19T10:00:00+00:00",
+            with patch.dict(
+                os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+            ), patch("_bus.emit_event"):
+                # Bus emit mocked — projector NOT triggered; we only verify
+                # the source side does not touch disk.
+                append(project, "design",
+                       reviewer="security-engineer",
+                       gate="design-quality",
+                       dispatch_id="d-1",
+                       dispatched_at="2026-04-19T10:00:00+00:00")
+
+            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
+            self.assertFalse(
+                log_path.exists(),
+                "PR #800 deleted the source-side disk write — the helper "
+                "must emit only.  The projector materialises the file.",
             )
 
-            os.environ.pop("WG_BUS_AS_TRUTH_DISPATCH_LOG", None)
-            append(project_off, "design", **common_kwargs)
-            off_bytes = (
-                project_off / "phases" / "design" / "dispatch-log.jsonl"
-            ).read_bytes()
+    def test_explicit_off_value_emits_nothing_per_council_c1(self):
+        """Council C1 — explicit ``"off"`` (case/whitespace normalised) opts out.
+
+        Under the pre-#800 dual-write contract this test compared disk bytes.
+        Post-#800 the source never writes disk, so the contract becomes:
+        explicit-off → projector handler is a no-op (verified separately in
+        ``tests/daemon/test_projector_dispatch_log``).  At the source-side
+        boundary the emit fires regardless of flag value (the flag gates
+        the projector's handler, not the source emit).
+        """
+        captured: list = []
+
+        def _capture(event_type, payload, chain_id=None, metadata=None):
+            captured.append({"event_type": event_type, "payload": payload,
+                             "chain_id": chain_id})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = _make_project(tmp)
+            dispatch_log._reset_state_for_tests()
+            dispatch_log.set_hmac_secret("deterministic-secret")
 
             with patch.dict(
-                os.environ,
-                {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "off"},
-            ):
-                append(project_explicit_off, "design", **common_kwargs)
-            explicit_off_bytes = (
-                project_explicit_off / "phases" / "design" / "dispatch-log.jsonl"
-            ).read_bytes()
+                os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "off"}
+            ), patch("_bus.emit_event", side_effect=_capture):
+                append(project, "design",
+                       reviewer="r", gate="g",
+                       dispatch_id="d-off",
+                       dispatched_at="2026-04-19T10:00:00+00:00")
 
-            self.assertEqual(off_bytes, explicit_off_bytes)
+            # Source emits regardless of the consumer-side flag.  Disk is
+            # untouched (no source-side write post-#800).
+            self.assertEqual(len(captured), 1)
+            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
+            self.assertFalse(log_path.exists())
 
 
 class ChainIdIncludesDispatchId(unittest.TestCase):
@@ -383,12 +478,11 @@ class ChainIdIncludesDispatchId(unittest.TestCase):
 
 
 class ChainIdRequiresGate(unittest.TestCase):
-    """Council C5 — `gate` is always supplied per current line 298, so
-    the conditional `if gate else` branch is dropped.  An empty-string
-    gate trips the in-emit assertion which is swallowed by the fail-open
-    guard, so no emit fires.  We assert the absence of the emit; the
-    disk write still succeeds (orphan check catches the missing entry
-    via the file-based path)."""
+    """Council C5 — `gate` is always supplied per current line 298.  An
+    empty-string gate trips the in-emit assertion which is swallowed by
+    the fail-open guard, so no emit fires.  Post PR-#800 (legacy disk
+    write deleted) there is no on-disk fallback either: the helper is
+    emit-only, so empty-gate produces neither an emit nor a disk write."""
 
     def test_missing_gate_skips_emit_via_assertion(self):
         with tempfile.TemporaryDirectory() as tmp, \
@@ -401,11 +495,11 @@ class ChainIdRequiresGate(unittest.TestCase):
                 append(project, "design", reviewer="r", gate="",
                        dispatch_id="d-1",
                        dispatched_at="2026-04-19T10:00:00+00:00")
-                # Disk write still succeeded.
+                # PR #800: source-side disk write was deleted.  Empty
+                # gate now produces neither an emit (assertion trips +
+                # fail-open swallow) nor a disk file.
                 log_path = project / "phases" / "design" / "dispatch-log.jsonl"
-                self.assertTrue(log_path.is_file())
-                # But the emit was skipped — assertion swallowed by the
-                # fail-open guard before emit_event was reached.
+                self.assertFalse(log_path.exists())
                 target_calls = [
                     c for c in mock_emit.call_args_list
                     if c.args and c.args[0] == "wicked.dispatch.log_entry_appended"

--- a/tests/crew/test_dispatch_log.py
+++ b/tests/crew/test_dispatch_log.py
@@ -98,14 +98,6 @@ def _simulate_bus_pipeline(db_path: Path):
         conn = _sqlite3.connect(str(db_path))
         conn.row_factory = _sqlite3.Row
         try:
-            conn.execute(
-                "INSERT INTO event_log (event_id, event_type, chain_id, "
-                "payload_json, projection_status, ingested_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (eid, event_type, chain_id or "",
-                 json.dumps(payload), "pending", 1_700_000_000 + eid),
-            )
-            conn.commit()
             event = {
                 "event_id": eid,
                 "event_type": event_type,
@@ -113,7 +105,24 @@ def _simulate_bus_pipeline(db_path: Path):
                 "created_at": 1_700_000_000 + eid,
                 "payload": payload,
             }
+            # Production ordering (mirrors ``daemon/consumer.py::process_batch``,
+            # PR #800 fix-up): projector runs FIRST, event_log row is
+            # appended AFTER.  The original fixture inverted this and
+            # masked the append→read race the cutover introduced; fixing
+            # the order here lets test_read_entries observe the actual
+            # production ordering.  The in-process cache in
+            # ``dispatch_log.append`` is what makes synchronous read-after-
+            # write correct; the event_log row is materialised after the
+            # projector returns.
             _dispatch_log_appended(conn, event)
+            conn.commit()
+            conn.execute(
+                "INSERT INTO event_log (event_id, event_type, chain_id, "
+                "payload_json, projection_status, ingested_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (eid, event_type, chain_id or "",
+                 json.dumps(payload), "applied", 1_700_000_000 + eid),
+            )
             conn.commit()
         finally:
             conn.close()
@@ -326,15 +335,17 @@ class BusCutoverFlagSourceContract(unittest.TestCase):
                 "must emit only.  The projector materialises the file.",
             )
 
-    def test_explicit_off_value_emits_nothing_per_council_c1(self):
-        """Council C1 — explicit ``"off"`` (case/whitespace normalised) opts out.
+    def test_explicit_off_value_does_not_short_circuit_source_emit(self):
+        """Council C1 — explicit ``"off"`` (case/whitespace normalised) opts
+        out at the projector boundary, not the source.
 
         Under the pre-#800 dual-write contract this test compared disk bytes.
         Post-#800 the source never writes disk, so the contract becomes:
         explicit-off → projector handler is a no-op (verified separately in
-        ``tests/daemon/test_projector_dispatch_log``).  At the source-side
+        ``tests/daemon/test_projector_dispatch_log``).  At the SOURCE-side
         boundary the emit fires regardless of flag value (the flag gates
-        the projector's handler, not the source emit).
+        the projector's handler, not the source emit).  This test pins
+        that source-side behaviour.
         """
         captured: list = []
 

--- a/tests/crew/test_dispatch_log_hmac.py
+++ b/tests/crew/test_dispatch_log_hmac.py
@@ -46,6 +46,15 @@ def _make_project(tmp: str, phase: str = "design") -> Path:
     return project
 
 
+# Reuse the daemon-pipeline scaffolding from the sibling dispatch-log test
+# file (PR #800).  Site 1 source-side disk write was deleted; HMAC tests
+# need a real projector roundtrip to observe the on-disk JSONL line.
+from tests.crew.test_dispatch_log import (  # noqa: E402
+    _setup_daemon_db_for_test,
+    _simulate_bus_pipeline,
+)
+
+
 class _HmacTestBase(unittest.TestCase):
     """Shared fixture that pins the HMAC secret so tests are deterministic."""
 
@@ -55,6 +64,7 @@ class _HmacTestBase(unittest.TestCase):
 
     def tearDown(self) -> None:
         dispatch_log._reset_state_for_tests()
+        os.environ.pop("WG_DAEMON_DB", None)
 
 
 class HmacHappyPath(_HmacTestBase):
@@ -62,14 +72,19 @@ class HmacHappyPath(_HmacTestBase):
         """Round-trip: appended record carries an ``hmac`` hex string."""
         with tempfile.TemporaryDirectory() as tmp:
             project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="security-engineer",
-                gate="design-quality",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T10:00:00+00:00",
-            )
-            entries = read_entries(project, "design")
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            with patch.dict(
+                os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+            ), patch("_bus.emit_event",
+                     side_effect=_simulate_bus_pipeline(db_path)):
+                append(
+                    project, "design",
+                    reviewer="security-engineer",
+                    gate="design-quality",
+                    dispatch_id="d-1",
+                    dispatched_at="2026-04-19T10:00:00+00:00",
+                )
+                entries = read_entries(project, "design")
             self.assertEqual(len(entries), 1)
             self.assertIn("hmac", entries[0])
             self.assertRegex(entries[0]["hmac"], r"^[0-9a-f]{64}$")
@@ -81,22 +96,59 @@ class HmacHappyPath(_HmacTestBase):
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="security-engineer",
-                gate="design-quality",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
-            parsed = {
-                "reviewer": "security-engineer",
-                "recorded_at": "2026-04-19T10:00:00+00:00",
-                "gate": "design-quality",
-            }
-            check_orphan(parsed, project, "design")  # no raise
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
+            with patch.dict(
+                os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+            ), patch("_bus.emit_event",
+                     side_effect=_simulate_bus_pipeline(db_path)):
+                append(
+                    project, "design",
+                    reviewer="security-engineer",
+                    gate="design-quality",
+                    dispatch_id="d-1",
+                    dispatched_at="2026-04-19T09:00:00+00:00",
+                )
+                parsed = {
+                    "reviewer": "security-engineer",
+                    "recorded_at": "2026-04-19T10:00:00+00:00",
+                    "gate": "design-quality",
+                }
+                check_orphan(parsed, project, "design")  # no raise
 
 
 class HmacMismatch(_HmacTestBase):
+    """HMAC tamper detection.
+
+    Post PR-#800 the source of truth is the bus event_log; the on-disk
+    JSONL is a projection.  These tests pre-create a tampered disk file
+    WITHOUT a daemon DB (so the event_log path returns None and
+    ``read_entries`` falls back to disk).  This exercises the
+    legacy-disk tamper path the same way it always did — and surfaces
+    the threat model end-to-end: a disk-only tampering attempt by an
+    attacker WITHOUT bus access still trips the MAC.
+    """
+
+    def _planted_entry(self, secret: str) -> dict:
+        """Build a real, HMAC-signed record without going through ``append``.
+
+        Bypasses the bus emit so the test can plant a record on disk
+        without relying on the projector roundtrip.  HMAC is computed
+        the same way ``append`` would compute it under the fixture
+        secret, so legitimate entries pass verification while tampered
+        copies still fail.
+        """
+        record = {
+            "reviewer": "security-engineer",
+            "phase": "design",
+            "gate": "design-quality",
+            "dispatched_at": "2026-04-19T09:00:00+00:00",
+            "dispatcher_agent": "wicked-garden:crew:phase-manager",
+            "expected_result_path": "gate-result.json",
+            "dispatch_id": "d-1",
+        }
+        record["hmac"] = dispatch_log._compute_hmac(record, secret)
+        return record
+
     def test_tampered_hmac_raises_tamper_error(self):
         """Rewriting an entry's ``hmac`` → DispatchLogTamperError on verify."""
         with tempfile.TemporaryDirectory() as tmp, patch.dict(
@@ -104,18 +156,9 @@ class HmacMismatch(_HmacTestBase):
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="security-engineer",
-                gate="design-quality",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
-            # Forge the log: keep the entry body but rewrite the HMAC
-            # to something an attacker without the secret would pick.
-            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
-            entry = json.loads(log_path.read_text().strip())
+            entry = self._planted_entry(_FIXED_SECRET)
             entry["hmac"] = "0" * 64  # deterministic fake
+            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
             log_path.write_text(json.dumps(entry) + "\n")
 
             parsed = {
@@ -137,18 +180,11 @@ class HmacMismatch(_HmacTestBase):
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="security-engineer",
-                gate="design-quality",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
-            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
-            entry = json.loads(log_path.read_text().strip())
+            entry = self._planted_entry(_FIXED_SECRET)
             # Swap the dispatcher identity to simulate an attacker
             # promoting a fast-pass reviewer into the slot.
             entry["dispatcher_agent"] = "wicked-garden:crew:auto-approve"
+            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
             log_path.write_text(json.dumps(entry) + "\n")
 
             parsed = {
@@ -241,39 +277,58 @@ class LegacyFallback(_HmacTestBase):
 
 class SecretManagement(_HmacTestBase):
     def test_secret_never_appears_in_record(self):
-        """Safety net: the secret itself must never land on disk."""
-        with tempfile.TemporaryDirectory() as tmp:
-            project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="r",
-                gate="g",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
-            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
-            raw = log_path.read_text()
-            self.assertNotIn(_FIXED_SECRET, raw)
+        """Safety net: the secret itself must never land in the canonical
+        record bytes (raw_payload + on-disk JSONL).
+
+        Compute the same record + HMAC the source side would produce, then
+        check that the serialized bytes never contain the secret.  This
+        verifies the contract without going through the bus pipeline —
+        the contract is purely about how _compute_hmac handles the secret,
+        and that's testable in isolation.
+        """
+        record = {
+            "reviewer": "r",
+            "phase": "design",
+            "gate": "g",
+            "dispatched_at": "2026-04-19T09:00:00+00:00",
+            "dispatcher_agent": "wicked-garden:crew:phase-manager",
+            "expected_result_path": "gate-result.json",
+            "dispatch_id": "d-1",
+        }
+        record["hmac"] = dispatch_log._compute_hmac(record, _FIXED_SECRET)
+        canonical = json.dumps(record, separators=(",", ":"))
+        # Both the on-disk JSONL line and the bus emit's raw_payload use
+        # this canonical form — assert the secret never appears in it.
+        self.assertNotIn(_FIXED_SECRET, canonical)
 
     def test_canonical_signing_order_insensitive(self):
-        """Verify uses sorted JSON — field-order reshuffles still verify."""
+        """Verify uses sorted JSON — field-order reshuffles still verify.
+
+        Plant a re-ordered (canonically equivalent) entry on disk WITHOUT a
+        daemon DB so ``read_entries`` falls back to disk and verifies the
+        re-ordered bytes.  Pre PR-#800 this test relied on the
+        source-side disk write; post-#800 it explicitly exercises the
+        legacy-fallback path.
+        """
         with tempfile.TemporaryDirectory() as tmp, patch.dict(
             os.environ,
             {"WG_GATE_RESULT_STRICT_AFTER": "2099-01-01"},
         ):
             project = _make_project(tmp)
-            append(
-                project, "design",
-                reviewer="r",
-                gate="g",
-                dispatch_id="d-1",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
-            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
-            entry = json.loads(log_path.read_text().strip())
-            # Re-serialize with reversed key order — byte-wise different,
-            # canonically equivalent.
+            # Build an HMAC-signed record without going through the bus path.
+            entry = {
+                "reviewer": "r",
+                "phase": "design",
+                "gate": "g",
+                "dispatched_at": "2026-04-19T09:00:00+00:00",
+                "dispatcher_agent": "wicked-garden:crew:phase-manager",
+                "expected_result_path": "gate-result.json",
+                "dispatch_id": "d-1",
+            }
+            entry["hmac"] = dispatch_log._compute_hmac(entry, _FIXED_SECRET)
+            # Write reversed-key form: byte-wise different, canonically same.
             reordered = {k: entry[k] for k in reversed(list(entry.keys()))}
+            log_path = project / "phases" / "design" / "dispatch-log.jsonl"
             log_path.write_text(json.dumps(reordered) + "\n")
 
             parsed = {

--- a/tests/crew/test_dispatch_log_integration.py
+++ b/tests/crew/test_dispatch_log_integration.py
@@ -55,6 +55,74 @@ def _project_dir_of(tmp_base: Path, name: str) -> Path:
     return project_dir
 
 
+def _setup_daemon_pipeline(tmp_base: Path, project_dir: Path):
+    """Setup an in-memory daemon DB + bus emit replacement (PR #800).
+
+    Site 1's source-side disk write was deleted in PR #800 — these
+    integration tests need a real projector roundtrip to observe
+    dispatch-log entries.  Returns the bus-emit replacement; caller
+    uses ``patch("_bus.emit_event", side_effect=_emit)`` and remembers
+    to ``os.environ.pop("WG_DAEMON_DB", None)`` in finally.
+    """
+    sys.path.insert(0, str(_REPO_ROOT / "daemon"))
+    import db as daemon_db  # noqa: PLC0415
+    import sqlite3 as _sqlite3  # noqa: PLC0415
+    from projector import _dispatch_log_appended  # noqa: PLC0415
+
+    db_path = tmp_base / "projections.db"
+    conn = _sqlite3.connect(str(db_path))
+    daemon_db.init_schema(conn)
+    project_id = project_dir.name
+    conn.execute(
+        "INSERT OR IGNORE INTO projects "
+        "(id, name, directory, status, current_phase, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (project_id, project_id, str(project_dir), "active", "build",
+         1_700_000_000, 1_700_000_000),
+    )
+    conn.commit()
+    conn.close()
+    os.environ["WG_DAEMON_DB"] = str(db_path)
+    os.environ["WG_BUS_AS_TRUTH_DISPATCH_LOG"] = "on"
+
+    counter = {"event_id": 0}
+
+    def _emit(event_type, payload, chain_id=None, metadata=None):
+        if event_type != "wicked.dispatch.log_entry_appended":
+            return  # only the dispatch-log handler is wired in this fixture
+        counter["event_id"] += 1
+        eid = counter["event_id"]
+        c = _sqlite3.connect(str(db_path))
+        c.row_factory = _sqlite3.Row  # daemon.db.get_project requires Row factory
+        try:
+            c.execute(
+                "INSERT INTO event_log (event_id, event_type, chain_id, "
+                "payload_json, projection_status, ingested_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (eid, event_type, chain_id or "",
+                 json.dumps(payload), "pending", 1_700_000_000 + eid),
+            )
+            c.commit()
+            event = {
+                "event_id": eid,
+                "event_type": event_type,
+                "chain_id": chain_id,
+                "created_at": 1_700_000_000 + eid,
+                "payload": payload,
+            }
+            _dispatch_log_appended(c, event)
+            c.commit()
+        finally:
+            c.close()
+
+    return _emit
+
+
+def _teardown_daemon_pipeline() -> None:
+    os.environ.pop("WG_DAEMON_DB", None)
+    os.environ.pop("WG_BUS_AS_TRUTH_DISPATCH_LOG", None)
+
+
 class DispatchLogWiringFastEvaluator(unittest.TestCase):
     """B-1: ``_dispatch_fast_evaluator`` MUST append a dispatch-log entry
     BEFORE invoking the reviewer dispatcher."""
@@ -64,43 +132,48 @@ class DispatchLogWiringFastEvaluator(unittest.TestCase):
             tmp_base = Path(tmp)
             state = _mk_state(tmp_base)
             project_dir = _project_dir_of(tmp_base, state.name)
+            emit = _setup_daemon_pipeline(tmp_base, project_dir)
+            try:
+                with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                     patch("_bus.emit_event", side_effect=emit):
+                    calls = []
 
-            with patch.object(pm, "get_project_dir", return_value=project_dir):
-                calls = []
+                    def spy_dispatcher(subagent_type, prompt, ctx):
+                        # Assert a matching dispatch-log entry exists BEFORE
+                        # the reviewer is invoked.
+                        entries = dispatch_log.read_entries(project_dir, "build")
+                        calls.append({"subagent": subagent_type,
+                                      "log_len_at_call": len(entries)})
+                        return {"verdict": "APPROVE", "score": 0.9,
+                                "reason": "ok", "conditions": []}
 
-                def spy_dispatcher(subagent_type, prompt, ctx):
-                    # Assert a matching dispatch-log entry exists BEFORE
-                    # the reviewer is invoked.
-                    entries = dispatch_log.read_entries(project_dir, "build")
-                    calls.append({"subagent": subagent_type,
-                                  "log_len_at_call": len(entries)})
-                    return {"verdict": "APPROVE", "score": 0.9,
-                            "reason": "ok", "conditions": []}
+                    pm._dispatch_fast_evaluator(
+                        state, "build", "code-quality",
+                        dispatcher=spy_dispatcher,
+                    )
 
-                pm._dispatch_fast_evaluator(
-                    state, "build", "code-quality",
-                    dispatcher=spy_dispatcher,
+                # Log entry MUST have been appended BEFORE the spy was invoked.
+                self.assertEqual(len(calls), 1)
+                self.assertGreaterEqual(
+                    calls[0]["log_len_at_call"], 1,
+                    "dispatch-log must be appended BEFORE reviewer dispatch",
                 )
 
-            # Log entry MUST have been appended BEFORE the spy was invoked.
-            self.assertEqual(len(calls), 1)
-            self.assertGreaterEqual(
-                calls[0]["log_len_at_call"], 1,
-                "dispatch-log must be appended BEFORE reviewer dispatch",
-            )
-
-            entries = dispatch_log.read_entries(project_dir, "build")
-            self.assertEqual(len(entries), 1)
-            self.assertEqual(entries[0]["reviewer"], "gate-evaluator")
-            self.assertEqual(entries[0]["phase"], "build")
-            self.assertEqual(entries[0]["gate"], "code-quality")
-            self.assertEqual(
-                entries[0]["dispatcher_agent"],
-                "wicked-garden:crew:phase-manager",
-            )
-            self.assertEqual(
-                entries[0]["expected_result_path"], "gate-result.json",
-            )
+                with patch("_bus.emit_event", side_effect=emit):
+                    entries = dispatch_log.read_entries(project_dir, "build")
+                self.assertEqual(len(entries), 1)
+                self.assertEqual(entries[0]["reviewer"], "gate-evaluator")
+                self.assertEqual(entries[0]["phase"], "build")
+                self.assertEqual(entries[0]["gate"], "code-quality")
+                self.assertEqual(
+                    entries[0]["dispatcher_agent"],
+                    "wicked-garden:crew:phase-manager",
+                )
+                self.assertEqual(
+                    entries[0]["expected_result_path"], "gate-result.json",
+                )
+            finally:
+                _teardown_daemon_pipeline()
 
 
 class DispatchLogWiringSequential(unittest.TestCase):
@@ -109,24 +182,27 @@ class DispatchLogWiringSequential(unittest.TestCase):
             tmp_base = Path(tmp)
             state = _mk_state(tmp_base)
             project_dir = _project_dir_of(tmp_base, state.name)
+            emit = _setup_daemon_pipeline(tmp_base, project_dir)
+            try:
+                with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                     patch("_bus.emit_event", side_effect=emit):
+                    def mock_dispatcher(subagent_type, prompt, ctx):
+                        return {"verdict": "APPROVE", "score": 0.85,
+                                "reason": "ok", "conditions": []}
 
-            with patch.object(pm, "get_project_dir", return_value=project_dir):
-                def mock_dispatcher(subagent_type, prompt, ctx):
-                    return {"verdict": "APPROVE", "score": 0.85,
-                            "reason": "ok", "conditions": []}
-
-                pm._dispatch_sequential(
-                    state, "build", "code-quality",
-                    ["security-engineer", "senior-engineer"],
-                    dispatcher=mock_dispatcher,
+                    pm._dispatch_sequential(
+                        state, "build", "code-quality",
+                        ["security-engineer", "senior-engineer"],
+                        dispatcher=mock_dispatcher,
+                    )
+                    entries = dispatch_log.read_entries(project_dir, "build")
+                self.assertEqual(len(entries), 2)
+                self.assertEqual(
+                    {e["reviewer"] for e in entries},
+                    {"security-engineer", "senior-engineer"},
                 )
-
-            entries = dispatch_log.read_entries(project_dir, "build")
-            self.assertEqual(len(entries), 2)
-            self.assertEqual(
-                {e["reviewer"] for e in entries},
-                {"security-engineer", "senior-engineer"},
-            )
+            finally:
+                _teardown_daemon_pipeline()
 
 
 class DispatchLogWiringParallel(unittest.TestCase):
@@ -135,22 +211,25 @@ class DispatchLogWiringParallel(unittest.TestCase):
             tmp_base = Path(tmp)
             state = _mk_state(tmp_base)
             project_dir = _project_dir_of(tmp_base, state.name)
+            emit = _setup_daemon_pipeline(tmp_base, project_dir)
+            try:
+                with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                     patch("_bus.emit_event", side_effect=emit):
+                    def mock_dispatcher(subagent_type, prompt, ctx):
+                        return {"verdict": "APPROVE", "score": 0.85,
+                                "reason": "ok", "conditions": []}
 
-            with patch.object(pm, "get_project_dir", return_value=project_dir):
-                def mock_dispatcher(subagent_type, prompt, ctx):
-                    return {"verdict": "APPROVE", "score": 0.85,
-                            "reason": "ok", "conditions": []}
-
-                pm._dispatch_parallel_and_merge(
-                    state, "build", "code-quality",
-                    ["security-engineer", "senior-engineer"],
-                    dispatcher=mock_dispatcher,
-                )
-
-            entries = dispatch_log.read_entries(project_dir, "build")
-            reviewers = {e["reviewer"] for e in entries}
-            self.assertIn("security-engineer", reviewers)
-            self.assertIn("senior-engineer", reviewers)
+                    pm._dispatch_parallel_and_merge(
+                        state, "build", "code-quality",
+                        ["security-engineer", "senior-engineer"],
+                        dispatcher=mock_dispatcher,
+                    )
+                    entries = dispatch_log.read_entries(project_dir, "build")
+                reviewers = {e["reviewer"] for e in entries}
+                self.assertIn("security-engineer", reviewers)
+                self.assertIn("senior-engineer", reviewers)
+            finally:
+                _teardown_daemon_pipeline()
 
 
 class DispatchLogWiringCouncil(unittest.TestCase):
@@ -159,32 +238,35 @@ class DispatchLogWiringCouncil(unittest.TestCase):
             tmp_base = Path(tmp)
             state = _mk_state(tmp_base)
             project_dir = _project_dir_of(tmp_base, state.name)
+            emit = _setup_daemon_pipeline(tmp_base, project_dir)
+            try:
+                with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                     patch("_bus.emit_event", side_effect=emit):
+                    def mock_dispatcher(subagent_type, prompt, ctx):
+                        return {"verdict": "APPROVE", "score": 0.85,
+                                "reason": "ok", "conditions": []}
 
-            with patch.object(pm, "get_project_dir", return_value=project_dir):
-                def mock_dispatcher(subagent_type, prompt, ctx):
-                    return {"verdict": "APPROVE", "score": 0.85,
-                            "reason": "ok", "conditions": []}
-
-                pm._dispatch_council(
-                    state, "build", "code-quality",
-                    ["security-engineer", "senior-engineer"],
-                    dispatcher=mock_dispatcher,
+                    pm._dispatch_council(
+                        state, "build", "code-quality",
+                        ["security-engineer", "senior-engineer"],
+                        dispatcher=mock_dispatcher,
+                    )
+                    entries = dispatch_log.read_entries(project_dir, "build")
+                # Council records its own entries; parallel-and-merge
+                # underneath records additional entries.  We only assert
+                # the council-tagged entries exist.
+                council_entries = [
+                    e for e in entries
+                    if e.get("dispatcher_agent") ==
+                    "wicked-garden:crew:phase-manager:council"
+                ]
+                self.assertEqual(len(council_entries), 2)
+                self.assertEqual(
+                    {e["reviewer"] for e in council_entries},
+                    {"security-engineer", "senior-engineer"},
                 )
-
-            entries = dispatch_log.read_entries(project_dir, "build")
-            # Council records its own entries; parallel-and-merge underneath
-            # records additional entries. We only assert the council-tagged
-            # entries exist.
-            council_entries = [
-                e for e in entries
-                if e.get("dispatcher_agent") ==
-                "wicked-garden:crew:phase-manager:council"
-            ]
-            self.assertEqual(len(council_entries), 2)
-            self.assertEqual(
-                {e["reviewer"] for e in council_entries},
-                {"security-engineer", "senior-engineer"},
-            )
+            finally:
+                _teardown_daemon_pipeline()
 
 
 class DispatchLogOrphanCheckIntegration(unittest.TestCase):

--- a/tests/crew/test_dispatch_log_integration.py
+++ b/tests/crew/test_dispatch_log_integration.py
@@ -95,14 +95,6 @@ def _setup_daemon_pipeline(tmp_base: Path, project_dir: Path):
         c = _sqlite3.connect(str(db_path))
         c.row_factory = _sqlite3.Row  # daemon.db.get_project requires Row factory
         try:
-            c.execute(
-                "INSERT INTO event_log (event_id, event_type, chain_id, "
-                "payload_json, projection_status, ingested_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (eid, event_type, chain_id or "",
-                 json.dumps(payload), "pending", 1_700_000_000 + eid),
-            )
-            c.commit()
             event = {
                 "event_id": eid,
                 "event_type": event_type,
@@ -110,7 +102,19 @@ def _setup_daemon_pipeline(tmp_base: Path, project_dir: Path):
                 "created_at": 1_700_000_000 + eid,
                 "payload": payload,
             }
+            # Production ordering (mirrors ``daemon/consumer.py::process_batch``,
+            # PR #800 fix-up): projector runs FIRST, event_log row is
+            # appended AFTER.  Same change as
+            # ``tests/crew/test_dispatch_log.py::_simulate_bus_pipeline``.
             _dispatch_log_appended(c, event)
+            c.commit()
+            c.execute(
+                "INSERT INTO event_log (event_id, event_type, chain_id, "
+                "payload_json, projection_status, ingested_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (eid, event_type, chain_id or "",
+                 json.dumps(payload), "applied", 1_700_000_000 + eid),
+            )
             c.commit()
         finally:
             c.close()

--- a/tests/crew/test_emit_additions_part_c.py
+++ b/tests/crew/test_emit_additions_part_c.py
@@ -71,22 +71,20 @@ class TestDispatchLogEmits(unittest.TestCase):
                         "demo-proj.build.testability.abc123",
                     )
 
-    def test_no_emit_when_write_fails(self):
-        """Disk write fails → no orphan emit. Otherwise the projector
-        would record a phantom dispatch that never made it to disk.
+    def test_emit_fires_independently_of_disk_state(self):
+        """Site 1 emit-only contract (PR #800).
 
-        Patches ``Path.open`` (which the dispatch-log path uses) rather
-        than ``builtins.open`` — patching builtins.open would also break
-        the lazy ``from _bus import emit_event`` import inside the
-        function, masking what the test is trying to measure.
+        Pre-PR-#800 the helper did write-then-emit: a disk failure
+        suppressed the emit (no phantom event in event_log).  After
+        legacy-write deletion the helper is emit-only — the projector
+        materialises the file from the bus event.  The emit must fire
+        regardless of any disk state at the source side.
         """
         with TemporaryDirectory() as tmp:
             project_dir = Path(tmp) / "demo-proj"
             project_dir.mkdir()
             with patch.object(dl, "_compute_hmac", return_value="deadbeef"), \
-                 patch.object(dl, "_current_hmac_secret", return_value=b"secret"), \
-                 patch("crew.dispatch_log.Path.open",
-                       side_effect=OSError("disk full")):
+                 patch.object(dl, "_current_hmac_secret", return_value=b"secret"):
                 import _bus  # type: ignore[import]
                 with patch.object(_bus, "emit_event") as mock_emit:
                     dl.append(
@@ -96,17 +94,33 @@ class TestDispatchLogEmits(unittest.TestCase):
                         gate="testability",
                         dispatch_id="abc123",
                     )
-                    # Filter to just the Part-C emit (rotate may emit others).
                     target_calls = [
                         c for c in mock_emit.call_args_list
                         if c.args
                         and c.args[0] == "wicked.dispatch.log_entry_appended"
                     ]
-                    self.assertEqual(target_calls, [],
-                                     "emit must NOT fire when the disk write failed")
+                    self.assertEqual(
+                        len(target_calls), 1,
+                        "emit-only contract: the bus event must fire — "
+                        "the projector materialises the file from raw_payload.",
+                    )
+                    # Source-side never touches disk.
+                    log_path = dl._resolve_log_path(project_dir, "build")
+                    self.assertFalse(
+                        log_path.exists(),
+                        "PR #800 deleted the source-side disk write; helper "
+                        "must emit only.",
+                    )
 
     def test_emit_failure_does_not_break_dispatch(self):
-        """Bus emit raising must not propagate — fail-open contract."""
+        """Bus emit raising must not propagate — fail-open contract.
+
+        Post PR-#800 the source side never touches disk; we just verify
+        the caller does not see the bus exception.  The on-disk file
+        appears later when the daemon's projector replays the queued
+        event (which doesn't exist in this test, so we assert nothing
+        about the file).
+        """
         with TemporaryDirectory() as tmp:
             project_dir = Path(tmp) / "demo-proj"
             project_dir.mkdir()
@@ -123,12 +137,6 @@ class TestDispatchLogEmits(unittest.TestCase):
                         gate="testability",
                         dispatch_id="abc123",
                     )
-                    # And the JSONL line must still be on disk.
-                    log_path = dl._resolve_log_path(project_dir, "build")
-                    self.assertTrue(log_path.is_file())
-                    line = log_path.read_text(encoding="utf-8").strip()
-                    record = json.loads(line)
-                    self.assertEqual(record["reviewer"], "rev-1")
 
 
 class TestConsensusEmits(unittest.TestCase):

--- a/tests/crew/test_log_retention.py
+++ b/tests/crew/test_log_retention.py
@@ -153,25 +153,45 @@ class DispatchLogRotatesOnAppend(unittest.TestCase):
         dispatch_log._reset_state_for_tests()
 
     def test_append_triggers_rotation_above_threshold(self):
+        """Rotation runs in the projector path post PR-#800.
+
+        Pre-PR-#800 ``dispatch_log.append`` called ``rotate_if_needed``
+        before writing — that lived alongside the legacy direct write.
+        Both moved to the projector handler ``_dispatch_log_appended``
+        when the source-side write was deleted.  This test drives a
+        real bus → projector roundtrip so rotation fires under the new
+        architecture.
+        """
+        # Reuse the daemon-pipeline helper from sibling test file.
+        from tests.crew.test_dispatch_log import (
+            _setup_daemon_db_for_test,
+            _simulate_bus_pipeline,
+        )
+
         with tempfile.TemporaryDirectory() as tmp, patch.dict(
             os.environ, {"WG_LOG_RETENTION_MAX_MB": "0.001"}  # ~1KB
         ):
             project = Path(tmp) / "proj"
             (project / "phases" / "design").mkdir(parents=True)
+            db_path = _setup_daemon_db_for_test(Path(tmp), project)
 
             # Pre-seed the log beyond threshold so the next append rotates.
             log = project / "phases" / "design" / "dispatch-log.jsonl"
             log.write_text("x" * 2048)
 
-            dispatch_log.append(
-                project, "design",
-                reviewer="r",
-                gate="g",
-                dispatch_id="d-after-rotate",
-                dispatched_at="2026-04-19T09:00:00+00:00",
-            )
+            with patch.dict(
+                os.environ, {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"}
+            ), patch("_bus.emit_event",
+                     side_effect=_simulate_bus_pipeline(db_path)):
+                dispatch_log.append(
+                    project, "design",
+                    reviewer="r",
+                    gate="g",
+                    dispatch_id="d-after-rotate",
+                    dispatched_at="2026-04-19T09:00:00+00:00",
+                )
 
-            # Archive was created.
+            # Archive was created (rotation ran inside the projector).
             archive_dir = log.parent / DEFAULT_ARCHIVE_DIR
             self.assertTrue(archive_dir.exists())
             archives = list(archive_dir.glob("dispatch-log.*.jsonl.gz"))
@@ -181,6 +201,7 @@ class DispatchLogRotatesOnAppend(unittest.TestCase):
             self.assertEqual(len(lines), 1)
             record = json.loads(lines[0])
             self.assertEqual(record["dispatch_id"], "d-after-rotate")
+            os.environ.pop("WG_DAEMON_DB", None)
 
 
 class AuditLogRotatesOnAppend(unittest.TestCase):

--- a/tests/crew/test_solo_mode_hitl.py
+++ b/tests/crew/test_solo_mode_hitl.py
@@ -399,49 +399,56 @@ class TestDispatchLogHumanInlineOrphan(unittest.TestCase):
         check_orphan finds the matching (reviewer, phase, gate, dispatched_at)
         entry, HMAC-verifies it, and returns without raising.
 
-        The env override WG_GATE_RESULT_DISPATCH_CHECK=off was removed in
-        #662 blocker-3.  The test now exercises the real orphan-check path.
-        The HMAC used by append and check_orphan is the same process-local
-        secret (auto-generated once per process), so the verify succeeds.
+        Post PR-#800: source-side disk write was deleted; the dispatch-log
+        is materialised by the projector handler.  This test drives a real
+        bus → projector pipeline so check_orphan reads the resulting
+        event_log entry and validates HMAC.
         """
         from dispatch_log import append, check_orphan, set_hmac_secret
+        from tests.crew.test_dispatch_log import (
+            _setup_daemon_db_for_test,
+            _simulate_bus_pipeline,
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            proj_dir = Path(tmpdir)
+            proj_dir = Path(tmpdir) / "proj"
+            (proj_dir / "phases" / "build").mkdir(parents=True)
             phase = "build"
             gate = "code-quality"
             reviewer = REVIEWER_NAME
             dispatched_at = "2026-04-25T10:00:00+00:00"
 
-            # Pin a known secret so append and check_orphan share it
-            # deterministically within this test (avoids SessionState I/O).
+            db_path = _setup_daemon_db_for_test(Path(tmpdir), proj_dir)
+
             test_secret = "test-hmac-secret-662-blocker3"
             set_hmac_secret(test_secret)
             try:
-                # Write a dispatch-log entry (as _dispatch_human_inline does)
-                append(
-                    proj_dir, phase,
-                    reviewer=reviewer,
-                    gate=gate,
-                    dispatch_id=f"{phase}:{gate}:{reviewer}:{dispatched_at}",
-                    dispatcher_agent="wicked-garden:crew:phase-manager:human-inline",
-                    dispatched_at=dispatched_at,
-                )
+                with patch.dict(
+                    os.environ,
+                    {"WG_BUS_AS_TRUTH_DISPATCH_LOG": "on"},
+                ), patch("_bus.emit_event",
+                         side_effect=_simulate_bus_pipeline(db_path)):
+                    append(
+                        proj_dir, phase,
+                        reviewer=reviewer,
+                        gate=gate,
+                        dispatch_id=f"{phase}:{gate}:{reviewer}:{dispatched_at}",
+                        dispatcher_agent="wicked-garden:crew:phase-manager:human-inline",
+                        dispatched_at=dispatched_at,
+                    )
 
-                # check_orphan for a gate-result with recorded_at >= dispatched_at
-                parsed = {
-                    "reviewer": reviewer,
-                    "gate": gate,
-                    "recorded_at": "2026-04-25T10:01:00+00:00",
-                }
-
-                # Must match the pre-registered entry and HMAC-verify successfully
-                try:
-                    check_orphan(parsed, proj_dir, phase)
-                except Exception as exc:
-                    self.fail(f"check_orphan raised unexpectedly: {exc}")
+                    parsed = {
+                        "reviewer": reviewer,
+                        "gate": gate,
+                        "recorded_at": "2026-04-25T10:01:00+00:00",
+                    }
+                    try:
+                        check_orphan(parsed, proj_dir, phase)
+                    except Exception as exc:
+                        self.fail(f"check_orphan raised unexpectedly: {exc}")
             finally:
-                set_hmac_secret(None)  # restore neutral state for other tests
+                set_hmac_secret(None)
+                os.environ.pop("WG_DAEMON_DB", None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bus-cutover Site 1 deletion — the **last gate-critical write site**.  Source-side ``dispatch_log.append`` is now emit-only; the projector handler ``_dispatch_log_appended`` materialises the on-disk JSONL via ``_jsonl_append_projection`` and owns rotation.  ``check_orphan`` reads from the bus event_log first via the W6/W7/W8 helper template, falling back to disk for pre-cutover projects.

## Why this needed careful work

Site 1 was held back from earlier deletion PRs because:
- Reordering write-then-emit → emit-only changes the failure semantics (disk failure no longer suppresses the emit; bus failure no longer aborts dispatch).
- ``check_orphan`` is security-critical (gate-result authorisation) — false negatives let a rogue gate-result pass; false positives reject legitimate dispatches.
- HMAC signatures need to survive the cutover unchanged.

## Changes

### daemon/projector.py
- ``_dispatch_log_appended`` now calls ``_jsonl_append_projection`` after the SQL INSERT.
- Rotation moved from source to projector — pre-append stat() check, fail-open on missing module.
- Disk-side wrapped in fail-open envelope so write failure never taints SQL projection.

### scripts/crew/dispatch_log.py
- ``append``: deleted disk write + rotation + write-success gating.  Emit fires unconditionally; bus failure fail-open per Decision #8.
- ``read_entries``: new ``_read_event_log_entries`` helper prefers event_log (mirrors W6/W7/W8 pattern); falls back to disk for pre-cutover projects.
- ``check_orphan`` and ``read_latest`` benefit transitively.

### Tests — 8 files, daemon-pipeline scaffolding added
- ``test_dispatch_log.py``: new helpers ``_setup_daemon_db_for_test`` + ``_simulate_bus_pipeline`` create an in-memory daemon DB and route bus emits through the projector synchronously.  ``BusCutoverFlagByteIdentity`` rewritten as ``BusCutoverFlagSourceContract`` (emit-only contract).
- ``test_dispatch_log_hmac.py``: HMAC tampering tests plant pre-signed entries on disk WITHOUT a daemon DB so ``read_entries`` falls back to disk and detects tampering.
- ``test_dispatch_log_integration.py``: 4 tests updated to use the daemon pipeline.
- ``test_emit_additions_part_c.py``: ``no_emit_when_write_fails`` → ``emit_fires_independently_of_disk_state``.
- ``test_log_retention.py``: rotation test drives the daemon pipeline so rotation fires inside the projector.
- ``test_solo_mode_hitl.py``: orphan-check test uses the daemon pipeline.

### Bonus fix
The test scaffolding sets ``conn.row_factory = sqlite3.Row`` because ``daemon.db.get_project()`` does ``dict(row)`` — production daemon already sets this in ``daemon/runtime.py``; the test scaffolding now matches.

## Tests

\`\`\`
2,472 pass / 7 skipped — no regressions
\`\`\`

## Cutover complete

All 4 gate-critical write sites deleted (Sites 1, 2, 3, 4) and all 3 read-after-write audit sites have read-from-event-log refactors (W6, W7, W8).  Bus is now the source of truth for every gate-critical and audit-load-bearing artifact in the cutover scope.  Closes the architectural debt captured in ``memory/bus-cutover-legacy-write-deletion-is-per-site-architecture``.

## Test plan

- [x] ``pytest tests/crew/test_dispatch_log.py`` — 14 pass
- [x] ``pytest tests/crew/test_dispatch_log_hmac.py`` — 8 pass
- [x] ``pytest tests/crew/test_dispatch_log_integration.py`` — 6 pass
- [x] ``pytest tests/daemon/test_projector_dispatch_log.py`` — 13 pass
- [x] ``pytest tests/crew/test_log_retention.py`` — 12 pass
- [x] Full sweep — 2,472 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)