### PR TITLE
fix(qe): add run_semantic_review wrapper for Guard pipeline (v9.2.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [9.2.1] - 2026-05-06
+
+**Patch — fix the Guard pipeline's `semantic-review-unavailable` finding that fired every session.**
+
+`scripts/platform/guard_pipeline.py::_call_semantic_reviewer` does `from semantic_review import run_semantic_review`. The module exists at `scripts/qe/semantic_review.py` and exposes `review_project` + `report_to_dict` separately, but never exposed a unified `run_semantic_review` entry point. The import has been silently failing on every Guard run since the module shipped — surfacing as the harmless-looking `[info] semantic-review-unavailable` finding noted in every session-end Guard summary.
+
+### Fix
+
+Added a thin wrapper to `scripts/qe/semantic_review.py`:
+
+```python
+def run_semantic_review(project_dir: Path, complexity: int = 3) -> Dict[str, Any]:
+    report = review_project(project_dir=project_dir, complexity=complexity)
+    return report_to_dict(report)
+```
+
+12 lines including the docstring. Returns the dict shape the guard pipeline already knows how to consume (`verdict`, `findings`, `summary`).
+
+### Why it stayed broken
+
+The `_call_semantic_reviewer` function in `guard_pipeline.py` is wrapped in a defensive try/except that returns `None` on import failure, then surfaces it as a benign INFO-level finding. It looked like an intentional opt-in skip, not a contract regression. Every Guard run for an unknown number of sessions has been flagging it as "info" with no consumer noticing it was actually a real bug.
+
+### Tests
+
+15/15 tests in `tests/qe/test_semantic_review.py` pass (12 existing + 3 new):
+- `test_wrapper_exists_and_returns_dict` — module-level export check
+- `test_wrapper_no_ac_file_returns_approve_zero_findings` — wicked-garden repo case (no `phases/clarify/acceptance-criteria.md`, vacuously APPROVE)
+- `test_wrapper_includes_required_keys_for_guard_pipeline` — contract keys (`verdict`, `findings`, `summary`)
+
+### Plugin version
+
+9.2.0 → 9.2.1 (patch — wrapper addition + tests, zero behavior code change).
+
+### Expected effect
+
+Next session's Guard pipeline summary should drop the `semantic-review-unavailable` line. On the wicked-garden repo itself (no spec files), it'll silently APPROVE with zero findings. On a crew project with AC files, it'll surface real spec-to-code drift findings.
+
 ## [9.2.0] - 2026-05-06
 
 **Cleanup — remove legacy `pull_*` SessionState fields and their orphan write-paths.**

--- a/scripts/qe/semantic_review.py
+++ b/scripts/qe/semantic_review.py
@@ -891,6 +891,24 @@ def report_to_dict(report: GapReport) -> Dict[str, Any]:
     return asdict(report)
 
 
+def run_semantic_review(project_dir: Path, complexity: int = 3) -> Dict[str, Any]:
+    """Public entry point used by ``scripts/platform/guard_pipeline.py``.
+
+    Thin wrapper that runs ``review_project`` on a directory and returns the
+    JSON-safe dict ``GapReport`` representation. Returns the dict shape the
+    guard pipeline expects — keys: ``verdict``, ``findings`` (list of dicts
+    with ``message`` / ``rule_id`` / ``file`` / ``line``), ``summary``.
+
+    Fail-open responsibility lives in the caller — if the project layout
+    has no clarify-phase spec files (the common case for the wicked-garden
+    repo itself), ``review_project`` returns a vacuously-APPROVE report
+    with zero findings, which is exactly what the guard pipeline needs to
+    silently no-op.
+    """
+    report = review_project(project_dir=project_dir, complexity=complexity)
+    return report_to_dict(report)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------

--- a/tests/qe/test_semantic_review.py
+++ b/tests/qe/test_semantic_review.py
@@ -424,5 +424,49 @@ class TestSpecExtraction(unittest.TestCase):
         self.assertEqual(items, [])
 
 
+class TestRunSemanticReviewWrapper(unittest.TestCase):
+    """v9.2.1 contract: ``run_semantic_review(project_dir, complexity)`` is
+    the entry point that ``scripts/platform/guard_pipeline.py`` imports.
+    Returns the JSON-safe dict shape the guard pipeline expects.
+
+    Without this wrapper, every Guard-pipeline run reports
+    ``semantic-review-unavailable`` because the import fails — the producer
+    only exposed ``review_project`` (returns a GapReport dataclass) and
+    ``report_to_dict`` separately. The wrapper bridges the contract.
+    """
+
+    def test_wrapper_exists_and_returns_dict(self) -> None:
+        # Module-level export — the import that guard_pipeline does.
+        self.assertTrue(hasattr(semantic_review, "run_semantic_review"))
+
+    def test_wrapper_no_ac_file_returns_approve_zero_findings(self) -> None:
+        """Wicked-garden repo case: no phases/clarify/acceptance-criteria.md
+        means zero spec items, vacuously APPROVE, zero findings. The guard
+        pipeline silently no-ops in this case — that's the desired behavior."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = semantic_review.run_semantic_review(Path(tmp), complexity=3)
+            self.assertIsInstance(result, dict)
+            self.assertEqual(result["verdict"], "APPROVE")
+            self.assertEqual(result["total"], 0)
+            self.assertEqual(result["findings"], [])
+
+    def test_wrapper_includes_required_keys_for_guard_pipeline(self) -> None:
+        """guard_pipeline.py reads .verdict, .findings, .summary off the
+        returned dict — make sure all three round-trip through the
+        wrapper for a non-trivial project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = _make_project(
+                Path(tmp),
+                ac_text="| ID | Description |\n|---|---|\n| AC-1 | Persist sessions |\n",
+                impl_map={"src/session.py": "# AC-1: persist sessions\nclass Session: pass\n"},
+                test_map={},
+            )
+            result = semantic_review.run_semantic_review(project, complexity=3)
+            self.assertIn("verdict", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn(result["verdict"], {"APPROVE", "CONDITIONAL", "REJECT"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the `[info] semantic-review-unavailable` finding that has been silently appearing on every session-end Guard summary for an unknown number of sessions.

`scripts/platform/guard_pipeline.py::_call_semantic_reviewer` imports `run_semantic_review` from `scripts/qe/semantic_review.py`. The function never existed — the module only exposed `review_project` and `report_to_dict` separately. Defensive try/except in the guard pipeline silenced the ImportError and surfaced it as a benign-looking INFO finding instead.

**Fix**: 12-line thin wrapper combining `review_project` + `report_to_dict`.

**Tests**: 12 existing + 3 new = 15/15 pass.

**Effect**: next Guard run should silently APPROVE with no `semantic-review-unavailable` finding on the wicked-garden repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)