### PR TITLE
crew: steer-not-block on risk_level/reading drift (validator papercut fix)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -447,7 +447,7 @@ When testing wicked-garden machinery (hooks, skills, agents, scripts) and you hi
 **Template**:
 
 ```
-gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
+gh issue create --label bug --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
 ```
 
 - `<location>`: file path + line, or command path (e.g. `hooks/scripts/pre_tool.py:142` or `/wicked-garden:crew:start`)
@@ -455,13 +455,7 @@ gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --bod
 - `<impact>`: who/what breaks (single user, all crew runs, audit trail, etc.)
 - `<fix proposal>`: rough direction even if uncertain — gives the triager a starting point
 
-**One-time setup** (the `machinery` label must exist on the repo or `gh issue create` exits non-zero):
-
-```
-gh label create machinery --description "Plugin machinery (hooks/skills/agents/scripts) bugs surfaced via dogfooding" --color B60205
-```
-
-If `gh label create` fails because the label already exists, that's the success case — proceed. If you don't have permission to create labels on the repo, fall back to `--label bug` and prefix the title with `machinery:` so triagers can route by hand.
+Use the `bug` label — it's the canonical label for plugin defects surfaced via dogfooding. (`machinery` is not used.)
 
 If you discover the bug mid-session, file it before continuing the work that surfaced it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,10 @@ Cross-system bugs at the boundary between subsystems (phase-state transitions, g
 When dogfooding wicked-garden machinery (hooks, skills, agents, scripts) and hitting a bug, file a GitHub issue **immediately** — never accumulate in a local `.md` log file. Template:
 
 ```
-gh issue create --label machinery --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
+gh issue create --label bug --title "<hook|skill|agent>: <one-line>" --body "<location> | <observed vs expected> | <impact> | <fix proposal>"
 ```
 
-The `machinery` label must exist on the repo (one-time: `gh label create machinery --description "Plugin machinery bugs" --color B60205`). If you can't create labels, fall back to `--label bug` and prefix the title with `machinery:`.
+Use the `bug` label — it's the canonical label for plugin defects. (`machinery` is not used.)
 
 File before continuing the work that surfaced the bug. See [`.claude/CLAUDE.md`](.claude/CLAUDE.md) "Operating notes / Dogfooding bug protocol".
 

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -99,6 +99,15 @@ SCHEMA_DOC = "skills/propose-process/refs/output-schema.md"
 _WARN_TEST_STRATEGY_MISSING = "test-strategy-missing"
 _TEST_STRATEGY_PHASE_NAME = "test-strategy"
 
+# Steering-not-blocking principle (2026-05-05): `risk_level` drift relative
+# to `reading` was previously a fatal violation, forcing hand-patches on
+# every facilitator output that picked the more intuitive direction (LOW
+# reversibility = low semantic risk). Now downgraded to an advisory warning
+# emitted by `_check_factor_risk_consistency`. The reading-derived
+# `_EXPECTED_RISK_LEVEL_FOR_READING` mapping remains the authoritative
+# direction; consumers preferring `reading` are unaffected.
+_WARN_RISK_LEVEL_INVERTED = "risk-level-inverted-vs-reading"
+
 # Per-section anchors within SCHEMA_DOC. Key is the violation-message prefix
 # (the text before ' — ', with [] / . suffixes stripped).
 _SECTION_ANCHORS = {
@@ -271,14 +280,12 @@ def _check_factors(plan: dict, violations: list) -> None:
                     f"factors.{key}.risk_level — '{risk_level}' is not one of "
                     f"{sorted(VALID_FACTOR_RISK_LEVELS)}"
                 )
-            elif reading in _EXPECTED_RISK_LEVEL_FOR_READING:
-                expected = _EXPECTED_RISK_LEVEL_FOR_READING[reading]
-                if risk_level != expected:
-                    violations.append(
-                        f"factors.{key} — risk_level '{risk_level}' does not "
-                        f"match reading '{reading}' (expected '{expected}'; "
-                        f"see scripts/crew/factor_questionnaire.py::_RISK_INVERSION)"
-                    )
+            # Steering, not blocking: cross-field consistency between
+            # `reading` and `risk_level` is an advisory warning emitted by
+            # `_check_factor_risk_consistency` rather than a fatal violation.
+            # Producer drift is a hint, not an error — `reading` carries the
+            # authoritative direction (HIGH=safest), so consumers preferring
+            # `reading` are unaffected when `risk_level` lags.
         why = value.get("why")
         if not why or not str(why).strip():
             violations.append(f"factors.{key}.why — must be a non-empty string")
@@ -478,6 +485,60 @@ def _check_test_strategy_present(plan: dict) -> list:
     ]
 
 
+def _check_factor_risk_consistency(plan: dict) -> list:
+    """Steering-not-blocking advisory: surface drift between a factor's
+    ``reading`` and its ``risk_level`` field.
+
+    Previously enforced as a fatal violation (Issue #627). Downgraded
+    2026-05-05 because the reject loop forced hand-patching on every
+    facilitator output that picked the more intuitive direction
+    (LOW reversibility = low semantic risk). The authoritative direction
+    still lives in ``reading`` (HIGH=safest); consumers preferring
+    ``reading`` are unaffected.
+
+    Each warning dict has:
+      - ``code``: stable identifier (``risk-level-inverted-vs-reading``)
+      - ``severity``: ``"warn"``
+      - ``factor``: the factor key with drift
+      - ``reading``: the reading value seen on the factor
+      - ``risk_level``: the actual risk_level value seen on the factor
+      - ``expected_risk_level``: what risk_level should be per the
+        HIGH=safest inversion mapping
+      - ``message``: human-readable explanation citing
+        ``factor_questionnaire.py::_RISK_INVERSION``
+    """
+    factors = plan.get("factors")
+    if not isinstance(factors, dict):
+        return []
+    out: list = []
+    for key, value in factors.items():
+        if not isinstance(value, dict):
+            continue
+        reading = value.get("reading")
+        risk_level = value.get("risk_level")
+        if (
+            reading in _EXPECTED_RISK_LEVEL_FOR_READING
+            and risk_level in VALID_FACTOR_RISK_LEVELS
+        ):
+            expected = _EXPECTED_RISK_LEVEL_FOR_READING[reading]
+            if risk_level != expected:
+                out.append({
+                    "code": _WARN_RISK_LEVEL_INVERTED,
+                    "severity": "warn",
+                    "factor": key,
+                    "reading": reading,
+                    "risk_level": risk_level,
+                    "expected_risk_level": expected,
+                    "message": (
+                        f"factors.{key} — risk_level '{risk_level}' does not "
+                        f"match reading '{reading}' (expected '{expected}'; "
+                        f"see scripts/crew/factor_questionnaire.py::_RISK_INVERSION). "
+                        f"Advisory only — `reading` carries authoritative direction."
+                    ),
+                })
+    return out
+
+
 def validate(plan: dict) -> list:
     """Return a list of violation strings (empty means valid)."""
     violations = []
@@ -490,14 +551,22 @@ def validate(plan: dict) -> list:
 
 
 def warnings(plan: dict) -> list:
-    """Return a list of non-blocking warning dicts (Issue #583).
+    """Return a list of non-blocking warning dicts.
 
     Warnings are distinct from violations: they do NOT fail validation but
-    surface advisory gaps (test-strategy missing, etc.). Kept as a separate
-    function so callers that only care about reject/accept can ignore them.
+    surface advisory gaps. Kept as a separate function so callers that only
+    care about reject/accept can ignore them.
+
+    Sources:
+      - Issue #583: ``test-strategy-missing`` when ``test_required: true``
+        tasks exist but the plan omits the test-strategy phase.
+      - 2026-05-05 (steering-not-blocking): ``risk-level-inverted-vs-reading``
+        when a factor's risk_level disagrees with the HIGH=safest inversion
+        of its reading.
     """
     out: list = []
     out.extend(_check_test_strategy_present(plan))
+    out.extend(_check_factor_risk_consistency(plan))
     return out
 
 
@@ -588,14 +657,10 @@ _INVALID_FIXTURES = [
             "reversibility": {"reading": "LOW", "why": "idk"},
         },
     }),
-    # #627: risk_level mismatched against reading (LOW reading == high_risk)
-    ("factor risk_level inverted vs reading", lambda p: {
-        **p,
-        "factors": {
-            **p["factors"],
-            "reversibility": {"reading": "LOW", "risk_level": "low_risk", "why": "idk"},
-        },
-    }),
+    # 2026-05-05 (steering-not-blocking): inversion mismatch is no longer
+    # a fatal violation. It now surfaces as an advisory warning emitted by
+    # `_check_factor_risk_consistency` and exposed via `warnings()`. The
+    # corresponding positive assertion lives in `_run_selftest` below.
     # #722: affected_repos must be a list when present
     ("affected_repos not a list", lambda p: {**p, "affected_repos": "foo"}),
     # #722: affected_repos entries must be non-empty strings
@@ -668,6 +733,38 @@ def _run_selftest() -> None:
         result = validate(mutated)
         if not result:
             failures.append(f"invalid fixture '{desc}' produced no violations (expected >=1)")
+
+    # 2026-05-05 (steering-not-blocking): risk_level/reading drift no longer
+    # rejects, but must surface as exactly one warning with the expected code.
+    drifted = copy.deepcopy(_VALID_FIXTURE)
+    drifted["factors"]["reversibility"] = {
+        "reading": "LOW", "risk_level": "low_risk", "why": "drift"
+    }
+    drift_violations = validate(drifted)
+    if drift_violations:
+        failures.append(
+            f"steering: risk_level drift produced violations (should warn only): "
+            f"{drift_violations}"
+        )
+    drift_warnings = warnings(drifted)
+    drift_warn_codes = {w.get("code") for w in drift_warnings}
+    if _WARN_RISK_LEVEL_INVERTED not in drift_warn_codes:
+        failures.append(
+            f"steering: risk_level drift did not produce expected warning "
+            f"'{_WARN_RISK_LEVEL_INVERTED}' (got codes: {sorted(drift_warn_codes)})"
+        )
+    # The drift warning must include enough audit detail to fix the producer.
+    drift_warn = next(
+        (w for w in drift_warnings if w.get("code") == _WARN_RISK_LEVEL_INVERTED),
+        None,
+    )
+    if drift_warn is not None:
+        for required_field in ("factor", "reading", "risk_level", "expected_risk_level"):
+            if required_field not in drift_warn:
+                failures.append(
+                    f"steering: drift warning missing required field "
+                    f"'{required_field}' (got keys: {sorted(drift_warn.keys())})"
+                )
 
     if failures:
         for msg in failures:

--- a/scripts/crew/validate_plan.py
+++ b/scripts/crew/validate_plan.py
@@ -532,8 +532,8 @@ def _check_factor_risk_consistency(plan: dict) -> list:
                     "message": (
                         f"factors.{key} — risk_level '{risk_level}' does not "
                         f"match reading '{reading}' (expected '{expected}'; "
-                        f"see scripts/crew/factor_questionnaire.py::_RISK_INVERSION). "
-                        f"Advisory only — `reading` carries authoritative direction."
+                        f"see scripts/crew/factor_questionnaire.py::_RISK_INVERSION); "
+                        f"advisory only — `reading` carries authoritative direction"
                     ),
                 })
     return out
@@ -747,11 +747,14 @@ def _run_selftest() -> None:
             f"{drift_violations}"
         )
     drift_warnings = warnings(drifted)
-    drift_warn_codes = {w.get("code") for w in drift_warnings}
-    if _WARN_RISK_LEVEL_INVERTED not in drift_warn_codes:
+    drift_warn_matching = [
+        w for w in drift_warnings if w.get("code") == _WARN_RISK_LEVEL_INVERTED
+    ]
+    if len(drift_warn_matching) != 1:
         failures.append(
-            f"steering: risk_level drift did not produce expected warning "
-            f"'{_WARN_RISK_LEVEL_INVERTED}' (got codes: {sorted(drift_warn_codes)})"
+            f"steering: risk_level drift produced {len(drift_warn_matching)} "
+            f"matching warnings (expected exactly 1; got codes "
+            f"{sorted({w.get('code') for w in drift_warnings})})"
         )
     # The drift warning must include enough audit detail to fix the producer.
     drift_warn = next(

--- a/tests/test_validate_plan_test_strategy_check.py
+++ b/tests/test_validate_plan_test_strategy_check.py
@@ -193,15 +193,49 @@ def test_validate_rejects_bad_factor_risk_level_enum():
     ), violations
 
 
-def test_validate_rejects_inverted_factor_risk_level():
-    """Issue #689: risk_level must agree with reading."""
+def test_validate_does_not_reject_inverted_factor_risk_level():
+    """Steering-not-blocking (2026-05-05): inversion drift between
+    risk_level and reading was previously a fatal violation (Issue #689).
+    Downgraded to an advisory warning emitted by `warnings()`. The plan
+    still validates; producer drift is recorded with enough audit detail
+    to fix the upstream emitter.
+
+    The old behavior forced hand-patching on every facilitator output that
+    picked the more intuitive direction (LOW reversibility = low semantic
+    risk). The principle: structure stays prescriptive, but the enforcement
+    model steers (auto-correct + audit) instead of blocking.
+    """
     plan = _base_plan()
     plan["factors"]["reversibility"]["risk_level"] = "low_risk"
+
+    # validate() must not reject — drift is no longer fatal.
     violations = validate_plan.validate(plan)
-    assert any(
+    assert not any(
         "factors.reversibility" in v and "does not match reading" in v
         for v in violations
-    ), violations
+    ), f"inversion drift should warn, not reject: {violations}"
+
+    # warnings() must surface the drift with full audit detail.
+    warns = validate_plan.warnings(plan)
+    drift = [w for w in warns if w.get("code") == "risk-level-inverted-vs-reading"]
+    assert len(drift) == 1, warns
+    w = drift[0]
+    assert w["severity"] == "warn"
+    assert w["factor"] == "reversibility"
+    assert w["reading"] == "LOW"
+    assert w["risk_level"] == "low_risk"
+    assert w["expected_risk_level"] == "high_risk"
+    assert "factor_questionnaire.py::_RISK_INVERSION" in w["message"]
+
+
+def test_warnings_silent_when_risk_level_matches_reading():
+    """No drift → no risk-level warning. Confirms the warning is
+    targeted, not noisy."""
+    plan = _base_plan()  # baseline factors all have matching reading/risk_level
+    warns = validate_plan.warnings(plan)
+    assert not any(
+        w.get("code") == "risk-level-inverted-vs-reading" for w in warns
+    ), warns
 
 
 def test_existing_specialist_check_still_passes():

--- a/tests/test_validate_plan_test_strategy_check.py
+++ b/tests/test_validate_plan_test_strategy_check.py
@@ -194,30 +194,34 @@ def test_validate_rejects_bad_factor_risk_level_enum():
 
 
 def test_validate_does_not_reject_inverted_factor_risk_level():
-    """Steering-not-blocking (2026-05-05): inversion drift between
-    risk_level and reading was previously a fatal violation (Issue #689).
-    Downgraded to an advisory warning emitted by `warnings()`. The plan
-    still validates; producer drift is recorded with enough audit detail
-    to fix the upstream emitter.
+    """Steering-not-blocking (2026-05-05, supersedes the prior #627/#689
+    enforcement): inversion drift between risk_level and reading was a
+    fatal violation. Downgraded to an advisory warning emitted by
+    `warnings()`. The plan still validates; producer drift is recorded
+    with enough audit detail to fix the upstream emitter.
 
-    The old behavior forced hand-patching on every facilitator output that
-    picked the more intuitive direction (LOW reversibility = low semantic
-    risk). The principle: structure stays prescriptive, but the enforcement
-    model steers (auto-correct + audit) instead of blocking.
+    The old behavior forced hand-patching on every facilitator output
+    that picked the more intuitive direction (LOW reversibility = low
+    semantic risk). The principle: structure stays prescriptive, but
+    the enforcement model emits an advisory warning rather than rejecting
+    — the validator does NOT mutate the plan; downstream consumers
+    preferring `reading` are already correct on the authoritative direction.
     """
     plan = _base_plan()
     plan["factors"]["reversibility"]["risk_level"] = "low_risk"
 
-    # validate() must not reject — drift is no longer fatal.
+    # validate() must accept the plan cleanly — drift is no longer fatal,
+    # and we want to catch any new violations that creep in unrelated to
+    # this codepath, so we assert the full violations list is empty.
     violations = validate_plan.validate(plan)
-    assert not any(
-        "factors.reversibility" in v and "does not match reading" in v
-        for v in violations
-    ), f"inversion drift should warn, not reject: {violations}"
+    assert violations == [], f"drift must not produce violations: {violations}"
 
     # warnings() must surface the drift with full audit detail.
     warns = validate_plan.warnings(plan)
-    drift = [w for w in warns if w.get("code") == "risk-level-inverted-vs-reading"]
+    drift = [
+        w for w in warns
+        if w.get("code") == validate_plan._WARN_RISK_LEVEL_INVERTED
+    ]
     assert len(drift) == 1, warns
     w = drift[0]
     assert w["severity"] == "warn"
@@ -234,8 +238,15 @@ def test_warnings_silent_when_risk_level_matches_reading():
     plan = _base_plan()  # baseline factors all have matching reading/risk_level
     warns = validate_plan.warnings(plan)
     assert not any(
-        w.get("code") == "risk-level-inverted-vs-reading" for w in warns
+        w.get("code") == validate_plan._WARN_RISK_LEVEL_INVERTED for w in warns
     ), warns
+
+
+def test_risk_level_warning_code_is_stable():
+    """2026-05-05: downstream consumers (gate reviewers, dashboards, audit
+    logs) key on the literal warning code string. Pin the value so a
+    rename here surfaces as a test failure rather than silent drift."""
+    assert validate_plan._WARN_RISK_LEVEL_INVERTED == "risk-level-inverted-vs-reading"
 
 
 def test_existing_specialist_check_still_passes():


### PR DESCRIPTION
## Summary

First demonstration of the **steering-not-blocking principle** established 2026-05-05.

The plan validator no longer REJECTs facilitator output when a factor's `risk_level` disagrees with the HIGH=safest inversion of its `reading`. Drift now surfaces as a structured advisory warning emitted by `warnings()` with full audit detail (`factor`, `reading`, `risk_level`, `expected_risk_level`, `message`). `validate()` keeps the same signature and no longer fails on this case — backward-compatible for all existing downstream consumers.

Daily papercut: the previous behavior forced hand-patching on every facilitator run that picked the more intuitive direction (LOW reversibility = low semantic risk). The `reading` field carries the authoritative direction (HIGH=safest); `risk_level` is the user-facing translation. Drift is a producer-side hint, not a fatal error.

## Why this PR exists

Mid-session feedback this week documented the same friction repeatedly across multiple crew runs:

> *"Plan validator vs facilitator output mismatch — facilitator writes intuitive readings (LOW reversibility = low risk semantically); validator enforces `_RISK_INVERSION` (LOW = high_risk). Hand-patched readings on both runs this session."*

The principle codified in response: **prescriptive defaults, steering enforcement, reduced overhead. Structure stays — but the enforcement model changes from blocking to steering.** This PR is the smallest possible move that demonstrates the principle on the loudest blocker.

## What changed

`scripts/crew/validate_plan.py`:
- New helper `_check_factor_risk_consistency(plan)` produces structured warning dicts on inversion drift.
- `warnings()` now includes those dicts alongside the existing `test-strategy-missing` advisories.
- The corresponding violation in `_check_factors` (lines 274–281 in the pre-fix file) is removed; a comment in its place documents the steering rationale.
- Selftest gains a positive assertion that drift produces exactly one warning with the expected `risk-level-inverted-vs-reading` code and full audit detail.
- The obsolete `factor risk_level inverted vs reading` entry is removed from `_INVALID_FIXTURES` (it should now PASS validation).

`tests/test_validate_plan_test_strategy_check.py`:
- `test_validate_rejects_inverted_factor_risk_level` is renamed to `test_validate_does_not_reject_inverted_factor_risk_level` and flipped to assert WARN-not-REJECT semantics, including audit-detail shape.
- New `test_warnings_silent_when_risk_level_matches_reading` confirms the warning is targeted, not noisy.

`.claude/CLAUDE.md` + `AGENTS.md`:
- Bundled minor docs correction: dogfooding bug protocol template now uses `--label bug` (the canonical label) rather than the never-adopted `machinery`. Both files updated in lock-step.

## Test plan

- [x] `validate_plan.py --selftest` PASS
- [x] `tests/test_validate_plan_test_strategy_check.py` — drift WARN, no-drift silent, audit detail
- [x] `tests/test_validate_plan_archetype.py`
- [x] `tests/test_specialist_resolver.py`
- [x] All 92 validate_plan + factor + risk-related tests pass
- [ ] Dogfood on next two crew runs; confirm no false-positive blocks; confirm reviewers see the new warning when drift happens.

## Out of scope

Deep-guard pipeline flagged five warnings on this file (long functions, swallowed exception, magic value `7`). All pre-date this PR (the function bodies were not modified at the warned line numbers). Bundling their cleanup would violate the *"don't refactor beyond what the task requires"* rule. They can be filed as follow-up `--label bug` issues if they accumulate.

## Backward compatibility

- `validate(plan)` signature unchanged.
- `warnings(plan)` return shape unchanged (still a list of dicts; new dicts share the same `code`/`severity`/`message` keys as the existing `test-strategy-missing` warning, plus the additional drift-detail fields).
- Plans that previously rejected on inversion drift now pass validation. Plans that previously passed are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)