### PR TITLE
fix(smaht): intent skill frontmatter name field — v9.1.1 patch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [9.1.1] - 2026-05-06
+
+**Patch — fix Phase 1 intent skill discovery regression.**
+
+The `/wicked-garden:intent` skill shipped in v9.0.0 (PR #814) had a frontmatter `name:` field set to the full namespaced form (`name: wicked-garden:intent`). Claude Code's auto-discovery derives the registered namespace from the file path; the `name:` field should be the leaf only. As shipped, the skill was on disk but never registered, so the user-facing override path was unreachable. Auto-detection and directive emission (the `prompt_submit.py` paths) were unaffected.
+
+Surfaced via dogfooding on the v9.1.0 plugin reload — `116 skills` count was missing one entry. Fix:
+
+- `skills/smaht/intent/SKILL.md`: `name: wicked-garden:intent` → `name: intent`. The skill now registers as `wicked-garden:smaht:intent`.
+- Frontmatter description converted to block-scalar with explicit `Use when:` clause matching the convention of peer smaht skills.
+- No code changes; the script body in the skill (which interacts with `_session.py`) was always correct.
+
+This is a v10 follow-on bug per the dogfooding protocol — same kind of frontmatter-vs-discovery mismatch CLAUDE.md called out at v6.3.6 ("Claude Code's skill auto-discovery doesn't recurse into skills/<domain>/<name>/"). Phase 4's wg-check rule does NOT yet validate frontmatter `name:` fields; adding that to wg-check is a follow-on enhancement.
+
 ## [9.1.0] - 2026-05-06
 
 **Phase 4 of the v10 architectural series: agent description discipline.**

--- a/skills/smaht/intent/SKILL.md
+++ b/skills/smaht/intent/SKILL.md
@@ -1,6 +1,13 @@
 ---
-name: wicked-garden:intent
-description: Show or set the session intent variable. Intent gates how loud the framework is — simple-edit (silent), feature/research (synthesis directive), rigor (full crew context). Auto-detected on the first turn; this skill overrides explicitly. Sticky for the session.
+name: intent
+description: |
+  Show or set the session intent variable. Intent gates how loud the
+  framework is — simple-edit (silent), feature/research (synthesis
+  directive), rigor (full crew context). Auto-detected on turn 1;
+  this skill overrides explicitly. Sticky for the session.
+
+  Use when: "set intent", "intent override", "/wicked-garden:intent",
+  "make the framework quiet", "force rigor", "what's my intent".
 ---
 
 # /wicked-garden:intent


### PR DESCRIPTION
## What

Patch fix surfaced via dogfooding on the v9.1.0 plugin reload.

The \`/wicked-garden:intent\` skill shipped in PR #814 (v9.0.0) had \`name: wicked-garden:intent\` in its frontmatter. Claude Code's auto-discovery derives the registered namespace from the file path (\`skills/smaht/intent/SKILL.md\` → \`wicked-garden:smaht:intent\`); the \`name:\` field should be the leaf only.

As shipped, the skill was on disk but **never registered** — the plugin reload report on v9.1.0 was \`116 skills · 127 agents\`, missing the intent entry. Auto-detection and directive emission (the \`prompt_submit.py\` paths) worked because those don't depend on the skill being callable; only the explicit-set surface (\`/wicked-garden:intent rigor\`) was unreachable.

## Fix

\`skills/smaht/intent/SKILL.md\`:
- \`name: wicked-garden:intent\` → \`name: intent\`
- Description converted to block-scalar with \`Use when:\` clause (peer-skill convention)

Plugin: 9.1.0 → 9.1.1 (patch — frontmatter only, no code changes).

## Why this is a recurring class of bug

CLAUDE.md already called out at v6.3.6: \"Claude Code's skill auto-discovery doesn't recurse into \`skills/<domain>/<name>/\` [for misconfigured frontmatter].\" The \`wicked-garden:smaht:synthesize\` skill was retired for the same kind of mismatch. Phase 4's \`/wg-check\` agent-description-discipline rule does NOT yet validate skill frontmatter \`name:\` fields. Worth filing a follow-on \`--label bug\` issue to add that lint.

## Test plan

- [x] Frontmatter parses cleanly
- [ ] After merge + reload, plugin count should be \`117 skills\` (one more than v9.1.0)
- [ ] \`/wicked-garden:smaht:intent rigor\` resolves and writes to \`SessionState.intent\`
- [ ] Bare \`<wg intent=\"rigor\" t=N />\` label appears in next system-reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)