### PR TITLE
crew: v10 Phase 2A — extract crew:start prep into write_brief.py

### DIFF
--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -7,298 +7,128 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:crew:start
 
-Create a new project and begin work. The **facilitator rubric** is the path —
-no router, no legacy engine. The v5 rule engine (`smart_decisioning.py`) and
-the `WG_FACILITATOR` env var were removed in v6 (#428).
+Start a new wicked-crew project. Phase 2A of v10 (#813 successor): the
+slug algorithm, flag parsing, conflict check, project shell creation,
+and crew-brief composition are all encapsulated in
+`scripts/crew/write_brief.py`. This command body is the slim Pattern B
+shape — it writes the brief, dispatches the facilitator, and surfaces
+the result. Full ≤28-line target lands in Phase 2B once the facilitator
+agent absorbs the post-rubric steps.
 
-## Instructions
+## 1. Empty-args guard
 
-### 1. Parse Arguments
+If `$ARGUMENTS` is empty, ask the user for a project description and STOP.
+Do not proceed with an empty description.
 
-Extract the project description from `$ARGUMENTS`. If empty, ask the user for one and
-STOP. Do not proceed with an empty description.
-
-**v6 flags (orthogonal axes):**
-
-| Flag | Axis | Effect |
-|---|---|---|
-| `--yolo` / `--just-finish` | interaction mode | Run to completion without user confirmations; auto-approve APPROVE gates; escalate only on REJECT or intent-changing CONDITIONAL. Does **not** change phase plan, rigor, or specialists — the facilitator already chose those. |
-| `--rigor={minimal\|standard\|full}` | override | Override the facilitator's rigor tier (rarely needed). Sanity check: facilitator's selection is usually right. |
-| `--force` | override | Suppress complexity-based stop prompts (e.g. low-complexity → single-task recommendation). |
-| `--consensus-threshold=N` | gate policy | Per-phase consensus threshold for multi-perspective gate decisions. |
-
-**Removed in v6** (were v5 conflations):
-- `--quick` — was shorthand for "minimal rigor AND yolo mode." These are now
-  orthogonal axes. Use `--rigor=minimal` for fewer phases, `--yolo` for no user
-  prompts, or both.
-- `--no-auto-finish` — no longer needed. Yolo is opt-IN via `--yolo`, not opt-OUT.
-
-The facilitator decides phase plan + specialists + rigor tier from the work itself.
-Flags only adjust interaction mode or override downstream gate behavior.
-
-### 2. Generate Project Slug
-
-Use a three-stage theme-aware slug algorithm (theme prefix + key concepts + assembly),
-truncated to 64 characters on a word boundary. The slug feeds into `chain_id` as
-`{slug}.root`.
-
-**Stage 1: Detect theme prefix** — scan the description (case-insensitive) for the
-first matching signal group:
-
-| Signal Keywords | Theme Prefix |
-|-----------------|--------------|
-| "issue", "gh-", "github issue", `#\d+` | `issue` |
-| "bug", "fix", "broken", "regression", "crash" | `fix` |
-| "refactor", "cleanup", "clean up", "reorganize" | `refactor` |
-| "docs", "documentation", "readme", "changelog" | `docs` |
-| "feature", "feat", "add", "implement", "new", "introduce" | `feat` |
-| (no match) | (no prefix — fall through to Stage 3 fallback) |
-
-**Stage 2: Extract key concepts** — from the description, remove the matched theme
-keywords and stop words ("the", "a", "an", "for", "to", "of", "in", "and", "with"),
-then take the first 3–4 remaining meaningful nouns or phrases and kebab-case each one.
-
-**Stage 3: Assemble** — join as `{theme-prefix}-{concept1}-{concept2}-{concept3}`.
-Truncate at 64 characters on a word boundary (never split mid-word). If no theme
-prefix was matched, fall back to plain kebab-case behavior: lowercase the full
-description, replace spaces with hyphens, strip special characters, truncate at 64.
-
-### 3. Check for Existing Project
+## 2. Write the brief (slug, flags, project shell, crew-brief.md)
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/write_brief.py" \
+   --command crew:start \
+   --description "$ARGUMENTS"
 ```
 
-Parse the JSON result. If an active project exists, ask the user to choose one of
-four options:
+The script generates the theme-aware slug, parses v6 flags
+(`--yolo` / `--just-finish`, `--rigor={minimal|standard|full}`, `--force`,
+`--consensus-threshold=N`), checks for an existing active project, creates
+the project shell, and writes `{project_dir}/crew-brief.md`.
 
-1. **Resume** — continue working on the existing project (abort new project creation)
-2. **Rename** — rename the new project to avoid conflict, then proceed with creation
-3. **Cancel** — abort entirely
-4. **Switch** — pause the current project and create the new one
+**Exit codes**:
+- `0` → parse the JSON on stdout: `{slug, theme_prefix, project_dir, brief_path, flags, conflict_resolved}`. Continue to step 3.
+- `2` → conflict: an active project exists. Parse the JSON on stderr: `{conflict, existing_slug, existing_phase}`. Surface the conflict to the user as a numbered plain-text list of choices (Resume / Rename / Cancel / Switch). Re-invoke `write_brief.py` with `--on-conflict={switch|resume|rename|cancel}` matching the user's choice. On Resume / Cancel, STOP — do not create a new project.
+- `1` → validation/IO error. Surface the stderr message to the user and STOP.
 
-If the user chooses **Switch**:
+## 3. Invoke the facilitator (rubric scoring + plan emission)
 
-1. Set `paused: true` on the existing project via phase_manager so it no longer
-   appears as active:
-   ```bash
-   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/phase_manager.py {existing-project} update \
-     --data '{"paused": true}' \
-     --json
-   ```
-2. The old project's state remains intact (not archived, not deleted) and can be
-   resumed later by setting `paused: false`.
-3. Proceed to Step 4 to create the new project.
-
-### 4. Create Project Shell
-
-Create the project via `phase_manager` so the DomainStore record and project dir exist
-before the facilitator writes `process-plan.md`:
-
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/phase_manager.py {slug} create \
-  --description "{description}" \
-  --json
-```
-
-Parse the JSON response for `project_dir`. This path is where `process-plan.md` will
-land in step 7.
-
-### 5. Invoke the Facilitator Skill
-
-Invoke the `wicked-garden:propose-process` skill with the description. The skill
-is a rubric (Tier-1/2/3 progressive disclosure) that reasons over the 9 factors and
-emits a full plan.
+Read the brief, then dispatch the facilitator skill with the parsed inputs:
 
 ```
 Skill(
   skill="wicked-garden:propose-process",
   args={
-    "description": "{description}",
+    "description": "<description from brief>",
     "mode": "propose",
-    "project_slug": "{slug}",
+    "project_slug": "<slug from step 2>",
     "output": "json"
   }
 )
 ```
 
-The skill returns a single JSON object matching
-`skills/propose-process/refs/output-schema.md` — with `project_slug`, `summary`,
-`factors`, `specialists`, `phases`, `rigor_tier`, `complexity`, `open_questions`,
-`tasks[]`. Each task carries full metadata (chain_id, event_type, source_agent:
-"facilitator", phase, test_required, test_types, evidence_required, rigor_tier).
+The skill returns a JSON plan matching `skills/propose-process/refs/output-schema.md`
+(`project_slug`, `summary`, `factors`, `specialists`, `phases`, `rigor_tier`,
+`complexity`, `open_questions`, `tasks[]`).
 
-**Failure modes**: if the skill is unavailable, returns non-JSON, or omits required
-fields (`tasks`, `phases`, `rigor_tier`), STOP and surface the error to the user with
-the first 200 chars of output. There is no legacy fallback in v6 — the rubric IS the
-path. If the facilitator cannot produce a plan, the user needs to know so they can
-refine the description or file an issue.
+**Failure modes**: if the skill is unavailable, returns non-JSON, or omits
+required fields, STOP and surface the error with the first 200 chars of output.
+There is no legacy fallback — the rubric IS the path. Brief and project shell
+remain on disk; the user can refine and re-invoke.
 
-### 5.5. Validate the Facilitator Plan
-
-After the facilitator skill returns its JSON, run the plan validator before doing anything else with the output:
+## 4. Validate the plan
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/validate_plan.py" "${project_dir}/process-plan.json"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/validate_plan.py" \
+   "${project_dir}/process-plan.json"
 ```
 
-**If exit non-zero** (validator printed violations to stderr):
+Note: per PR #812, `risk_level/reading` drift is now an advisory warning,
+not a fatal violation — plans with intuitive direction parse cleanly. If
+the validator exits non-zero, copy the draft to
+`${project_dir}/process-plan.draft.json`, surface stderr to the user, and STOP.
 
-1. Copy the draft plan to `${project_dir}/process-plan.draft.json` for debugging.
-2. STOP the command — do not create tasks or advance further.
-3. Show the validator's stderr output to the user verbatim.
-4. Instruct the user: "The facilitator returned a malformed plan. Please file a bug at `/wicked-garden:report-issue` with the above violations and the draft plan at `${project_dir}/process-plan.draft.json`."
+## 5. Open Questions gate
 
-**If exit zero**: continue to Step 6.
+If `open_questions` is non-empty AND `rigor_tier == "full"` AND `--force`
+was NOT in the parsed flags: STOP and surface questions as a numbered
+plain-text list. Persist the draft to `${project_dir}/process-plan.draft.md`.
+For `standard` / `minimal` rigor, questions are surfaced but do NOT block —
+they're appended to `process-plan.md` for the clarify phase to answer.
 
-### 6. Open Questions Gate
+## 6. Persist `process-plan.md` + emit the task chain
 
-If `open_questions` is non-empty AND `rigor_tier == "full"` AND `--force` was NOT
-passed: STOP and surface the questions to the user as a numbered plain-text list. Do
-NOT create tasks yet. Store the facilitator's draft plan to
-`${project_dir}/process-plan.draft.md` for resumption. The user's answers feed a
-follow-up invocation with `mode: "propose"` + their answers appended to the
-description.
+Render the plan JSON into the markdown template at
+`skills/propose-process/refs/plan-template.md` and write to
+`${project_dir}/process-plan.md`. Persist the raw JSON as
+`${project_dir}/process-plan.json` for audit.
 
-For `standard` or `minimal` rigor, questions are surfaced but do NOT block task
-creation — they're included in `process-plan.md` for the clarify phase to answer.
+For each task in `plan.tasks[]`, issue one `TaskCreate` call carrying the
+task's metadata envelope (`chain_id`, `event_type`, `source_agent="facilitator"`,
+`phase`, `test_required`, `test_types`, `evidence_required`, `rigor_tier`).
+Use parallel `TaskCreate` calls when tasks within a phase have no
+inter-dependencies; `blockedBy` captures the DAG.
 
-### 7. Persist `process-plan.md`
-
-Render the returned JSON into the Markdown template at
-`skills/propose-process/refs/plan-template.md`. Write to
-`${project_dir}/process-plan.md` using the Write tool.
-
-Also persist the raw JSON alongside for audit at
-`${project_dir}/process-plan.json` so re-evaluation runs can diff cleanly.
-
-### 8. Emit the Task Chain
-
-For each task in the JSON's `tasks[]` array, issue one `TaskCreate` call:
-
-```
-TaskCreate(
-  subject="<task.title>",
-  description="<optional longer description if present>",
-  blockedBy=<task.blockedBy>,
-  metadata={
-    "chain_id": "<task.metadata.chain_id>",     # e.g. "{slug}.root"
-    "event_type": "<task.metadata.event_type>", # "task" | "coding-task" | ...
-    "source_agent": "facilitator",              # always
-    "phase": "<task.metadata.phase>",
-    "test_required": <bool>,
-    "test_types": [...],
-    "evidence_required": [...],
-    "rigor_tier": "<minimal|standard|full>"
-  }
-)
-```
-
-Use **parallel TaskCreate calls** when the chain has multiple tasks with no
-inter-dependencies within a phase. `blockedBy` captures the DAG, so downstream
-tasks wait on upstream ones regardless of creation order.
-
-### 8.5 Verify Emission (issue #432)
-
-After all TaskCreate calls, verify that every plan task has a corresponding
-native task record:
+After emission, verify chain integrity:
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verify_chain_emission.py" \
-  "${project_dir}/process-plan.json" "{slug}.root"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/crew/verify_chain_emission.py" \
+   "${project_dir}/process-plan.json" "{slug}.root"
 ```
 
-- **Exit 0**: all plan tasks emitted. Continue to Step 9.
-- **Exit 1**: count mismatch. The validator prints the delta + likely-missing
-  titles to stderr. Surface the output to the user, offer to re-emit the
-  missing tasks (you can pick the missing titles straight from the plan JSON),
-  and only advance to Step 9 after the counts match. Do NOT silently ignore.
+Exit 1 → count mismatch; surface the delta and offer to re-emit missing tasks
+before advancing.
 
-### 9. Persist Plan Metadata on Project
-
-Store the facilitator-derived fields on the crew project record so `status` /
-`execute` / downstream commands can read them without re-invoking the skill:
+## 7. Persist plan metadata + store decision in wicked-brain
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/phase_manager.py {slug} update \
-  --data '{"phase_plan": ["clarify","design","build","test","review"], "phase_plan_mode": "facilitator", "complexity_score": <N>, "rigor_tier": "<tier>", "facilitator_version": "propose-process-v1", "initiative": "{slug}"}' \
-  --json
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+   "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/phase_manager.py {slug} update \
+   --data '{"phase_plan": [...], "phase_plan_mode": "facilitator", "complexity_score": <N>, "rigor_tier": "<tier>", "facilitator_version": "propose-process-v1", "initiative": "{slug}"}' \
+   --json
 ```
 
-### 10. Store Decision in wicked-brain
+Store the planning decision via `wicked-brain:memory` (type `decision`,
+importance 6) so future runs surface it as a prior. On brain failure, retry
+once; on second failure, write `${project_dir}/.pending-brain-store.json`
+sentinel and surface a WARN — do NOT fail silently.
 
-Record the planning decision as a memory so future runs can surface it as a prior:
+## 8. Report + optional --yolo handoff
 
-```
-Skill(
-  skill="wicked-brain:memory",
-  args={"action": "store", "type": "decision",
-        "title": "crew:start facilitator plan for {slug}",
-        "content": "<summary from JSON + per-factor risk_level (low_risk/medium_risk/high_risk — see #627; do NOT paste raw `reading` HIGH/MED/LOW into human-readable text) + rigor_tier + specialist list>",
-        "tags": ["crew", "facilitator", "process-plan", "{slug}"],
-        "importance": 6}
-)
-```
+Render a short markdown summary: rigor + complexity, factors (per-factor
+`risk_level`, NOT the inverted `reading`), specialists with one-line whys,
+phases with one-line whys, task count, next-step prompt.
 
-**Failure handling (issue #433)** — brain storage is best-effort but not silent:
-
-1. If the skill call raises, retry ONCE (most brain failures are transient connection blips).
-2. If the retry also fails, write a sentinel at `${project_dir}/.pending-brain-store.json` with:
-   ```json
-   {
-     "title": "crew:start facilitator plan for {slug}",
-     "type": "decision",
-     "content": "<same content that was passed to the failed call>",
-     "tags": ["crew", "facilitator", "process-plan", "{slug}"],
-     "importance": 6,
-     "queued_at": "<ISO 8601 timestamp>",
-     "attempts": 2
-   }
-   ```
-   A later `/wicked-garden:crew:execute` (or any future crew command) should check
-   for this sentinel and flush it if the brain is now reachable.
-3. Surface a WARNING to the user — do NOT fail silently. Example:
-   > `[crew:start] wicked-brain unreachable after 2 attempts — plan decision queued at .pending-brain-store.json. Future sessions may produce divergent plans until this is flushed.`
-
-The plan file (`process-plan.md` + `process-plan.json`) remains the system of record;
-the sentinel is a recovery mechanism for the brain-as-prior-source path.
-
-### 11. Report to User
-
-Summarize the facilitator's decision in a short markdown report:
-
-```markdown
-## Project Created: {slug}
-
-**Rigor**: {standard | minimal | full} — {rigor_why}
-**Complexity**: {N}/7 — {complexity_why}
-
-### Factors (facilitator risk reading)
-Render each factor using its `risk_level` field (`low_risk` / `medium_risk` /
-`high_risk`) — NOT the backward-compat `reading` field, which is inverted
-(HIGH = safest). See #627.
-
-- Reversibility: {low_risk / medium_risk / high_risk} — {why}
-- Blast radius: {low_risk / medium_risk / high_risk} — {why}
-- ... (rest of 9 factors)
-
-### Specialists
-{bulleted list with one-sentence why per pick}
-
-### Phases
-{ordered list of phases with one-sentence why}
-
-### Task chain
-{count} tasks created. See `process-plan.md` for the full table.
-
-### Next step
-Run `/wicked-garden:crew:execute` to begin the first phase (`{first_phase}`).
-```
-
-If `--yolo` was passed, skip the "Next step" prompt and immediately invoke:
-
-```
-Skill(skill="wicked-garden:crew:just-finish")
-```
-
-Otherwise exit and let the user drive.
+If the parsed flags include `yolo: true`, skip the next-step prompt and
+immediately invoke `Skill('wicked-garden:crew:just-finish')`. Otherwise
+exit and let the user drive.

--- a/commands/crew/start.md
+++ b/commands/crew/start.md
@@ -35,9 +35,12 @@ The script generates the theme-aware slug, parses v6 flags
 the project shell, and writes `{project_dir}/crew-brief.md`.
 
 **Exit codes**:
-- `0` → parse the JSON on stdout: `{slug, theme_prefix, project_dir, brief_path, flags, conflict_resolved}`. Continue to step 3.
-- `2` → conflict: an active project exists. Parse the JSON on stderr: `{conflict, existing_slug, existing_phase}`. Surface the conflict to the user as a numbered plain-text list of choices (Resume / Rename / Cancel / Switch). Re-invoke `write_brief.py` with `--on-conflict={switch|resume|rename|cancel}` matching the user's choice. On Resume / Cancel, STOP — do not create a new project.
-- `1` → validation/IO error. Surface the stderr message to the user and STOP.
+- `0` → parse the JSON on stdout. The `action` key tells you what happened:
+  - `action=create` → new shell + brief written. Fields: `{slug, theme_prefix, project_dir, brief_path, flags}`. Continue to step 3.
+  - `action=resume` → user chose Resume; carry on with the existing project. Fields: `{slug, phase, project_dir}`. Skip steps 3–8 — the existing project is unchanged.
+  - `action=cancel` → user aborted. STOP cleanly. No further work this command.
+- `2` → conflict: an active project exists and `--on-conflict` was not supplied. Parse the JSON on stderr: `{conflict, existing_slug, existing_phase}`. Surface the conflict to the user as a numbered plain-text list of four choices (Resume / Rename / Cancel / Switch). For **Switch**, **Resume**, **Cancel**, re-invoke `write_brief.py` with the matching `--on-conflict=...` value and parse the next exit-0 response. For **Rename**, ask the user for a new project description and re-invoke `write_brief.py` from step 2 (no `--on-conflict` flag).
+- `1` → validation/IO error (or `--on-conflict=rename` was passed by mistake — write_brief expects the user to re-invoke with a fresh description, not to handle rename in-script). Surface the stderr message and STOP.
 
 ## 3. Invoke the facilitator (rubric scoring + plan emission)
 
@@ -64,7 +67,17 @@ required fields, STOP and surface the error with the first 200 chars of output.
 There is no legacy fallback — the rubric IS the path. Brief and project shell
 remain on disk; the user can refine and re-invoke.
 
-## 4. Validate the plan
+## 4. Persist the plan JSON to disk
+
+The validator and downstream consumers read from disk. Write the raw plan
+JSON to `${project_dir}/process-plan.json` BEFORE running the validator —
+this avoids the file-not-found failure mode where validation tries to
+read a path that hasn't been written yet.
+
+(The human-readable `process-plan.md` rendering happens in step 6 after
+the open-questions gate and the validator both pass.)
+
+## 5. Validate the plan
 
 ```bash
 sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
@@ -74,10 +87,10 @@ sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
 
 Note: per PR #812, `risk_level/reading` drift is now an advisory warning,
 not a fatal violation — plans with intuitive direction parse cleanly. If
-the validator exits non-zero, copy the draft to
+the validator exits non-zero, copy the JSON to
 `${project_dir}/process-plan.draft.json`, surface stderr to the user, and STOP.
 
-## 5. Open Questions gate
+## 5.5. Open Questions gate
 
 If `open_questions` is non-empty AND `rigor_tier == "full"` AND `--force`
 was NOT in the parsed flags: STOP and surface questions as a numbered
@@ -85,12 +98,12 @@ plain-text list. Persist the draft to `${project_dir}/process-plan.draft.md`.
 For `standard` / `minimal` rigor, questions are surfaced but do NOT block —
 they're appended to `process-plan.md` for the clarify phase to answer.
 
-## 6. Persist `process-plan.md` + emit the task chain
+## 6. Render `process-plan.md` + emit the task chain
 
 Render the plan JSON into the markdown template at
 `skills/propose-process/refs/plan-template.md` and write to
-`${project_dir}/process-plan.md`. Persist the raw JSON as
-`${project_dir}/process-plan.json` for audit.
+`${project_dir}/process-plan.md`. The raw JSON was already persisted in
+step 4 for the validator.
 
 For each task in `plan.tasks[]`, issue one `TaskCreate` call carrying the
 task's metadata envelope (`chain_id`, `event_type`, `source_agent="facilitator"`,

--- a/scripts/crew/write_brief.py
+++ b/scripts/crew/write_brief.py
@@ -35,7 +35,6 @@ import argparse
 import datetime
 import json
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -61,15 +60,6 @@ _ISSUE_NUMBER_RE = re.compile(r"#\d+")
 _STOP_WORDS = frozenset({
     "the", "a", "an", "for", "to", "of", "in", "and", "with",
     "on", "at", "by", "from", "is", "are", "be", "as",
-})
-
-# v6 flags — orthogonal axes. Anything not in this set is treated as part
-# of the description (so "implement --turbo flag" doesn't get parsed as a
-# `--turbo` flag).
-_KNOWN_FLAGS = frozenset({
-    "--yolo", "--just-finish", "--force",
-    # Flags with values:
-    "--rigor", "--consensus-threshold",
 })
 
 _SLUG_MAX = 64
@@ -123,25 +113,49 @@ this brief carries only what's session-specific.
 # Slug generation — three-stage theme-aware algorithm (see start.md history).
 # ---------------------------------------------------------------------------
 
+def _kw_pattern(kw: str) -> re.Pattern:
+    """Word-boundary regex for a theme keyword.
+
+    For multi-word phrases like "github issue" or "clean up", embed the
+    space as `\\s+` so any whitespace separator matches. For single words,
+    use plain `\\b...\\b` so substrings (e.g. "add" inside "address",
+    "fix" inside "suffix") never match.
+    """
+    if " " in kw:
+        # Multi-word: wrap each part in word boundaries, join by \s+.
+        parts = [re.escape(p) for p in kw.split() if p]
+        body = r"\s+".join(parts)
+        return re.compile(rf"\b{body}\b", re.IGNORECASE)
+    return re.compile(rf"\b{re.escape(kw)}\b", re.IGNORECASE)
+
+
 def _detect_theme(text_lower: str) -> str:
-    """Return the matching theme prefix, or '' if no signal matches."""
+    """Return the matching theme prefix, or '' if no signal matches.
+
+    Uses word-boundary regex so short keywords ('add', 'fix', 'new')
+    don't match inside unrelated words (e.g. 'address', 'suffix',
+    'newcomer'). Per PR #815 review feedback.
+    """
     if _ISSUE_NUMBER_RE.search(text_lower):
         return "issue"
     for theme, keywords in _THEME_SIGNALS:
-        if any(kw in text_lower for kw in keywords):
+        if any(_kw_pattern(kw).search(text_lower) for kw in keywords):
             return theme
     return ""
 
 
 def _strip_theme_keywords(text_lower: str, theme: str) -> str:
     """Remove the theme keywords from the description so they don't
-    leak into the concept extraction step."""
+    leak into the concept extraction step. Word-boundary respecting —
+    `fix` does not strip from `suffix`, `add` does not strip from
+    `address`. Per PR #815 review feedback.
+    """
     if not theme:
         return text_lower
     for t, keywords in _THEME_SIGNALS:
         if t == theme:
             for kw in keywords:
-                text_lower = text_lower.replace(kw, " ")
+                text_lower = _kw_pattern(kw).sub(" ", text_lower)
             break
     # Strip issue-number tokens too — they're noise once the theme is set.
     text_lower = _ISSUE_NUMBER_RE.sub(" ", text_lower)
@@ -212,8 +226,13 @@ def parse_flags(description: str) -> tuple[dict[str, Any], str]:
     """Extract recognised v6 flags from the description.
 
     Returns ``(flags_dict, description_clean)`` where description_clean
-    has the parsed flag tokens removed so they don't leak into slug
-    concept extraction.
+    has the parsed flag tokens removed by INDEX (not by global string
+    substitution). The index-based approach prevents over-stripping —
+    e.g. ``Implement full feature --rigor full`` retains the literal
+    word ``full`` in the description while stripping only the flag's
+    own value token.
+
+    Per PR #815 review feedback.
     """
     flags: dict[str, Any] = {
         "yolo": False,
@@ -221,50 +240,54 @@ def parse_flags(description: str) -> tuple[dict[str, Any], str]:
         "force": False,
         "consensus_threshold": None,
     }
-    tokens_to_strip: list[str] = []
+    rigor_values = {"minimal", "standard", "full"}
 
-    # Walk tokens; recognise --flag / --flag=value / --flag value.
     tokens = description.split()
+    consumed: set[int] = set()
+
     i = 0
     while i < len(tokens):
+        if i in consumed:
+            i += 1
+            continue
         tok = tokens[i]
-        # --flag=value form
-        if tok.startswith("--") and "=" in tok:
-            name, _, value = tok.partition("=")
-            if name == "--rigor" and value in {"minimal", "standard", "full"}:
-                flags["rigor"] = value
-                tokens_to_strip.append(tok)
-            elif name == "--consensus-threshold":
-                try:
-                    flags["consensus_threshold"] = int(value)
-                    tokens_to_strip.append(tok)
-                except ValueError:
-                    pass  # unparseable → leave as part of description
-        elif tok in ("--yolo", "--just-finish"):
+
+        if tok in ("--yolo", "--just-finish"):
             flags["yolo"] = True
-            tokens_to_strip.append(tok)
+            consumed.add(i)
         elif tok == "--force":
             flags["force"] = True
-            tokens_to_strip.append(tok)
+            consumed.add(i)
+        elif tok.startswith("--rigor="):
+            value = tok.split("=", 1)[1]
+            if value in rigor_values:
+                flags["rigor"] = value
+                consumed.add(i)
+            # Unrecognised value (e.g. --rigor=turbo): leave the flag
+            # token in the description so the user sees their typo.
         elif tok == "--rigor" and i + 1 < len(tokens):
-            v = tokens[i + 1]
-            if v in {"minimal", "standard", "full"}:
-                flags["rigor"] = v
-                tokens_to_strip.extend([tok, v])
-                i += 1  # skip the value token next loop
+            value = tokens[i + 1]
+            if value in rigor_values:
+                flags["rigor"] = value
+                consumed.add(i)
+                consumed.add(i + 1)
+        elif tok.startswith("--consensus-threshold="):
+            try:
+                flags["consensus_threshold"] = int(tok.split("=", 1)[1])
+                consumed.add(i)
+            except ValueError:
+                pass
         elif tok == "--consensus-threshold" and i + 1 < len(tokens):
             try:
                 flags["consensus_threshold"] = int(tokens[i + 1])
-                tokens_to_strip.extend([tok, tokens[i + 1]])
-                i += 1
+                consumed.add(i)
+                consumed.add(i + 1)
             except ValueError:
                 pass
+
         i += 1
 
-    description_clean = description
-    for t in tokens_to_strip:
-        # Remove with surrounding whitespace, idempotent.
-        description_clean = re.sub(rf"\s*{re.escape(t)}\s*", " ", description_clean)
+    description_clean = " ".join(t for idx, t in enumerate(tokens) if idx not in consumed)
     return flags, description_clean.strip()
 
 
@@ -276,6 +299,42 @@ def _python_shim() -> str:
     return str(_SCRIPTS_DIR / "_python.sh")
 
 
+def _parse_json_block(stdout: str) -> dict:
+    """Parse pretty-printed JSON output from a CLI helper.
+
+    `phase_manager.py --json` and `crew.py --json` both pretty-print
+    multi-line JSON (indent=2), so the trailing line is just `}`. A
+    naive ``json.loads(last_line)`` would always fail. We try the full
+    stripped stdout first; if that fails, fall back to extracting the
+    last balanced ``{...}`` block. Per PR #815 review feedback.
+    """
+    text = stdout.strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    # Fallback: find the last top-level JSON object by walking backwards
+    # from end-of-string for matching braces. Tolerant to leading prelude.
+    depth = 0
+    end_idx = len(text)
+    for i in range(len(text) - 1, -1, -1):
+        c = text[i]
+        if c == "}":
+            if depth == 0:
+                end_idx = i + 1
+            depth += 1
+        elif c == "{":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(text[i:end_idx])
+                except json.JSONDecodeError:
+                    return {}
+    return {}
+
+
 def _phase_manager(*args: str) -> dict:
     """Invoke phase_manager.py with --json and return its parsed output.
 
@@ -285,31 +344,37 @@ def _phase_manager(*args: str) -> dict:
     cmd = ["sh", _python_shim(), str(_SCRIPTS_DIR / "_run.py"),
            "scripts/crew/phase_manager.py", *args]
     out = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
-    # phase_manager prints JSON to stdout when --json passed; tolerate prelude.
-    last_line = out.strip().splitlines()[-1] if out.strip() else "{}"
-    try:
-        return json.loads(last_line)
-    except json.JSONDecodeError:
-        return {"raw": out}
+    return _parse_json_block(out)
 
 
 def find_active_project() -> dict | None:
-    """Return the active project record or None when no active project exists.
+    """Return a normalised active-project record, or None when nothing active.
 
-    `phase_manager find-active --json` prints `{}` (or `{"slug": null}`)
-    when nothing is active; treat both as "none."
+    ``crew.py find-active --json`` prints ``{"project": <record>|null,
+    "project_dir": <path>|null}``. We normalise into a flat dict with
+    keys ``slug``, ``phase``, ``project_dir`` so callers don't have to
+    know the wrapper shape. Per PR #815 review feedback.
     """
     try:
         cmd = ["sh", _python_shim(), str(_SCRIPTS_DIR / "_run.py"),
                "scripts/crew/crew.py", "find-active", "--json"]
         out = subprocess.check_output(cmd, text=True, stderr=subprocess.PIPE)
-        last_line = out.strip().splitlines()[-1] if out.strip() else "{}"
-        record = json.loads(last_line)
-        if not record or not record.get("slug"):
-            return None
-        return record
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
+    except subprocess.CalledProcessError:
         return None
+    record = _parse_json_block(out)
+    if not isinstance(record, dict):
+        return None
+    project = record.get("project")
+    if not isinstance(project, dict):
+        return None
+    name = project.get("name") or project.get("slug")
+    if not name:
+        return None
+    return {
+        "slug": name,
+        "phase": project.get("current_phase") or project.get("phase"),
+        "project_dir": record.get("project_dir") or project.get("project_dir"),
+    }
 
 
 def create_project_shell(slug: str, description: str) -> dict:
@@ -368,7 +433,12 @@ def write_crew_brief(
     project_dir.mkdir(parents=True, exist_ok=True)
     brief_path = project_dir / "crew-brief.md"
     timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    description_quoted = "> " + description.strip().replace("\n", "\n> ")
+    # Curly braces in user-controlled text would otherwise be interpreted
+    # by str.format() as placeholders and raise KeyError. Escape by
+    # doubling. Per PR #815 review feedback.
+    description_quoted = (
+        "> " + description.strip().replace("\n", "\n> ")
+    ).replace("{", "{{").replace("}", "}}")
     body = _BRIEF_TEMPLATE.format(
         command=command,
         slug=slug,
@@ -417,10 +487,18 @@ def main() -> int:
         print("error: could not derive slug from description", file=sys.stderr)
         return 1
 
-    # Conflict check — fail fast with structured info if the parent didn't
-    # supply --on-conflict resolution.
+    # Conflict check. Outcome contract — every successful exit emits a
+    # JSON object on stdout with an explicit ``action`` key:
+    #   action=create   → new project shell created + brief written
+    #   action=resume   → user chose Resume; nothing created/written
+    #   action=cancel   → user chose Cancel; nothing created/written
+    # Conflict detected without --on-conflict supplied → exit 2 so the
+    # caller can prompt the user. Rename is implemented client-side: the
+    # user re-invokes with a new description, so we treat --on-conflict=rename
+    # as a structured "abort, re-invoke" signal (exit 1 with action=rename).
     existing = find_active_project()
     conflicting_slug = existing.get("slug") if existing else None
+
     if existing and args.on_conflict is None:
         sys.stderr.write(json.dumps({
             "conflict": True,
@@ -430,22 +508,40 @@ def main() -> int:
         }) + "\n")
         return 2
 
+    if existing and args.on_conflict == "resume":
+        # Resume: surface the existing project info so the parent can
+        # carry on with that project. No new shell, no brief, no mutation.
+        print(json.dumps({
+            "action": "resume",
+            "slug": conflicting_slug,
+            "phase": existing.get("phase"),
+            "project_dir": existing.get("project_dir"),
+        }, indent=2))
+        return 0
+
+    if args.on_conflict == "cancel":
+        # Cancel: explicit no-op success. Caller exits cleanly.
+        print(json.dumps({"action": "cancel"}, indent=2))
+        return 0
+
+    if args.on_conflict == "rename":
+        # Rename is "user picks a new description and re-invokes". We
+        # cannot synthesize a new description; surface a structured
+        # signal so the caller can prompt for one.
+        sys.stderr.write(json.dumps({
+            "action": "rename",
+            "hint": "user must supply a new --description and re-invoke",
+        }) + "\n")
+        return 1
+
     if existing and args.on_conflict == "switch":
         try:
             pause_existing_project(conflicting_slug)
         except subprocess.CalledProcessError as exc:
             print(f"error: pause_existing_project failed: {exc}", file=sys.stderr)
             return 1
-    if args.on_conflict in ("resume", "cancel"):
-        # Parent should have aborted before calling us — but if we got here,
-        # surface a clear no-op response.
-        sys.stderr.write(json.dumps({
-            "noop": True,
-            "reason": f"on_conflict={args.on_conflict} — caller should not create new project",
-        }) + "\n")
-        return 1
 
-    # Create the project shell (unless we're in a no-op resume/cancel path).
+    # Default path: create the project shell.
     try:
         shell = create_project_shell(slug, description_clean)
     except subprocess.CalledProcessError as exc:
@@ -470,6 +566,7 @@ def main() -> int:
     )
 
     out = {
+        "action": "create",
         "slug": slug,
         "theme_prefix": theme,
         "project_dir": str(project_dir),

--- a/scripts/crew/write_brief.py
+++ b/scripts/crew/write_brief.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""scripts/crew/write_brief.py — produce a crew-brief.md handoff file.
+
+Phase 2A of the v10 slim-skill-body shape. Absorbs the procedural prep
+work that lived in `commands/crew/start.md` (slug generation, flag
+parsing, existing-project conflict check, project shell creation) so
+the command body can shrink to a Pattern B shape (≤30 lines).
+
+The brief is the dynamic handoff artifact — it carries session-specific
+data (parsed args, generated slug, project_dir, flags) into the
+facilitator agent's task. Static rubric content (the 9-factor scoring,
+phase catalog, gate policy) stays in the agent's body or refs/ — see
+the static-vs-dynamic boundary rule documented in CLAUDE.md.
+
+Brief is append-only with `---` separators. First call initializes the
+project + writes the brief; subsequent calls append. Single-writer
+convention prevents the file-sprawl failure mode that bit hitl-decision.json.
+
+Usage:
+  write_brief.py --command crew:start --description "..."
+  write_brief.py --command crew:start --description "..." --on-conflict {switch,resume,rename,cancel}
+
+Exit codes:
+  0  brief written; JSON {slug, project_dir, ...} on stdout
+  1  validation / IO error
+  2  conflict — existing active project; structured info on stderr;
+     parent re-invokes with --on-conflict to resolve
+
+Design record: brainstorms/v10-session-02-slim-skill-body-shape.md
+Decision memory: memory/v10-slim-skill-body-shape-decision.md
+Issue: #813 (v10 series)
+"""
+
+import argparse
+import datetime
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = _PLUGIN_ROOT / "scripts"
+
+# Theme prefix detection — first matching signal group wins. Keep keywords
+# lowercased; matched against lowercased description. Ordered by specificity
+# (issue patterns before fix because "issue with bug" should be issue, not fix).
+_THEME_SIGNALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("issue", ("issue", "gh-", "github issue")),
+    ("fix",   ("bug", "fix", "broken", "regression", "crash")),
+    ("refactor", ("refactor", "cleanup", "clean up", "reorganize")),
+    ("docs",  ("docs", "documentation", "readme", "changelog")),
+    ("feat",  ("feature", "feat", "add", "implement", "new", "introduce")),
+)
+
+# Issue-number pattern (#1234) signals the issue theme regardless of words.
+_ISSUE_NUMBER_RE = re.compile(r"#\d+")
+
+_STOP_WORDS = frozenset({
+    "the", "a", "an", "for", "to", "of", "in", "and", "with",
+    "on", "at", "by", "from", "is", "are", "be", "as",
+})
+
+# v6 flags — orthogonal axes. Anything not in this set is treated as part
+# of the description (so "implement --turbo flag" doesn't get parsed as a
+# `--turbo` flag).
+_KNOWN_FLAGS = frozenset({
+    "--yolo", "--just-finish", "--force",
+    # Flags with values:
+    "--rigor", "--consensus-threshold",
+})
+
+_SLUG_MAX = 64
+
+# crew-brief.md format — kept minimal; absorbs only what's session-specific.
+# The static procedure that the facilitator agent follows lives in the
+# agent body / refs/, not duplicated here per turn.
+_BRIEF_TEMPLATE = """\
+# Crew Brief — {command} → {slug}
+
+> One-file handoff. Append-only. Single writer: scripts/crew/write_brief.py.
+> Static procedure lives in the facilitator agent body + refs/.
+
+## Session
+
+- **Command**: `/{command}`
+- **Slug**: `{slug}` (theme: `{theme_prefix}`)
+- **Project dir**: `{project_dir}`
+- **Created**: {timestamp}
+
+## User intent (raw $ARGUMENTS)
+
+{description_quoted}
+
+## Parsed flags
+
+{flags_block}
+
+## Conflict resolution
+
+{conflict_block}
+
+## Procedure pointer
+
+The facilitator agent must:
+1. Run the 9-factor rubric on the user intent above.
+2. Validate the resulting plan via `scripts/crew/validate_plan.py`.
+3. Persist `process-plan.md` + `process-plan.json` to the project dir.
+4. Emit the task chain via TaskCreate (one per task in plan.tasks[]).
+5. Verify emission via `scripts/crew/verify_chain_emission.py`.
+6. Persist plan metadata via `scripts/crew/phase_manager.py update`.
+7. Store the planning decision via `wicked-brain:memory`.
+8. Return JSON: `{{rigor_tier, reason, phase_count, specialist_count, complexity, slug, project_dir}}`.
+
+The full procedure rubric lives in the facilitator agent's body + refs/ —
+this brief carries only what's session-specific.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Slug generation — three-stage theme-aware algorithm (see start.md history).
+# ---------------------------------------------------------------------------
+
+def _detect_theme(text_lower: str) -> str:
+    """Return the matching theme prefix, or '' if no signal matches."""
+    if _ISSUE_NUMBER_RE.search(text_lower):
+        return "issue"
+    for theme, keywords in _THEME_SIGNALS:
+        if any(kw in text_lower for kw in keywords):
+            return theme
+    return ""
+
+
+def _strip_theme_keywords(text_lower: str, theme: str) -> str:
+    """Remove the theme keywords from the description so they don't
+    leak into the concept extraction step."""
+    if not theme:
+        return text_lower
+    for t, keywords in _THEME_SIGNALS:
+        if t == theme:
+            for kw in keywords:
+                text_lower = text_lower.replace(kw, " ")
+            break
+    # Strip issue-number tokens too — they're noise once the theme is set.
+    text_lower = _ISSUE_NUMBER_RE.sub(" ", text_lower)
+    return text_lower
+
+
+def _extract_concepts(text: str) -> list[str]:
+    """Return up to 4 kebab-cased concept tokens drawn from the
+    description after stop-word removal."""
+    # Split on non-word; lowercase each fragment.
+    words = re.split(r"[^a-z0-9]+", text.lower())
+    concepts: list[str] = []
+    for w in words:
+        if not w or w in _STOP_WORDS or len(w) < 2:
+            continue
+        concepts.append(w)
+        if len(concepts) >= 4:
+            break
+    return concepts
+
+
+def _truncate_on_word_boundary(s: str, max_len: int) -> str:
+    """Truncate `s` at <= max_len without splitting a word. Returns
+    the longest prefix that ends on `-` (or end-of-string)."""
+    if len(s) <= max_len:
+        return s
+    cut = s[:max_len]
+    last = cut.rfind("-")
+    return cut[:last] if last > 0 else cut
+
+
+def generate_slug(description: str) -> tuple[str, str]:
+    """Return ``(slug, theme_prefix)`` for a description.
+
+    Three-stage:
+      1. detect theme prefix
+      2. extract concepts (theme keywords + stop words removed)
+      3. assemble + truncate at word boundary
+
+    No-match fallback: kebab-case the full description.
+    """
+    text_lower = description.lower().strip()
+    if not text_lower:
+        return "", ""
+
+    theme = _detect_theme(text_lower)
+    concept_text = _strip_theme_keywords(text_lower, theme)
+    concepts = _extract_concepts(concept_text)
+
+    if theme and concepts:
+        slug = f"{theme}-" + "-".join(concepts)
+    elif theme:
+        slug = theme
+    elif concepts:
+        slug = "-".join(concepts)
+    else:
+        # Pure fallback: kebab-case the original.
+        slug = re.sub(r"[^a-z0-9]+", "-", text_lower).strip("-")
+
+    return _truncate_on_word_boundary(slug, _SLUG_MAX), theme
+
+
+# ---------------------------------------------------------------------------
+# Flag parsing
+# ---------------------------------------------------------------------------
+
+def parse_flags(description: str) -> tuple[dict[str, Any], str]:
+    """Extract recognised v6 flags from the description.
+
+    Returns ``(flags_dict, description_clean)`` where description_clean
+    has the parsed flag tokens removed so they don't leak into slug
+    concept extraction.
+    """
+    flags: dict[str, Any] = {
+        "yolo": False,
+        "rigor": None,
+        "force": False,
+        "consensus_threshold": None,
+    }
+    tokens_to_strip: list[str] = []
+
+    # Walk tokens; recognise --flag / --flag=value / --flag value.
+    tokens = description.split()
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        # --flag=value form
+        if tok.startswith("--") and "=" in tok:
+            name, _, value = tok.partition("=")
+            if name == "--rigor" and value in {"minimal", "standard", "full"}:
+                flags["rigor"] = value
+                tokens_to_strip.append(tok)
+            elif name == "--consensus-threshold":
+                try:
+                    flags["consensus_threshold"] = int(value)
+                    tokens_to_strip.append(tok)
+                except ValueError:
+                    pass  # unparseable → leave as part of description
+        elif tok in ("--yolo", "--just-finish"):
+            flags["yolo"] = True
+            tokens_to_strip.append(tok)
+        elif tok == "--force":
+            flags["force"] = True
+            tokens_to_strip.append(tok)
+        elif tok == "--rigor" and i + 1 < len(tokens):
+            v = tokens[i + 1]
+            if v in {"minimal", "standard", "full"}:
+                flags["rigor"] = v
+                tokens_to_strip.extend([tok, v])
+                i += 1  # skip the value token next loop
+        elif tok == "--consensus-threshold" and i + 1 < len(tokens):
+            try:
+                flags["consensus_threshold"] = int(tokens[i + 1])
+                tokens_to_strip.extend([tok, tokens[i + 1]])
+                i += 1
+            except ValueError:
+                pass
+        i += 1
+
+    description_clean = description
+    for t in tokens_to_strip:
+        # Remove with surrounding whitespace, idempotent.
+        description_clean = re.sub(rf"\s*{re.escape(t)}\s*", " ", description_clean)
+    return flags, description_clean.strip()
+
+
+# ---------------------------------------------------------------------------
+# Project-shell helpers (call into existing phase_manager.py)
+# ---------------------------------------------------------------------------
+
+def _python_shim() -> str:
+    return str(_SCRIPTS_DIR / "_python.sh")
+
+
+def _phase_manager(*args: str) -> dict:
+    """Invoke phase_manager.py with --json and return its parsed output.
+
+    Raises CalledProcessError on non-zero exit. Caller decides what to do
+    with the failure (typically: print stderr, exit non-zero).
+    """
+    cmd = ["sh", _python_shim(), str(_SCRIPTS_DIR / "_run.py"),
+           "scripts/crew/phase_manager.py", *args]
+    out = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+    # phase_manager prints JSON to stdout when --json passed; tolerate prelude.
+    last_line = out.strip().splitlines()[-1] if out.strip() else "{}"
+    try:
+        return json.loads(last_line)
+    except json.JSONDecodeError:
+        return {"raw": out}
+
+
+def find_active_project() -> dict | None:
+    """Return the active project record or None when no active project exists.
+
+    `phase_manager find-active --json` prints `{}` (or `{"slug": null}`)
+    when nothing is active; treat both as "none."
+    """
+    try:
+        cmd = ["sh", _python_shim(), str(_SCRIPTS_DIR / "_run.py"),
+               "scripts/crew/crew.py", "find-active", "--json"]
+        out = subprocess.check_output(cmd, text=True, stderr=subprocess.PIPE)
+        last_line = out.strip().splitlines()[-1] if out.strip() else "{}"
+        record = json.loads(last_line)
+        if not record or not record.get("slug"):
+            return None
+        return record
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return None
+
+
+def create_project_shell(slug: str, description: str) -> dict:
+    """Call phase_manager create and return its JSON response."""
+    return _phase_manager(slug, "create", "--description", description, "--json")
+
+
+def pause_existing_project(slug: str) -> None:
+    """Set paused=true on an existing project so it stops surfacing as active."""
+    _phase_manager(slug, "update", "--data", json.dumps({"paused": True}), "--json")
+
+
+# ---------------------------------------------------------------------------
+# Brief composition
+# ---------------------------------------------------------------------------
+
+def _format_flags_block(flags: dict[str, Any]) -> str:
+    """Render the flags dict as a compact markdown table or 'none'."""
+    populated = {k: v for k, v in flags.items() if v not in (False, None)}
+    if not populated:
+        return "_None._"
+    rows = "\n".join(f"- `{k}`: `{v}`" for k, v in populated.items())
+    return rows
+
+
+def _format_conflict_block(resolution: str | None, conflicting_slug: str | None) -> str:
+    if not conflicting_slug:
+        return "_No conflict — fresh project._"
+    if resolution == "switch":
+        return (
+            f"Existing active project `{conflicting_slug}` was paused via "
+            f"`phase_manager.py update --data '{{\"paused\": true}}'`. "
+            f"Resume later by setting `paused: false`."
+        )
+    if resolution in ("resume", "cancel", "rename"):
+        return f"User chose `{resolution}` for conflict with `{conflicting_slug}`."
+    return f"Unresolved conflict with `{conflicting_slug}` — see stderr."
+
+
+def write_crew_brief(
+    project_dir: Path,
+    *,
+    command: str,
+    slug: str,
+    theme_prefix: str,
+    description: str,
+    flags: dict[str, Any],
+    resolution: str | None,
+    conflicting_slug: str | None,
+) -> Path:
+    """Write (or append to) {project_dir}/crew-brief.md and return its path.
+
+    Append-only convention with `---` separators. First call initializes;
+    subsequent calls append a new dated section.
+    """
+    project_dir.mkdir(parents=True, exist_ok=True)
+    brief_path = project_dir / "crew-brief.md"
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    description_quoted = "> " + description.strip().replace("\n", "\n> ")
+    body = _BRIEF_TEMPLATE.format(
+        command=command,
+        slug=slug,
+        theme_prefix=theme_prefix or "(none)",
+        project_dir=str(project_dir),
+        timestamp=timestamp,
+        description_quoted=description_quoted,
+        flags_block=_format_flags_block(flags),
+        conflict_block=_format_conflict_block(resolution, conflicting_slug),
+    )
+
+    if brief_path.exists() and brief_path.stat().st_size > 0:
+        with brief_path.open("a", encoding="utf-8") as fh:
+            fh.write("\n\n---\n\n")
+            fh.write(body)
+    else:
+        brief_path.write_text(body, encoding="utf-8")
+
+    return brief_path
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--command", required=True, help="The slash-command this brief is for, e.g. crew:start")
+    p.add_argument("--description", required=True, help="Raw $ARGUMENTS (project description + flags)")
+    p.add_argument(
+        "--on-conflict",
+        choices=("switch", "resume", "rename", "cancel"),
+        default=None,
+        help="Resolution for an existing active project. Required when "
+             "find-active returns a project unless caller wants exit 2.",
+    )
+    args = p.parse_args()
+
+    flags, description_clean = parse_flags(args.description)
+    if not description_clean.strip():
+        print("error: empty description after flag parsing", file=sys.stderr)
+        return 1
+
+    slug, theme = generate_slug(description_clean)
+    if not slug:
+        print("error: could not derive slug from description", file=sys.stderr)
+        return 1
+
+    # Conflict check — fail fast with structured info if the parent didn't
+    # supply --on-conflict resolution.
+    existing = find_active_project()
+    conflicting_slug = existing.get("slug") if existing else None
+    if existing and args.on_conflict is None:
+        sys.stderr.write(json.dumps({
+            "conflict": True,
+            "existing_slug": conflicting_slug,
+            "existing_phase": existing.get("phase"),
+            "hint": "re-invoke with --on-conflict={switch|resume|rename|cancel}",
+        }) + "\n")
+        return 2
+
+    if existing and args.on_conflict == "switch":
+        try:
+            pause_existing_project(conflicting_slug)
+        except subprocess.CalledProcessError as exc:
+            print(f"error: pause_existing_project failed: {exc}", file=sys.stderr)
+            return 1
+    if args.on_conflict in ("resume", "cancel"):
+        # Parent should have aborted before calling us — but if we got here,
+        # surface a clear no-op response.
+        sys.stderr.write(json.dumps({
+            "noop": True,
+            "reason": f"on_conflict={args.on_conflict} — caller should not create new project",
+        }) + "\n")
+        return 1
+
+    # Create the project shell (unless we're in a no-op resume/cancel path).
+    try:
+        shell = create_project_shell(slug, description_clean)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: create_project_shell failed: {exc.output}", file=sys.stderr)
+        return 1
+
+    project_dir_str = shell.get("project_dir")
+    if not project_dir_str:
+        print(f"error: phase_manager create returned no project_dir: {shell}", file=sys.stderr)
+        return 1
+    project_dir = Path(project_dir_str)
+
+    brief_path = write_crew_brief(
+        project_dir,
+        command=args.command,
+        slug=slug,
+        theme_prefix=theme,
+        description=description_clean,
+        flags=flags,
+        resolution=args.on_conflict,
+        conflicting_slug=conflicting_slug,
+    )
+
+    out = {
+        "slug": slug,
+        "theme_prefix": theme,
+        "project_dir": str(project_dir),
+        "brief_path": str(brief_path),
+        "flags": flags,
+        "conflict_resolved": args.on_conflict,
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_write_brief.py
+++ b/tests/test_write_brief.py
@@ -22,12 +22,14 @@ T6: docstrings cite the design record
 import sys
 from pathlib import Path
 
-# write_brief.py lives under scripts/crew — needs scripts/ on sys.path
-# AND scripts/crew on sys.path so its own intra-script imports resolve.
+# conftest.py keeps `scripts/` at sys.path[0]. Append `scripts/crew/` (do NOT
+# insert at 0) so write_brief.py can be imported by name without shadowing
+# scripts/ — same pattern as the rest of the repo's test suite (avoids the
+# scripts/crew/crew.py-shadowing-the-crew-package bug).
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
-    if str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
+_CREW_DIR = _REPO_ROOT / "scripts" / "crew"
+if str(_CREW_DIR) not in sys.path:
+    sys.path.append(str(_CREW_DIR))
 
 import write_brief  # noqa: E402
 
@@ -195,6 +197,103 @@ def test_multiple_flags_all_parsed():
     assert flags["consensus_threshold"] == 2
     # All flag tokens removed; clean description is just the work text.
     assert clean.strip() == "Build the auth feature"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — review feedback on PR #815
+# ---------------------------------------------------------------------------
+
+def test_flag_stripping_preserves_literal_word_in_description():
+    """PR #815 review (gemini high): the previous implementation used
+    global re.sub with bare token text, so 'Implement full feature
+    --rigor full' would strip BOTH the flag value `full` (correct) AND
+    the literal word 'full' from the description (data corruption). The
+    fix tracks token indices and removes only the flag tokens. The
+    literal 'full' must remain in the cleaned description."""
+    flags, clean = write_brief.parse_flags(
+        "Implement full feature --rigor full"
+    )
+    assert flags["rigor"] == "full"
+    assert clean == "Implement full feature"
+    assert "--rigor" not in clean
+
+
+def test_theme_detection_word_boundary_protects_short_keyword_add():
+    """PR #815 review (gemini medium / copilot): substring matching on
+    'add' would falsely match inside 'address'. Use word-boundary
+    regex so only the standalone word triggers the feat theme."""
+    # 'address' contains 'add' but is not a feat signal in isolation.
+    _slug, theme = write_brief.generate_slug("update the address book schema")
+    assert theme != "feat"
+
+
+def test_theme_detection_word_boundary_protects_short_keyword_fix():
+    """PR #815 review (gemini medium): 'fix' inside 'suffix', 'prefix'
+    must NOT trigger the fix theme."""
+    _slug, theme = write_brief.generate_slug("update the file suffix logic")
+    assert theme != "fix"
+
+
+def test_theme_keyword_stripping_word_boundary_preserves_debug():
+    """PR #815 review (gemini medium): when fix theme matches via 'bug',
+    keyword stripping must not also drop substrings of unrelated words.
+    'fix the debug counter' should detect fix theme, strip 'fix', but
+    PRESERVE 'debug' (which contains 'bug') so concept extraction sees
+    'debug' as a slug concept."""
+    slug, theme = write_brief.generate_slug("fix the debug counter")
+    assert theme == "fix"
+    assert "debug" in slug
+
+
+def test_brief_template_handles_curly_braces_in_user_description(tmp_path):
+    """PR #815 review (gemini high): user-controlled text inserted into
+    _BRIEF_TEMPLATE via .format() must escape curly braces or .format()
+    raises KeyError. This drives write_crew_brief end-to-end with a
+    brace-bearing description and asserts no exception."""
+    project_dir = tmp_path / "test-project-curly"
+    brief_path = write_brief.write_crew_brief(
+        project_dir,
+        command="crew:start",
+        slug="feat-curly-braces",
+        theme_prefix="feat",
+        description="render {x} as {y} JSON",  # literal braces in user input
+        flags={
+            "yolo": False, "rigor": None, "force": False,
+            "consensus_threshold": None,
+        },
+        resolution=None,
+        conflicting_slug=None,
+    )
+    body = brief_path.read_text(encoding="utf-8")
+    # Doubled braces collapse to single in the rendered output, so the
+    # literal text round-trips faithfully.
+    assert "{x}" in body
+    assert "{y}" in body
+
+
+def test_parse_json_block_handles_pretty_printed_full_object():
+    """PR #815 review (copilot): _phase_manager and find_active_project
+    used to parse `last_line` of pretty-printed JSON, where the last
+    line is `}`. _parse_json_block must parse the FULL stdout."""
+    pretty = '{\n  "project": null,\n  "project_dir": null\n}'
+    parsed = write_brief._parse_json_block(pretty)
+    assert parsed == {"project": None, "project_dir": None}
+
+
+def test_parse_json_block_tolerates_prelude():
+    """_parse_json_block tolerates optional non-JSON prelude lines."""
+    with_prelude = (
+        "[some log line]\n"
+        '{\n  "slug": "my-proj",\n  "project_dir": "/tmp/foo"\n}'
+    )
+    parsed = write_brief._parse_json_block(with_prelude)
+    assert parsed == {"slug": "my-proj", "project_dir": "/tmp/foo"}
+
+
+def test_parse_json_block_returns_empty_dict_on_garbage():
+    """Defensive: unparseable input → empty dict, never raise."""
+    assert write_brief._parse_json_block("not json") == {}
+    assert write_brief._parse_json_block("") == {}
 
 
 def test_no_flags_returns_default_dict_and_unchanged_description():

--- a/tests/test_write_brief.py
+++ b/tests/test_write_brief.py
@@ -1,0 +1,208 @@
+"""tests/test_write_brief.py — slug + flag parsing for the v10 Phase 2A
+slim-skill-body shape.
+
+Provenance: brainstorm session 02 (slim skill body shape) proposed
+extracting `commands/crew/start.md`'s slug algorithm + flag parsing
+into `scripts/crew/write_brief.py` so the command body could shrink
+from 304 lines to a Pattern B shape. These tests cover the pure
+functions that live in that script — slug generation and flag parsing.
+
+Project-shell creation and brief composition involve subprocess calls
+(`phase_manager.py`) and filesystem writes; those are intentionally
+not unit-tested here. They are exercised by the existing crew scenario
+suite (scenarios/crew/) that runs end-to-end.
+
+T1: deterministic — pure functions, no I/O
+T3: isolated — each test passes its own input
+T4: single focus per test
+T5: descriptive names spell out input + expected outcome
+T6: docstrings cite the design record
+"""
+
+import sys
+from pathlib import Path
+
+# write_brief.py lives under scripts/crew — needs scripts/ on sys.path
+# AND scripts/crew on sys.path so its own intra-script imports resolve.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import write_brief  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# generate_slug — three-stage theme-aware algorithm
+# ---------------------------------------------------------------------------
+
+def test_implement_oauth_routes_to_feat_theme():
+    """Brainstorm session 02: 'implement' is a feat signal; concept
+    extraction kebab-cases the remaining nouns; truncation respects
+    the 64-char word boundary."""
+    slug, theme = write_brief.generate_slug("Implement OAuth flow with session tokens")
+    assert theme == "feat"
+    assert slug.startswith("feat-")
+    assert "oauth" in slug
+    assert "session" in slug
+    assert len(slug) <= 64
+
+
+def test_fix_bug_routes_to_fix_theme():
+    """'bug' / 'fix' / 'broken' are fix-theme signals."""
+    slug, theme = write_brief.generate_slug("fix the bug in the login flow")
+    assert theme == "fix"
+    assert slug.startswith("fix-")
+    assert "login" in slug
+
+
+def test_issue_number_pattern_routes_to_issue_theme():
+    """`#NNN` token is a stronger issue signal than the surrounding words —
+    issue theme wins even when 'fix' is also present."""
+    slug, theme = write_brief.generate_slug("address the bug in #813")
+    assert theme == "issue"
+    assert slug.startswith("issue-")
+
+
+def test_refactor_keyword_routes_to_refactor_theme():
+    slug, theme = write_brief.generate_slug("refactor the phase manager")
+    assert theme == "refactor"
+    assert slug.startswith("refactor-")
+
+
+def test_docs_keyword_routes_to_docs_theme():
+    slug, theme = write_brief.generate_slug("update the README and changelog")
+    assert theme == "docs"
+    assert slug.startswith("docs-")
+
+
+def test_no_theme_match_falls_back_to_kebab_case():
+    """When no theme keyword matches, the slug is plain kebab-case of
+    the description — no prefix."""
+    slug, theme = write_brief.generate_slug("rotate the api key")
+    assert theme == ""
+    assert "-" in slug  # at least some kebab structure
+    assert slug == slug.lower()  # always lowercased
+
+
+def test_stop_words_excluded_from_concepts():
+    """'the', 'a', 'with', etc. are stop words — they don't appear
+    in the concept tokens."""
+    slug, _ = write_brief.generate_slug("Implement the new auth flow with the api")
+    # No bare 'the', 'with', 'a', 'an' as a concept fragment.
+    parts = slug.split("-")
+    assert "the" not in parts
+    assert "with" not in parts
+
+
+def test_slug_truncated_on_word_boundary():
+    """Long descriptions truncate without splitting a word mid-token."""
+    long_desc = "Implement " + " ".join([f"keyword{i}" for i in range(20)])
+    slug, _ = write_brief.generate_slug(long_desc)
+    assert len(slug) <= 64
+    # If truncated, the last char must not be a hanging partial token.
+    # Verify: no slug ends with a half-word followed by truncation.
+    assert not slug.endswith("-")
+
+
+def test_empty_description_returns_empty_slug():
+    """Defensive — empty input doesn't crash; returns empty slug + theme."""
+    slug, theme = write_brief.generate_slug("")
+    assert slug == ""
+    assert theme == ""
+
+
+def test_whitespace_only_description_returns_empty_slug():
+    slug, theme = write_brief.generate_slug("   \n\t  ")
+    assert slug == ""
+    assert theme == ""
+
+
+# ---------------------------------------------------------------------------
+# parse_flags — v6 orthogonal axes
+# ---------------------------------------------------------------------------
+
+def test_yolo_flag_parsed_and_stripped():
+    flags, clean = write_brief.parse_flags("Build the auth feature --yolo")
+    assert flags["yolo"] is True
+    assert "--yolo" not in clean
+
+
+def test_just_finish_aliases_yolo():
+    """`--just-finish` is documented as an alias for `--yolo`."""
+    flags, clean = write_brief.parse_flags("Build the feature --just-finish")
+    assert flags["yolo"] is True
+    assert "--just-finish" not in clean
+
+
+def test_rigor_equals_form_parsed():
+    flags, clean = write_brief.parse_flags("Build the feature --rigor=full")
+    assert flags["rigor"] == "full"
+    assert "--rigor" not in clean
+
+
+def test_rigor_space_form_parsed():
+    """`--rigor full` (separate token) is also accepted."""
+    flags, clean = write_brief.parse_flags("Build the feature --rigor full")
+    assert flags["rigor"] == "full"
+    assert "--rigor" not in clean
+    assert " full" not in clean  # value also stripped
+
+
+def test_invalid_rigor_value_is_left_in_description():
+    """`--rigor=turbo` is not a known value — leave it in the
+    description so the slug doesn't accidentally absorb a flag-shaped
+    token but the user still sees their typo surface as a slug."""
+    flags, clean = write_brief.parse_flags("Build it --rigor=turbo")
+    assert flags["rigor"] is None
+    assert "--rigor=turbo" in clean
+
+
+def test_force_flag_parsed():
+    flags, clean = write_brief.parse_flags("Refactor the module --force")
+    assert flags["force"] is True
+    assert "--force" not in clean
+
+
+def test_consensus_threshold_equals_form():
+    flags, clean = write_brief.parse_flags("Plan it --consensus-threshold=3")
+    assert flags["consensus_threshold"] == 3
+
+
+def test_consensus_threshold_space_form():
+    flags, clean = write_brief.parse_flags("Plan it --consensus-threshold 4")
+    assert flags["consensus_threshold"] == 4
+
+
+def test_unknown_flag_left_in_description():
+    """Unrecognised --flag tokens are NOT treated as flags — they stay
+    in the description so the user's literal text isn't silently
+    swallowed (e.g. 'implement --turbo flag' should describe a
+    `--turbo` flag, not parse one)."""
+    flags, clean = write_brief.parse_flags("implement --turbo flag")
+    assert flags["yolo"] is False
+    assert flags["rigor"] is None
+    assert "--turbo" in clean
+
+
+def test_multiple_flags_all_parsed():
+    flags, clean = write_brief.parse_flags(
+        "Build the auth feature --yolo --rigor=full --force --consensus-threshold=2"
+    )
+    assert flags["yolo"] is True
+    assert flags["rigor"] == "full"
+    assert flags["force"] is True
+    assert flags["consensus_threshold"] == 2
+    # All flag tokens removed; clean description is just the work text.
+    assert clean.strip() == "Build the auth feature"
+
+
+def test_no_flags_returns_default_dict_and_unchanged_description():
+    flags, clean = write_brief.parse_flags("Just a normal description")
+    assert flags == {
+        "yolo": False,
+        "rigor": None,
+        "force": False,
+        "consensus_threshold": None,
+    }
+    assert clean == "Just a normal description"


### PR DESCRIPTION
## Summary

First validation move for the **slim-skill-body shape** decided in brainstorm session 02. Proves the script-extraction principle on `crew:start`: pull the prep procedure into `scripts/crew/write_brief.py` and slim the command body accordingly.

**The brainstorm's load-bearing finding** — the fat bodies aren't in `skills/`, they're in `commands/`. `commands/crew/execute.md` is 1,460 lines; `just-finish.md` is 462; `start.md` was 304. These are procedural shell-scripts the model mentally executes every turn, paying parent-context cost permanently.

## Net diff

| File | Before | After | Change |
|---|---|---|---|
| `commands/crew/start.md` | 304 lines | **134 lines** | **-56%** |
| `scripts/crew/write_brief.py` | — | 485 lines | NEW (deterministic Python) |
| `tests/test_write_brief.py` | — | 21 tests | NEW (all pass) |

## Why this matters

The 304-line command body was a procedural shell-script the model had to load into parent context on every `crew:start` invocation — and stays there permanently across the session. Extracting prep into a Python script removes the prose procedure from the model's permanent context surface.

Per the `subagent-skill-loading-is-feature-not-bug` memory (importance 9) — the user correction that scoped this PR — parent-context bloat is the problem. Subagent skill loading on demand is fine. Python scripts are the right tool for deterministic prep work that doesn't need to live in any prompt.

The Python extraction also gains testability — slug generation now has 10 unit tests covering the three-stage theme-aware algorithm. Previously it lived as prose in markdown that the model interpreted differently every run.

## Behavior preservation

- Slug algorithm matches the prior table: theme prefix (`issue` / `fix` / `refactor` / `docs` / `feat`), concept extraction with stop-word filtering, kebab-case assembly, 64-char word-boundary truncation, kebab-case fallback.
- `#NNN` issue-number patterns route to `issue` regardless of surrounding words.
- v6 flags: `--yolo` / `--just-finish`, `--rigor={minimal|standard|full}`, `--force`, `--consensus-threshold=N`. Unknown `--flag` tokens stay in the description.
- Existing-project conflict: `write_brief.py` exits 2 with structured JSON on stderr; the command body prompts Resume/Rename/Cancel/Switch and re-invokes with `--on-conflict`. Identical user experience.
- `crew-brief.md`: append-only with `---` separators, single writer, carries session-specific data only.

## Phase 2A scope (vs. brainstorm's full Pattern B target)

This PR proves the script-extraction principle. It does NOT yet hit the brainstorm's ≤28-line Pattern B target. To get there, post-rubric work (validate plan, persist `process-plan.md`, emit task chain, verify, store brain memory, render report) must move into the facilitator agent or a `post_brief.py` companion. **That's Phase 2B**, gated on dogfooding 2A first.

## Test plan

- [x] `pytest tests/test_write_brief.py -q` → 21/21 pass
- [x] Smoke: `generate_slug("Implement OAuth flow with session tokens")` → `("feat-oauth-flow-session-tokens", "feat")`
- [x] Smoke: `parse_flags("Build the auth feature --yolo --rigor=full")` → `{yolo: True, rigor: 'full', ...}`, clean = `"Build the auth feature"`
- [ ] Dogfood: `/wicked-garden:crew:start "implement OAuth flow"` → slug `feat-oauth-flow`, project_dir created, brief written, facilitator dispatched
- [ ] Dogfood: provoke active-project conflict, confirm exit 2 + structured info, confirm `--on-conflict=switch` resolves
- [ ] Dogfood: measure parent-context size before/after — `commands/crew/start.md` should be measurably absent from the model's loaded procedural context after this lands

## Dogfood criteria

**Worked if:**
- `crew:start` produces identical artifacts to before (same `process-plan.md`, same task chain, same brain memory)
- Parent-context burn from invoking `crew:start` is measurably smaller (~56% on this command body alone)
- The slug algorithm now has deterministic behavior — ten different sessions on the same description produce identical slugs

**Failed if:**
- Slug generation produces different results from the prose algorithm on real-world descriptions (regression on existing scenarios)
- The conflict-resolution flow becomes confusing because the script-and-command split lost a UX cue
- The 134-line command body is still too procedural — meaning Phase 2B's post-rubric extraction is more urgent than expected

## Out of scope (deferred)

- **Phase 2B**: facilitator agent absorption to hit ≤28 lines on `start.md`.
- **Phase 2C**: same treatment for `crew:just-finish.md` (462 → ~32) and `crew:execute.md` (1460 → ~35).
- **Tooling PR**: add the Slim Body Contract checks to `/wg-check`.

## Design records

- Brainstorm: `~/.wicked-brain/projects/wicked-garden/brainstorms/v10-session-02-slim-skill-body-shape.md`
- Decision: `memory/v10-slim-skill-body-shape-decision.md` (importance 8)
- User correction memory: `memory/subagent-skill-loading-is-feature-not-bug.md` (importance 9 — scoped this PR away from over-engineering subagent loading as a problem)
- Phase 1 (PR #814): intent variable; same shape — parent-context reduction via single-purpose extraction
- PR #812: steer-not-block proof on plan validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)