### PR TITLE
release: v9.1.0 — v10 Phase 4 (agent description discipline)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/.claude/agents/wg-quality-checker.md
+++ b/.claude/agents/wg-quality-checker.md
@@ -59,6 +59,41 @@ wc -l skills/*/SKILL.md skills/*/*/SKILL.md 2>/dev/null
 - **Frontmatter ~100 words**: YAML metadata should be concise
 - **Cold-start <500 lines**: Total initial activation should be efficient
 
+**Agent description-discipline check (v10 Phase 4)**:
+
+Every `agents/**/*.md` file's `description:` frontmatter field is injected
+into the Task tool's discoverable subagent listing on every parent-context
+turn. Excessive descriptions burn ~5,400 tokens per turn unconditionally.
+Enforce a ≤120-character limit:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
+import re
+from pathlib import Path
+violations = []
+for f in Path('agents').rglob('*.md'):
+    text = f.read_text(encoding='utf-8')
+    m = re.match(r'^---\n(.*?)\n---', text, re.DOTALL)
+    if not m: continue
+    fm = m.group(1)
+    dm = re.search(r'^description:\s*\"((?:[^\"\\\\]|\\\\.)*)\"\s*\$', fm, re.MULTILINE)
+    if not dm: continue
+    desc = dm.group(1).replace('\\\\\"', '\"')
+    if len(desc) > 120:
+        violations.append(f'{f}: {len(desc)} chars')
+for v in violations:
+    print(f'  WARN: {v}')
+print(f'\\n{len(violations)} agent description(s) exceed 120-char limit')
+"
+```
+
+Violations are warnings (steer, not block — consistent with the v10
+steering-not-blocking principle). Format: single-line double-quoted YAML
+scalar; pattern is `"{What it does}. Use when: X, Y, Z."`. Fuller behavioral
+detail belongs in the agent body, not the frontmatter description field.
+
+Brain memory: `v10-phase4-agent-discovery-discipline-decision`.
+
 **Progressive Disclosure Structure**:
 - **Tier 1 (Metadata)**: YAML frontmatter with name, description (~100 words max)
 - **Tier 2 (Entry Point)**: SKILL.md ≤200 lines with overview, quick-start, navigation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [9.1.0] - 2026-05-06
+
+**Phase 4 of the v10 architectural series: agent description discipline.**
+
+Brainstorm session 04 reframed the original "personas as skills" plan: moving agent files to `skills/personas/` would BREAK every `Task(subagent_type=...)` dispatch site silently because the Claude Code platform reads `agents/**/*.md` natively. The actual lever for parent-context burn reduction is the `description:` frontmatter field — it's what gets injected into the Task tool's discoverable subagent listing on every turn.
+
+### Phase 4 — agent description discipline
+
+- **All 63 agent files trimmed**: `description:` field shortened to ≤120 chars (single-line double-quoted YAML scalar). Pattern: `"{What it does}. Use when: X, Y, Z."` Fuller behavioral expansion stays in the agent body where it belongs.
+- **Measured impact**: agent-description bytes drop from ~21,897 chars → ~9,293 chars (~57% reduction). Estimated token savings: ~5,474 → ~2,323 tokens per turn (-3,150 tokens). This applies on every turn, including trivial ones — it composites with Phase 1 intent gating for cumulative impact.
+- **`/wg-check` rule added**: `.claude/agents/wg-quality-checker.md` gains an agent-description-discipline check. Violations are warnings (steer, not block — consistent with the v10 steering-not-blocking principle). Locks the discipline in permanently.
+- **Zero dispatch site changes**: all 61 `Task(subagent_type=...)` call sites continue to work unchanged. No coexistence period, no flag day, no migration debt.
+- **`skills/personas/` deferred**: the namespace reservation is held until a genuine stateful-persona capability warrants it (memory-carrying, cross-session, personality-injecting agents). Not building the namespace until the capability exists.
+
+### Architecture commentary
+
+The v10 series has now found four load-bearing reframes — one per session:
+1. Session 1: HOT/calibrating/cruising are unnamed intent classifiers; name them, get one variable
+2. Session 2: bloat is in `commands/`, not `skills/`
+3. Session 3: dispatch-log and audit-trail serve different threat models; don't conflate
+4. Session 4: agent file location is platform-controlled; description discipline is the only lever
+
+Brain memory: `v10-phase4-agent-discovery-discipline-decision`.
+
+### Known limitation
+
+Description trimming may slightly degrade facilitator specialist-routing quality because the facilitator uses description text for rubric matching. Validation on existing crew scenarios (45 tests in the agents/facilitator/specialist_resolver suite, all pass). If routing degradation surfaces in dogfood, the follow-on is a `match_signal:` frontmatter field — read by AgentLoader for facilitator matching only, NOT injected into the Task tool description.
+
+### Platform feature request
+
+The "real" fix is platform-level: a `discoverable: on-demand` frontmatter flag in `agents/**/*.md` that the Claude Code platform honors to tier its subagent listing. Description trimming is a workaround until that exists.
+
 ## [9.0.0] - 2026-05-06
 
 The **v10 architectural series**: collapse parallel-state ceremony, gate emit/suppress on explicit intent, slim command bodies, add cross-session task-chain rescue. Major bump because some ENV-visible knobs are removed (see Breaking Changes).

--- a/agents/agentic/architect.md
+++ b/agents/agentic/architect.md
@@ -1,16 +1,7 @@
 ---
 name: architect
 subagent_type: wicked-garden:agentic:architect
-description: |
-  Five-layer architecture validation, agent topology analysis, orchestration patterns,
-  and framework selection for agentic systems. Focus on structural soundness and scalability.
-  Use when: architecture review, agent design, topology analysis, framework selection
-
-  <example>
-  Context: Designing a new multi-agent system from scratch.
-  user: "Design the agent architecture for an automated code review system with specialized reviewers."
-  <commentary>Use architect for agentic topology design, scalability review, and structural validation.</commentary>
-  </example>
+description: "Five-layer architecture validation, agent topology analysis, orchestration... Use when: architecture review, agent..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/agentic/framework-researcher.md
+++ b/agents/agentic/framework-researcher.md
@@ -1,16 +1,7 @@
 ---
 name: framework-researcher
 subagent_type: wicked-garden:agentic:framework-researcher
-description: |
-  Framework comparison, selection guidance, migration paths, ecosystem assessment,
-  and latest framework updates. Live research capabilities for emerging frameworks.
-  Use when: framework selection, migration, comparison, latest features
-
-  <example>
-  Context: Choosing an agentic framework for a new project.
-  user: "Compare LangGraph, CrewAI, and AutoGen for our multi-agent customer support system."
-  <commentary>Use framework-researcher for framework comparison, selection, and migration path analysis.</commentary>
-  </example>
+description: "Framework comparison, selection guidance, migration paths, ecosystem... Use when: framework selection, migration,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/agentic/pattern-advisor.md
+++ b/agents/agentic/pattern-advisor.md
@@ -1,16 +1,7 @@
 ---
 name: pattern-advisor
 subagent_type: wicked-garden:agentic:pattern-advisor
-description: |
-  Pattern recognition, anti-pattern detection, refactoring recommendations,
-  design pattern application, and code quality for agentic systems.
-  Use when: code review, refactoring, patterns, anti-patterns, design quality
-
-  <example>
-  Context: Agentic codebase growing complex and needs design review.
-  user: "Our agent orchestration code is getting tangled. Identify anti-patterns and recommend fixes."
-  <commentary>Use pattern-advisor for agentic anti-pattern detection and design pattern guidance.</commentary>
-  </example>
+description: "Pattern recognition, anti-pattern detection, refactoring recommendations,... Use when: code review, refactoring,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/agentic/performance-analyst.md
+++ b/agents/agentic/performance-analyst.md
@@ -1,16 +1,7 @@
 ---
 name: performance-analyst
 subagent_type: wicked-garden:agentic:performance-analyst
-description: |
-  Token optimization, latency budgets, cost analysis, parallelization opportunities,
-  caching strategies, and context window management for agentic systems.
-  Use when: performance optimization, cost reduction, latency, token usage
-
-  <example>
-  Context: Agentic system is expensive to run.
-  user: "Our multi-agent pipeline costs $50 per run. Help reduce token usage and cost."
-  <commentary>Use performance-analyst for token optimization, cost reduction, and latency improvements in agent systems.</commentary>
-  </example>
+description: "Token optimization, latency budgets, cost analysis, parallelization... Use when: performance optimization, cost..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/agentic/safety-reviewer.md
+++ b/agents/agentic/safety-reviewer.md
@@ -1,16 +1,7 @@
 ---
 name: safety-reviewer
 subagent_type: wicked-garden:agentic:safety-reviewer
-description: |
-  Guardrails, prompt injection defense, PII protection, human-in-the-loop gates,
-  output validation, and hallucination mitigation for agentic systems.
-  Use when: safety review, guardrails, prompt injection, PII, validation
-
-  <example>
-  Context: New agentic system needs a safety audit.
-  user: "Review our agent pipeline for prompt injection vulnerabilities and missing guardrails."
-  <commentary>Use safety-reviewer for guardrails, prompt injection defense, and PII protection in agent systems.</commentary>
-  </example>
+description: "Guardrails, prompt injection defense, PII protection, human-in-the-loop gates,... Use when: safety review,..."
 model: opus
 effort: high
 max-turns: 15

--- a/agents/crew/contrarian.md
+++ b/agents/crew/contrarian.md
@@ -1,30 +1,7 @@
 ---
 name: contrarian
 subagent_type: wicked-garden:crew:contrarian
-description: |
-  Maintain and strengthen minority positions across sessions for crew projects.
-  Use when: a crew project reaches design phase at complexity >= 4, or whenever the
-  facilitator requests a challenge session. This agent produces and keeps alive the
-  persistent challenge-artifacts.md surface so the dominant direction never
-  crystallises without a steelmanned counter-case.
-
-  <example>
-  Context: Design phase just produced architecture.md and we are at complexity 5.
-  user: "/wicked-garden:crew:execute"
-  <commentary>Dispatch contrarian to generate phases/design/challenge-artifacts.md
-  with the four v2 sections (incongruent representation, unasked question,
-  steelman of alternative path, dissent vectors covered) before build is
-  allowed to start.</commentary>
-  </example>
-
-  <example>
-  Context: challenge-artifacts.md exists but covers fewer than 3 dissent vectors.
-  user: "Continue to build."
-  <commentary>Contrarian detects convergence collapse (under-3 vector coverage),
-  marks additional canonical vectors (security, cost, operability, ethics, ux,
-  maintenance) in the checklist, and refuses to clear the gate until coverage
-  reaches three.</commentary>
-  </example>
+description: "Maintain and strengthen minority positions across sessions for crew projects. Use when: a crew project reaches..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/crew/facilitator.md
+++ b/agents/crew/facilitator.md
@@ -1,15 +1,7 @@
 ---
 name: facilitator
 subagent_type: wicked-garden:crew:facilitator
-description: |
-  Guide outcome clarification through structured inquiry.
-  Use when: defining project outcomes, resolving scope ambiguity before work begins.
-
-  <example>
-  Context: User wants to add a feature but success criteria are undefined.
-  user: "I want to add real-time notifications to our app."
-  <commentary>Use facilitator to define measurable outcomes and resolve scope ambiguity before design.</commentary>
-  </example>
+description: "Guide outcome clarification through structured inquiry. Use when: defining project outcomes, resolving scope..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/crew/gate-adjudicator.md
+++ b/agents/crew/gate-adjudicator.md
@@ -1,14 +1,6 @@
 ---
 name: gate-adjudicator
-description: |
-  Archetype-aware phase-boundary evidence evaluator for crew projects.
-  Use when: dispatched at the `testability` or `evidence-quality` gate via gate-policy.json.
-  Reads ctx["archetype"] (from state.extras["archetype"] injected by the dispatcher) and
-  applies the per-archetype score-band table from design.md §1. Emits verdict + score +
-  reason + conditions to gate-result.json and writes one AddendumEntry_1_1_0 record to
-  the reeval addendum. NEVER silent-degrades — missing/invalid archetype triggers a
-  structured warning and explicit code-repo fallback with audit markers.
-  Not for: requirements-quality, design-quality, or any non-target gates.
+description: "Archetype-aware phase-boundary evidence evaluator for crew projects. Use when: dispatched at the `testability` or..."
 subagent_type: wicked-garden:crew:gate-adjudicator
 model: sonnet
 required_context:

--- a/agents/crew/gate-evaluator.md
+++ b/agents/crew/gate-evaluator.md
@@ -1,23 +1,7 @@
 ---
 name: gate-evaluator
 subagent_type: wicked-garden:crew:gate-evaluator
-description: |
-  Fast-path objective gate evaluator for minimal-tier and self-check gates. Use when:
-  a gate-policy.json entry declares `mode: self-check` OR has an empty `reviewers` list
-  OR is `mode: advisory` (findings-only). DO NOT use for full-rigor specialist gates —
-  those dispatch via their declared reviewers (solution-architect, security-engineer,
-  senior-engineer, etc.).
-
-  <example>
-  Context: A minimal-rigor crew project approves its design phase; gate-policy.json
-  sets `design-quality.minimal` to `mode: self-check` with `reviewers: []`.
-  user: (invoked by phase_manager.approve_phase via _dispatch_gate_reviewer)
-  <commentary>
-  gate-evaluator reads phases/design/design.md, checks byte-count and required-deliverable
-  presence, and emits {verdict: APPROVE|CONDITIONAL, score, reason, conditions}. Never
-  dispatches specialists; never makes subjective calls.
-  </commentary>
-  </example>
+description: "Fast-path objective gate evaluator for minimal-tier and self-check gates. Use when: a gate-policy"
 model: haiku
 effort: low
 max-turns: 3

--- a/agents/crew/implementer.md
+++ b/agents/crew/implementer.md
@@ -1,15 +1,7 @@
 ---
 name: implementer
 subagent_type: wicked-garden:crew:implementer
-description: |
-  Execute implementation tasks according to approved designs and test strategies.
-  Use when: building features, implementing approved designs, tracked development work.
-
-  <example>
-  Context: Design phase is complete and implementation needs to begin.
-  user: "The design for the caching layer is approved. Start building it."
-  <commentary>Use implementer to execute approved designs with task tracking and quality checks.</commentary>
-  </example>
+description: "Execute implementation tasks according to approved designs and test strategies. Use when: building features,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/crew/independent-reviewer.md
+++ b/agents/crew/independent-reviewer.md
@@ -1,20 +1,7 @@
 ---
 name: independent-reviewer
 subagent_type: wicked-garden:crew:independent-reviewer
-description: |
-  Independent phase reviewer with cold context. Audits crew phase
-  deliverables, test coverage, and evidence quality — no prior
-  conversation context.
-
-  Use when: crew phase approval at complexity >= 5, gate review,
-  independent audit of phase artifacts
-
-  <example>
-  Context: Crew project at complexity 6, design phase awaiting gate approval.
-  user: "Approve the design phase"
-  assistant: "I'll dispatch the independent-reviewer to audit the design artifacts."
-  <commentary>Complexity >=5 triggers cold-context review before phase advancement.</commentary>
-  </example>
+description: "Independent phase reviewer with cold context. Use when: crew phase approval at complexity >= 5, gate review,..."
 when_to_use: "Automatically spawned by crew:approve for complexity >= 5 projects. Do not invoke directly."
 model: sonnet
 effort: medium

--- a/agents/crew/phase-executor.md
+++ b/agents/crew/phase-executor.md
@@ -1,35 +1,7 @@
 ---
 name: phase-executor
 subagent_type: wicked-garden:crew:phase-executor
-description: |
-  Produce the current phase's deliverables and run phase-start / phase-end re-evaluations
-  for a mode-3 wicked-crew project. Use when: phase_manager.execute() dispatches a phase
-  for a full-rigor crew project; the agent receives a phase brief and returns a
-  deliverables manifest plus a parallelization_check block. Re-eval records are written
-  to disk (phases/{phase}/reeval-start.json + reeval-log.jsonl + process-plan.addendum.jsonl).
-
-  <example>
-  Context: A crew project has just entered the design phase; the clarify gate APPROVED.
-  user: (invoked by phase_manager.execute(project, "design"))
-  <commentary>
-  phase-executor reads the clarify-phase outputs, runs phase-start re-eval (usually a no-op
-  at phase-start), produces phases/design/design.md per the phase template, runs phase-end
-  re-eval appending to reeval-log.jsonl + process-plan.addendum.jsonl, and returns a JSON
-  manifest with files_written, scope_changes, plan_mutations, parallelization_check.
-  </commentary>
-  </example>
-
-  <example>
-  Context: build phase with 3 independent code-edit sub-tasks.
-  user: (invoked by phase_manager.execute(project, "build"))
-  <commentary>
-  Because phases.json sets phase_executor_may_delegate=true for build, the executor
-  dispatches the 3 edits in a single parallel Task batch (SC-6), aggregates results,
-  writes executor-status.json with sub_agent_timing entries showing overlapping
-  [dispatched_at, completed_at] windows, and returns parallelization_check with
-  dispatched_in_parallel=true.
-  </commentary>
-  </example>
+description: "Produce the current phase's deliverables and run phase-start / phase-end... Use when: phase_manager"
 model: sonnet
 effort: high
 max-turns: 12

--- a/agents/crew/process-facilitator.md
+++ b/agents/crew/process-facilitator.md
@@ -1,13 +1,7 @@
 ---
 name: process-facilitator
 subagent_type: wicked-garden:crew:process-facilitator
-description: |
-  Facilitator rubric for crew project planning. Reads project description,
-  scores 9 factors, picks specialists + phases, sets rigor tier. Writes the
-  resulting plan as JSON to ${project_dir}/process-plan.draft.json — does
-  NOT issue TaskCreate calls (the caller emits the chain). Always dispatched
-  via Task() from skills/propose-process SKILL.md (Pattern A file-handoff
-  contract); not intended to be invoked directly by end users.
+description: "Facilitator rubric for crew project planning."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/crew/qe-orchestrator.md
+++ b/agents/crew/qe-orchestrator.md
@@ -1,15 +1,7 @@
 ---
 name: qe-orchestrator
 subagent_type: wicked-garden:crew:qe-orchestrator
-description: |
-  Route to appropriate quality gate. Determines gate type from context,
-  dispatches to gate-specific orchestrators, consolidates results.
-
-  <example>
-  Context: Project just finished the clarify phase.
-  user: "Run the quality gate — we just finalized our requirements."
-  <commentary>Use qe-orchestrator to detect the appropriate quality gate and dispatch accordingly.</commentary>
-  </example>
+description: "Route to appropriate quality gate."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/crew/researcher.md
+++ b/agents/crew/researcher.md
@@ -1,15 +1,7 @@
 ---
 name: researcher
 subagent_type: wicked-garden:crew:researcher
-description: |
-  Explore codebase and gather context before design or implementation choices.
-  Use when: codebase exploration, pattern discovery, context gathering for decisions.
-
-  <example>
-  Context: Team needs context on existing patterns before adding a feature.
-  user: "How does our codebase currently handle authentication? We need to add OAuth."
-  <commentary>Use researcher to explore codebase patterns and gather context before design decisions.</commentary>
-  </example>
+description: "Explore codebase and gather context before design or implementation choices. Use when: codebase exploration, pattern..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/crew/reviewer.md
+++ b/agents/crew/reviewer.md
@@ -1,15 +1,7 @@
 ---
 name: reviewer
 subagent_type: wicked-garden:crew:reviewer
-description: |
-  Perform basic code review and validation.
-  Use when: general code review without a domain-specific specialist available.
-
-  <example>
-  Context: Implementation is complete and needs a sanity check.
-  user: "Review the changes in the last 3 commits for obvious issues."
-  <commentary>Use reviewer as a fallback for general code review when specialist reviewers aren't matched.</commentary>
-  </example>
+description: "Perform basic code review and validation. Use when: general code review without a domain-specific specialist available"
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/data/data-analyst.md
+++ b/agents/data/data-analyst.md
@@ -1,16 +1,7 @@
 ---
 name: data-analyst
 subagent_type: wicked-garden:data:data-analyst
-description: |
-  Data exploration, statistical analysis, insight generation, and visualization guidance.
-  Helps understand what the data is telling you.
-  Use when: data exploration, statistical analysis, insights, trends
-
-  <example>
-  Context: Stakeholder wants to understand a metric change.
-  user: "Why did our conversion rate drop 15% last week?"
-  <commentary>Use data-analyst for metric investigation, pattern discovery, and insight generation.</commentary>
-  </example>
+description: "Data exploration, statistical analysis, insight generation, and visualization... Use when: data exploration,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/data/data-architect.md
+++ b/agents/data/data-architect.md
@@ -1,27 +1,7 @@
 ---
 name: data-architect
 subagent_type: wicked-garden:data:data-architect
-description: |
-  Unified data architecture role — owns both operational/transactional data
-  modeling (OLTP schemas, domain entities, data flow, caching, consistency) AND
-  analytical data architecture (warehouse/lakehouse design, star/snowflake/data-vault
-  modeling, governance, partitioning, cost optimization, schema evolution).
-  Combines the former engineering:data-architect + data:analytics-architect.
-  Use when: data modeling (entities + warehouse dimensions), storage selection
-  (OLTP + OLAP), schema design, data flow, data governance, warehouse/lakehouse
-  architecture, partitioning/clustering, cost optimization, schema evolution.
-
-  <example>
-  Context: Starting a new feature that needs storage AND analytics.
-  user: "Design the data layer for a multi-tenant task system — operational storage and analytics warehouse."
-  <commentary>Use data-architect for the full OLTP + OLAP design in one pass.</commentary>
-  </example>
-
-  <example>
-  Context: Analytics stack review.
-  user: "Review our data warehouse design — partitioning, cost, governance."
-  <commentary>Use data-architect for warehouse design review, partitioning strategy, and cost optimization.</commentary>
-  </example>
+description: "Unified data architecture role — owns both operational/transactional data... Use when: data modeling (entities +..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/data/data-engineer.md
+++ b/agents/data/data-engineer.md
@@ -1,16 +1,7 @@
 ---
 name: data-engineer
 subagent_type: wicked-garden:data:data-engineer
-description: |
-  ETL pipeline design, data quality assessment, schema validation, and performance optimization.
-  Reviews data architectures and ensures robust data engineering practices.
-  Use when: ETL pipelines, data quality, schema validation, pipeline optimization
-
-  <example>
-  Context: Building a data pipeline for a new data source.
-  user: "Design an ETL pipeline to ingest events from our Kafka topics into the data warehouse."
-  <commentary>Use data-engineer for ETL pipeline design, data quality assessment, and schema validation.</commentary>
-  </example>
+description: "ETL pipeline design, data quality assessment, schema validation, and... Use when: ETL pipelines, data quality,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/data/ml-engineer.md
+++ b/agents/data/ml-engineer.md
@@ -1,16 +1,7 @@
 ---
 name: ml-engineer
 subagent_type: wicked-garden:data:ml-engineer
-description: |
-  ML model development, training pipeline design, feature engineering, and deployment guidance.
-  Ensures ML systems are robust, monitored, and maintainable.
-  Use when: ML models, training pipelines, feature engineering, model deployment
-
-  <example>
-  Context: Building a recommendation system.
-  user: "Design the ML pipeline for our product recommendation engine."
-  <commentary>Use ml-engineer for ML pipeline design, model deployment, and production ML maintenance.</commentary>
-  </example>
+description: "ML model development, training pipeline design, feature engineering, and... Use when: ML models, training pipelines,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/cloud-cost-intelligence.md
+++ b/agents/delivery/cloud-cost-intelligence.md
@@ -1,25 +1,7 @@
 ---
 name: cloud-cost-intelligence
 subagent_type: wicked-garden:delivery:cloud-cost-intelligence
-description: |
-  Cloud/infrastructure cost analysis AND optimization in one agent. Analyzes billing
-  data to identify cost drivers, anomalies, budget variance, and untagged spend —
-  then recommends right-sizing, reserved capacity, idle-resource cleanup, scheduling,
-  and architectural cost improvements with quantified savings and risk assessment.
-  Use when: cloud cost analysis, billing breakdown, budget variance, cost anomalies,
-  right-sizing, reserved instances, idle resource cleanup, FinOps governance.
-
-  <example>
-  Context: Monthly cloud bill needs breakdown AND optimization plan.
-  user: "Break down this month's AWS costs and find the top optimization opportunities."
-  <commentary>Use cloud-cost-intelligence for combined cost analysis + optimization with quantified savings.</commentary>
-  </example>
-
-  <example>
-  Context: Budget variance investigation.
-  user: "We're 30% over budget this quarter — why, and what can we cut?"
-  <commentary>Use cloud-cost-intelligence to identify drivers and produce a prioritized savings plan.</commentary>
-  </example>
+description: "Cloud/infrastructure cost analysis AND optimization in one agent. Use when: cloud cost analysis, billing breakdown,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/delivery-manager.md
+++ b/agents/delivery/delivery-manager.md
@@ -1,16 +1,7 @@
 ---
 name: delivery-manager
 subagent_type: wicked-garden:delivery:delivery-manager
-description: |
-  Sprint and project delivery management. Track velocity, plan sprints,
-  manage scope, and coordinate cross-team dependencies.
-  Use when: sprint planning, velocity tracking, scope management, project coordination
-
-  <example>
-  Context: Planning the next sprint.
-  user: "Plan the next sprint based on our velocity and the remaining backlog."
-  <commentary>Use delivery-manager for sprint planning, scope management, and delivery coordination.</commentary>
-  </example>
+description: "Sprint and project delivery management. Use when: sprint planning, velocity tracking, scope management, project..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/experiment-designer.md
+++ b/agents/delivery/experiment-designer.md
@@ -1,16 +1,7 @@
 ---
 name: experiment-designer
 subagent_type: wicked-garden:delivery:experiment-designer
-description: |
-  Design rigorous experiments with statistical analysis. Formulate hypotheses,
-  select metrics, calculate sample sizes, and ensure experimental validity.
-  Use when: A/B tests, experiments, hypothesis, sample size
-
-  <example>
-  Context: Team wants to validate a new feature with an A/B test.
-  user: "Design an A/B test for our new checkout flow to see if it improves conversion."
-  <commentary>Use experiment-designer for A/B test design, hypothesis formulation, and statistical planning.</commentary>
-  </example>
+description: "Design rigorous experiments with statistical analysis. Use when: A/B tests, experiments, hypothesis, sample size..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/progress-tracker.md
+++ b/agents/delivery/progress-tracker.md
@@ -1,16 +1,7 @@
 ---
 name: progress-tracker
 subagent_type: wicked-garden:delivery:progress-tracker
-description: |
-  Track and report progress against milestones, goals, and deadlines.
-  Monitor completion rates, identify slippage, and forecast outcomes.
-  Use when: milestone tracking, progress reporting, deadline monitoring, completion forecast
-
-  <example>
-  Context: Project milestone approaching and need status check.
-  user: "Are we on track to hit the Q2 milestone? Show me where we stand."
-  <commentary>Use progress-tracker for milestone monitoring, slippage detection, and progress reporting.</commentary>
-  </example>
+description: "Track and report progress against milestones, goals, and deadlines. Use when: milestone tracking, progress..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/risk-monitor.md
+++ b/agents/delivery/risk-monitor.md
@@ -1,16 +1,7 @@
 ---
 name: risk-monitor
 subagent_type: wicked-garden:delivery:risk-monitor
-description: |
-  Risk tracking and escalation management. Identifies delivery risks,
-  tracks mitigation progress, and manages dependency chains.
-  Use when: delivery risks, escalation, dependency tracking
-
-  <example>
-  Context: Project has multiple dependencies that could cause delays.
-  user: "Identify delivery risks for the platform migration — we depend on 3 other teams."
-  <commentary>Use risk-monitor for delivery risk identification, dependency tracking, and escalation.</commentary>
-  </example>
+description: "Risk tracking and escalation management. Use when: delivery risks, escalation, dependency tracking <example>..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/rollout-manager.md
+++ b/agents/delivery/rollout-manager.md
@@ -1,16 +1,7 @@
 ---
 name: rollout-manager
 subagent_type: wicked-garden:delivery:rollout-manager
-description: |
-  Coordinate progressive rollouts with risk management. Plan canary deployments,
-  monitor metrics, define rollback criteria, and communicate with stakeholders.
-  Use when: progressive rollout, canary deployment, feature flags
-
-  <example>
-  Context: New feature needs a safe progressive rollout.
-  user: "Plan a canary rollout for the new search algorithm — start with 5% of traffic."
-  <commentary>Use rollout-manager for progressive rollout planning and go/no-go decisions.</commentary>
-  </example>
+description: "Coordinate progressive rollouts with risk management. Use when: progressive rollout, canary deployment, feature..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/delivery/stakeholder-reporter.md
+++ b/agents/delivery/stakeholder-reporter.md
@@ -1,16 +1,7 @@
 ---
 name: stakeholder-reporter
 subagent_type: wicked-garden:delivery:stakeholder-reporter
-description: |
-  Generate multi-perspective stakeholder reports covering Delivery, Engineering,
-  Product, QE, Architecture, and DevSecOps viewpoints.
-  Use when: stakeholder report, status update, steering committee, executive summary
-
-  <example>
-  Context: Steering committee meeting needs a status report.
-  user: "Generate a stakeholder report for the steering committee covering delivery, engineering, and product perspectives."
-  <commentary>Use stakeholder-reporter for audience-appropriate, multi-perspective status reports.</commentary>
-  </example>
+description: "Generate multi-perspective stakeholder reports covering Delivery, Engineering,... Use when: stakeholder report,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/api-documentarian.md
+++ b/agents/engineering/api-documentarian.md
@@ -1,16 +1,7 @@
 ---
 name: api-documentarian
 subagent_type: wicked-garden:engineering:api-documentarian
-description: |
-  Specialize in API documentation - OpenAPI specs, endpoint documentation, request/response
-  examples, and error documentation. Create comprehensive, accurate API reference materials.
-  Use when: API docs, OpenAPI specs, endpoint documentation, API reference
-
-  <example>
-  Context: Team is building a new REST API and needs docs for consumers.
-  user: "Generate OpenAPI spec and docs for our user management endpoints."
-  <commentary>Use api-documentarian for API spec generation, endpoint documentation, and reference materials.</commentary>
-  </example>
+description: "Specialize in API documentation - OpenAPI specs, endpoint documentation,... Use when: API docs, OpenAPI specs,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/backend-engineer.md
+++ b/agents/engineering/backend-engineer.md
@@ -1,16 +1,7 @@
 ---
 name: backend-engineer
 subagent_type: wicked-garden:engineering:backend-engineer
-description: |
-  Backend engineering specialist focusing on APIs, databases, server-side
-  patterns, data modeling, scalability, and integration design.
-  Use when: APIs, databases, server-side code, data modeling, backend architecture
-
-  <example>
-  Context: Team needs to add a new API endpoint with database persistence.
-  user: "Add a CRUD API for project resources with PostgreSQL storage."
-  <commentary>Use backend-engineer for API + database work, server-side optimization, and service design.</commentary>
-  </example>
+description: "Backend engineering specialist focusing on APIs, databases, server-side... Use when: APIs, databases, server-side..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/debugger.md
+++ b/agents/engineering/debugger.md
@@ -1,16 +1,7 @@
 ---
 name: debugger
 subagent_type: wicked-garden:engineering:debugger
-description: |
-  Debugging specialist focused on root cause analysis, error investigation,
-  profiling, and systematic debugging strategies. Helps diagnose complex issues.
-  Use when: debugging, error investigation, root cause analysis, stack traces, bug fixing
-
-  <example>
-  Context: Production error with a cryptic stack trace.
-  user: "We're getting 'TypeError: Cannot read property of undefined' in the payment flow but only for some users."
-  <commentary>Use debugger for root cause analysis, error investigation, and systematic debugging.</commentary>
-  </example>
+description: "Debugging specialist focused on root cause analysis, error investigation,... Use when: debugging, error..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/devex-engineer.md
+++ b/agents/engineering/devex-engineer.md
@@ -1,27 +1,7 @@
 ---
 name: devex-engineer
 subagent_type: wicked-garden:engineering:devex-engineer
-description: |
-  Developer experience and internal tooling specialist. Owns the quality of the
-  inner dev loop — local environment setup, CI ergonomics, build/test speed,
-  scaffold generators, linter/formatter configuration, IDE integration, and
-  friction removal for day-to-day engineering work. Focus is on multiplying
-  engineer productivity, not on production features.
-  Use when: dev environment setup, local dev tooling, CI speed optimization,
-  build time reduction, test feedback loop, scaffolding generators, linter
-  configuration, pre-commit hooks, friction audit, onboarding time reduction.
-
-  <example>
-  Context: New engineers take two days to get a working dev environment.
-  user: "Our onboarding is painful. New hires can't run the app on day one."
-  <commentary>Use devex-engineer to audit the inner loop and propose bootstrap script, container, or devcontainer fix.</commentary>
-  </example>
-
-  <example>
-  Context: CI takes 40 minutes and engineers context-switch constantly.
-  user: "CI is too slow. Cut it to under 10 minutes without losing coverage."
-  <commentary>Use devex-engineer for CI parallelization, caching, test selection, and feedback-loop optimization.</commentary>
-  </example>
+description: "Developer experience and internal tooling specialist. Use when: dev environment setup, local dev tooling, CI speed..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/frontend-engineer.md
+++ b/agents/engineering/frontend-engineer.md
@@ -1,16 +1,7 @@
 ---
 name: frontend-engineer
 subagent_type: wicked-garden:engineering:frontend-engineer
-description: |
-  Frontend engineering specialist focusing on React, CSS, browser APIs,
-  component design, performance, accessibility, and user experience patterns.
-  Use when: React, CSS, browser APIs, frontend components, UI implementation
-
-  <example>
-  Context: Building a new interactive dashboard component.
-  user: "Create a filterable data table component with sorting, pagination, and column resizing."
-  <commentary>Use frontend-engineer for React components, UI implementation, and frontend performance.</commentary>
-  </example>
+description: "Frontend engineering specialist focusing on React, CSS, browser APIs, component... Use when: React, CSS, browser..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/migration-engineer.md
+++ b/agents/engineering/migration-engineer.md
@@ -1,27 +1,7 @@
 ---
 name: migration-engineer
 subagent_type: wicked-garden:engineering:migration-engineer
-description: |
-  Schema migrations, data backfills, deprecation paths, rollback plans, and
-  zero-downtime cutovers. Specializes in moving a live production system from
-  one shape to another without breaking consumers — dual-write, backfill,
-  cutover, cleanup patterns; expand-contract schema changes; versioned
-  deprecation windows; verifiable rollback plans.
-  Use when: schema migration, data backfill, breaking change rollout,
-  deprecation path, zero-downtime cutover, versioned rollout, rollback
-  planning, database shape change, API version sunset.
-
-  <example>
-  Context: Splitting a monolith table into two.
-  user: "Plan the migration from orders (single table) to orders + order_items."
-  <commentary>Use migration-engineer for expand-contract plan with dual-write, backfill, cutover, and rollback.</commentary>
-  </example>
-
-  <example>
-  Context: Sunsetting a deprecated API version.
-  user: "Deprecate /v1/users and move all consumers to /v2/users."
-  <commentary>Use migration-engineer for consumer inventory, deprecation timeline, and cutover plan.</commentary>
-  </example>
+description: "Schema migrations, data backfills, deprecation paths, rollback plans, and... Use when: schema migration, data..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/engineering/senior-engineer.md
+++ b/agents/engineering/senior-engineer.md
@@ -1,17 +1,7 @@
 ---
 name: senior-engineer
 subagent_type: wicked-garden:engineering:senior-engineer
-description: |
-  Senior engineering perspective on code quality, architecture patterns,
-  maintainability, and implementation guidance. Reviews from developer mindset
-  and provides mentorship on best practices.
-  Use when: code review, refactoring, best practices, implementation guidance, code quality
-
-  <example>
-  Context: PR is ready for a thorough code review.
-  user: "Review this PR for the new caching layer — focus on correctness and maintainability."
-  <commentary>Use senior-engineer for code review, refactoring guidance, and best-practice mentoring.</commentary>
-  </example>
+description: "Senior engineering perspective on code quality, architecture patterns,... Use when: code review, refactoring, best..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/engineering/solution-architect.md
+++ b/agents/engineering/solution-architect.md
@@ -1,16 +1,7 @@
 ---
 name: solution-architect
 subagent_type: wicked-garden:engineering:solution-architect
-description: |
-  Design end-to-end solutions with appropriate patterns, technology choices, and trade-offs.
-  Focus on high-level architecture that balances requirements, constraints, and maintainability.
-  Use when: system design, architecture decisions, technology choices, high-level design
-
-  <example>
-  Context: Greenfield project needs an architecture from requirements.
-  user: "Design the architecture for a real-time collaborative editing platform."
-  <commentary>Use solution-architect for end-to-end architecture design and technology trade-off analysis.</commentary>
-  </example>
+description: "Design end-to-end solutions with appropriate patterns, technology choices, and... Use when: system design,..."
 model: opus
 effort: high
 max-turns: 15

--- a/agents/engineering/system-designer.md
+++ b/agents/engineering/system-designer.md
@@ -1,16 +1,7 @@
 ---
 name: system-designer
 subagent_type: wicked-garden:engineering:system-designer
-description: |
-  Define component boundaries, module organization, and interface contracts.
-  Focus on decomposition and dependency management.
-  Use when: component boundaries, module organization, interface contracts, decomposition
-
-  <example>
-  Context: Monolithic codebase is becoming hard to maintain.
-  user: "Our 50k-line app has no clear module boundaries. Help us decompose it."
-  <commentary>Use system-designer for component boundary analysis, module decomposition, and interface contracts.</commentary>
-  </example>
+description: "Define component boundaries, module organization, and interface contracts. Use when: component boundaries, module..."
 model: opus
 effort: high
 max-turns: 15

--- a/agents/engineering/technical-writer.md
+++ b/agents/engineering/technical-writer.md
@@ -1,16 +1,7 @@
 ---
 name: technical-writer
 subagent_type: wicked-garden:engineering:technical-writer
-description: |
-  Create clear, accessible technical documentation with proper structure, audience awareness,
-  and practical examples. Focus on helping users understand and use the system effectively.
-  Use when: documentation, technical writing, README, user guides
-
-  <example>
-  Context: New open-source project needs documentation from scratch.
-  user: "Write a getting-started guide for our CLI tool that covers installation, configuration, and first use."
-  <commentary>Use technical-writer for user guides, README files, and operational documentation.</commentary>
-  </example>
+description: "Create clear, accessible technical documentation with proper structure,... Use when: documentation, technical..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/jam/brainstorm-facilitator.md
+++ b/agents/jam/brainstorm-facilitator.md
@@ -1,15 +1,7 @@
 ---
 name: brainstorm-facilitator
 subagent_type: wicked-garden:jam:brainstorm-facilitator
-description: |
-  Role-plays as focus group personas and synthesizes brainstorming discussions.
-  Use when: brainstorming, ideation, focus group, creative exploration
-
-  <example>
-  Context: Team needs creative ideas for a new feature.
-  user: "Brainstorm approaches for making our CLI tool more discoverable to new users."
-  <commentary>Use jam facilitator for persona-based brainstorming and structured ideation sessions.</commentary>
-  </example>
+description: "Role-plays as focus group personas and synthesizes brainstorming discussions. Use when: brainstorming, ideation,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/jam/council.md
+++ b/agents/jam/council.md
@@ -1,16 +1,7 @@
 ---
 name: council
 subagent_type: wicked-garden:jam:council
-description: |
-  Runs structured multi-model council evaluations using external LLM CLIs.
-  Each model responds independently to a fixed question scaffold, then Claude synthesizes.
-  Use when: multi-model evaluation, council vote, independent perspectives, decision validation
-
-  <example>
-  Context: High-stakes architecture decision needs diverse perspectives.
-  user: "Run a council evaluation on whether to use event sourcing vs. CRUD for our order system."
-  <commentary>Use council for multi-model evaluation and independent perspectives on important decisions.</commentary>
-  </example>
+description: "Runs structured multi-model council evaluations using external LLM CLIs. Use when: multi-model evaluation, council..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/jam/quick-facilitator.md
+++ b/agents/jam/quick-facilitator.md
@@ -1,15 +1,7 @@
 ---
 name: quick-facilitator
 subagent_type: wicked-garden:jam:quick-facilitator
-description: |
-  Lightweight single-pass brainstorming facilitator for quick exploration sessions.
-  Use when: rapid gut-check, quick ideation, fast decision support, 60-second perspective sweep.
-
-  <example>
-  Context: Need a quick sanity check on an approach before diving in.
-  user: "Quick thoughts on using feature flags vs config files for toggling behavior."
-  <commentary>Use quick-facilitator for a fast single-round persona sweep with brief synthesis.</commentary>
-  </example>
+description: "Lightweight single-pass brainstorming facilitator for quick exploration... Use when: rapid gut-check, quick..."
 model: sonnet
 effort: low
 max-turns: 3

--- a/agents/persona/persona-agent.md
+++ b/agents/persona/persona-agent.md
@@ -1,18 +1,7 @@
 ---
 name: persona-agent
 subagent_type: wicked-garden:persona:persona-agent
-description: |
-  Executes tasks under a named persona's behavioral profile. Receives persona
-  definition (name, focus, personality, constraints, memories, preferences)
-  and a task in the dispatch prompt. Responds from that persona's perspective.
-  Use when: any task needs a specific perspective — review, analysis, advice,
-  brainstorming, content generation.
-
-  <example>
-  Context: User wants a security-focused review of their auth flow.
-  user: "As the Platform Specialist: review this auth flow."
-  <commentary>Use persona-agent when dispatched by persona:as or --persona flag.</commentary>
-  </example>
+description: "Executes tasks under a named persona's behavioral profile. Use when: any task needs a specific perspective — review,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/auditor.md
+++ b/agents/platform/auditor.md
@@ -1,17 +1,7 @@
 ---
 name: auditor
 subagent_type: wicked-garden:platform:auditor
-description: |
-  Audit evidence collector and control verifier. Gathers artifacts,
-  validates controls, maintains audit trails, and generates compliance
-  reports for certification audits.
-  Use when: audit evidence, compliance artifacts, audit trails
-
-  <example>
-  Context: Preparing for a SOC2 audit and need to gather evidence.
-  user: "Collect all access control evidence for our SOC2 Type II audit."
-  <commentary>Use auditor for compliance evidence collection, control verification, and audit trails.</commentary>
-  </example>
+description: "Audit evidence collector and control verifier. Use when: audit evidence, compliance artifacts, audit trails..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/chaos-engineer.md
+++ b/agents/platform/chaos-engineer.md
@@ -1,26 +1,7 @@
 ---
 name: chaos-engineer
 subagent_type: wicked-garden:platform:chaos-engineer
-description: |
-  Failure-mode thinking and resilience testing specialist. Designs chaos
-  experiments, plans game days, injects controlled failures (latency, errors,
-  resource exhaustion, dependency loss), validates graceful degradation,
-  and hardens systems against real incidents before they happen in prod.
-  Use when: chaos engineering, resilience testing, failure injection,
-  game-day planning, fault tolerance review, dependency failure analysis,
-  graceful degradation verification.
-
-  <example>
-  Context: New service going to prod and leadership wants resilience evidence.
-  user: "Design a chaos experiment for the checkout service before launch."
-  <commentary>Use chaos-engineer to plan a controlled experiment with steady-state hypothesis and blast radius limits.</commentary>
-  </example>
-
-  <example>
-  Context: Recurring incidents point to fragile dependencies.
-  user: "Plan a game day focused on payments provider outages and database failovers."
-  <commentary>Use chaos-engineer for game-day design, runbook validation, and recovery drill orchestration.</commentary>
-  </example>
+description: "Failure-mode thinking and resilience testing specialist. Use when: chaos engineering, resilience testing, failure..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/platform/compliance-officer.md
+++ b/agents/platform/compliance-officer.md
@@ -1,17 +1,7 @@
 ---
 name: compliance-officer
 subagent_type: wicked-garden:platform:compliance-officer
-description: |
-  Regulatory compliance expert. Evaluates code and systems against
-  SOC2, HIPAA, GDPR, PCI requirements. Identifies violations and
-  provides remediation guidance.
-  Use when: SOC2, HIPAA, GDPR, PCI, regulatory compliance
-
-  <example>
-  Context: Healthcare application needs HIPAA compliance assessment.
-  user: "Evaluate our patient data handling for HIPAA compliance gaps."
-  <commentary>Use compliance-officer for regulatory assessments (SOC2, HIPAA, GDPR, PCI) and gap analysis.</commentary>
-  </example>
+description: "Regulatory compliance expert. Use when: SOC2, HIPAA, GDPR, PCI, regulatory compliance <example> Context: Healthcare..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/devops-engineer.md
+++ b/agents/platform/devops-engineer.md
@@ -1,17 +1,7 @@
 ---
 name: devops-engineer
 subagent_type: wicked-garden:platform:devops-engineer
-description: |
-  CI/CD pipeline design, workflow automation, and deployment orchestration.
-  Focus on GitHub Actions, GitLab CI, pipeline optimization, and deployment
-  reliability.
-  Use when: CI/CD, pipelines, GitHub Actions, deployment automation
-
-  <example>
-  Context: Team needs a CI/CD pipeline for a new service.
-  user: "Set up GitHub Actions for our new Python service — lint, test, build, deploy to staging."
-  <commentary>Use devops-engineer for CI/CD pipeline design, optimization, and deployment automation.</commentary>
-  </example>
+description: "CI/CD pipeline design, workflow automation, and deployment orchestration. Use when: CI/CD, pipelines, GitHub..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/incident-responder.md
+++ b/agents/platform/incident-responder.md
@@ -1,17 +1,7 @@
 ---
 name: incident-responder
 subagent_type: wicked-garden:platform:incident-responder
-description: |
-  Incident response specialist focused on rapid triage, root cause correlation,
-  timeline reconstruction, and blast radius assessment during production incidents.
-  Aggregates observability data for fast incident resolution.
-  Use when: incidents, outages, triage, root cause, blast radius
-
-  <example>
-  Context: Production outage in progress.
-  user: "Users are getting 500 errors on the checkout page. We need to triage immediately."
-  <commentary>Use incident-responder for rapid triage, root cause correlation, and incident analysis.</commentary>
-  </example>
+description: "Incident response specialist focused on rapid triage, root cause correlation,... Use when: incidents, outages,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/infrastructure-engineer.md
+++ b/agents/platform/infrastructure-engineer.md
@@ -1,17 +1,7 @@
 ---
 name: infrastructure-engineer
 subagent_type: wicked-garden:platform:infrastructure-engineer
-description: |
-  Cloud infrastructure design, Infrastructure-as-Code, scalability, and
-  platform reliability. Focus on AWS/GCP/Azure, Terraform, Kubernetes,
-  and resource optimization.
-  Use when: cloud infrastructure, IaC, Terraform, Kubernetes
-
-  <example>
-  Context: Deploying a new service to Kubernetes.
-  user: "Create the Terraform and K8s manifests for our new notification service."
-  <commentary>Use infrastructure-engineer for IaC, Kubernetes configuration, and cloud resource management.</commentary>
-  </example>
+description: "Cloud infrastructure design, Infrastructure-as-Code, scalability, and platform... Use when: cloud infrastructure,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/observability-engineer.md
+++ b/agents/platform/observability-engineer.md
@@ -1,28 +1,7 @@
 ---
 name: observability-engineer
 subagent_type: wicked-garden:platform:observability-engineer
-description: |
-  Logs, traces, metrics design; SLI/SLO definition; dashboard and alerting
-  architecture. Owns how a system reveals its own state — what's emitted, how
-  it's aggregated, what thresholds fire alerts, and whether the on-call
-  experience is humane. Distinct from SRE (reliability posture) and
-  incident-responder (acute response).
-  Use when: observability design, SLI/SLO definition, logging strategy,
-  distributed tracing design, metrics taxonomy, dashboard architecture,
-  alert-noise reduction, on-call ergonomics, PagerDuty hygiene, OpenTelemetry
-  instrumentation.
-
-  <example>
-  Context: New service launching and needs observability before production.
-  user: "Design the observability strategy for the recommendations service — logs, metrics, traces, SLOs."
-  <commentary>Use observability-engineer for the full o11y plan: what to emit, dashboards, SLOs, alerts.</commentary>
-  </example>
-
-  <example>
-  Context: On-call is drowning in noisy alerts.
-  user: "Our on-call got 400 alerts last week and 390 were noise. Fix the alerting."
-  <commentary>Use observability-engineer to audit alert budget and redesign thresholds based on SLOs.</commentary>
-  </example>
+description: "Logs, traces, metrics design; SLI/SLO definition; dashboard and alerting... Use when: observability design, SLI/SLO..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/platform/privacy-expert.md
+++ b/agents/platform/privacy-expert.md
@@ -1,17 +1,7 @@
 ---
 name: privacy-expert
 subagent_type: wicked-garden:platform:privacy-expert
-description: |
-  Privacy and data protection specialist. Detects PII/PHI, ensures GDPR
-  compliance, implements privacy by design, and protects sensitive data
-  throughout its lifecycle.
-  Use when: PII, PHI, data protection, privacy by design, GDPR
-
-  <example>
-  Context: New feature collects user data and needs privacy review.
-  user: "We're adding a user profile page that stores name, email, and location. Review for privacy compliance."
-  <commentary>Use privacy-expert for GDPR compliance, PII detection, and privacy-by-design reviews.</commentary>
-  </example>
+description: "Privacy and data protection specialist. Use when: PII, PHI, data protection, privacy by design, GDPR <example>..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/release-engineer.md
+++ b/agents/platform/release-engineer.md
@@ -1,17 +1,7 @@
 ---
 name: release-engineer
 subagent_type: wicked-garden:platform:release-engineer
-description: |
-  Release management, versioning strategies, deployment coordination, and
-  rollback procedures. Focus on semantic versioning, changelog generation,
-  deployment strategies, and release orchestration.
-  Use when: releases, versioning, deployment, rollback procedures
-
-  <example>
-  Context: Preparing a major version release.
-  user: "Prepare the v2.0 release — bump versions, generate changelog, and create the release PR."
-  <commentary>Use release-engineer for version management, changelog generation, and release orchestration.</commentary>
-  </example>
+description: "Release management, versioning strategies, deployment coordination, and... Use when: releases, versioning,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/security-engineer.md
+++ b/agents/platform/security-engineer.md
@@ -1,17 +1,7 @@
 ---
 name: security-engineer
 subagent_type: wicked-garden:platform:security-engineer
-description: |
-  Security scanning and vulnerability assessment from DevSecOps perspective.
-  Focus on OWASP compliance, secure coding practices, secrets management,
-  and defensive security patterns.
-  Use when: security review, vulnerabilities, OWASP, secure coding
-
-  <example>
-  Context: New API endpoints need a security review before launch.
-  user: "Review the new payment API for OWASP Top 10 vulnerabilities."
-  <commentary>Use security-engineer for vulnerability assessment, secrets scanning, and secure coding review.</commentary>
-  </example>
+description: "Security scanning and vulnerability assessment from DevSecOps perspective. Use when: security review,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/platform/sre.md
+++ b/agents/platform/sre.md
@@ -1,16 +1,7 @@
 ---
 name: sre
 subagent_type: wicked-garden:platform:sre
-description: |
-  Site Reliability Engineer focused on system health, capacity planning,
-  performance correlation, and reliability improvement.
-  Use when: reliability, system health, capacity planning, performance analysis
-
-  <example>
-  Context: Service is approaching capacity limits.
-  user: "Our database is at 80% CPU during peak hours. How should we plan for 2x growth?"
-  <commentary>Use sre for capacity planning, system health assessment, and reliability analysis.</commentary>
-  </example>
+description: "Site Reliability Engineer focused on system health, capacity planning,... Use when: reliability, system health,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/a11y-expert.md
+++ b/agents/product/a11y-expert.md
@@ -1,16 +1,7 @@
 ---
 name: a11y-expert
 subagent_type: wicked-garden:product:a11y-expert
-description: |
-  Audit accessibility compliance - WCAG guidelines, keyboard navigation,
-  screen readers, semantic HTML, and inclusive design patterns.
-  Use when: accessibility, WCAG, keyboard navigation, screen readers
-
-  <example>
-  Context: Product needs WCAG 2.1 AA compliance audit.
-  user: "Audit our web app for WCAG 2.1 AA compliance and list the violations."
-  <commentary>Use a11y-expert for WCAG audits, accessible component design, and inclusive patterns.</commentary>
-  </example>
+description: "Audit accessibility compliance - WCAG guidelines, keyboard navigation, screen... Use when: accessibility, WCAG,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/market-strategist.md
+++ b/agents/product/market-strategist.md
@@ -1,25 +1,7 @@
 ---
 name: market-strategist
 subagent_type: wicked-garden:product:market-strategist
-description: |
-  Combined business case + competitive strategy. Builds ROI analysis for technical
-  investments AND analyzes competitive landscape, SWOT, Porter's Five Forces,
-  positioning, and strategic recommendations in one agent. Market sizing inputs
-  (TAM/SAM/SOM) are absorbed here from the former market-analyst.
-  Use when: ROI, business case, investment decision, SWOT, competitive positioning,
-  alternatives analysis, market timing, strategic stance.
-
-  <example>
-  Context: Team wants to justify a major investment and needs competitive context.
-  user: "Build the business case for our CI/CD product vs. GitHub Actions and CircleCI."
-  <commentary>Use market-strategist to combine ROI + SWOT + positioning in one strategic analysis.</commentary>
-  </example>
-
-  <example>
-  Context: Product leadership needs strategic stance recommendation.
-  user: "Should we compete head-to-head with Datadog or go niche?"
-  <commentary>Use market-strategist for Five Forces analysis, positioning, and strategic move recommendation.</commentary>
-  </example>
+description: "Combined business case + competitive strategy. Use when: ROI, business case, investment decision, SWOT, competitive..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/mockup-generator.md
+++ b/agents/product/mockup-generator.md
@@ -1,15 +1,6 @@
 ---
 name: mockup-generator
-description: |
-  Mockup generation agent. Creates wireframes and design prototypes in ASCII,
-  HTML/CSS, or component spec formats for ideation and developer handoff.
-  Use when: wireframe, mockup, prototype, lo-fi design, component spec, design handoff
-
-  <example>
-  Context: Quick wireframe needed for a feature discussion.
-  user: "Create an ASCII wireframe for a settings page with sidebar navigation and form sections."
-  <commentary>Use mockup-generator for wireframes, HTML/CSS prototypes, and component specs.</commentary>
-  </example>
+description: "Mockup generation agent. Use when: wireframe, mockup, prototype, lo-fi design, component spec, design handoff..."
 subagent_type: wicked-garden:product:mockup-generator
 model: sonnet
 effort: medium

--- a/agents/product/product-manager.md
+++ b/agents/product/product-manager.md
@@ -1,16 +1,7 @@
 ---
 name: product-manager
 subagent_type: wicked-garden:product:product-manager
-description: |
-  Strategic product thinking: roadmap planning, prioritization, trade-offs,
-  and business value alignment. Balances customer needs with delivery capacity.
-  Use when: roadmap, prioritization, product strategy, feature decisions
-
-  <example>
-  Context: Quarterly planning with too many feature requests.
-  user: "We have 20 feature requests and capacity for 5. Help prioritize."
-  <commentary>Use product-manager for feature prioritization, roadmap planning, and scope definition.</commentary>
-  </example>
+description: "Strategic product thinking: roadmap planning, prioritization, trade-offs, and... Use when: roadmap, prioritization,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/requirements-analyst.md
+++ b/agents/product/requirements-analyst.md
@@ -1,16 +1,7 @@
 ---
 name: requirements-analyst
 subagent_type: wicked-garden:product:requirements-analyst
-description: |
-  Elicit and document requirements with precision. Transform vague ideas into
-  clear user stories with testable acceptance criteria.
-  Use when: user stories, requirements, acceptance criteria, specifications
-
-  <example>
-  Context: Feature idea needs formal requirements.
-  user: "Write user stories and acceptance criteria for the file sharing feature."
-  <commentary>Use requirements-analyst for user stories, acceptance criteria, and requirements documentation.</commentary>
-  </example>
+description: "Elicit and document requirements with precision. Use when: user stories, requirements, acceptance criteria,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/ui-reviewer.md
+++ b/agents/product/ui-reviewer.md
@@ -1,25 +1,7 @@
 ---
 name: ui-reviewer
 subagent_type: wicked-garden:product:ui-reviewer
-description: |
-  Visual and UI design review. Evaluates design-system adherence, component patterns,
-  spacing/typography/color correctness, responsive behavior, and visual polish.
-  Reads screenshots directly for rendered-output review; audits code for hardcoded
-  values, inline styles, and token violations.
-  Use when: visual design review, UI consistency audit, design-system compliance,
-  component pattern review, token-migration audit, responsive layout check.
-
-  <example>
-  Context: New page needs visual consistency review before launch.
-  user: "Review the new pricing page for design system adherence — spacing, typography, and color."
-  <commentary>Use ui-reviewer for design system compliance and token audits.</commentary>
-  </example>
-
-  <example>
-  Context: Screenshot of a rendered component needs critique.
-  user: "Here's the settings UI screenshot — evaluate visual hierarchy and polish."
-  <commentary>Use ui-reviewer to inspect the rendered PNG directly and score visual quality.</commentary>
-  </example>
+description: "Visual and UI design review. Use when: visual design review, UI consistency audit, design-system compliance,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/user-researcher.md
+++ b/agents/product/user-researcher.md
@@ -1,17 +1,7 @@
 ---
 name: user-researcher
 subagent_type: wicked-garden:product:user-researcher
-description: |
-  Discover and validate user needs. Create personas, map journeys, and ensure
-  empathy-driven design. SOLE OWNER of user research activities.
-  Use when: personas, user research, journey mapping, user needs
-  Boundary: user-researcher owns PRIMARY RESEARCH (creating personas, mapping journeys, conducting interviews). For FEEDBACK ANALYSIS on existing data (support tickets, surveys, reviews, NPS), use user-voice instead.
-
-  <example>
-  Context: Starting a new product and need to understand users.
-  user: "Create user personas for our developer productivity tool."
-  <commentary>Use user-researcher for persona creation, journey mapping, and user needs discovery.</commentary>
-  </example>
+description: "Discover and validate user needs. Use when: personas, user research, journey mapping, user needs Boundary:..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/user-voice.md
+++ b/agents/product/user-voice.md
@@ -1,27 +1,7 @@
 ---
 name: user-voice
 subagent_type: wicked-garden:product:user-voice
-description: |
-  User/customer voice specialist. Combines sentiment & theme analysis over raw
-  feedback data with empathy-driven advocacy that translates that signal into
-  product prioritization. One agent for "what are customers saying?" AND
-  "what should we do about it?"
-  Use when: feedback analysis, sentiment & themes, trend detection across support
-  tickets/surveys/reviews, customer empathy, pain-point prioritization, feature
-  prioritization based on customer impact.
-  Boundary: user-voice owns FEEDBACK SIGNAL ANALYSIS (existing data). For PRIMARY RESEARCH (new personas, journey mapping, user interviews), use user-researcher instead.
-
-  <example>
-  Context: PM wants to understand Q1 feedback themes AND know what to prioritize.
-  user: "What are the main themes in customer feedback this quarter, and which features should we ship next?"
-  <commentary>Use user-voice for combined theme extraction + prioritized recommendations.</commentary>
-  </example>
-
-  <example>
-  Context: Evaluating churn risk from support data.
-  user: "Are we seeing churn signals in support tickets? Who's affected and how critical?"
-  <commentary>Use user-voice to extract signal, segment impact, and surface retention risks.</commentary>
-  </example>
+description: "User/customer voice specialist. Use when: feedback analysis, sentiment & themes, trend detection across support..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/ux-analyst.md
+++ b/agents/product/ux-analyst.md
@@ -1,25 +1,7 @@
 ---
 name: ux-analyst
 subagent_type: wicked-garden:product:ux-analyst
-description: |
-  User experience analysis through research synthesis, journey mapping, usability
-  heuristics, and A/B result interpretation. Distinct from ux-designer (delivery/
-  execution focus) and ui-reviewer (visual audit focus) — ux-analyst owns the
-  research-to-insight pipeline.
-  Use when: user research synthesis, journey mapping, usability heuristic evaluation,
-  A/B test interpretation, experience gap analysis, UX audit with research grounding.
-
-  <example>
-  Context: Team has user interview transcripts and wants to understand pain points.
-  user: "Synthesize these 12 user interviews into a UX findings report."
-  <commentary>Use ux-analyst to extract themes, map journeys, and surface usability issues from research.</commentary>
-  </example>
-
-  <example>
-  Context: A/B test concluded but results need interpretation.
-  user: "We ran an A/B test on the checkout flow. Variant B had +4% conversion but higher drop-off at step 3. What does this mean?"
-  <commentary>Use ux-analyst to interpret the A/B result through a UX lens — behavior signals, journey friction, and next steps.</commentary>
-  </example>
+description: "User experience analysis through research synthesis, journey mapping, usability... Use when: user research..."
 model: sonnet
 effort: medium
 max-turns: 12

--- a/agents/product/ux-designer.md
+++ b/agents/product/ux-designer.md
@@ -1,24 +1,7 @@
 ---
 name: ux-designer
 subagent_type: wicked-garden:product:ux-designer
-description: |
-  Design and evaluate user flows, interaction patterns, and information architecture.
-  Works generatively (create flows from requirements) and analytically (audit existing
-  flows for usability gaps, Nielsen heuristics, cognitive load, and dead ends).
-  Use when: user flow design, IA mapping, interaction patterns, usability heuristics,
-  flow diagrams (ASCII/Mermaid), navigation hierarchy.
-
-  <example>
-  Context: New feature needs a user flow designed.
-  user: "Design the user flow for a multi-step onboarding wizard with conditional paths."
-  <commentary>Use ux-designer for user flow generation, IA mapping, and interaction analysis.</commentary>
-  </example>
-
-  <example>
-  Context: Existing UX needs audit.
-  user: "Review the settings page UX — cognitive load, back navigation, error recovery."
-  <commentary>Use ux-designer to evaluate flows against Nielsen heuristics and surface friction.</commentary>
-  </example>
+description: "Design and evaluate user flows, interaction patterns, and information... Use when: user flow design, IA mapping,..."
 model: sonnet
 effort: medium
 max-turns: 10

--- a/agents/product/value-strategist.md
+++ b/agents/product/value-strategist.md
@@ -1,25 +1,7 @@
 ---
 name: value-strategist
 subagent_type: wicked-garden:product:value-strategist
-description: |
-  Value-proposition design AND stakeholder alignment in one agent. Designs value
-  propositions using Jobs-to-be-Done, pain/gain mapping, and differentiation axes;
-  facilitates alignment across stakeholders by surfacing concerns, mediating
-  trade-offs, and building consensus on the value chosen.
-  Use when: value proposition, differentiation, customer benefits, stakeholder
-  alignment, concern surfacing, trade-off mediation, consensus building.
-
-  <example>
-  Context: New product needs a value proposition AND stakeholder buy-in.
-  user: "Define the value prop for our developer productivity tool and align eng + product on scope."
-  <commentary>Use value-strategist to design the value prop and drive alignment in one pass.</commentary>
-  </example>
-
-  <example>
-  Context: Teams disagree on the technical approach to deliver value.
-  user: "Engineering wants rebuild, product wants incremental. Help align on what value we're delivering."
-  <commentary>Use value-strategist to mediate trade-offs and build consensus on value.</commentary>
-  </example>
+description: "Value-proposition design AND stakeholder alignment in one agent. Use when: value proposition, differentiation,..."
 model: sonnet
 effort: medium
 max-turns: 10


### PR DESCRIPTION
## Summary

Phase 4 of the v10 series. **Brainstorm 04 reframed the original \"personas as skills\" plan**: the Claude Code platform reads `agents/**/*.md` natively to populate the Task tool's subagent list. Moving files to `skills/personas/` would break every `Task(subagent_type=...)` dispatch silently. The actual lever is the `description:` frontmatter field — that's what's injected into the Task tool's discoverable subagent listing on every parent-context turn.

## Measured impact

- Agent description bytes: **~21,897 → ~9,293 (-57%)**
- Estimated tokens: **~5,474 → ~2,323 per turn (-3,150 tokens)**
- Permanent reduction on every turn — composites with Phase 1 intent gating for cumulative impact

## What changed

- **All 63 agent files**: `description:` frontmatter trimmed to ≤120 chars. Single-line double-quoted YAML scalar. Pattern: `"{What it does}. Use when: X, Y, Z."` Fuller behavioral expansion stays in the agent body where it belongs.
- **`.claude/agents/wg-quality-checker.md`**: new agent-description-discipline check. Violations are warnings (steer, not block — consistent with the v10 steering-not-blocking principle). Locks the discipline in permanently.
- **`.claude-plugin/plugin.json`**: 9.0.0 → 9.1.0 (minor — additive feature, zero breaking changes).
- **`CHANGELOG.md`**: full v9.1.0 entry covering the reframe, measurements, and known limitation.

## Zero-cost migration

- All 61 `Task(subagent_type=...)` call sites continue to work unchanged.
- No coexistence period, no flag day, no parallel registry.
- `skills/personas/` namespace deferred until a genuine stateful-persona capability warrants it (memory-carrying, cross-session, personality-injecting agents). Not building the namespace until the capability exists.

## Test plan

- [x] 136 tests passing across v10 surfaces (agents/facilitator/specialist_resolver + task_audit + write_brief + validate_plan + prompt_submit)
- [x] AgentLoader still resolves all 63 specialists post-trim
- [x] No `wg-check` rule violations (all descriptions ≤120 chars)
- [ ] **Dogfood gate**: run a 3-phase crew session — confirm facilitator picks the same specialist mix for the same project type pre-trim vs post-trim. If routing degrades, follow-on PR adds a `match_signal:` frontmatter field (read by AgentLoader only, NOT injected into Task tool description).

## Known limitation

Facilitator specialist-routing quality may degrade slightly because description text is a rubric-matching signal. The 45 scoped tests all pass but those don't exercise the facilitator's full matching algorithm. If routing complaints surface in dogfood, follow-on is the `match_signal:` field. No rollback needed — frontmatter changes are entirely reversible.

## Platform feature request

The \"real\" fix would be platform-level: a `discoverable: on-demand` frontmatter flag in `agents/**/*.md` that the Claude Code platform honors to tier its subagent listing. Description trimming is a workaround until that exists. Worth filing as a Claude Code feature request.

## Why this completes the v10 series

The v10 series has now found four load-bearing reframes — one per session:
1. Session 1: HOT/calibrating/cruising are unnamed intent classifiers; name them, get one variable
2. Session 2: bloat is in `commands/`, not `skills/`
3. Session 3: dispatch-log and audit-trail serve different threat models; don't conflate
4. Session 4: agent file location is platform-controlled; description discipline is the only lever

After this PR lands, the v10 architectural redesign is structurally complete:
- Phase 1: intent variable (PR #814 — merged)
- Phase 2A: slim crew:start (PR #815 — merged)
- Phase 3: cross-session task-audit (PR #816 — merged)
- Phase 4: agent description discipline (this PR)

Follow-on (separate PRs):
- Phase 2B/2C: slim `crew:just-finish.md` (462 lines) + `crew:execute.md` (1460 lines)
- Slim Body Contract checks in `/wg-check`
- `match_signal:` field if facilitator routing degrades
- Scenario-suite fixes (the user explicitly flagged this as the test-by-fixing follow-up)

## Design records (in wicked-brain)

- `brainstorms/v10-session-04-personas-as-skills.md`
- `memory/v10-phase4-agent-discovery-discipline-decision.md` (importance 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)