### PR TITLE
fix: add commands/intent.md for /wicked-garden:intent slash form (v9.1.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [9.1.3] - 2026-05-06
+
+**Patch — `/wicked-garden:intent` needs a `commands/` file, not just a skill.**
+
+After v9.1.1 (frontmatter `name:` fix) and v9.1.2 (`user-invocable: true` fix), the skill was *still* missing from the registered listing after `/reload-plugins`. Investigated by comparing the actual file structure of registered peers:
+
+- `wicked-garden:smaht:propose-skills` — registered. The file is `commands/smaht/propose-skills.md` (NOT `skills/smaht/propose-skills/SKILL.md` as I'd assumed).
+- All four smaht entries in the user-facing listing (`propose-skills`, `state`, `briefing`, `events-import`) come from `commands/smaht/*.md`.
+- Skills at `skills/{domain}/{name}/SKILL.md` apparently do not surface as user-invocable slash entries in this Claude Code build.
+
+Fix: add `commands/intent.md` (top-level, no domain) so `/wicked-garden:intent` works as documented. The body is the same Python heredoc that was in `skills/smaht/intent/SKILL.md`. The skill file is left in place for now (it can be invoked via the `Skill` tool when present in the registered list); the command file is what users actually need.
+
+Two patches at the wrong layer (frontmatter shape) before realizing the layer itself was wrong (skills vs commands). The pattern: when discoverability fails, check what kind of artifact peers are first.
+
 ## [9.1.2] - 2026-05-06
 
 **Patch — intent skill needs `user-invocable: true` to appear in the skill listing.**

--- a/commands/intent.md
+++ b/commands/intent.md
@@ -1,0 +1,54 @@
+---
+allowed-tools: ["Bash"]
+description: "Show or set the session intent variable (simple-edit | feature | rigor | research). Sticky for the session; auto-detect resets next session."
+argument-hint: "[simple-edit|feature|rigor|research]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
+
+# /wicked-garden:intent
+
+Show or override the session intent variable — the v10 Phase 1 keystone (#813). Auto-detected on turn 1; sticky for the session; this command overrides explicitly.
+
+**Vocabulary (locked)**: `simple-edit | feature | rigor | research`. To change, run a brainstorm — don't add ad-hoc.
+
+**Usage**:
+- `/wicked-garden:intent` — show the effective current value and how it was set
+- `/wicked-garden:intent <value>` — explicit override; sticky until session end
+
+```bash
+ARG="${1:-}"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - "$ARG" <<'PY'
+import os
+import sys
+
+plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+if not plugin_root:
+    print("error: CLAUDE_PLUGIN_ROOT not set", file=sys.stderr)
+    sys.exit(1)
+sys.path.insert(0, os.path.join(plugin_root, "scripts"))
+
+from _session import SessionState
+
+VALID = ("simple-edit", "feature", "rigor", "research")
+arg = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+state = SessionState.load()
+
+if not arg:
+    eff = state.intent or "(not set; auto-detect runs on next turn)"
+    src = "explicit" if state.intent_explicit else "auto-detected" if state.intent else "n/a"
+    print(f"intent: {eff}  ({src})")
+    sys.exit(0)
+
+if arg not in VALID:
+    print(f"error: '{arg}' not in {VALID}", file=sys.stderr)
+    sys.exit(1)
+
+state.update(intent=arg, intent_explicit=True)
+print(f"intent set: {arg}  (explicit override; sticky until session end)")
+PY
+```
+
+After explicit override, the next system-reminder echoes a bare `<wg intent="X" t=N />` label so the model can see the user steered the framework. Auto-detected intent stays invisible (prevents confirmation bias).
+
+References: brain memory `v10-intent-variable-design-decision`, brainstorm `v10-session-01-intent-and-hook-gating`, PR #814 (the original Phase 1 ship), PRs #818/#819 (skill-discovery patches that proved skills under `skills/{domain}/{name}/SKILL.md` don't surface as slash commands — hence this command file).


### PR DESCRIPTION
Third patch in this series. v9.1.1 fixed `name:`, v9.1.2 added `user-invocable: true`, and the skill *still* didn't appear in `/reload-plugins`. Empirical investigation revealed: all registered `wicked-garden:smaht:*` entries come from `commands/smaht/*.md`, not from `skills/smaht/{name}/SKILL.md`. The skill layer doesn't surface as slash commands in this Claude Code build.

Fix: add `commands/intent.md` at the top level (matches the documented `/wicked-garden:intent` — no domain). Body is the same Python heredoc that's in the skill file.

After reload: 117 skills, with `wicked-garden:intent` in the user-facing listing.

Lesson: two patches at the wrong layer (frontmatter shape) before realizing the layer itself was wrong (skills vs commands). Issue #820 (wg-check lint) should now grow to also enforce: if a skill documents itself as `/wicked-garden:X`, there must be a matching `commands/{X}.md` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)