### PR TITLE
crew: silent-fallback hardening + dispatch liveness audit

### DIFF
--- a/.claude-plugin/gate-policy.json
+++ b/.claude-plugin/gate-policy.json
@@ -1,9 +1,14 @@
 {
-  "version": "1.1.0",
-  "description": "Codified Gate x Rigor reviewer matrix (D1, D4). Source of truth loaded by phase_manager._resolve_gate_reviewer(). Human-readable description at skills/propose-process/refs/gate-policy.md. v1.1.0: added bus_health block for Site 3 emit-success monitoring (threshold in config, not code — per site-3-threshold-lives-in-gate-policy-user-override-2026-05-02.md).",
+  "version": "1.2.0",
+  "description": "Codified Gate x Rigor reviewer matrix (D1, D4). Source of truth loaded by phase_manager._resolve_gate_reviewer(). Human-readable description at skills/propose-process/refs/gate-policy.md. v1.1.0: added bus_health block for Site 3 emit-success monitoring (threshold in config, not code — per site-3-threshold-lives-in-gate-policy-user-override-2026-05-02.md). v1.2.0: added dispatch_liveness block (Theme 4, cluster B) — operator tunables for the dispatch-log liveness audit (scripts/crew/dispatch_liveness.py).",
   "bus_health": {
     "emit_success_threshold": 0.999,
     "min_n_for_assertion": 500
+  },
+  "dispatch_liveness": {
+    "stale_dispatch_secs": 300,
+    "producer_event_required": "warn",
+    "_doc": "stale_dispatch_secs: a dispatch-log entry older than this with no matching gate-result.json is reported as stuck. producer_event_required: 'warn' surfaces CONDITIONAL conditions that defer to external triggers without naming the producer event as findings; 'strict' fails the audit non-zero; 'off' disables the check. Env-vars WG_DISPATCH_LIVENESS_STALE_SECS and WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED override these values."
   },
   "gates": {
     "requirements-quality": {

--- a/scenarios/crew/dispatch-liveness-stuck-state.md
+++ b/scenarios/crew/dispatch-liveness-stuck-state.md
@@ -97,10 +97,12 @@ gp = Path('${TEST_PROJECT_DIR}') / 'phases' / 'review' / 'gate-result.json'
 gp.write_text(json.dumps(gate_result))
 
 import dispatch_liveness as dl
-# Re-audit (now BOTH stale-dispatch and external-trigger findings should appear,
-# because the gate-result.json arrived for evidence-quality but doesn't resolve
-# the dispatch entry whose orphan-detection lives elsewhere — and the CONDITIONAL
-# external-trigger condition is a separate finding class).
+# Audit ONLY the external-trigger class here. Note: now that gate-result.json
+# exists, audit_phase_dispatches() suppresses the stale-dispatch finding (the
+# gate-result.json present check on line 338-342) — orphan detection for that
+# case lives in the dispatch-log schema/orphan layer, not in the liveness
+# audit. So we call audit_conditional_externals directly to isolate the
+# external-trigger finding class.
 findings = dl.audit_conditional_externals(Path('${TEST_PROJECT_DIR}'), 'review')
 assert len(findings) == 1, f'Expected 1 external-trigger finding, got {len(findings)}: {findings}'
 assert findings[0]['kind'] == 'external-trigger-no-producer'

--- a/scenarios/crew/dispatch-liveness-stuck-state.md
+++ b/scenarios/crew/dispatch-liveness-stuck-state.md
@@ -1,0 +1,175 @@
+---
+name: dispatch-liveness-stuck-state
+title: Dispatch Liveness Audit — Stuck Dispatch + External-Trigger Conditions
+description: Verify scripts/crew/dispatch_liveness.py surfaces stale dispatch-log entries and CONDITIONAL gate-results that defer to external triggers without naming a producer event
+type: testing
+difficulty: standard
+estimated_minutes: 5
+covers:
+  - "Theme 4 — terminal-state deferred paths need bounded retry, not 'next event' reliance"
+  - "Stale dispatch-log entries detection (default 5min threshold)"
+  - "CONDITIONAL gate-result conditions referencing external triggers must declare producer_event/trigger_event/resolves_on"
+  - "Configuration override via gate-policy.json::dispatch_liveness block (additive)"
+ac_ref: "Theme 4 (cross-project memory synthesis cluster B)"
+---
+
+# Dispatch Liveness — Stuck-State Audit
+
+This scenario exercises the new liveness audit added by cluster B. The audit
+catches two classes of "deferred to next responder, but the state is terminal"
+bugs:
+
+1. **Stale dispatch-log entries.** A reviewer was dispatched (entry written to
+   `phases/{phase}/dispatch-log.jsonl` via the bus-as-truth projector), but the
+   reviewer never delivered. After 5 minutes (configurable), the entry is
+   reported as stuck — there is no next event coming.
+2. **CONDITIONAL gate-results with external-trigger conditions.** The verdict
+   text says "wait for", "external", "deferred", "awaiting", etc. — but the
+   condition does NOT carry a `producer_event` / `trigger_event` / `resolves_on`
+   field naming the event that will resolve it. Operators have no way to
+   advance the gate.
+
+## Setup
+
+```bash
+export PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+export TEST_PROJECT_DIR="${TMPDIR:-/tmp}/dispatch-liveness-scenario-$$"
+rm -rf "${TEST_PROJECT_DIR}"
+mkdir -p "${TEST_PROJECT_DIR}/phases/review"
+```
+
+## Step 1 — Stale dispatch-log entry surfaced as `stale-dispatch`
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts/crew')
+
+# Write a dispatch-log entry that's 10 minutes old with no matching gate-result.
+old = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+entry = {
+    'reviewer': 'security-engineer',
+    'phase': 'review',
+    'gate': 'evidence-quality',
+    'dispatch_id': 'liveness-test-001',
+    'dispatched_at': old,
+    'dispatcher_agent': 'wicked-garden:crew:phase-manager',
+    'expected_result_path': 'gate-result.json',
+}
+log_path = Path('${TEST_PROJECT_DIR}') / 'phases' / 'review' / 'dispatch-log.jsonl'
+log_path.write_text(json.dumps(entry) + '\n')
+
+import dispatch_liveness as dl
+findings = dl.audit_phase(Path('${TEST_PROJECT_DIR}'), 'review')
+assert len(findings) == 1, f'Expected 1 finding, got {len(findings)}: {findings}'
+assert findings[0]['kind'] == 'stale-dispatch'
+assert findings[0]['evidence']['age_secs'] >= 600
+print('PASS step 1: stale-dispatch detected')
+"
+```
+
+## Step 2 — CONDITIONAL with external-trigger condition lacking producer surfaces as `external-trigger-no-producer`
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, sys
+from pathlib import Path
+
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts/crew')
+
+gate_result = {
+    'verdict': 'CONDITIONAL',
+    'gate': 'evidence-quality',
+    'reviewer': 'senior-engineer',
+    'conditions': [
+        {'description': 'Wait for external auditor sign-off'},  # MATCH — no producer
+        {'description': 'Awaiting next responder',                # OK — has producer
+         'producer_event': 'security.review.complete'},
+        {'description': 'Increase test coverage to 80%'},         # OK — not external
+    ],
+}
+gp = Path('${TEST_PROJECT_DIR}') / 'phases' / 'review' / 'gate-result.json'
+gp.write_text(json.dumps(gate_result))
+
+import dispatch_liveness as dl
+# Re-audit (now BOTH stale-dispatch and external-trigger findings should appear,
+# because the gate-result.json arrived for evidence-quality but doesn't resolve
+# the dispatch entry whose orphan-detection lives elsewhere — and the CONDITIONAL
+# external-trigger condition is a separate finding class).
+findings = dl.audit_conditional_externals(Path('${TEST_PROJECT_DIR}'), 'review')
+assert len(findings) == 1, f'Expected 1 external-trigger finding, got {len(findings)}: {findings}'
+assert findings[0]['kind'] == 'external-trigger-no-producer'
+assert findings[0]['evidence']['condition_index'] == 0
+print('PASS step 2: external-trigger-no-producer detected')
+"
+```
+
+## Step 3 — `--strict` exit code surfaces blocking findings to CI
+
+```bash
+WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED=strict sh "${PLUGIN_ROOT}/scripts/_python.sh" \
+    "${PLUGIN_ROOT}/scripts/crew/dispatch_liveness.py" \
+    "${TEST_PROJECT_DIR}" --json --strict > /tmp/liveness-out.json
+strict_exit=$?
+test "${strict_exit}" -eq 1 || { echo "FAIL: --strict should exit 1, got ${strict_exit}"; exit 1; }
+grep -q '"kind": "external-trigger-no-producer"' /tmp/liveness-out.json
+echo 'PASS step 3: --strict exit code = 1 with blocking findings'
+```
+
+## Step 4 — Operator can disable the audit via `WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED=off`
+
+```bash
+WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED=off sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import sys
+from pathlib import Path
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts')
+sys.path.insert(0, '${PLUGIN_ROOT}/scripts/crew')
+import dispatch_liveness as dl
+findings = dl.audit_conditional_externals(Path('${TEST_PROJECT_DIR}'), 'review')
+assert findings == [], f'Expected no findings with mode=off, got: {findings}'
+print('PASS step 4: producer-required=off disables the check')
+"
+```
+
+## Step 5 — Configuration via gate-policy.json (additive contract)
+
+```bash
+sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json
+gp = json.loads(open('${PLUGIN_ROOT}/.claude-plugin/gate-policy.json').read())
+block = gp.get('dispatch_liveness') or {}
+assert isinstance(block.get('stale_dispatch_secs'), int) and block['stale_dispatch_secs'] > 0
+assert block.get('producer_event_required') in ('warn', 'strict', 'off')
+print('PASS step 5: gate-policy.json::dispatch_liveness block present and well-formed')
+"
+```
+
+## Cleanup
+
+```bash
+rm -rf "${TEST_PROJECT_DIR}"
+```
+
+## Expected Results
+
+- Step 1: `stale-dispatch` finding emitted; evidence carries `age_secs >= 600`.
+- Step 2: `external-trigger-no-producer` finding for the bare condition; the
+  one with `producer_event` is silent.
+- Step 3: `--strict` exits non-zero so CI / cron scripts can pipeline-fail.
+- Step 4: `WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED=off` disables the check
+  cleanly (no stuck-state findings; rollback lever for false positives).
+- Step 5: gate-policy.json carries the operator-tunable defaults; env-vars
+  override them but the canonical source is the JSON config (Theme 2 — no
+  hidden hardcoded constants).
+
+## Notes — bus-as-truth invariant
+
+The audit reads dispatch-log entries via `dispatch_log.read_entries`, which
+honors the `WG_BUS_AS_TRUTH_DISPATCH_LOG` flag and pulls from the event_log
+when bus-as-truth is on. It does NOT bypass the bus or write to disk —
+liveness is a read-only audit, fail-open, and never mutates gate-results.

--- a/scripts/crew/_gate_policy.py
+++ b/scripts/crew/_gate_policy.py
@@ -28,8 +28,11 @@ load_bus_health(policy_path=None) -> dict
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger("wicked-crew.gate-policy")
 
 
 # ---------------------------------------------------------------------------
@@ -91,13 +94,28 @@ def load_bus_health(
         "emit_success_threshold": 0.999,
         "min_n_for_assertion": 500,
     }
+    # Theme 2 (cluster B): every fallback path now emits an observable WARN
+    # so a missing or malformed bus_health block diverging from the
+    # operator-declared values is surfaced to logs instead of silently
+    # substituting code's idea of "safe defaults".
     try:
         policy = load_gate_policy(policy_path)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[gate-policy] bus_health fallback engaged — gate-policy.json "
+            "unreadable (%s): %s. Substituting code defaults %r.",
+            type(exc).__name__, exc, _DEFAULTS,
+        )
         return dict(_DEFAULTS)
 
     bus_health = policy.get("bus_health")
     if not isinstance(bus_health, dict):
+        logger.warning(
+            "[gate-policy] bus_health fallback engaged — gate-policy.json has "
+            "no 'bus_health' block (got type=%s). Substituting code defaults %r. "
+            "Add a bus_health block to silence this WARN.",
+            type(bus_health).__name__, _DEFAULTS,
+        )
         return dict(_DEFAULTS)
 
     result = dict(_DEFAULTS)
@@ -106,13 +124,23 @@ def load_bus_health(
             bus_health.get("emit_success_threshold", _DEFAULTS["emit_success_threshold"])
         )
     except (TypeError, ValueError):
-        pass  # keep default
+        logger.warning(
+            "[gate-policy] bus_health.emit_success_threshold=%r is not a "
+            "valid float — substituting default %r.",
+            bus_health.get("emit_success_threshold"),
+            _DEFAULTS["emit_success_threshold"],
+        )
 
     try:
         result["min_n_for_assertion"] = int(
             bus_health.get("min_n_for_assertion", _DEFAULTS["min_n_for_assertion"])
         )
     except (TypeError, ValueError):
-        pass  # keep default
+        logger.warning(
+            "[gate-policy] bus_health.min_n_for_assertion=%r is not a "
+            "valid int — substituting default %r.",
+            bus_health.get("min_n_for_assertion"),
+            _DEFAULTS["min_n_for_assertion"],
+        )
 
     return result

--- a/scripts/crew/consensus_gate.py
+++ b/scripts/crew/consensus_gate.py
@@ -117,6 +117,18 @@ def should_use_consensus(project_state: Dict[str, Any], phase_config: Dict[str, 
         complexity = int(complexity)
         threshold = int(threshold)
     except (TypeError, ValueError):
+        # Theme 2 (cluster B): silently returning False here meant consensus
+        # evaluation could be DISABLED by a typo'd threshold without any
+        # signal — the gate would behave as if no consensus was configured.
+        # WARN loudly so the divergence is observable; still return False
+        # (callers expect a bool, not an exception, mid-gate).
+        logger.warning(
+            "[consensus-gate] should_use_consensus: complexity_score=%r or "
+            "consensus_threshold=%r is not a valid int — disabling consensus "
+            "for this evaluation. Fix project state or phases.json to silence.",
+            project_state.get("complexity_score"),
+            phase_config.get("consensus_threshold"),
+        )
         return False
 
     return complexity >= threshold
@@ -390,9 +402,23 @@ def evaluate_consensus_gate(
                 "reason": f"Strong dissent from consensus council: {dissent_summary}"}
 
     # Rule 2: Low agreement ratio triggers CONDITIONAL
+    # Theme 2 (cluster B): the bare `except: conf_threshold = 0.7` silently
+    # substituted a hardcoded value when phases.json carried a malformed
+    # confidence_threshold. That's a divergence — the operator's gate-tier
+    # config was effectively replaced by code's idea of a "safe default".
+    # Emit a warning so the divergence is observable. The fallback value is
+    # preserved (we don't want to crash mid-gate), but the user/operator
+    # gets a clear log line that points at the malformed config.
     try:
         conf_threshold = float(confidence_threshold)
     except (TypeError, ValueError):
+        logger.warning(
+            "[consensus-gate] phases.json confidence_threshold=%r for phase "
+            "'%s' is not a valid float — substituting 0.7. Fix phases.json to "
+            "silence this WARN and ensure the gate uses the operator-declared "
+            "threshold.",
+            confidence_threshold, phase,
+        )
         conf_threshold = 0.7
 
     if agreement_ratio < conf_threshold:

--- a/scripts/crew/dispatch_liveness.py
+++ b/scripts/crew/dispatch_liveness.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""dispatch_liveness.py — Theme 4 stuck-state audit for gate dispatch.
+
+Cross-project memory synthesis flagged a class of bug where code defers
+resolution to a "next responder" on conflict, but the underlying state is
+**terminal** — last writer wins, the resource is exhausted, or the trigger
+is purely external. The liveness audit scans for two forms of this:
+
+1. **Stale dispatch-log entries** — entries appended via
+   ``dispatch_log.append`` but never matched by a corresponding gate-result.
+   When ``dispatched_at`` is older than a configurable threshold (default
+   300 seconds for active sessions), the entry is "stuck" — there is no
+   next event coming, the reviewer never delivered.
+
+2. **CONDITIONAL gate-results with external-trigger conditions** — a gate
+   that emits a CONDITIONAL verdict whose condition text says "wait for X"
+   / "external" / "deferred" / "awaiting" but does NOT name a producer
+   event. There is no path back to APPROVE because nothing knows what to
+   listen for. These are gate-results that have already shipped, so the
+   audit reports them as findings rather than rewriting the verdict.
+
+The audit is non-destructive: it READS gate-result.json + dispatch-log
+entries (via ``dispatch_log.read_entries`` so the bus-as-truth read path
+applies) and emits findings to stdout (or JSON when ``--json`` is set).
+Wired into the phase_manager liveness CLI surface so operators can run
+``phase_manager.py <project> liveness`` to see stuck dispatches at a
+glance, and into a standalone CLI here for cron-style polling.
+
+Stdlib-only. Cross-platform.
+
+Configuration
+-------------
+``WG_DISPATCH_LIVENESS_STALE_SECS`` (default ``300``):
+    Threshold above which a dispatch-log entry without a matching
+    gate-result is considered stuck. Five minutes covers a normal
+    council-mode panel; longer windows belong in an operator-tunable
+    setting, not a code constant.
+
+``WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED`` (default ``warn``):
+    ``warn`` (default) — surface external-trigger conditions without a
+    producer_event field as findings only. ``strict`` — exit non-zero so
+    CI/cron can pipeline-fail. ``off`` — disable the check.
+
+Output shape
+------------
+Findings are dicts with::
+
+    {
+        "kind": "stale-dispatch" | "external-trigger-no-producer",
+        "phase": str,
+        "gate": str,
+        "reviewer": str | None,
+        "severity": "warn" | "block",
+        "message": str,
+        "evidence": dict,  # kind-specific
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Resolve sibling crew imports from scripts/
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+logger = logging.getLogger("wicked-crew.dispatch-liveness")
+
+# ---------------------------------------------------------------------------
+# Tunables (env-driven so operators can adjust without a code change)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_STALE_SECS = 300  # 5 minutes — covers a normal council panel
+_VALID_PRODUCER_MODES = ("warn", "strict", "off")
+
+# Keywords that mark a condition as deferring to an external actor. These
+# are deliberately broad — the goal is to catch "next event will fix it"
+# language. False positives are visible (operator reads the WARN), false
+# negatives are silent (the bug we're fixing).
+_EXTERNAL_TRIGGER_KEYWORDS: Tuple[str, ...] = (
+    "wait for",
+    "waiting for",
+    "external",
+    "deferred",
+    "awaiting",
+    "pending external",
+    "after notification",
+    "on receipt of",
+    "next responder",
+    "out-of-band",
+    "out of band",
+)
+
+
+def _config_block() -> Dict[str, Any]:
+    """Load the dispatch_liveness block from gate-policy.json. Fail-open.
+
+    Theme 2 alignment: gate-policy.json is the canonical source for these
+    knobs. We read it via _gate_policy.load_gate_policy so the divergence
+    pattern (silent fallback to hardcoded values) is funneled through the
+    instrumented loader. Missing/malformed config returns {} and the env-var
+    + hardcoded defaults take over — every step logs.
+    """
+    try:
+        from _gate_policy import load_gate_policy  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning(
+            "dispatch_liveness: _gate_policy unavailable (%s) — falling back "
+            "to env-var + hardcoded defaults.", exc,
+        )
+        return {}
+    try:
+        policy = load_gate_policy()
+    except (FileNotFoundError, ValueError, OSError) as exc:
+        logger.warning(
+            "dispatch_liveness: gate-policy.json unreadable (%s) — falling "
+            "back to env-var + hardcoded defaults.", exc,
+        )
+        return {}
+    block = policy.get("dispatch_liveness")
+    if not isinstance(block, dict):
+        return {}
+    return block
+
+
+def _stale_threshold_secs() -> int:
+    """Resolve the stale-dispatch threshold.
+
+    Resolution order (highest priority first):
+      1. ``WG_DISPATCH_LIVENESS_STALE_SECS`` env-var
+      2. ``gate-policy.json::dispatch_liveness.stale_dispatch_secs``
+      3. ``_DEFAULT_STALE_SECS`` constant
+
+    Theme 2 mirror: invalid values WARN and walk to the next priority — they
+    do not silently flip the audit into "everything is stuck" or "nothing is
+    stuck".
+    """
+    raw = os.environ.get("WG_DISPATCH_LIVENESS_STALE_SECS", "").strip()
+    if raw:
+        try:
+            val = int(raw)
+        except ValueError:
+            logger.warning(
+                "dispatch_liveness: invalid WG_DISPATCH_LIVENESS_STALE_SECS=%r "
+                "— falling through to gate-policy.json + default.", raw,
+            )
+        else:
+            if val < 0:
+                logger.warning(
+                    "dispatch_liveness: negative WG_DISPATCH_LIVENESS_STALE_SECS"
+                    "=%r — falling through to gate-policy.json + default.", raw,
+                )
+            else:
+                return val
+
+    block = _config_block()
+    if "stale_dispatch_secs" in block:
+        candidate = block.get("stale_dispatch_secs")
+        try:
+            val = int(candidate)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            logger.warning(
+                "dispatch_liveness: gate-policy.json dispatch_liveness."
+                "stale_dispatch_secs=%r is not an int — using default %d.",
+                candidate, _DEFAULT_STALE_SECS,
+            )
+            return _DEFAULT_STALE_SECS
+        if val < 0:
+            logger.warning(
+                "dispatch_liveness: gate-policy.json dispatch_liveness."
+                "stale_dispatch_secs=%r is negative — using default %d.",
+                candidate, _DEFAULT_STALE_SECS,
+            )
+            return _DEFAULT_STALE_SECS
+        return val
+
+    return _DEFAULT_STALE_SECS
+
+
+def _producer_mode() -> str:
+    """Resolve the producer-event-required mode.
+
+    Resolution order: env > gate-policy.json > 'warn'. Invalid values WARN
+    and walk to the next priority.
+    """
+    raw = os.environ.get("WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED", "").strip().lower()
+    if raw:
+        if raw in _VALID_PRODUCER_MODES:
+            return raw
+        logger.warning(
+            "dispatch_liveness: invalid WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED"
+            "=%r (valid: %s) — falling through to gate-policy.json + 'warn'.",
+            raw, _VALID_PRODUCER_MODES,
+        )
+
+    block = _config_block()
+    candidate = block.get("producer_event_required") if block else None
+    if isinstance(candidate, str) and candidate.strip().lower() in _VALID_PRODUCER_MODES:
+        return candidate.strip().lower()
+    if candidate is not None:
+        logger.warning(
+            "dispatch_liveness: gate-policy.json dispatch_liveness."
+            "producer_event_required=%r is not one of %s — using 'warn'.",
+            candidate, _VALID_PRODUCER_MODES,
+        )
+    return "warn"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp; return None when malformed."""
+    if not isinstance(ts, str) or not ts:
+        return None
+    # datetime.fromisoformat handles "+00:00" and naive forms but stumbles on
+    # the trailing "Z" used by some emitters. Normalise it.
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _condition_text(condition: Any) -> str:
+    """Extract the human-readable text from a condition (str or dict shape)."""
+    if isinstance(condition, str):
+        return condition
+    if isinstance(condition, dict):
+        for key in ("description", "text", "message", "finding"):
+            val = condition.get(key)
+            if isinstance(val, str) and val:
+                return val
+    return ""
+
+
+def _condition_has_producer(condition: Any) -> bool:
+    """True iff the condition declares the event/agent that will resolve it."""
+    if not isinstance(condition, dict):
+        return False
+    # Accept any of these forms — gate authors don't all use the same key.
+    for key in ("producer_event", "producer", "trigger_event", "resolves_on"):
+        val = condition.get(key)
+        if isinstance(val, str) and val.strip():
+            return True
+    return False
+
+
+def _matches_external_trigger(text: str) -> bool:
+    lowered = text.lower()
+    return any(kw in lowered for kw in _EXTERNAL_TRIGGER_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# Audit: stale dispatch-log entries
+# ---------------------------------------------------------------------------
+
+
+def audit_phase_dispatches(
+    project_dir: Path,
+    phase: str,
+    *,
+    now: Optional[datetime] = None,
+    stale_secs: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Find dispatch-log entries with no gate-result older than the threshold.
+
+    Returns a list of findings; empty when everything is healthy. Reads
+    dispatch-log via ``dispatch_log.read_entries`` so the bus-as-truth path
+    applies (#746 — entries materialise from the event_log).
+
+    A "matching gate-result" is detected by checking for the existence of
+    ``phases/{phase}/gate-result.json``. The gate-result schema validator
+    + orphan check live elsewhere — this audit is purely about LIVENESS,
+    not authentication. If gate-result.json exists, we trust the existing
+    orphan-detection layer to handle authorisation.
+    """
+    findings: List[Dict[str, Any]] = []
+    threshold = stale_secs if stale_secs is not None else _stale_threshold_secs()
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    try:
+        from dispatch_log import read_entries  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning("dispatch_liveness: dispatch_log unavailable: %s", exc)
+        return findings
+
+    try:
+        entries = read_entries(Path(project_dir), phase)
+    except Exception as exc:  # noqa: BLE001 — fail-open audit
+        logger.warning(
+            "dispatch_liveness: read_entries failed for phase=%r: %s",
+            phase, exc,
+        )
+        return findings
+
+    gate_result_path = Path(project_dir) / "phases" / phase / "gate-result.json"
+    gate_result_present = gate_result_path.exists()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        dispatched_at = _parse_iso(entry.get("dispatched_at", ""))
+        if dispatched_at is None:
+            # Malformed timestamps are an audit signal in their own right —
+            # they break the orphan-window check. Surface as a finding.
+            findings.append({
+                "kind": "stale-dispatch",
+                "phase": phase,
+                "gate": entry.get("gate", ""),
+                "reviewer": entry.get("reviewer"),
+                "severity": "warn",
+                "message": (
+                    f"dispatch-log entry has unparseable dispatched_at="
+                    f"{entry.get('dispatched_at')!r} — cannot determine age"
+                ),
+                "evidence": {
+                    "dispatch_id": entry.get("dispatch_id"),
+                    "dispatched_at": entry.get("dispatched_at"),
+                },
+            })
+            continue
+        age_secs = (now - dispatched_at).total_seconds()
+        if age_secs < threshold:
+            continue
+        if gate_result_present:
+            # The gate-result has already shipped; the orphan check + schema
+            # validator own authentication. We only flag dispatches with NO
+            # corresponding result.
+            continue
+        findings.append({
+            "kind": "stale-dispatch",
+            "phase": phase,
+            "gate": entry.get("gate", ""),
+            "reviewer": entry.get("reviewer"),
+            "severity": "warn",
+            "message": (
+                f"dispatch-log entry for reviewer={entry.get('reviewer')!r} "
+                f"is {int(age_secs)}s old (threshold {threshold}s) and has no "
+                f"matching gate-result.json — the reviewer never delivered"
+            ),
+            "evidence": {
+                "dispatch_id": entry.get("dispatch_id"),
+                "dispatched_at": entry.get("dispatched_at"),
+                "age_secs": int(age_secs),
+                "threshold_secs": threshold,
+            },
+        })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Audit: CONDITIONAL gate-results with external-trigger conditions
+# ---------------------------------------------------------------------------
+
+
+def audit_conditional_externals(
+    project_dir: Path,
+    phase: str,
+) -> List[Dict[str, Any]]:
+    """Find CONDITIONAL gate-results that defer to external triggers w/o a producer.
+
+    Reads ``phases/{phase}/gate-result.json``, walks its conditions list,
+    and flags any condition whose text matches an external-trigger keyword
+    AND that does NOT declare a producer_event / trigger_event / resolves_on
+    field. These are gate verdicts with no return path — the operator
+    cannot know what would clear the condition.
+
+    This audit is read-only: the gate-result is NOT mutated. Findings are
+    intended to be surfaced as warnings (default) or as a non-zero exit
+    in strict mode for CI pipelines.
+    """
+    findings: List[Dict[str, Any]] = []
+    mode = _producer_mode()
+    if mode == "off":
+        return findings
+
+    gate_file = Path(project_dir) / "phases" / phase / "gate-result.json"
+    if not gate_file.exists():
+        return findings
+    try:
+        data = json.loads(gate_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # The schema validator owns reporting on malformed gate-result files;
+        # liveness audit just skips and moves on.
+        return findings
+    if not isinstance(data, dict):
+        return findings
+
+    verdict = data.get("verdict") or data.get("result")
+    if verdict != "CONDITIONAL":
+        return findings
+
+    conditions = data.get("conditions")
+    if not isinstance(conditions, list):
+        return findings
+
+    severity = "block" if mode == "strict" else "warn"
+    for idx, condition in enumerate(conditions):
+        text = _condition_text(condition)
+        if not text:
+            continue
+        if not _matches_external_trigger(text):
+            continue
+        if _condition_has_producer(condition):
+            continue
+        findings.append({
+            "kind": "external-trigger-no-producer",
+            "phase": phase,
+            "gate": data.get("gate", ""),
+            "reviewer": data.get("reviewer"),
+            "severity": severity,
+            "message": (
+                f"CONDITIONAL condition[{idx}] references an external trigger "
+                f"({_first_match(text)!r}) but does not declare a "
+                "producer_event / trigger_event / resolves_on field — there "
+                "is no path back to APPROVE"
+            ),
+            "evidence": {
+                "condition_index": idx,
+                "condition_text_excerpt": text[:200],
+            },
+        })
+    return findings
+
+
+def _first_match(text: str) -> str:
+    lowered = text.lower()
+    for kw in _EXTERNAL_TRIGGER_KEYWORDS:
+        if kw in lowered:
+            return kw
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Phase / project drivers
+# ---------------------------------------------------------------------------
+
+
+def audit_phase(
+    project_dir: Path,
+    phase: str,
+    *,
+    now: Optional[datetime] = None,
+    stale_secs: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Run all liveness audits for a single phase. Concatenates findings."""
+    out: List[Dict[str, Any]] = []
+    out.extend(audit_phase_dispatches(
+        project_dir, phase, now=now, stale_secs=stale_secs,
+    ))
+    out.extend(audit_conditional_externals(project_dir, phase))
+    return out
+
+
+def audit_project(
+    project_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+    stale_secs: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Run liveness audit across every phase directory in the project."""
+    out: List[Dict[str, Any]] = []
+    phases_dir = Path(project_dir) / "phases"
+    if not phases_dir.is_dir():
+        return out
+    for phase_dir in sorted(phases_dir.iterdir()):
+        if not phase_dir.is_dir():
+            continue
+        out.extend(audit_phase(
+            project_dir, phase_dir.name, now=now, stale_secs=stale_secs,
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_text(findings: Iterable[Dict[str, Any]]) -> str:
+    findings_list = list(findings)
+    if not findings_list:
+        return "dispatch_liveness: no stuck dispatches or external-trigger conditions found."
+    lines: List[str] = []
+    for f in findings_list:
+        lines.append(
+            f"[{f['severity'].upper()}] {f['kind']} phase={f['phase']!r} "
+            f"gate={f.get('gate', '')!r} reviewer={f.get('reviewer')!r}\n"
+            f"  {f['message']}\n"
+            f"  evidence={json.dumps(f.get('evidence', {}), separators=(',', ':'))}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit a crew project for stuck gate dispatches and "
+            "CONDITIONAL gate-results that defer to external triggers "
+            "without naming the producer event."
+        ),
+    )
+    parser.add_argument(
+        "project_dir",
+        help="Path to the crew project directory (e.g. ~/.something-wicked/wicked-garden/local/wicked-crew/projects/<name>)",
+    )
+    parser.add_argument(
+        "--phase", default=None,
+        help="Audit a single phase (default: every phase under phases/).",
+    )
+    parser.add_argument(
+        "--stale-secs", type=int, default=None,
+        help=f"Override stale threshold (default: env or {_DEFAULT_STALE_SECS}).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Exit non-zero when any blocking finding is reported.",
+    )
+    args = parser.parse_args(argv)
+
+    project_dir = Path(args.project_dir).expanduser()
+    if not project_dir.exists():
+        sys.stderr.write(f"dispatch_liveness: project_dir does not exist: {project_dir}\n")
+        return 2
+
+    if args.phase:
+        findings = audit_phase(project_dir, args.phase, stale_secs=args.stale_secs)
+    else:
+        findings = audit_project(project_dir, stale_secs=args.stale_secs)
+
+    if args.json:
+        sys.stdout.write(json.dumps({"findings": findings}, indent=2) + "\n")
+    else:
+        sys.stdout.write(_format_text(findings) + "\n")
+
+    if args.strict and any(f.get("severity") == "block" for f in findings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crew/gate_dispatch.py
+++ b/scripts/crew/gate_dispatch.py
@@ -56,13 +56,18 @@ _WICKED_GARDEN_PREFIX = "wicked-garden:"
 
 
 def _get_window_secs() -> int:
-    """Read WG_GATE_VERDICT_WINDOW_SECS from env. Returns 0 for test-mode sentinel."""
+    """Read WG_GATE_VERDICT_WINDOW_SECS from env. Returns 0 for test-mode sentinel.
+
+    Theme 2 (cluster B): a negative value previously clamped silently to 0,
+    flipping production into test-mode aggregation without warning. Now warns
+    on the divergence and falls back to the default (rather than test-mode)
+    so a typo can't accidentally skip the verdict window.
+    """
     raw = os.environ.get("WG_GATE_VERDICT_WINDOW_SECS", "").strip()
     if not raw:
         return _DEFAULT_WINDOW_SECS
     try:
         val = int(raw)
-        return max(0, val)
     except ValueError:
         logger.warning(
             "gate_dispatch: invalid WG_GATE_VERDICT_WINDOW_SECS=%r — using default %d",
@@ -70,6 +75,19 @@ def _get_window_secs() -> int:
             _DEFAULT_WINDOW_SECS,
         )
         return _DEFAULT_WINDOW_SECS
+    if val < 0:
+        # Negative values previously silent-clamped to 0 (test-mode sentinel).
+        # That's a divergence: the operator wrote a number meaning "no wait at
+        # all" but the code interpreted "skip aggregation window entirely".
+        # Warn loudly and refuse the divergence — fall back to the default.
+        logger.warning(
+            "gate_dispatch: negative WG_GATE_VERDICT_WINDOW_SECS=%r is not "
+            "valid (clamping to 0 would silently flip aggregation to test-mode) "
+            "— using default %d. Set explicitly to 0 if test-mode is intended.",
+            raw, _DEFAULT_WINDOW_SECS,
+        )
+        return _DEFAULT_WINDOW_SECS
+    return val
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -446,23 +446,66 @@ def load_phases_config() -> dict:
     audit-visible). Intended only for narrow test scenarios that run with
     no plugin tree mounted — production must always have phases.json.
     """
-    global _PHASES_FALLBACK_WARNED
     config_path = _get_plugin_root() / ".claude-plugin" / "phases.json"
+    fallback_mode = os.environ.get("WG_PHASES_FALLBACK", "").strip().lower()
+
+    def _legacy_fallback(reason: str) -> dict:
+        """Substitute the minimal 3-phase config when WG_PHASES_FALLBACK=allow.
+
+        Shared between the missing-file path and the malformed-content path so
+        operator behaviour is consistent — one env-var, one WARN log line, one
+        substituted config. Uses globals() to set the once-per-process latch
+        because nested functions can't `global` a name they only mutate.
+        """
+        if not globals().get("_PHASES_FALLBACK_WARNED"):
+            sys.stderr.write(
+                f"[phase-manager] WARN: {reason} at {config_path}; "
+                "WG_PHASES_FALLBACK=allow — substituting a 3-phase minimal "
+                "config (clarify, build, review). Phase set diverges from the "
+                "canonical configuration.\n"
+            )
+            globals()["_PHASES_FALLBACK_WARNED"] = True
+        return dict(_PHASES_FALLBACK_MINIMAL)
+
     if config_path.exists():
         with open(config_path) as f:
-            return json.load(f).get("phases", {})
-
-    fallback_mode = os.environ.get("WG_PHASES_FALLBACK", "").strip().lower()
-    if fallback_mode == "allow":
-        if not _PHASES_FALLBACK_WARNED:
-            sys.stderr.write(
-                "[phase-manager] WARN: phases.json missing at "
-                f"{config_path}; WG_PHASES_FALLBACK=allow — substituting a "
-                "3-phase minimal config (clarify, build, review). Phase "
-                "set diverges from the canonical configuration.\n"
+            parsed = json.load(f)
+        # Theme 2 (silent-fallback hardening): a non-dict top-level or a
+        # missing/non-dict `phases` key is a malformed config — we used to
+        # silently substitute {} via `.get("phases", {})`, which let
+        # approve_phase advance through an empty phase set. Raise loudly so
+        # the caller fixes the config; operators with no plugin tree mounted
+        # opt back in via WG_PHASES_FALLBACK=allow (same gate as missing file).
+        if not isinstance(parsed, dict):
+            if fallback_mode == "allow":
+                return _legacy_fallback(
+                    f"phases.json top-level is {type(parsed).__name__}, expected dict"
+                )
+            raise ValueError(
+                f"phases.json at {config_path} top-level is "
+                f"{type(parsed).__name__}, expected a dict. This is a "
+                "configuration error — restore the file from git, or set "
+                "WG_PHASES_FALLBACK=allow to substitute a minimal 3-phase "
+                "config (logs a divergence WARN; intended for tests, not "
+                "production)."
             )
-            _PHASES_FALLBACK_WARNED = True
-        return dict(_PHASES_FALLBACK_MINIMAL)
+        if "phases" not in parsed or not isinstance(parsed.get("phases"), dict):
+            if fallback_mode == "allow":
+                return _legacy_fallback(
+                    "phases.json is missing the `phases` key or its value is "
+                    "not a dict"
+                )
+            raise ValueError(
+                f"phases.json at {config_path} is missing the `phases` key "
+                "or its value is not a dict. This is a configuration error — "
+                "restore the file from git, or set WG_PHASES_FALLBACK=allow "
+                "to substitute a minimal 3-phase config (logs a divergence "
+                "WARN; intended for tests, not production)."
+            )
+        return parsed["phases"]
+
+    if fallback_mode == "allow":
+        return _legacy_fallback("phases.json missing")
 
     raise FileNotFoundError(
         f"phases.json not found at {config_path}. This is a configuration "
@@ -6152,12 +6195,19 @@ def main():
     elif args.action == "liveness":
         # Theme 4 (cluster B): scan dispatch-log + gate-results for stuck
         # state. See scripts/crew/dispatch_liveness.py for the audit logic.
+        # Match the package-qualified-with-flat-fallback pattern used by other
+        # optional crew imports in this file (yolo_constants, consensus_gate)
+        # so the import survives both invocation modes — scripts/ on sys.path
+        # (qualified) and scripts/crew/ on sys.path (bare).
         try:
-            from dispatch_liveness import audit_phase, audit_project
-        except ImportError as exc:
-            msg = f"Error: dispatch_liveness import failed: {exc}"
-            print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr)
-            sys.exit(1)
+            from crew.dispatch_liveness import audit_phase, audit_project
+        except ImportError:
+            try:
+                from dispatch_liveness import audit_phase, audit_project  # type: ignore
+            except ImportError as exc:
+                msg = f"Error: dispatch_liveness import failed: {exc}"
+                print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr)
+                sys.exit(1)
         project_dir = get_project_dir(args.project)
         try:
             if args.phase:

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -415,18 +415,61 @@ def _detect_dispatch_mode(state: "ProjectState") -> str:
         return _DISPATCH_MODE_DEFAULT_LEGACY
 
 
+# Theme 2 (cluster B): silent fallback to a 3-phase hardcoded minimal config
+# when phases.json is missing was a divergence-from-canonical-source hazard —
+# code paths would silently see a different phase set than the canonical
+# .claude-plugin/phases.json defines. Replaced with loud failure. The env-var
+# `WG_PHASES_FALLBACK=allow` opts back into the legacy fallback for narrow
+# test/CI scenarios that need to run with no plugin tree mounted; when used,
+# a stderr WARN logs the divergence so the substitution is observable.
+_PHASES_FALLBACK_MINIMAL: Dict[str, Dict[str, Any]] = {
+    "clarify": {"is_skippable": False, "depends_on": [], "required_deliverables": ["outcome.md"]},
+    "build": {"is_skippable": False, "depends_on": ["clarify"], "required_deliverables": []},
+    "review": {"is_skippable": False, "depends_on": ["build"], "required_deliverables": ["review-findings.md"]},
+}
+_PHASES_FALLBACK_WARNED: bool = False
+
+
 def load_phases_config() -> dict:
-    """Load phase definitions from phases.json in .claude-plugin/."""
+    """Load phase definitions from phases.json in .claude-plugin/.
+
+    Theme 2 (silent-fallback hardening): missing/malformed phases.json now
+    raises FileNotFoundError or json.JSONDecodeError loudly instead of
+    silently substituting a 3-phase hardcoded minimal config. The previous
+    fallback would let approve_phase advance through a phase set that
+    diverged from the canonical phases.json (e.g. missing required test/
+    test-strategy phases) — a "safer-looking" default that produces wrong
+    enforcement.
+
+    Escape hatch: ``WG_PHASES_FALLBACK=allow`` opts back into the minimal
+    fallback (logs a stderr WARN once per process so the substitution is
+    audit-visible). Intended only for narrow test scenarios that run with
+    no plugin tree mounted — production must always have phases.json.
+    """
+    global _PHASES_FALLBACK_WARNED
     config_path = _get_plugin_root() / ".claude-plugin" / "phases.json"
     if config_path.exists():
         with open(config_path) as f:
             return json.load(f).get("phases", {})
-    # Minimal fallback if phases.json missing
-    return {
-        "clarify": {"is_skippable": False, "depends_on": [], "required_deliverables": ["outcome.md"]},
-        "build": {"is_skippable": False, "depends_on": ["clarify"], "required_deliverables": []},
-        "review": {"is_skippable": False, "depends_on": ["build"], "required_deliverables": ["review-findings.md"]},
-    }
+
+    fallback_mode = os.environ.get("WG_PHASES_FALLBACK", "").strip().lower()
+    if fallback_mode == "allow":
+        if not _PHASES_FALLBACK_WARNED:
+            sys.stderr.write(
+                "[phase-manager] WARN: phases.json missing at "
+                f"{config_path}; WG_PHASES_FALLBACK=allow — substituting a "
+                "3-phase minimal config (clarify, build, review). Phase "
+                "set diverges from the canonical configuration.\n"
+            )
+            _PHASES_FALLBACK_WARNED = True
+        return dict(_PHASES_FALLBACK_MINIMAL)
+
+    raise FileNotFoundError(
+        f"phases.json not found at {config_path}. This is a configuration "
+        "error — restore the file from git, or set WG_PHASES_FALLBACK=allow "
+        "to substitute a minimal 3-phase config (logs a divergence WARN; "
+        "intended for tests, not production)."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +494,11 @@ _FALLBACK_REQUIRED_DELIVERABLES: Dict[str, List[Dict[str, Any]]] = {
     "review": [{"file": "review-findings.md", "min_bytes": 200}],
     "clarify": [{"file": "objective.md", "min_bytes": 100}],
 }
+
+# Theme 2 (cluster B): track which phases have hit the hardcoded deliverable
+# fallback this process so the WARN fires exactly once per (phase) — without
+# this, every approve_phase iteration would re-log and obscure the signal.
+_DELIVERABLE_FALLBACK_PHASES_WARNED: set = set()
 
 
 def get_min_test_coverage(phase_name: str) -> Optional[float]:
@@ -1207,6 +1255,18 @@ def _check_phase_deliverables(state: ProjectState, phase: str) -> List[str]:
         # older schema). Keep this list minimal and additive — phases.json is
         # the preferred source.
         deliverables = _FALLBACK_REQUIRED_DELIVERABLES.get(phase, [])
+        # Theme 2 (cluster B): instrument silent-fallback usage. Without this
+        # log line, divergence between the canonical phases.json and the
+        # hardcoded floor is invisible — operators only notice when a deliverable
+        # check passes/fails surprisingly. Emit once per (phase) per process.
+        if deliverables and phase not in _DELIVERABLE_FALLBACK_PHASES_WARNED:
+            logger.warning(
+                "[phase-manager] phases.json has no required_deliverables for "
+                "phase '%s' — using _FALLBACK_REQUIRED_DELIVERABLES floor "
+                "(divergence from canonical config; edit phases.json to "
+                "silence this).", phase,
+            )
+            _DELIVERABLE_FALLBACK_PHASES_WARNED.add(phase)
     if not deliverables:
         return issues
 
@@ -5500,7 +5560,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Phase manager for wicked-crew")
     parser.add_argument("project", help="Project name")
-    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode", "phase-spec", "adopt-clarify"])
+    parser.add_argument("action", choices=["status", "start", "complete", "approve", "skip", "can-advance", "validate", "create", "update", "advance", "execute", "yolo", "cutover", "detect-mode", "phase-spec", "adopt-clarify", "liveness"])
     parser.add_argument("--phase", help="Target phase")
     parser.add_argument("--reason", help="Reason for skip or gate override")
     parser.add_argument("--approved-by", default=None, help="Approver identity (default: 'auto' for skip, 'user' for approve)")
@@ -6088,6 +6148,39 @@ def main():
             print(json.dumps({"ok": True, **dm}, indent=2))
         else:
             print(json.dumps(dm, indent=2))
+
+    elif args.action == "liveness":
+        # Theme 4 (cluster B): scan dispatch-log + gate-results for stuck
+        # state. See scripts/crew/dispatch_liveness.py for the audit logic.
+        try:
+            from dispatch_liveness import audit_phase, audit_project
+        except ImportError as exc:
+            msg = f"Error: dispatch_liveness import failed: {exc}"
+            print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr)
+            sys.exit(1)
+        project_dir = get_project_dir(args.project)
+        try:
+            if args.phase:
+                findings = audit_phase(project_dir, args.phase)
+            else:
+                findings = audit_project(project_dir)
+        except Exception as exc:  # noqa: BLE001 — audit must always emit something
+            msg = f"Error: liveness audit failed: {exc}"
+            print(json.dumps({"ok": False, "error": msg}) if args.json else msg, file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps({"ok": True, "findings": findings}, indent=2))
+        else:
+            if not findings:
+                print("liveness: no stuck dispatches or external-trigger conditions found.")
+            else:
+                for f in findings:
+                    print(
+                        f"[{f['severity'].upper()}] {f['kind']} "
+                        f"phase={f['phase']!r} gate={f.get('gate', '')!r} "
+                        f"reviewer={f.get('reviewer')!r}"
+                    )
+                    print(f"  {f['message']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Cross-project memory mining surfaced two patterns that map onto crew/gate code: silent fallbacks substitute hardcoded values when config is missing (Theme 2), and CONDITIONAL gates that defer to "next event" can stuck-state when the deferred path is terminal (Theme 4).

## Themes addressed

### #2 Silent fallbacks (audit + fix)

| File:line | Before | After |
|---|---|---|
| `phase_manager.py:418` `load_phases_config` | Silent 3-phase hardcoded fallback on missing `phases.json` | Raises; legacy fallback gated behind `WG_PHASES_FALLBACK=allow` with one-time WARN |
| `phase_manager.py:1209` `_check_phase_deliverables` | `_FALLBACK_REQUIRED_DELIVERABLES` fired silently | Once-per-phase WARN; behaviour preserved (additive) |
| `gate_dispatch.py:58` `_get_window_secs()` | Negative env clamped to 0, flipped aggregation into test-mode silently | WARN + falls back to `_DEFAULT_WINDOW_SECS=60` |
| `consensus_gate.py:122,402` | Bad int/float coercion silently used `False`/`0.7` | WARN with offending values; behaviour preserved |
| `_gate_policy.py:90` `load_bus_health` | All three fallback paths silent | Every path now WARNs |

### #4 Liveness audit

- New scanner: `scripts/crew/dispatch_liveness.py` — finds `stale-dispatch` (entry older than threshold with no matching gate-result) and `external-trigger-no-producer` (CONDITIONAL conditions that name an external trigger without naming the producer event).
- Threshold default 300s. Resolution: `WG_DISPATCH_LIVENESS_STALE_SECS` env > `gate-policy.json::dispatch_liveness.stale_dispatch_secs` > 300s.
- Wired into `phase_manager.py` CLI as new `liveness` action; standalone `dispatch_liveness.py <project_dir> [--strict]` for CI.
- Bus-as-truth preserved: reads via `dispatch_log.read_entries` only, never mutates state.

## Test plan

- [x] All 325 targeted crew tests green
- [x] gate-policy.json bumped to 1.2.0 (additive `dispatch_liveness` block)
- [x] New scenario: `scenarios/crew/dispatch-liveness-stuck-state.md`

## Risks

- Test fixtures using `WG_GATE_VERDICT_WINDOW_SECS=-1` for test-mode aggregation will now use the default — full crew suite passes, but downstream fixtures should be checked.
- `load_phases_config` raises on missing file unless `WG_PHASES_FALLBACK=allow`. No internal callers affected.
- External-trigger keyword match is intentionally broad (false positives are visible WARNs; false negatives are silent stuck-state). Disable per-project via `WG_DISPATCH_LIVENESS_PRODUCER_REQUIRED=off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)