### PR TITLE
lint(hooks): enforce computed-field shape + tighten substring matchers

### DIFF
--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -1210,6 +1210,29 @@ def _handle_bash_consensus(tool_input: dict, tool_response) -> dict:
 # Handler: Bash (general activity tracking)
 # ---------------------------------------------------------------------------
 
+# Theme 9: word-boundary check for search-tool invocations.  The discovery
+# hint must NOT fire on benign references like ``echo "use grep instead"``
+# or comments.  A real invocation appears at start-of-line/command-start or
+# after a shell separator (``;``, ``&&``, ``||``, ``|``, newline).
+_SEARCH_INVOCATION_RE = re.compile(
+    r"(?:^|[\n;|&]\s*)(?:grep|rg|ripgrep|ag)\b",
+)
+
+
+def _looks_like_search_invocation(command_lower: str) -> bool:
+    """Return True iff ``command_lower`` actually invokes grep/rg/ag/ripgrep.
+
+    Caller passes the lowercased command string.  Returns False on empty
+    input or any regex failure (fail-quiet — discovery hints are advisory).
+    """
+    if not command_lower:
+        return False
+    try:
+        return bool(_SEARCH_INVOCATION_RE.search(command_lower))
+    except (TypeError, re.error):
+        return False
+
+
 def _handle_bash(tool_input: dict, tool_response) -> dict:
     """Track bash activity + detect usage patterns for discovery hints."""
     messages = []
@@ -1225,8 +1248,11 @@ def _handle_bash(tool_input: dict, tool_response) -> dict:
     # --- Discovery hints from bash command patterns ---
     command = (tool_input.get("command") or "").lower()
     if command:
-        # Manual grep/rg usage → suggest wicked-garden search
-        if any(kw in command for kw in ["grep ", "rg ", "ripgrep", "ag "]):
+        # Theme 9: bare ``"grep " in command`` matches comments like
+        # ``# grep is fine``.  Require the tool to appear at command start
+        # OR after a separator (``;``, ``&&``, ``||``, ``|``, newline) so
+        # the hint only fires on actual invocations, not stale references.
+        if _looks_like_search_invocation(command):
             hint = _try_discovery_hint("grep_search")
             if hint:
                 messages.append(hint)

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -1213,9 +1213,18 @@ def _handle_bash_consensus(tool_input: dict, tool_response) -> dict:
 # Theme 9: word-boundary check for search-tool invocations.  The discovery
 # hint must NOT fire on benign references like ``echo "use grep instead"``
 # or comments.  A real invocation appears at start-of-line/command-start or
-# after a shell separator (``;``, ``&&``, ``||``, ``|``, newline).
+# after a shell separator (``;``, ``&&``, ``||``, ``|``, ``&``, newline).
+#
+# Precision rules:
+#   * Allow optional leading whitespace after ``^`` and after each separator,
+#     so ``"  grep pattern"`` and ``"ls;   grep foo"`` both match.
+#   * Use ``\b`` before each tool name — without it, ``"ls; tag"`` would
+#     false-match ``ag`` inside ``tag``.
+#   * Accept multi-char ``&&`` and ``||`` as well as single ``;`` ``|`` ``&``;
+#     ``&&`` must precede ``&`` (and ``||`` precede ``|``) in the alternation
+#     so the longer separator wins the leftmost-match.
 _SEARCH_INVOCATION_RE = re.compile(
-    r"(?:^|[\n;|&]\s*)(?:grep|rg|ripgrep|ag)\b",
+    r"(?:^\s*|[\n;]\s*|&&\s*|\|\|\s*|[|&]\s*)\b(?:grep|rg|ripgrep|ag)\b",
 )
 
 

--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -265,8 +265,14 @@ def _handle_write_guard(tool_input: dict) -> str:
     # AGENTS.md is a cross-tool instruction file shared with Codex, Cursor, Amp, etc.
     # Writes are allowed — a PostToolUse hook keeps CLAUDE.md and AGENTS.md in sync.
 
-    # Block writes to MEMORY.md or Claude's auto-memory directory
-    is_memory_md = file_path.endswith("MEMORY.md")
+    # Theme 9: bare endswith("MEMORY.md") would match e.g. "notMEMORY.md".
+    # Use Path().name for a true basename check, which is platform-agnostic
+    # (works for both POSIX and Windows separators).
+    try:
+        _basename = Path(file_path).name
+    except (TypeError, ValueError):
+        _basename = ""
+    is_memory_md = _basename == "MEMORY.md"
     is_auto_memory = _AUTO_MEMORY_MARKER in file_path and "/memory/" in file_path
 
     if is_memory_md or is_auto_memory:
@@ -430,12 +436,21 @@ _ORCHESTRATOR_PHASES = {"build", "review"}
 
 
 def _is_allowlisted(file_path: str) -> bool:
-    """Return True if file_path is on the orchestrator write allowlist."""
+    """Return True if file_path is on the orchestrator write allowlist.
+
+    Theme 9: ``endswith("status.md")`` would false-match ``bogusstatus.md``.
+    Suffix entries match against the basename (Path.name) so the check
+    requires the exact filename, not a tail-substring.
+    """
     for fragment in _ORCHESTRATOR_ALLOWLIST:
         if fragment in file_path:
             return True
+    try:
+        basename = Path(file_path).name
+    except (TypeError, ValueError):
+        return False
     for suffix in _ORCHESTRATOR_ALLOWLIST_SUFFIXES:
-        if file_path.endswith(suffix):
+        if basename == suffix:
             return True
     return False
 

--- a/scenarios/qe/hook-script-lints.md
+++ b/scenarios/qe/hook-script-lints.md
@@ -1,0 +1,133 @@
+---
+name: hook-script-lints
+title: Hook script lints — computed-field enforcement, path-suffix tightening, error wrap context
+description: Acceptance checks for the three lint themes added to pre_tool.py, post_tool.py, and _event_schema.py
+type: testing
+difficulty: beginner
+estimated_minutes: 5
+execution: manual
+---
+
+# Hook Script Lints
+
+Three lint themes harden the hook entry points and the schema they enforce:
+
+1. **Theme 1 — computed-without-enforcement.** `_event_schema.py::COMPUTED_FIELD_VALIDATORS` enforces shape on `content_hash`, `dedup_key`, `idempotency_key`, and `event_id` whenever a producer attaches them to TaskCreate/TaskUpdate metadata. The schema's promise now matches runtime behavior.
+2. **Theme 9 — grep-based contract checks need functional context.** Two bare-substring checks were tightened to functional-syntax checks: `pre_tool.py` now matches `MEMORY.md` and `status.md` by basename (not tail-substring); `post_tool.py` requires grep/rg/ag/ripgrep to appear at command start or after a shell separator, not as a comment fragment.
+3. **Theme 10 — wrap domain errors at architectural boundaries.** Hooks must fail-open and never raise, so `_event_schema.py::validate_metadata` cannot use `raise WrapperError(...) from e`. Instead, the boundary preserves the original exception's `type(e).__name__` and message inside the returned error string so callers (and operators reading `_logger`) retain the chain.
+
+## Setup
+
+```bash
+cd "$CLAUDE_PLUGIN_ROOT"
+python3 -m pytest tests/test_event_schema_archetype.py tests/test_event_schema_gate_finding_lifecycle.py -q
+# Existing schema tests must still pass.
+```
+
+## Theme 1 — computed-field enforcement
+
+```bash
+python3 - <<'PY'
+import sys
+sys.path.insert(0, "scripts")
+from _event_schema import validate_metadata
+
+base = {
+    "chain_id": "p.clarify",
+    "event_type": "task",
+    "source_agent": "facilitator",
+    "phase": "clarify",
+}
+
+# Empty content_hash MUST be rejected
+err = validate_metadata({**base, "content_hash": ""})
+assert err and "content_hash" in err and "shape check" in err, err
+
+# Short content_hash MUST be rejected (< 8 hex chars)
+err = validate_metadata({**base, "content_hash": "abc"})
+assert err and "content_hash" in err, err
+
+# Valid hex content_hash MUST pass
+assert validate_metadata({**base, "content_hash": "deadbeef"}) is None
+
+# Blank dedup_key MUST be rejected
+err = validate_metadata({**base, "dedup_key": "   "})
+assert err and "dedup_key" in err, err
+
+# Non-positive event_id MUST be rejected
+assert validate_metadata({**base, "event_id": 0})
+assert validate_metadata({**base, "event_id": -1})
+
+# Positive int event_id MUST pass
+assert validate_metadata({**base, "event_id": 42}) is None
+
+print("Theme 1 OK")
+PY
+```
+
+Expected: `Theme 1 OK`. A regression here means a producer can attach a malformed computed field and the validator silently accepts it.
+
+## Theme 9 — basename and word-boundary checks
+
+```bash
+python3 - <<'PY'
+import os, sys
+os.environ["CLAUDE_PLUGIN_ROOT"] = os.getcwd()
+sys.path.insert(0, "hooks/scripts")
+import pre_tool, post_tool
+
+# pre_tool: bogusstatus.md MUST NOT be allowlisted, status.md MUST be
+assert pre_tool._is_allowlisted("foo/bogusstatus.md") is False
+assert pre_tool._is_allowlisted("foo/status.md") is True
+assert pre_tool._is_allowlisted(".something-wicked/x.json") is True
+
+# pre_tool: MEMORY.md guard uses basename match
+from pathlib import Path
+assert Path("notMEMORY.md").name != "MEMORY.md"
+assert Path("docs/MEMORY.md").name == "MEMORY.md"
+
+# post_tool: grep word-boundary
+assert post_tool._looks_like_search_invocation("grep foo") is True
+assert post_tool._looks_like_search_invocation("cat x | grep y") is True
+assert post_tool._looks_like_search_invocation("cmd; rg foo") is True
+assert post_tool._looks_like_search_invocation("echo grep is here") is False
+assert post_tool._looks_like_search_invocation("# rg later") is False
+print("Theme 9 OK")
+PY
+```
+
+Expected: `Theme 9 OK`. A regression means stale references (comments, echo strings, partial filenames) trigger the hint or guard.
+
+## Theme 10 — preserved error context
+
+```bash
+python3 - <<'PY'
+import sys
+sys.path.insert(0, "scripts")
+from _event_schema import validate_metadata
+
+bad = {
+    "chain_id": "p.review.gate1",
+    "event_type": "gate-finding",
+    "source_agent": "reviewer",
+    "phase": "review",
+    "verdict": "APPROVE",
+    "score": "not-a-number",
+    "min_score": 0.7,
+}
+err = validate_metadata(bad)
+assert err is not None
+# The original ValueError type and message MUST appear in the returned string
+assert "ValueError" in err, err
+assert "could not convert string to float" in err, err
+print("Theme 10 OK")
+PY
+```
+
+Expected: `Theme 10 OK`. A regression means the architectural boundary swallows the underlying coercion failure without preserving any chain context, making operator debugging harder.
+
+## Files touched
+
+- `scripts/_event_schema.py` — `COMPUTED_FIELD_VALIDATORS`, validation hook, preserved error chain on numeric coercion failure.
+- `hooks/scripts/pre_tool.py` — basename-based MEMORY.md guard and `_is_allowlisted` suffix check.
+- `hooks/scripts/post_tool.py` — `_looks_like_search_invocation` word-boundary regex.

--- a/scripts/_event_schema.py
+++ b/scripts/_event_schema.py
@@ -274,10 +274,18 @@ def validate_metadata(
     # Theme 1: computed-without-enforcement.  When a producer sets one of
     # the known deterministic fields, enforce shape — otherwise the schema
     # promises a contract the runtime doesn't keep.
+    # Treat ``None`` as "absent" to stay consistent with the required-field
+    # check above (~line 193): a producer passing ``key=None`` is signalling
+    # "not set", not "present with a None value", so skip the predicate.
     for field, predicate, hint in COMPUTED_FIELD_VALIDATORS:
-        if field in metadata and not predicate(metadata[field]):
+        if field not in metadata:
+            continue
+        value = metadata[field]
+        if value is None:
+            continue
+        if not predicate(value):
             return (
-                f"metadata.{field}={metadata[field]!r} fails computed-field "
+                f"metadata.{field}={value!r} fails computed-field "
                 f"shape check (expected {hint})"
             )
 

--- a/scripts/_event_schema.py
+++ b/scripts/_event_schema.py
@@ -58,6 +58,47 @@ VALID_ARCHETYPES = frozenset({
     "schema-migration",
 })
 
+# Theme 1 (computed-without-enforcement): when a producer attaches a
+# deterministic-by-construction field (hash, dedup, idempotency token,
+# bus event id), the validator enforces shape so the schema's promise
+# matches runtime behavior.  Without this check a producer could write
+# ``content_hash=""`` and consumers downstream would silently treat the
+# row as un-deduped.  Each entry is ``(field_name, predicate, hint)``.
+#
+#   * content_hash      — must be a non-empty hex string >= 8 chars
+#   * dedup_key         — must be a non-empty string
+#   * idempotency_key   — must be a non-empty string (uuid-shaped or token)
+#   * event_id          — bus-stamped int when emitted by the bus, but a
+#                          producer-supplied event_id MUST be a non-empty
+#                          string or positive int
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def _is_nonempty_str(v) -> bool:
+    return isinstance(v, str) and bool(v.strip())
+
+
+def _is_hex_hash(v) -> bool:
+    return _is_nonempty_str(v) and len(v) >= 8 and bool(_HEX_RE.match(v))
+
+
+def _is_event_id(v) -> bool:
+    if isinstance(v, int):
+        return v > 0
+    return _is_nonempty_str(v)
+
+
+# Each predicate returns True when the value is acceptable.  Validation
+# only fires when the field is PRESENT — these fields stay optional, but
+# if a caller chooses to set them, the schema enforces the contract.
+COMPUTED_FIELD_VALIDATORS = (
+    ("content_hash", _is_hex_hash,
+     "non-empty hex string of at least 8 characters"),
+    ("dedup_key", _is_nonempty_str, "non-empty string"),
+    ("idempotency_key", _is_nonempty_str, "non-empty string"),
+    ("event_id", _is_event_id, "non-empty string or positive int"),
+)
+
 # Per-event_type required and optional metadata fields.
 SCHEMA: dict[str, dict[str, list[str]]] = {
     "task": {
@@ -194,14 +235,23 @@ def validate_metadata(
                 score = metadata.get("score")
                 min_score = metadata.get("min_score")
                 if score is not None and min_score is not None:
+                    # Theme 10: this validator is the architectural boundary
+                    # for gate-finding metadata; it cannot raise (callers
+                    # expect a string|None contract and hooks fail-open),
+                    # so preserve the underlying coercion failure detail in
+                    # the returned message instead of dropping it.
                     try:
                         if float(score) < float(min_score):
                             return (
                                 f"APPROVE verdict requires score >= min_score "
                                 f"({score} < {min_score})"
                             )
-                    except (TypeError, ValueError):
-                        return "gate-finding.score and min_score must be numeric"
+                    except (TypeError, ValueError) as e:
+                        return (
+                            f"gate-finding.score and min_score must be "
+                            f"numeric (score={score!r}, min_score="
+                            f"{min_score!r}): {type(e).__name__}: {e}"
+                        )
 
     if event_type == "subtask":
         parent = metadata.get("parent_chain_id", "")
@@ -221,6 +271,16 @@ def validate_metadata(
             f"Allowed: {sorted(VALID_ARCHETYPES)}"
         )
 
+    # Theme 1: computed-without-enforcement.  When a producer sets one of
+    # the known deterministic fields, enforce shape — otherwise the schema
+    # promises a contract the runtime doesn't keep.
+    for field, predicate, hint in COMPUTED_FIELD_VALIDATORS:
+        if field in metadata and not predicate(metadata[field]):
+            return (
+                f"metadata.{field}={metadata[field]!r} fails computed-field "
+                f"shape check (expected {hint})"
+            )
+
     return None
 
 
@@ -231,6 +291,7 @@ __all__ = [
     "VALID_ARCHETYPES",
     "BANNED_REVIEWERS",
     "BANNED_SOURCE_AGENT_PREFIXES",
+    "COMPUTED_FIELD_VALIDATORS",
     "SCHEMA",
     "validate_metadata",
 ]


### PR DESCRIPTION
## Summary

Hook-script lints from cross-project memory synthesis (gcp-ai-sdlc, command_iq, wicked-bus, wicked-garden brains).

## Themes addressed

- **#1 Computed-without-enforcement is a false signal** — adds `COMPUTED_FIELD_VALIDATORS` to `scripts/_event_schema.py` for `content_hash`, `dedup_key`, `idempotency_key`, `event_id`. Optional fields stay optional, but if set, the schema enforces shape.
- **#9 Grep-based contract checks need functional context** — three bare-substring matchers tightened: `pre_tool.py` MEMORY.md guard, allowlist suffix check, `post_tool.py` discovery hint regex.
- **#10 Wrap domain errors at architectural boundaries** — adapted: hook entry points are intentionally fail-open (no `raise`). The architectural boundary that swallowed errors was `validate_metadata`'s coercion path; now preserves `type(e).__name__` + original message in the returned error string so operators keep the exception chain.

## Test plan

- [x] 81 existing tests green (`tests/test_event_schema_*`, `tests/test_post_tool_site3.py`, `tests/hooks/test_post_tool_skill.py`, `tests/crew/test_steering_event_schema.py`)
- [x] New acceptance scenario: `scenarios/qe/hook-script-lints.md`

## Risks

- `_SEARCH_INVOCATION_RE` matches `ag` (silver searcher) — could fire on unrelated tokens. Advisory hint only.
- `event_id` predicate accepts positive int OR non-empty string. Producers using `event_id=None` for "let bus stamp" still allowed.
- Error-string length: now embeds `repr(score)` and exception detail. Realistic gate metadata is small but worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)