### PR TITLE
chore: remove legacy pull_* SessionState fields + orphan write paths (v9.2.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.1.5",
+  "version": "9.2.0",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -123,7 +123,7 @@ The "brain" of the plugin. Intercepts every prompt via UserPromptSubmit hook. v6
 - **Directive emission**: `simple-edit` (auto-detected) emits NOTHING — silence is the signal. `feature` / `research` emit the synthesis directive. `rigor` adds active-chain context. Auto-detected intent stays invisible to the model; only explicit overrides echo a bare `<wg intent="X" t=N />` label.
 - **Tag format**: `<wg intent="X" t=N />` (~30 bytes), replaces the legacy `<wg id="ctx" t=N phase="X" cal="Y/Z">` (~80 bytes).
 - **Empty-reminder suppression**: when nothing material is being injected (auto-detected simple-edit, no WIP, no onboarding, no hints), the entire `<system-reminder>` block is omitted rather than wrapped around an empty body.
-- **Migration boundary** (Phase 1 only): only `prompt_submit.py` reads `state.intent`. Gate-critical hooks (`phase_manager`, `gate_dispatch`) keep independent detection through one release cycle — same soak pattern as the bus-cutover. Legacy `pull_phase` / `pull_count` / `unpulled_ok` / `corrections` / `pull_regress_at` fields stay on `SessionState` for telemetry compatibility; slated for removal in a follow-up.
+- **Migration boundary** (Phase 1 only): only `prompt_submit.py` reads `state.intent`. Gate-critical hooks (`phase_manager`, `gate_dispatch`) keep independent detection through one release cycle — same soak pattern as the bus-cutover. The legacy `pull_phase` / `pull_count` / `unpulled_ok` / `corrections` / `pull_regress_at` SessionState fields shipped during Phase 1 for telemetry compatibility were removed in v9.2.0 (no consumer ever read them after v10).
 
 Six adapters query domain scripts directly: `domain`, `brain`, `events`, `context7`, `tools`, `delegation`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [9.2.0] - 2026-05-06
+
+**Cleanup — remove legacy `pull_*` SessionState fields and their orphan write-paths.**
+
+v9.0.0 (Phase 1) preserved five legacy SessionState fields (`pull_phase`, `pull_count`, `unpulled_ok`, `corrections`, `pull_regress_at`) for telemetry compatibility during the soak window. Investigation: every read site is a read-to-increment write expression (e.g. `(state.pull_count or 0) + 1`). The fields are write-only in v10 — no consumer reads them, no telemetry script references them. Pure orphan dead code that adds hook latency and confuses maintainers.
+
+### Removed
+
+- `hooks/scripts/prompt_submit.py`: `_detect_correction()` function, `_CORRECTION_SIGNALS` constant, `_REGRESS_DURATION` constant, and the call site in `main()`. The function existed only to update `corrections` / `unpulled_ok` / `pull_regress_at` for `_resolve_pull_phase` (deleted in v9.0.0). Net: -40 lines, one fewer SessionState write per turn.
+- `hooks/scripts/post_tool.py`: `pull_count` increment in the Skill handler. The branch fired on every `wicked-brain:query` / `wicked-brain:search` call to update a counter nothing reads. Net: -10 lines, one fewer SessionState write per matching Skill call.
+- `hooks/scripts/stop.py`: `_update_pull_calibration()` function and its call site. Wrote `unpulled_ok` at end-of-turn for a calibration loop that no longer exists. Net: -25 lines, one fewer SessionState write per turn.
+- `scripts/_session.py`: 5 fields removed from the `SessionState` dataclass — `pull_phase`, `pull_count`, `unpulled_ok`, `corrections`, `pull_regress_at`. Net: -15 lines including the comment block.
+- `.claude/CLAUDE.md`: updated the Phase 1 migration-boundary note to reflect that the soak window is closed and the fields are removed.
+
+### Total impact
+
+- 4 hook files cleaner; 5 SessionState fields gone; ~80 lines deleted.
+- 3 fewer SessionState writes per turn (one each from `prompt_submit`, `post_tool` on brain calls, `stop`).
+- Smaller `SessionState` JSON file on disk per session.
+
+### Plugin version
+
+9.1.5 → 9.2.0 (minor — surface change: SessionState shape changed; old session-state JSON files with the removed fields are silently ignored thanks to `_from_dict`'s unknown-key filter, so the change is backward-compatible at runtime).
+
+### Tests
+
+77/77 v10-surface tests pass: `test_prompt_submit_context_assembly_classifier`, `test_task_audit_writer`, `test_write_brief`, `test_validate_plan_test_strategy_check`.
+
 ## [9.1.5] - 2026-05-06
 
 **Cleanup — 9 skill bodies referenced slash commands that don't exist; lint regex hardened against path-fragment false positives.**

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -751,18 +751,6 @@ def _handle_skill(tool_input: dict) -> dict:
     """
     skill = (tool_input.get("skill") or "").lower()
 
-    # Pull-model tracking (Issue #416): increment pull_count when the model
-    # calls wicked-brain:query or wicked-brain:search. This feeds the
-    # calibration stats shown in the next turn's pull directive.
-    _PULL_SKILLS = ("wicked-brain:query", "wicked-brain:search")
-    if any(s in skill for s in _PULL_SKILLS):
-        try:
-            from _session import SessionState
-            state = SessionState.load()
-            state.update(pull_count=(state.pull_count or 0) + 1)
-        except Exception:
-            pass  # fail open
-
     # Memory compliance reset: zero the escalation counter when the model
     # calls wicked-brain:memory, confirming it acted on the directive.
     # Issue #608: exact match only — substring would false-positive on future

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -807,49 +807,6 @@ def _check_onboarding_gate(prompt: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Pull-model directive builder (Issue #416)
-# ---------------------------------------------------------------------------
-
-_CORRECTION_SIGNALS = frozenset({
-    "no,", "no ", "wrong", "that's not", "that isn't", "incorrect",
-    "actually,", "actually ", "not what i", "i meant", "i said",
-    "try again", "redo", "you missed", "you forgot", "you ignored",
-})
-
-
-_REGRESS_DURATION = 3  # mandatory pull lasts this many turns after regression
-
-
-def _detect_correction(prompt: str, turn_count: int, state) -> None:
-    """Check if the user's prompt is correcting the model's last response.
-
-    If so, decrement unpulled_ok, increment corrections, and trigger phase
-    regression to mandatory pull when the model has been overconfident.
-    Regression lasts for _REGRESS_DURATION turns, then normal phase resumes.
-    """
-    if not state or not prompt.strip():
-        return
-    lower = prompt.strip().lower()
-    if not any(lower.startswith(s) or s in lower for s in _CORRECTION_SIGNALS):
-        return
-    try:
-        corrections = (state.corrections or 0) + 1
-        unpulled_ok = max((state.unpulled_ok or 0) - 1, 0)
-        updates = {"corrections": corrections, "unpulled_ok": unpulled_ok}
-
-        # Trigger phase regression: force mandatory pull for the next few turns.
-        # Activates when: past bootstrap (turn > 2) and not already in regression.
-        regress_at = getattr(state, "pull_regress_at", 0) or 0
-        already_regressed = regress_at > 0 and (turn_count - regress_at) < _REGRESS_DURATION
-        if turn_count > 2 and not already_regressed:
-            updates["pull_regress_at"] = turn_count
-
-        state.update(**updates)
-    except Exception:
-        pass
-
-
-# ---------------------------------------------------------------------------
 # v10 Phase 1 (#813) — intent variable
 # ---------------------------------------------------------------------------
 # The intent variable names what five overlapping classifiers were collectively
@@ -1161,10 +1118,6 @@ def main():
         state = None
 
     turn_count = _increment_turn(state)
-
-    # Pull-model correction detection (Issue #416): check if user is correcting
-    # the model, which means it was overconfident on the previous turn.
-    _detect_correction(prompt, turn_count, state)
 
     # Session goal capture on turns 1-2
     _capture_session_goal(prompt, turn_count, project, session_id)

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -385,33 +385,6 @@ def _run_guard_pipeline() -> list:
 # Main
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Pull-model calibration update (Issue #416)
-# ---------------------------------------------------------------------------
-
-def _update_pull_calibration() -> None:
-    """Update pull-model calibration stats at the end of each model response.
-
-    Tracks whether the model pulled context this turn (via pull_count delta)
-    and increments unpulled_ok when it didn't pull but wasn't corrected.
-    Correction detection happens in prompt_submit.py at the START of the
-    next turn by checking if the new prompt contains correction signals.
-    Here we just track the "didn't pull" baseline.
-    """
-    try:
-        from _session import SessionState
-        state = SessionState.load()
-
-        # Snapshot pull_count at turn end so next turn can detect delta
-        # (stored as a transient field — no schema change needed, we use turn_tool_count)
-        # If pull_count hasn't changed since turn start, model didn't pull this turn
-        # We'll increment unpulled_ok optimistically; prompt_submit corrects on next turn
-        # if the user's follow-up contains correction signals.
-        state.update(unpulled_ok=(state.unpulled_ok or 0) + 1)
-    except Exception:
-        pass  # fail open
-
-
 def main():
     _t0 = time.monotonic()
     _log("session", "debug", "hook.start")
@@ -425,9 +398,6 @@ def main():
     try:
         session_id = input_data.get("session_id", os.environ.get("CLAUDE_SESSION_ID", "default"))
         turn_count = _get_turn_count()
-
-        # 0. Pull-model calibration update (Issue #416)
-        _update_pull_calibration()
 
         # 1. Session outcome check
         outcome_messages = _check_session_outcome()

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -220,26 +220,6 @@ class SessionState:
     turn_start_ts: str = ""
     turn_tool_count: int = 0
 
-    # Pull-model context assembly (Issue #416).
-    # Phase: bootstrap (turns 1-2, mandatory pull), calibrating (turns 3-8),
-    # cruising (turns 9+, minimal directive). Transition driven by turn count.
-    #
-    # v10 Phase 1 (#813): superseded by `intent` field below for directive
-    # selection. `pull_phase` is kept for telemetry compatibility — handler
-    # still writes it during the soak window, but `_build_intent_directive`
-    # no longer reads it. Slated for removal in Phase 2.
-    pull_phase: str = "bootstrap"  # bootstrap | calibrating | cruising
-    # Count of brain:query/search pulls the model made this session.
-    pull_count: int = 0
-    # Turns where the model answered without pulling and was NOT corrected.
-    unpulled_ok: int = 0
-    # Turns where the model was corrected after not pulling.
-    corrections: int = 0
-    # Turn number when phase was regressed to mandatory pull due to corrections.
-    # 0 means no regression active. When set, mandatory pull lasts for 3 turns
-    # from this turn number, then resumes normal phase progression.
-    pull_regress_at: int = 0
-
     # v10 Phase 1 (#813) — intent variable, the keystone for steer-not-block.
     # One explicit, queryable value replaces five overlapping classifiers
     # in prompt_submit.py (HOT fast-exit, near-HOT guard, complexity scorer,


### PR DESCRIPTION
v9.0.0 left 5 SessionState fields for telemetry compatibility during the soak window. Investigation: every read site was a read-to-increment self-write. No consumer ever read them after v10. Pure orphan dead code that added hook latency, ~80 lines of complexity, and confusion for maintainers.

**Removed**:
- `_detect_correction` + helpers in prompt_submit.py
- `pull_count` increment in post_tool.py
- `_update_pull_calibration` in stop.py
- 5 fields from SessionState (`pull_phase`, `pull_count`, `unpulled_ok`, `corrections`, `pull_regress_at`)

**Net**: -111/+30 across 4 hook files. Three fewer SessionState writes per turn.

**Backward-compat**: `SessionState._from_dict` silently filters unknown keys, so old session-state JSON files load cleanly without those fields.

**Tests**: 77/77 v10-surface tests pass.

Plugin: 9.1.5 → 9.2.0 (minor — additive cleanup, runtime-backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)