### PR TITLE
docs(crew): inline agent output contracts + parallel-dispatch defaults

### DIFF
--- a/agents/crew/implementer.md
+++ b/agents/crew/implementer.md
@@ -50,7 +50,25 @@ Break down into atomic tasks:
 - Create tasks with `TaskCreate` using phase-prefixed subjects
 - Set dependencies with `addBlockedBy`/`addBlocks`
 
+**Identify independent units of work.** Tasks that touch disjoint files, do
+not share state, and have no `blockedBy` relationship to each other are
+independent. Mark them as such in the plan.
+
 ### 3. Execute
+
+**Default: parallel dispatch when independent.** When you are spawned by
+phase-executor with `phase_executor_may_delegate=true` (build / test phases)
+and you have N >= 2 independent sub-tasks (no shared file edits, no producer
+→ consumer ordering), dispatch them in a **single-message multi-Task batch**.
+Serial execution is allowed only when:
+- One sub-task's output is a documented input to another (`blockedBy` set), or
+- Sub-tasks edit the same file where order matters, or
+- You record a principled `serial_reason` in your return summary.
+
+A serial run with no documented reason is a protocol violation — phase-executor
+will fail the parent execution with `parallelization-check-missing` (SC-6 /
+AC-α10). When you are dispatched as a single sub-task by phase-executor, you
+do not re-dispatch — execute the assigned slice directly.
 
 For each task:
 1. **Start**: Call `TaskUpdate(taskId="{id}", status="in_progress")`

--- a/agents/crew/process-facilitator.md
+++ b/agents/crew/process-facilitator.md
@@ -55,10 +55,56 @@ archetype check is needed.
 
 ## Outputs (file-handoff contract)
 
+### Output contract — INLINED, do not rely on skill bodies being loaded
+
+Skill descriptions are injected into agent context; full skill bodies (including
+`skills/propose-process/refs/output-schema.md`) are NOT loaded unless explicitly
+invoked. The required-keys list below is the authoritative shape — the slim
+SKILL.md and `scripts/ci/measure_facilitator.py` validate against these keys.
+Read `output-schema.md` only when you need a worked example or optional-field
+reference; do not rely on it being available at call time.
+
+**Required top-level keys** (every emit must contain all of these):
+
+- `project_slug` — snake_case short id matching the `project_slug` input.
+- `mode` — one of `propose | re-evaluate | yolo`.
+- `summary` — 2-3 sentences in your own words.
+- `factors` — dict of all 9 factor keys (`reversibility`, `blast_radius`,
+  `compliance_scope`, `user_facing_impact`, `novelty`, `scope_effort`,
+  `state_complexity`, `operational_risk`, `coordination_cost`). Each value
+  is `{"reading": "LOW|MEDIUM|HIGH", "risk_level": "low_risk|medium_risk|high_risk", "why": "..."}`.
+  Both `reading` AND `risk_level` are mandatory and must be in sync.
+- `specialists` — non-empty array of `{"name": "...", "why": "..."}` (optionally
+  `domain` + `subagent_type`).
+- `phases` — non-empty array of `{"name": "...", "why": "...", "primary": [...]}`.
+- `rigor_tier` — one of `minimal | standard | full`.
+- `complexity` — integer 0-7.
+- `tasks` — array of task entries; each has `id`, `title`, `phase`, `specialist`,
+  `blockedBy: [...]`, and a `metadata` dict containing `chain_id`, `event_type`
+  (one of `task | coding-task | gate-finding | phase-transition | procedure-trigger | subtask`),
+  `source_agent`, `phase`, plus archetype-aware `test_required`, `test_types`,
+  `evidence_required`, `rigor_tier`. May be `[]` only when `open_questions` is
+  non-empty (block-on-ambiguity path).
+
+**Optional but contractful** (when present, MUST match shape):
+
+- `priors` — array of `{"path", "source_type", "why"}`.
+- `complexity_why`, `rigor_why` — one-sentence rationales.
+- `open_questions` — array of strings; non-empty implies `tasks: []`.
+- `re_evaluation` — `{"pruned": [], "augmented": [], "re_tiered": []}` for
+  `mode: re-evaluate`.
+- `affected_repos` — array of repo short-names; advisory metadata for
+  `multi-repo` archetype.
+
+The full worked-example envelope (with field-by-field commentary) lives in
+`skills/propose-process/refs/output-schema.md`; the keys above are what
+`measure_facilitator.py` and the slim caller validate.
+
 1. **`${project_dir}/process-plan.draft.json`** (REQUIRED) — JSON object matching
-   `skills/propose-process/refs/output-schema.md`. The slim SKILL.md reads this
-   back after Task() returns. Always write before returning. If `${project_dir}`
-   does not exist, create it via `mkdir -p` first.
+   the keys listed above (full schema in
+   `skills/propose-process/refs/output-schema.md`). The slim SKILL.md reads
+   this back after Task() returns. Always write before returning. If
+   `${project_dir}` does not exist, create it via `mkdir -p` first.
 2. **Task chain**: DO NOT issue `TaskCreate` calls from inside this agent. The
    caller emits tasks from the JSON `tasks[]` array — keeps the agent pure
    (no side effects beyond the draft file) and preserves measurement reproducibility.

--- a/agents/crew/qe-orchestrator.md
+++ b/agents/crew/qe-orchestrator.md
@@ -48,27 +48,37 @@ From explicit `--gate` argument or infer from context:
 - If target is implemented code post-build → **Execution Gate**
 - Default: **Strategy Gate**
 
-### 2. Dispatch Specialists Inline
+### 2. Dispatch Specialists in Parallel (default)
 
 The v5 `value-orchestrator` and `execution-orchestrator` routing agents are
 deprecated (see `skills/propose-process/refs/specialist-selection.md` §6).
-Dispatch specialists directly per gate type:
+Dispatch specialists directly per gate type.
 
-**Value Gate** (post-clarify):
-1. Dispatch `wicked-garden:product:requirements-analyst` to check requirement clarity and testability.
-2. Dispatch `wicked-testing:requirements-quality-analyst` to score acceptance criteria quality.
-3. Consolidate findings.
+**Default: parallel dispatch.** Every gate below names 2+ independent reviewers
+whose verdicts do not depend on each other. Issue ALL Task() calls for a gate
+in a **single message** (multi-Task batch). Serial dispatch is allowed only
+when one reviewer's output is a documented input to the next; if you fall back
+to serial, state the dependency reason inline in your consolidation summary
+(e.g. `serial_reason: "test-strategist needs testability findings as input"`).
+A serial dispatch with no documented reason is a protocol violation per SC-6 /
+AC-α10 — the same enforcement that applies to phase-executor sub-task batches
+applies here.
 
-**Strategy Gate** (post-design):
-1. Dispatch `wicked-testing:testability-reviewer` for design-testability review.
-2. Dispatch `wicked-testing:test-strategist` for scenario coverage.
-3. Dispatch `wicked-testing:risk-assessor` for the risk matrix.
-4. Consolidate findings.
+**Value Gate** (post-clarify) — dispatch in one batch:
+- `wicked-garden:product:requirements-analyst` — requirement clarity and testability.
+- `wicked-testing:requirements-quality-analyst` — acceptance-criteria quality scoring.
 
-**Execution Gate** (post-build):
-1. Dispatch `wicked-testing:code-analyzer` for static analysis and coverage gaps.
-2. Dispatch `wicked-testing:semantic-reviewer` for spec-to-code alignment (complexity ≥ 3).
-3. Consolidate findings.
+**Strategy Gate** (post-design) — dispatch in one batch:
+- `wicked-testing:testability-reviewer` — design-testability review.
+- `wicked-testing:test-strategist` — scenario coverage.
+- `wicked-testing:risk-assessor` — risk matrix.
+
+**Execution Gate** (post-build) — dispatch in one batch:
+- `wicked-testing:code-analyzer` — static analysis and coverage gaps.
+- `wicked-testing:semantic-reviewer` — spec-to-code alignment (complexity ≥ 3).
+
+After all parallel reviewers return, consolidate findings into the gate decision
+(see step 5).
 
 ### 3. Track Gate Task
 
@@ -106,6 +116,47 @@ Skill(skill="wicked-brain:memory", args="store \"QE {gate} Gate: {decision} for 
 ```
 
 ### 5. Return Gate Decision
+
+#### Output contract — INLINED, do not rely on skill bodies being loaded
+
+Skill descriptions get injected into context; full skill bodies do not unless
+explicitly invoked. The contract below is the authoritative shape callers
+(phase_manager, gate_dispatch) consume — do not defer to a skill ref for it.
+
+Your final message MUST end with a fenced JSON block of this shape:
+
+```json
+{
+  "gate": "value | strategy | execution",
+  "target": "<file path or task id>",
+  "decision": "APPROVE | CONDITIONAL | REJECT",
+  "score": 0.85,
+  "reviewer": "qe-orchestrator",
+  "reviewers_dispatched": ["wicked-testing:test-strategist", "wicked-testing:risk-assessor"],
+  "dispatch_mode": "parallel | serial",
+  "serial_reason": null,
+  "per_reviewer_verdicts": [
+    {"reviewer": "wicked-testing:test-strategist", "verdict": "APPROVE", "score": 0.88, "summary": "..."}
+  ],
+  "findings": ["<one-line finding>", "..."],
+  "conditions": [
+    {"id": "QE-1", "severity": "major|minor", "reason": "...", "manifest_path": "phases/{phase}/conditions-manifest.json"}
+  ],
+  "blockers": ["<reason>"],
+  "evidence_artifact": "phases/{phase}/{gate}-gate-{TIMESTAMP}.md"
+}
+```
+
+Invariants:
+- APPROVE → `conditions: []` AND `blockers: []` AND `score >= 0.70`.
+- CONDITIONAL → `conditions` non-empty AND `blockers: []`.
+- REJECT → `blockers` non-empty.
+- `dispatch_mode: "serial"` MUST be paired with a non-empty `serial_reason`.
+- `reviewer` MUST NOT be a banned auto-approve identity (`fast-pass`,
+  `just-finish-auto`, `auto-approve-*`).
+
+A human-readable mirror in `phases/{phase}/{gate}-gate-{TIMESTAMP}.md` is also
+written for evidence purposes:
 
 ```markdown
 ## Gate Result

--- a/agents/crew/reviewer.md
+++ b/agents/crew/reviewer.md
@@ -100,13 +100,35 @@ If evidence is missing or incomplete, flag as a **Critical** finding. Task compl
 
 ### 5. Document Findings
 
+#### Output contract — INLINED, do not rely on skill bodies being loaded
+
+Skill descriptions get injected into context; full skill bodies do not unless
+invoked. The fallback reviewer is the agent most likely to be dispatched
+when a specialist is missing — its output must be consumable by gate
+adjudicators that have no other context. The frontmatter below is the
+authoritative shape; the prose body is human-readable evidence.
+
 Write to `phases/review/findings.md`:
 
 ```markdown
+---
+verdict: APPROVE | CONDITIONAL | REJECT
+score: 0.85
+reviewer: wicked-garden:crew:reviewer
+external_review: true | false
+external_reviewer: "<subagent_type or cli_name>" | null
+reviewed_at: "<ISO-8601 UTC Z>"
+findings:
+  - "<critical-or-concern finding 1>"
+  - "<critical-or-concern finding 2>"
+conditions:
+  - "<condition 1>"
+---
+
 # Review Findings
 
 ## Summary
-[Overall assessment: APPROVE / NEEDS CHANGES]
+[Overall assessment: APPROVE / CONDITIONAL / REJECT]
 
 ## Changes Reviewed
 - [file]: [assessment]
@@ -128,6 +150,16 @@ Write to `phases/review/findings.md`:
 ## Recommendation
 [Final recommendation with reasoning]
 ```
+
+Frontmatter invariants:
+- `verdict: APPROVE` requires `findings: []` AND `conditions: []`.
+- `verdict: CONDITIONAL` requires `conditions` non-empty.
+- `verdict: REJECT` requires at least one Critical finding.
+- At complexity >= 3, `external_review: true` AND `external_reviewer` MUST
+  identify a different subagent_type than `reviewer`. If unavailable, set
+  `verdict: CONDITIONAL` with the condition "External review required at
+  complexity >= 3 but was not obtained."
+- `reviewer` MUST NOT be a banned auto-approve identity.
 
 ## Task Lifecycle
 

--- a/scenarios/crew/parallel-dispatch-verification.md
+++ b/scenarios/crew/parallel-dispatch-verification.md
@@ -196,6 +196,80 @@ Assert: PASS: parallelization-check violation detected (sub_task_count=3, dispat
 
 ---
 
+## Case 4: qe-orchestrator gate emits batched dispatch_mode + per_reviewer_verdicts
+
+**Verifies**: qe-orchestrator's inlined output contract — every gate verdict
+declares `dispatch_mode` and lists `per_reviewer_verdicts` for the reviewers
+named in step 2 of the agent body. Catches the "serial loop disguised as
+parallel" failure where an agent claims parallel but emits one verdict at
+a time.
+
+### Test — seed a strategy-gate qe-orchestrator output
+
+```bash
+Run: sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib
+go = {
+    'gate': 'strategy',
+    'target': 'phases/design/design.md',
+    'decision': 'APPROVE',
+    'score': 0.84,
+    'reviewer': 'qe-orchestrator',
+    'reviewers_dispatched': [
+        'wicked-testing:testability-reviewer',
+        'wicked-testing:test-strategist',
+        'wicked-testing:risk-assessor',
+    ],
+    'dispatch_mode': 'parallel',
+    'serial_reason': None,
+    'per_reviewer_verdicts': [
+        {'reviewer': 'wicked-testing:testability-reviewer', 'verdict': 'APPROVE', 'score': 0.86, 'summary': 'design is testable'},
+        {'reviewer': 'wicked-testing:test-strategist',     'verdict': 'APPROVE', 'score': 0.82, 'summary': 'scenarios cover ACs'},
+        {'reviewer': 'wicked-testing:risk-assessor',       'verdict': 'APPROVE', 'score': 0.84, 'summary': 'risk acceptable'},
+    ],
+    'findings': [],
+    'conditions': [],
+    'blockers': [],
+    'evidence_artifact': 'phases/design/strategy-gate-20260419.md',
+}
+pathlib.Path('${PROJECT_DIR}/phases/build/qe-orchestrator-output.json').write_text(json.dumps(go, indent=2))
+print('qe-orchestrator-output.json written')
+"
+Assert: qe-orchestrator-output.json written
+```
+
+### Assertion — dispatch_mode + reviewer count match the strategy-gate contract
+
+```bash
+Run: sh "${PLUGIN_ROOT}/scripts/_python.sh" -c "
+import json, pathlib, sys
+go = json.loads(pathlib.Path('${PROJECT_DIR}/phases/build/qe-orchestrator-output.json').read_text())
+# Strategy gate names 3 reviewers in agents/crew/qe-orchestrator.md
+assert go['gate'] == 'strategy', f'gate mismatch: {go[\"gate\"]}'
+assert go['dispatch_mode'] in ('parallel', 'serial'), f'dispatch_mode invalid: {go[\"dispatch_mode\"]}'
+if go['dispatch_mode'] == 'serial':
+    assert go.get('serial_reason'), 'serial dispatch missing serial_reason'
+verdicts = go['per_reviewer_verdicts']
+assert len(verdicts) == 3, f'strategy gate must batch 3 reviewers, got {len(verdicts)}'
+expected = {'wicked-testing:testability-reviewer','wicked-testing:test-strategist','wicked-testing:risk-assessor'}
+got = {v['reviewer'] for v in verdicts}
+assert got == expected, f'reviewer set mismatch: expected {expected}, got {got}'
+# APPROVE invariant: empty conditions + blockers + score >= 0.70
+if go['decision'] == 'APPROVE':
+    assert not go['conditions'], 'APPROVE with non-empty conditions'
+    assert not go['blockers'],   'APPROVE with non-empty blockers'
+    assert go['score'] >= 0.70,  'APPROVE with score < 0.70'
+# banned reviewer guard
+banned = {'fast-pass', 'just-finish-auto'}
+assert go['reviewer'] not in banned, 'banned reviewer identity'
+assert not go['reviewer'].startswith('auto-approve-'), 'banned auto-approve identity'
+print(f'PASS: qe-orchestrator strategy gate batched {len(verdicts)} reviewers, dispatch_mode={go[\"dispatch_mode\"]}, decision={go[\"decision\"]}')
+"
+Assert: PASS: qe-orchestrator strategy gate batched 3 reviewers, dispatch_mode=parallel, decision=APPROVE
+```
+
+---
+
 ## Teardown
 
 ```bash


### PR DESCRIPTION
## Summary

Two cross-project lessons (gcp-ai-sdlc, command_iq, wicked-garden) about how crew agents reason about output contracts and dispatch.

## Themes addressed

### #6 Parallel subagent dispatch as default

- **`qe-orchestrator.md`**: rewrote per-gate "Dispatch Specialists Inline" numbered-loop into a **single batched parallel dispatch** for Value (2 reviewers), Strategy (3), Execution (2). Explicit `dispatch_mode: serial` requires a documented `serial_reason`. References SC-6/AC-α10.
- **`implementer.md`**: added "identify independent units of work" planning step + a "default to parallel" execute() rule with same allow-serial conditions as phase-executor.
- Skipped: `phase-executor.md` (already enforces SC-6/AC-α10), and 8 single-reviewer agents where fan-out doesn't apply.

### #7 Output contracts inlined (skill bodies aren't auto-loaded)

- **`qe-orchestrator.md`**: added "Output contract — INLINED, do not rely on skill bodies being loaded" with fenced JSON shape + invariants.
- **`process-facilitator.md`**: inlined required-keys list from `output-schema.md` directly. Catches the recurring failure where the agent emits flat `factors: "string"` instead of `{reading, risk_level, why}` dicts (Issue #574 history).
- **`reviewer.md`**: replaced prose-only findings template with YAML-frontmatter contract (`verdict`, `score`, `findings`, `conditions`) + verdict-emptiness invariants + complexity≥3 external-review rule.
- Skipped: `phase-executor.md`, `gate-adjudicator.md`, `gate-evaluator.md`, `independent-reviewer.md`, `contrarian.md`, `implementer.md`, `facilitator.md`, `researcher.md` — all already have strong contracts.

## Test plan

- [x] New scenario `scenarios/crew/parallel-dispatch-verification.md` Case 4: fixtures a strategy-gate `qe-orchestrator` output and asserts the inlined contract (3 batched reviewers, dispatch_mode pairing, APPROVE invariants, banned-reviewer guard).

## Risks

1. `dispatch_mode` field in qe-orchestrator output — verify no downstream consumer expects the older flat `gate-result.json` `result` field.
2. `reviewer.md` frontmatter shape diverges slightly from `independent-reviewer.md` (no `evidence_items_checked`). Confirm gate adjudicators tolerate either shape.
3. Inlined required-keys list will drift if `output-schema.md` adds new mandatory keys — flag at next schema bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)