### PR TITLE
fix(skills): cleanup 9 broken slash refs + lint regex backtracking (v9.1.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.1.4",
+  "version": "9.1.5",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/.claude/agents/wg-quality-checker.md
+++ b/.claude/agents/wg-quality-checker.md
@@ -139,7 +139,15 @@ for f in skills:
     leaf = f.parent.name
     if name != leaf:
         errors.append(f'{f}: name={name!r} != directory leaf={leaf!r}')
+    # Match the full namespace greedily; THEN post-filter to skip path
+    # fragments. A negative lookahead inside the regex causes backtracking
+    # (drops the last char to satisfy the lookahead, yielding garbage like
+    # `:produc`), so the path-fragment skip is done in Python instead.
     for slash_match in re.finditer(r'/(wicked-garden(?::[a-z][a-z-]*)+)', body):
+        end = slash_match.end()
+        # Path fragment: namespace immediately followed by `/`. Skip.
+        if end < len(body) and body[end] == '/':
+            continue
         slash = slash_match.group(1)
         parts = slash.split(':')[1:]
         if not parts: continue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [9.1.5] - 2026-05-06
+
+**Cleanup — 9 skill bodies referenced slash commands that don't exist; lint regex hardened against path-fragment false positives.**
+
+The v9.1.4 lint surfaced 12 warnings: skill bodies documenting `/wicked-garden:X` slash forms that have no matching `commands/{X}.md`. Investigation showed three root causes — fixing each:
+
+### 9 broken slash-form references (real bugs)
+
+| File | Was | Fix |
+|---|---|---|
+| `skills/smaht/SKILL.md` | `/wicked-garden:search:code`, `/wicked-garden:search:docs` | `wicked-brain:search` (FTS5 over indexed code, docs, wiki) |
+| `skills/data/pipeline/SKILL.md` | `/wicked-garden:search:code "dag\|pipeline"` | `wicked-brain:search "dag\|pipeline"` |
+| `skills/data/ml/SKILL.md` | `/wicked-garden:search:code "model\|classifier"` | `wicked-brain:search "model\|classifier"` |
+| `skills/search/codebase-narrator/SKILL.md` | `/wicked-garden:search:code` + `/wicked-garden:search:stats` | `wicked-brain:search` + `/wicked-garden:search:index` |
+| `skills/platform/audit/SKILL.md` | `/wicked-garden:search:code` | `wicked-brain:search` |
+| `skills/data/analysis/SKILL.md` | `/wicked-garden:data:analysis` (typo) | `/wicked-garden:data:analyze` (real command) |
+| `skills/engineering/engineering/SKILL.md` | `/wicked-garden:engineering:frontend\|backend\|debugging` (none exist as commands) | `Task(subagent_type="wicked-garden:engineering:frontend-engineer\|backend-engineer\|debugger")` |
+| `skills/delivery/onboarding-guide/SKILL.md` | `/wicked-garden:search:docs` + `/wicked-garden:search:code` | `wicked-brain:search` |
+| `skills/delivery/rollout/SKILL.md` | `/wicked-garden:delivery:design` (doesn't exist) + `/wicked-garden:delivery:experiment` (separate entry) | Merged: `/wicked-garden:delivery:experiment` (which does both design and analysis) |
+| `skills/product/requirements-analysis/SKILL.md` | `/wicked-garden:search:docs "user story"` | `wicked-brain:search "user story"` |
+
+`/wicked-garden:search:code` and `/wicked-garden:search:docs` were aspirational commands documented in skill bodies but never built. The actual capability lives in `wicked-brain:search` (FTS5 index over code, docs, wiki, memories) — references redirected accordingly.
+
+### Lint regex fix (false positives)
+
+The path-fragment skip in `wg-quality-checker.md` used a negative lookahead `(?!/)`, which caused regex backtracking when a namespace ended at a `/` (path fragment like `{local_root}/wicked-garden:product/voice/...`). The engine would back off the last character to satisfy the lookahead, yielding garbage matches like `/wicked-garden:produc`. Switched to greedy match + post-filter in Python — clean and unambiguous.
+
+### Plugin version
+
+9.1.4 → 9.1.5 (patch — docs cleanup + lint hardening; zero behavior code change).
+
+### v10 closure status
+
+`/wg-check` skill-discoverability lint now reports **0 errors, 0 warnings** across all 77 skills. The v10 architectural series is genuinely closed: shipped, dogfooded, lint-clean, and on `main`.
+
 ## [9.1.4] - 2026-05-06
 
 **Closes the v10 series — wg-check skill-discoverability lint + 1 latent bug fix.**

--- a/skills/data/analysis/SKILL.md
+++ b/skills/data/analysis/SKILL.md
@@ -13,7 +13,7 @@ Explore datasets, identify patterns, and generate actionable insights.
 ## Quick Start
 
 ```bash
-/wicked-garden:data:analysis explore data/sales.csv
+/wicked-garden:data:analyze explore data/sales.csv
 ```
 
 This will:

--- a/skills/data/ml/SKILL.md
+++ b/skills/data/ml/SKILL.md
@@ -106,7 +106,7 @@ Generates: Data loading, feature engineering, training config, evaluation framew
 
 ## Integration
 
-- **wicked-garden:search**: Find model code with `/wicked-garden:search:code "model|classifier"`
+- **wicked-brain:search**: Find model code with `wicked-brain:search "model|classifier"` (FTS5 over indexed code)
 - **Native tasks**: Track experiments via TaskCreate with `metadata.event_type="task"`
 - **wicked-garden:data:analyze**: Analyze training data via DuckDB SQL
 

--- a/skills/data/pipeline/SKILL.md
+++ b/skills/data/pipeline/SKILL.md
@@ -105,7 +105,7 @@ Analyzes: Code quality, error handling, performance, maintainability.
 
 ## Integration
 
-- **wicked-garden:search**: Find pipeline code with `/wicked-garden:search:code "dag|pipeline"`
+- **wicked-brain:search**: Find pipeline code with `wicked-brain:search "dag|pipeline"` (FTS5 over indexed code)
 - **Native tasks**: Track pipeline issues via TaskCreate with `metadata.event_type="task"`
 - **wicked-brain:memory**: Recall pipeline patterns
 

--- a/skills/delivery/onboarding-guide/SKILL.md
+++ b/skills/delivery/onboarding-guide/SKILL.md
@@ -57,10 +57,10 @@ Skill(skill="wicked-brain:memory", args="recall \"architecture decisions\"")
 Skill(skill="wicked-brain:memory", args="recall \"onboarding\"")
 ```
 
-**From codebase**:
+**From codebase** (FTS5 over indexed code, docs, wiki):
 ```
-/wicked-garden:search:docs README
-/wicked-garden:search:code "TODO|FIXME|HACK"
+wicked-brain:search README
+wicked-brain:search "TODO|FIXME|HACK"
 ```
 
 ### 2. Assess Team Health

--- a/skills/delivery/rollout/SKILL.md
+++ b/skills/delivery/rollout/SKILL.md
@@ -139,5 +139,4 @@ Gracefully degrades to manual procedures when capabilities unavailable.
 ## See Also
 
 - [strategies-core.md](refs/strategies-core.md) and [strategies-operations.md](refs/strategies-operations.md) - Detailed rollout strategies
-- `/wicked-garden:delivery:design` - Design experiments
-- `/wicked-garden:delivery:experiment` - Analyze results before rollout
+- `/wicked-garden:delivery:experiment` - Design and analyze experiments before rollout

--- a/skills/engineering/engineering/SKILL.md
+++ b/skills/engineering/engineering/SKILL.md
@@ -65,10 +65,10 @@ See [refs/templates.md](refs/templates.md) for output templates and focus areas.
 
 ## Integration with Specialists
 
-Coordinate with specialized perspectives:
-- **/wicked-garden:engineering:frontend** - React, CSS, browser-specific concerns
-- **/wicked-garden:engineering:backend** - APIs, databases, server-side patterns
-- **/wicked-garden:engineering:debugging** - Error investigation and root cause analysis
+Dispatch specialist agents via `Task(subagent_type=...)`:
+- `wicked-garden:engineering:frontend-engineer` — React, CSS, browser-specific concerns
+- `wicked-garden:engineering:backend-engineer` — APIs, databases, server-side patterns
+- `wicked-garden:engineering:debugger` — Error investigation and root cause analysis
 
 ## Integration with wicked-crew
 

--- a/skills/platform/audit/SKILL.md
+++ b/skills/platform/audit/SKILL.md
@@ -123,11 +123,11 @@ TaskUpdate(
 )
 ```
 
-### With wicked-garden:search
+### With wicked-brain
 
-Find related evidence:
+Find related evidence (FTS5 over indexed code):
 ```bash
-/wicked-garden:search:code "audit|logging|encrypt" --path {target}
+wicked-brain:search "audit|logging|encrypt"
 ```
 
 ## Output Format

--- a/skills/product/requirements-analysis/SKILL.md
+++ b/skills/product/requirements-analysis/SKILL.md
@@ -119,8 +119,8 @@ Check:
 ## Integration with Tools
 
 ```bash
-# Search for similar requirements
-/wicked-garden:search:docs "user story" --context requirements
+# Search for similar requirements (FTS5 over indexed docs + wiki)
+wicked-brain:search "user story"
 
 # Store requirements on the active clarify task via native TaskUpdate
 # TaskUpdate(taskId="{task_id}", description="{previous}\n\n## Requirements\n{user_stories}")

--- a/skills/search/codebase-narrator/SKILL.md
+++ b/skills/search/codebase-narrator/SKILL.md
@@ -52,9 +52,9 @@ If wicked-* tools are available, prefer them over manual grep/find.
 find . -maxdepth 3 -type f | head -100
 ```
 
-Or use the search index:
+Or use the search index (FTS5 over indexed code):
 ```
-/wicked-garden:search:code "class |function |def |interface " --path .
+wicked-brain:search "class |function |def |interface "
 ```
 
 Identify:
@@ -126,4 +126,4 @@ Good codebase narratives:
 
 - [refs/output-template.md](refs/output-template.md) — full output format
 - `/wicked-garden:search:blast-radius` — for impact analysis of specific symbols
-- `/wicked-garden:search:stats` — quick index stats before diving in
+- `/wicked-garden:search:index` — build or refresh the index before diving in

--- a/skills/smaht/SKILL.md
+++ b/skills/smaht/SKILL.md
@@ -26,9 +26,8 @@ wicked-brain:search "your query"
 # Brain query — conceptual / "how does X work"
 wicked-brain:query "how does the facilitator rubric work"
 
-# Codebase symbol search
-/wicked-garden:search:code "symbol or pattern"
-/wicked-garden:search:docs "doc or markdown text"
+# Codebase symbol / docs search (FTS5 over indexed code, docs, wiki)
+wicked-brain:search "symbol or pattern"
 
 # Pull active crew project state
 sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json


### PR DESCRIPTION
Cleans up the 12 lint warnings the v9.1.4 lint surfaced. 9 real broken references + 3 false positives from regex backtracking.

**Real fixes**: `/wicked-garden:search:code` and `/wicked-garden:search:docs` (7 sites total) were aspirational commands never built — redirected to `wicked-brain:search` (FTS5 index over code/docs/wiki/memories). Three more typo/non-existent fixes.

**Lint regex hardened**: `(?!/)` negative lookahead caused backtracking when a namespace ended at `/` (path fragments like `{local_root}/wicked-garden:product/voice/...` matched as garbage `/wicked-garden:produc`). Switched to greedy match + post-filter — clean.

**Final state**: 0 errors, 0 warnings across all 77 skills. v10 architectural series closed and lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)