### PR TITLE
fix(smaht): intent skill user-invocable: true — v9.1.2 patch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [9.1.2] - 2026-05-06
+
+**Patch — intent skill needs `user-invocable: true` to appear in the skill listing.**
+
+v9.1.1 fixed the frontmatter `name:` field but the `/wicked-garden:smaht:intent` skill *still* didn't appear in the skill listing after `/reload-plugins`. Investigated by comparing peer skills under `skills/smaht/`:
+
+- `skills/smaht/propose-skills/SKILL.md` — has `user-invocable: true`, LOADS into the user-facing skill list.
+- `skills/smaht/discovery/SKILL.md` — has `user-invocable: false`, intentionally hidden (called by hooks only).
+- `skills/smaht/intent/SKILL.md` (this PR) — MISSING the field, defaulted to non-invocable.
+
+Skills without an explicit `user-invocable: true` default to hidden. Phase 1's intent skill needs the explicit opt-in because users CALL it directly to override auto-detected intent.
+
+Fix: add `user-invocable: true` to the intent skill frontmatter. Plugin: 9.1.1 → 9.1.2 (patch).
+
+After `/reload-plugins`, the skill count should go from 116 → 117 with `wicked-garden:smaht:intent` registered.
+
+Same `wg-check` follow-on still pending (validate skill frontmatter `name:` AND `user-invocable:` discoverability fields). The two failure modes shipped in the same skill in two consecutive patches — both should be machine-checkable.
+
 ## [9.1.1] - 2026-05-06
 
 **Patch — fix Phase 1 intent skill discovery regression.**

--- a/skills/smaht/intent/SKILL.md
+++ b/skills/smaht/intent/SKILL.md
@@ -8,6 +8,7 @@ description: |
 
   Use when: "set intent", "intent override", "/wicked-garden:intent",
   "make the framework quiet", "force rigor", "what's my intent".
+user-invocable: true
 ---
 
 # /wicked-garden:intent


### PR DESCRIPTION
Second patch for the same skill in v9.0.0/PR #814. v9.1.1 fixed the frontmatter `name:` field but the skill STILL didn't load — the missing `user-invocable: true` declaration kept it hidden by default. Add the field; bump 9.1.1 → 9.1.2.

After `/reload-plugins`, plugin count should report **117 skills** (one more than v9.1.1's 116) with `wicked-garden:smaht:intent` registered.

**Two failures shipped in the same skill across two consecutive patches** (`name:` namespace, `user-invocable:` opt-in). Both are machine-checkable. Worth filing a follow-on `--label bug` issue: `/wg-check` should validate skill frontmatter discoverability shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)