### PR TITLE
docs: cross-project memory learnings — council, test philosophy, dogfood protocol

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -335,7 +335,7 @@ Tests have a maintenance cost. Optimize for catching real failures, not for asse
 - Skill-description text matching and frontmatter wording assertions
 - Brittle path/format assertions (`assert "phase: build" in stdout`) where behavior is decoupled from string formatting
 
-**Splitting heuristic**: split a test where assertions have *independent failure causes* — different code paths can break each one. Keep a test composite when the assertions describe one failure mode from multiple angles (e.g. "verdict is APPROVE and score >= 0.8 and conditions is empty" — all three flow from the same gate decision and break together). Splitting 1:1 per assertion creates noise without adding coverage.
+**Splitting heuristic**: split a test where assertions have *independent failure causes* — different code paths can break each one. Keep a test composite when the assertions describe one failure mode from multiple angles (e.g. "verdict is APPROVE and score >= 0.8 and conditions are empty" — all three flow from the same gate decision and break together). Splitting 1:1 per assertion creates noise without adding coverage.
 
 ## Quality Checks
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -438,6 +438,25 @@ Issue #746 cutover is complete (PRs #751 → #791). Bus events are the source of
 
 **Architecture refs**: `docs/v9/bus-cutover-staging-plan.md` (wave-1 design), `docs/v9/wave-2-cutover-plan.md` (wave-2 per-site analysis + tranche sequencing), `docs/v9/adr-reconcile-v2.md` (why reconcile_v2 co-exists with reconcile.py).
 
+## Operating notes
+
+### Dogfooding bug protocol
+
+When testing wicked-garden machinery (hooks, skills, agents, scripts) and you hit a bug, file a GitHub issue immediately — do **not** accumulate findings in a local `.md` log file in the repo. Local logs rot, drift, and never get triaged.
+
+**Template**:
+
+```
+gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
+```
+
+- `<location>`: file path + line, or command path (e.g. `hooks/scripts/pre_tool.py:142` or `/wicked-garden:crew:start`)
+- `<observed vs expected>`: one sentence each
+- `<impact>`: who/what breaks (single user, all crew runs, audit trail, etc.)
+- `<fix proposal>`: rough direction even if uncertain — gives the triager a starting point
+
+If you discover the bug mid-session, file it before continuing the work that surfaced it.
+
 ## wicked-brain
 
 Digital brain: **wicked-garden** | 11,269 indexed items | 11,208 chunks, 23 wiki articles, 15 memories | server port 4243

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -319,6 +319,24 @@ Skills use **progressive disclosure** for context efficiency:
 - **Tier 2**: SKILL.md (≤200 lines) — overview, quick-start, navigation to refs/
 - **Tier 3**: refs/ directory (200-300 lines each) — loaded only when needed
 
+## Test value philosophy
+
+Tests have a maintenance cost. Optimize for catching real failures, not for assertion counts.
+
+**High-value (write and keep)**:
+- Phase-transition logic (`scripts/crew/phase_manager.py`, status legality, depends_on enforcement)
+- Condition evaluation and conditions-manifest resolution (auto-resolution vs escalation)
+- Cross-domain invariants (chain_id format, event-schema envelope, archetype fallback)
+- Event-bus contract assertions (`scripts/_bus.py` payload allow-lists, projection-resolver shape, idempotency keys)
+- Idempotency: replaying the same bus event must produce the same projection bytes
+
+**Low-value (delete on sight)**:
+- Snapshot tests on markdown gate output (reviewer reports, process-plan rendering, retro narratives)
+- Skill-description text matching and frontmatter wording assertions
+- Brittle path/format assertions (`assert "phase: build" in stdout`) where behavior is decoupled from string formatting
+
+**Splitting heuristic**: split a test where assertions have *independent failure causes* — different code paths can break each one. Keep a test composite when the assertions describe one failure mode from multiple angles (e.g. "verdict is APPROVE and score >= 0.8 and conditions is empty" — all three flow from the same gate decision and break together). Splitting 1:1 per assertion creates noise without adding coverage.
+
 ## Quality Checks
 
 **Quick** (`/wg-check`): JSON validity, plugin.json structure, skills ≤200 lines, agent frontmatter, no hardcoded external tool references.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -188,6 +188,18 @@ Quality gates are hard enforcement mechanisms, not advisory:
 
 **Re-eval artifacts**: checkpoint re-evaluations append to `phases/{phase}/reeval-log.jsonl` (schema 1.1.0, archetype-aware, additive over 1.0), `phases/{phase}/amendments.jsonl` (per-gate, append-only), and `phases/{phase}/process-plan.addendum.jsonl` (plan mutations). Phases can be added mid-flight, never silently removed.
 
+### Pre-merge council requirement
+
+Cross-system bugs — phase-state transitions, gate decisions, event-bus sync points, multi-step orchestrator logic — live at boundaries between subsystems and are structurally invisible to unit tests. Council review (multiple independent specialists rendering blind verdicts) catches them; pytest cannot.
+
+**Trigger paths** (changes here require a pre-merge council pass):
+- `scripts/crew/phase_manager.py`, `scripts/crew/gate_dispatch.py`, `scripts/crew/reconcile_v2.py`, `scripts/crew/convergence.py`
+- `scripts/_bus.py`, `scripts/_event_schema.py`, `scripts/_session.py`
+- `daemon/projector.py` and any new `_HANDLERS` / `_PROJECTION_RESOLVERS` entry
+- Anything under `agents/crew/` (facilitator, gate-adjudicator, contrarian, reviewer panels)
+
+**Convention**: run `/wicked-garden:jam:council` on the diff and attach the verdict bundle to the PR. This is a pre-merge convention, not a hook-enforced gate (yet) — reviewers should request it on PRs touching the trigger paths.
+
 ### Bulletproof Standards
 
 Engineering agents enforce R1-R6 coding rules (no dead code, no bare panics, no magic values, no swallowed errors, no unbounded ops, no god functions). QE agents enforce T1-T6 testing rules (determinism, no sleep-based sync, isolation, single assertion focus, descriptive names, provenance). Rules are adapted per agent focus.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Cross-system bugs at the boundary between subsystems (phase-state transitions, g
 - When debugging test failures, prefer structured output formats (JUnit XML, JSON) over parsing stdout. Do not spend multiple iterations trying to capture/parse terminal output that gets truncated.
 - When I report a bug or issue, investigate the systemic root cause first before applying surface-level fixes. Ask "why is this happening?" not "how do I patch this instance?".
 - When reviewing code or doing analysis, go deep into architectural patterns, agentic design, response validation, and context optimization. Do not produce surface-level checklist findings (e.g., "no auth", "no rate limits").
+- **Test value**: write tests for phase-transition logic, condition evaluation, cross-domain invariants, event-bus contracts, and idempotency. Delete shallow tests on markdown output, skill-description text, and brittle path/format strings. Split a composite test only when assertions have independent failure causes — not 1:1 per assertion. See CLAUDE.md "Test value philosophy".
 
 ## Architecture & Design
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the so
 
 **Soak window**: legacy direct-write paths still run alongside the bus path. Don't delete them yet — `docs/v9/bus-cutover-staging-plan.md` §4 requires two releases of zero drift before deletion. Content-hash idempotency in projector handlers makes the duplicate writes safe.
 
+## Pre-merge council requirement
+
+Cross-system bugs at the boundary between subsystems (phase-state transitions, gate decisions, event-bus sync points, orchestrator logic) are structurally invisible to unit tests. Council review catches them; pytest cannot.
+
+**Trigger paths**: `scripts/crew/phase_manager.py`, `scripts/crew/gate_dispatch.py`, `scripts/crew/reconcile_v2.py`, `scripts/_bus.py`, `scripts/_event_schema.py`, `daemon/projector.py`, anything under `agents/crew/`.
+
+**Convention**: run `/wicked-garden:jam:council` on the diff and attach the verdict bundle to the PR. Pre-merge convention — not a hook-enforced gate yet.
+
 ## Planning & Execution
 
 - When I say "just do it" or "just make the changes", execute immediately without presenting plans for approval. Do not enter plan mode or ask for confirmation unless I explicitly ask for a plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ and the unique-value test before their skills will be accepted in the marketplac
 
 ## Bus-as-truth contract (v9.x cutover)
 
-The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the source of truth** for every gate-critical and audit-load-bearing artifact; on-disk files are projections materialized by `daemon/projector.py`. 14 sites are default-ON. See CLAUDE.md "Bus-as-truth architecture" for the full inventory and resolver shape.
+The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the source of truth** for every gate-critical and audit-load-bearing artifact; on-disk files are projections materialized by `daemon/projector.py`. 14 sites are default-ON. See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) "Bus-as-truth architecture" for the full inventory and resolver shape.
 
 **Rules for agents writing code that produces a tracked artifact**:
 
@@ -33,7 +33,7 @@ The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the so
 2. **Fail-open per Decision #8.** Wrap the emit in `try/except`. A bus emit failure must NEVER block the legacy disk write — evidence loss is preferable visible (the disk write succeeds; missing event surfaces as drift).
 3. **chain_id includes a uniqueness segment** when the operation can repeat in a phase. Per `memory/bus-chain-id-must-include-uniqueness-segment-gotcha.md`: phase-level `chain_id` lets `is_processed` dedupe drop subsequent events in the same phase. Include `condition_id`, `artifact_id`, `amendment_id`, etc. as the discriminator.
 4. **Carve out `raw_payload`** in `scripts/_bus.py::_PAYLOAD_ALLOW_OVERRIDES` if the projector needs the canonical bytes (JSONL append handlers always do; full-file rewrite handlers may instead carry structured fields).
-5. **For new artifacts**: follow the 7-step add-a-bus-projected-artifact procedure in CLAUDE.md "Bus-as-truth architecture" — event registration → carve-out → handler → resolver → handler-available → file-flag → default-ON.
+5. **For new artifacts**: follow the 7-step add-a-bus-projected-artifact procedure in [`.claude/CLAUDE.md`](.claude/CLAUDE.md) "Bus-as-truth architecture" — event registration → carve-out → handler → resolver → handler-available → file-flag → default-ON.
 
 **Soak window**: legacy direct-write paths still run alongside the bus path. Don't delete them yet — `docs/v9/bus-cutover-staging-plan.md` §4 requires two releases of zero drift before deletion. Content-hash idempotency in projector handlers makes the duplicate writes safe.
 
@@ -41,7 +41,7 @@ The bus-cutover (#746) shipped across PRs #751 → #791. **Bus events are the so
 
 Cross-system bugs at the boundary between subsystems (phase-state transitions, gate decisions, event-bus sync points, orchestrator logic) are structurally invisible to unit tests. Council review catches them; pytest cannot.
 
-**Trigger paths**: `scripts/crew/phase_manager.py`, `scripts/crew/gate_dispatch.py`, `scripts/crew/reconcile_v2.py`, `scripts/_bus.py`, `scripts/_event_schema.py`, `daemon/projector.py`, anything under `agents/crew/`.
+**Trigger paths**: `scripts/crew/phase_manager.py`, `scripts/crew/gate_dispatch.py`, `scripts/crew/reconcile_v2.py`, `scripts/crew/convergence.py`, `scripts/_bus.py`, `scripts/_event_schema.py`, `scripts/_session.py`, `daemon/projector.py`, anything under `agents/crew/`.
 
 **Convention**: run `/wicked-garden:jam:council` on the diff and attach the verdict bundle to the PR. Pre-merge convention — not a hook-enforced gate yet.
 
@@ -53,7 +53,7 @@ When dogfooding wicked-garden machinery (hooks, skills, agents, scripts) and hit
 gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
 ```
 
-File before continuing the work that surfaced the bug. See CLAUDE.md "Operating notes / Dogfooding bug protocol".
+File before continuing the work that surfaced the bug. See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) "Operating notes / Dogfooding bug protocol".
 
 ## Planning & Execution
 
@@ -65,7 +65,7 @@ File before continuing the work that surfaced the bug. See CLAUDE.md "Operating 
 - When debugging test failures, prefer structured output formats (JUnit XML, JSON) over parsing stdout. Do not spend multiple iterations trying to capture/parse terminal output that gets truncated.
 - When I report a bug or issue, investigate the systemic root cause first before applying surface-level fixes. Ask "why is this happening?" not "how do I patch this instance?".
 - When reviewing code or doing analysis, go deep into architectural patterns, agentic design, response validation, and context optimization. Do not produce surface-level checklist findings (e.g., "no auth", "no rate limits").
-- **Test value**: write tests for phase-transition logic, condition evaluation, cross-domain invariants, event-bus contracts, and idempotency. Delete shallow tests on markdown output, skill-description text, and brittle path/format strings. Split a composite test only when assertions have independent failure causes — not 1:1 per assertion. See CLAUDE.md "Test value philosophy".
+- **Test value**: write tests for phase-transition logic, condition evaluation, cross-domain invariants, event-bus contracts, and idempotency. Delete shallow tests on markdown output, skill-description text, and brittle path/format strings. Split a composite test only when assertions have independent failure causes — not 1:1 per assertion. See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) "Test value philosophy".
 
 ## Architecture & Design
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,16 @@ Cross-system bugs at the boundary between subsystems (phase-state transitions, g
 
 **Convention**: run `/wicked-garden:jam:council` on the diff and attach the verdict bundle to the PR. Pre-merge convention — not a hook-enforced gate yet.
 
+## Dogfooding bug protocol
+
+When dogfooding wicked-garden machinery (hooks, skills, agents, scripts) and hitting a bug, file a GitHub issue **immediately** — never accumulate in a local `.md` log file. Template:
+
+```
+gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
+```
+
+File before continuing the work that surfaced the bug. See CLAUDE.md "Operating notes / Dogfooding bug protocol".
+
 ## Planning & Execution
 
 - When I say "just do it" or "just make the changes", execute immediately without presenting plans for approval. Do not enter plan mode or ask for confirmation unless I explicitly ask for a plan.


### PR DESCRIPTION
## Summary

Three documentation-only conventions distilled from cross-project memory mining. CLAUDE.md and AGENTS.md kept in sync.

## Themes addressed

### #3 Pre-merge council requirement

Bugs at boundaries between systems (phase-state transitions, gate decisions, event-bus sync points, multi-step orchestrator logic) are structurally invisible to unit tests. Council review catches them.

Added under Gate Enforcement: file/path patterns that trigger the requirement (`scripts/crew/phase_manager.py`, `gate_dispatch.py`, `reconcile_v2.py`, `convergence.py`, `_bus.py`, `_event_schema.py`, `_session.py`, `daemon/projector.py`, `agents/crew/*`). Convention: `/wicked-garden:jam:council` pre-merge. Not hook-enforced (yet).

### #5 Test value philosophy

Composite tests should split where assertions have **independent failure causes**, not 1:1 per assertion. Categorizes wicked-garden tests:
- **High-value**: phase-transition logic, condition evaluation, cross-domain invariants, event-bus contract assertions, idempotency
- **Low-value (delete on sight)**: snapshot tests on markdown gate output, skill-description text matching, brittle path/format assertions

### #11 Dogfooding bug protocol

When testing wicked-garden machinery and hitting bugs, file as GH issue immediately — don't accumulate in local `.md` files.

```
gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
```

## Files changed

- `.claude/CLAUDE.md` — three new sections
- `AGENTS.md` — mirrored in compact form with cross-references back to CLAUDE.md

## Risks

1. Theme 5 placement: new top-level `## Test value philosophy` before "Quality Checks" (no existing "Testing" section fit). Could move under "Bulletproof Standards" if preferred.
2. Theme 11 introduces a new top-level `## Operating notes` with a single subsection. If more dogfood/operating notes accumulate, this is the natural home.
3. Theme 3 trigger-paths list is hand-curated — sanity-check the listed files match current reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)