### PR TITLE
chore: silence recurring hook noise + sweep stale slash refs (v9.2.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -386,8 +386,8 @@ Tests have a maintenance cost. Optimize for catching real failures, not for asse
 ### Code Search
 
 **Always prefer search domain over native tools**:
-- For code symbol search: use `/wicked-garden:search:code` instead of Grep
-- For document search: use `/wicked-garden:search:docs` instead of Grep with glob
+- For code symbol search: use `wicked-brain:search` instead of Grep
+- For document search: use `wicked-brain:search` instead of Grep with glob
 - For impact analysis: use `/wicked-garden:search:blast-radius` instead of manual grep chains
 - For data lineage: use `/wicked-garden:search:lineage` — no native equivalent exists
 - **Fallback to Grep/Glob only** when: searching for simple string literals in known files, or index is not built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [9.2.2] - 2026-05-06
+
+**Cleanup — silence the recurring hook reminders that flooded every session.**
+
+User feedback (friction inventory item 11): the `[Memory] REQUIRED: Session ending` reminder fires every Stop hook (every turn end), creating false-urgency noise. Investigation surfaced a broader pattern — three classes of bugs causing the same kind of recurring noise.
+
+### Bugs fixed
+
+**1. Latch fields were silently dropped (real bug, multi-fire)**
+
+`SessionState.update(**kwargs)` silently drops unknown keys (prints to stderr, returns). Two latches in hooks were trying to persist via undeclared fields:
+- `instruction_sync_fired` (post_tool.py — `[Sync] CLAUDE.md was updated` reminder)
+- `scenario_stale_warned` (post_tool.py — `[Scenarios] Command/skill changed` reminder)
+
+The hooks set the fields on every fire, but the writes never persisted. The "once per session" / "once per domain" latches the comments promised never engaged. Same anti-pattern class as v9.2.0 (orphan write paths) and v9.2.1 (silent ImportError) — silent contract drift hidden by `update()`'s unknown-key tolerance.
+
+Fix: declare `instruction_sync_fired: list | None = None` in SessionState. (`scenario_stale_warned` was dropped along with the [Scenarios] notification — see #3 below.)
+
+**2. `[Memory] REQUIRED: Session ending` had no latch (every-turn fire)**
+
+The reminder in `stop.py` was unconditionally appended on every Stop hook. Stop fires at end of every model response — multiple times per session, possibly per turn. The "Session ending. REQUIRED" copy was misleading every fire after the first because the session was NOT ending. Friction inventory item 11 explicitly called this out.
+
+Fix: latched on new `memory_reminder_shown: bool` SessionState field — fires at most once per session. Copy rewritten to drop "REQUIRED" / "Session ending" / "Run TaskList" false-urgency framing. New text: "If any decisions, gotchas, or reusable patterns surfaced this session, consider storing them via wicked-brain:memory. Otherwise, no action needed. This reminder fires once per session."
+
+**3. `[Scenarios] Command/skill changed — N scenario(s) may need updating`**
+
+Low-signal heuristic that fired on every edit under `commands/{domain}/` or `skills/{domain}/`. Users rarely acted on it; the underlying premise (scenarios may need updating after a skill edit) was wrong most of the time because most edits don't invalidate scenario assertions. Plus the latch was broken (#1).
+
+Fix: dropped the call site AND removed the now-dead `_check_scenario_staleness` helper from `post_tool.py`. `/wg-test` stays available on demand for users who want to validate scenarios after edits.
+
+### Stale slash references swept
+
+Fixed 16 files that still referenced the deleted `/wicked-garden:search:code` and `/wicked-garden:search:docs` slash forms — the v9.1.5 cleanup only scanned `skills/**/SKILL.md`, missed `agents/`, `hooks/`, `scripts/`, `docs/`, `scenarios/`, and `.claude/`. Bulk-replaced with `wicked-brain:search` (the actual capability).
+
+Affected: `hooks/scripts/bootstrap.py` (Quick Start banner), `hooks/scripts/post_tool.py` (Tip suggestion), 6 agent definitions, 4 search scenarios, 1 crew scenario, `docs/getting-started.md`, `scripts/smaht/context_package.py`, `.claude/CLAUDE.md`. Lint stays at 0 errors / 0 warnings on the skills surface; the wider sweep was needed because the lint scope was scoped too narrow.
+
+### Plugin version
+
+9.2.1 → 9.2.2 (patch — pure noise reduction + sweep, zero behavior change visible to features).
+
+### Expected effect
+
+Next session should see:
+- `[Memory] ...` reminder fires AT MOST once (not on every Stop).
+- `[Sync] CLAUDE.md was updated` reminder fires AT MOST once per file (not on every edit).
+- No `[Scenarios] Command/skill in 'X' changed` reminders.
+- No `/wicked-garden:search:code` / `:docs` references in any system messages.
+
 ## [9.2.1] - 2026-05-06
 
 **Patch — fix the Guard pipeline's `semantic-review-unavailable` finding that fired every session.**

--- a/agents/data/data-engineer.md
+++ b/agents/data/data-engineer.md
@@ -32,7 +32,7 @@ When designing ETL/ELT pipelines:
 
 **Check existing patterns**:
 ```
-/wicked-garden:search:code "pipeline|etl|transform" --path {target}
+wicked-brain:search "pipeline|etl|transform" --path {target}
 ```
 
 **Design checklist**:

--- a/agents/delivery/risk-monitor.md
+++ b/agents/delivery/risk-monitor.md
@@ -40,7 +40,7 @@ Monitor these areas:
 
 Find warning signs:
 ```
-/wicked-garden:search:code "TODO|FIXME|HACK|blocked|delayed" --path .
+wicked-brain:search "TODO|FIXME|HACK|blocked|delayed" --path .
 ```
 
 Inspect the session's active tasks for blockers (native tasks live under `${CLAUDE_CONFIG_DIR}/tasks/{session_id}/`; filter by metadata.event_type).

--- a/agents/platform/devops-engineer.md
+++ b/agents/platform/devops-engineer.md
@@ -53,7 +53,7 @@ Before manual work, leverage available tools:
 
 Search for existing workflows:
 ```
-/wicked-garden:search:code "\.github/workflows|\.gitlab-ci\.yml" --path {target}
+wicked-brain:search "\.github/workflows|\.gitlab-ci\.yml" --path {target}
 ```
 
 Or manually:

--- a/agents/platform/infrastructure-engineer.md
+++ b/agents/platform/infrastructure-engineer.md
@@ -58,7 +58,7 @@ Before manual work, leverage available tools:
 
 Search for IaC files:
 ```
-/wicked-garden:search:code "terraform|\.tf$|cloudformation|kubernetes|k8s" --path {target}
+wicked-brain:search "terraform|\.tf$|cloudformation|kubernetes|k8s" --path {target}
 ```
 
 Or manually:

--- a/agents/platform/release-engineer.md
+++ b/agents/platform/release-engineer.md
@@ -59,7 +59,7 @@ Before manual work, leverage available tools:
 
 Find version files:
 ```
-/wicked-garden:search:code "version|package\.json|pyproject\.toml|Cargo\.toml|pom\.xml" --path {target}
+wicked-brain:search "version|package\.json|pyproject\.toml|Cargo\.toml|pom\.xml" --path {target}
 ```
 
 Or manually:

--- a/agents/platform/security-engineer.md
+++ b/agents/platform/security-engineer.md
@@ -57,8 +57,8 @@ Before manual analysis, leverage available tools:
 
 Use wicked-garden:search to find potential issues:
 ```
-/wicked-garden:search:code "password|secret|api_key|token" --path {target}
-/wicked-garden:search:code "eval\(|exec\(|system\(" --path {target}
+wicked-brain:search "password|secret|api_key|token" --path {target}
+wicked-brain:search "eval\(|exec\(|system\(" --path {target}
 ```
 
 Or manually:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ Runs a multi-pass review from a senior engineering perspective — architecture,
 ### 3. Search Your Codebase Structurally
 
 ```bash
-/wicked-garden:search:code "handleAuth"
+wicked-brain:search "handleAuth"
 ```
 
 Not grep — structural code intelligence across 73 languages. Find functions, classes, and methods by name. Trace data lineage from UI to database. Analyze blast radius before changing a symbol.

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -784,7 +784,7 @@ def _suggest_commands_for_project() -> str | None:
         has_ci = (cwd / ".github" / "workflows").is_dir()
 
         # Always useful
-        suggestions.append("`/wicked-garden:search:code` — semantic code search")
+        suggestions.append("`wicked-brain:search` — semantic code search")
         suggestions.append("`/wicked-garden:engineering:review` — structured code review")
 
         # Project-type-specific

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -111,7 +111,7 @@ def _bus_as_truth_flag_on() -> bool:
 _DISCOVERY_HINTS = {
     "grep_search": (
         "[Tip] wicked-garden has semantic code search: "
-        "`/wicked-garden:search:code <query>` finds symbols with context, "
+        "`wicked-brain:search <query>` finds symbols with context, "
         "or `/wicked-garden:search:blast-radius <symbol>` for impact analysis."
     ),
     "manual_review": (
@@ -208,10 +208,11 @@ def _handle_write_edit(tool_input: dict) -> dict:
     if qe_nudge:
         messages.append(qe_nudge)
 
-    # 3. Scenario staleness: warn when commands change but scenarios may be stale
-    scenario_nudge = _check_scenario_staleness(file_path)
-    if scenario_nudge:
-        messages.append(scenario_nudge)
+    # v9.2.2: dropped the [Scenarios] staleness nudge entirely. The heuristic
+    # (any edit under commands/{domain}/ or skills/{domain}/ → "scenarios in
+    # scenarios/{domain}/ may need updating") fired multiple times per
+    # session with low signal. Users rarely acted on it because most edits
+    # don't actually invalidate scenarios. /wg-test stays available on demand.
 
     result = {"continue": True}
     if messages:
@@ -441,62 +442,6 @@ def _classify_changed_files(file_paths: list) -> str:
         return "unknown"
     except Exception:
         return "unknown"
-
-
-def _check_scenario_staleness(file_path: str):
-    """When a command or skill file changes, check if scenarios exist and may be stale.
-
-    Detects edits to commands/{domain}/*.md or skills/{domain}/**.md and warns
-    if scenarios/{domain}/ exists — those scenarios may need updating to match
-    the changed command/skill behavior.
-
-    Only fires once per domain per session (avoids repeated nudges).
-    """
-    try:
-        p = Path(file_path)
-        parts = p.parts
-
-        # Detect if the file is in commands/ or skills/ under the plugin
-        domain = None
-        for i, part in enumerate(parts):
-            if part in ("commands", "skills") and i + 1 < len(parts):
-                # commands/{domain}/file.md or skills/{domain}/...
-                candidate = parts[i + 1]
-                # Skip if it looks like a filename (has extension)
-                if "." not in candidate:
-                    domain = candidate
-                    break
-
-        if not domain:
-            return None
-
-        # Check if scenarios exist for this domain
-        plugin_root = _PLUGIN_ROOT
-        scenario_dir = plugin_root / "scenarios" / domain
-        if not scenario_dir.is_dir():
-            return None
-
-        scenario_count = len(list(scenario_dir.glob("*.md")))
-        if scenario_count == 0:
-            return None
-
-        # Only nudge once per domain per session
-        from _session import SessionState
-        state = SessionState.load()
-        warned_domains = getattr(state, "scenario_stale_warned", None) or []
-        if domain in warned_domains:
-            return None
-
-        warned_domains.append(domain)
-        state.update(scenario_stale_warned=warned_domains)
-
-        return (
-            f"[Scenarios] Command/skill in '{domain}' changed — "
-            f"{scenario_count} scenario(s) in scenarios/{domain}/ may need updating. "
-            f"Run `/wg-test {domain}` or `/wicked-testing:execution scenarios/{domain}/ --all` to validate."
-        )
-    except Exception:
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -434,8 +434,12 @@ def main():
         except Exception:
             pass
 
-        # 2. Memory flush reminder — always included as directive to Claude.
-        # Auto-promotion already ran (step 2b); adjust directive accordingly.
+        # 2. Memory flush reminder — fires AT MOST once per session.
+        # Stop fires at end of every model response (per turn). Pre-v9.2.2 the
+        # reminder fired every Stop, creating false-urgency noise (friction
+        # inventory item 11). Now latched on session_state.memory_reminder_shown.
+        # After the first fire, subsequent Stop calls skip the reminder; auto-
+        # promotion (step 2b above) keeps doing its job silently.
         decay_prefix = f"{'; '.join(decay_messages)}. " if decay_messages else ""
         promoted_count = sum(
             int(m.split("Auto-extracted ")[1].split(" ")[0])
@@ -443,35 +447,47 @@ def main():
             if "Auto-extracted" in m
         ) if promotion_messages else 0
 
-        if promoted_count > 0:
-            reflection = (
-                f"[Memory] {decay_prefix}"
-                f"Auto-extracted {promoted_count} memories this session. "
-                "Review or supplement with wicked-brain:memory (recall mode) if needed. "
-                "If additional decisions or discoveries were made that were not captured, "
-                "store them with wicked-brain:memory (type: decision, procedural, or episodic)."
-            )
-        else:
-            task_count_note = (
-                f"You completed {tasks_completed_this_session} tasks this session — review each with TaskList. "
-                if tasks_completed_this_session > 0
-                else "Run TaskList to review completed tasks from this session. "
-            )
-            reflection = (
-                f"[Memory] {decay_prefix}REQUIRED: Session ending. "
-                f"{task_count_note}"
-                "For each completed task, evaluate: did it produce a decision, gotcha, or reusable pattern? "
-                "Store each learning with wicked-brain:memory "
-                "(type: decision, procedural, or episodic). "
-                "If no tasks completed or no learnings found, state 'No memories to store.' "
-                "Do NOT skip silently."
-            )
+        already_shown = bool(getattr(session_state, "memory_reminder_shown", False)) if session_state else False
+        reflection = ""
+        if not already_shown:
+            if promoted_count > 0:
+                reflection = (
+                    f"[Memory] {decay_prefix}"
+                    f"Auto-extracted {promoted_count} memories this session. "
+                    "Review or supplement with wicked-brain:memory (recall mode) if needed. "
+                    "If additional decisions or discoveries were made that were not captured, "
+                    "store them with wicked-brain:memory (type: decision, procedural, or episodic)."
+                )
+            else:
+                task_count_note = (
+                    f"You completed {tasks_completed_this_session} tasks this session. "
+                    if tasks_completed_this_session > 0
+                    else ""
+                )
+                reflection = (
+                    f"[Memory] {decay_prefix}"
+                    f"{task_count_note}"
+                    "If any decisions, gotchas, or reusable patterns surfaced this session, "
+                    "consider storing them via wicked-brain:memory (type: decision, procedural, "
+                    "or episodic). Otherwise, no action needed. This reminder fires once per session."
+                )
+            # Latch — subsequent Stop hooks skip this reminder.
+            try:
+                if session_state:
+                    session_state.update(memory_reminder_shown=True)
+            except Exception:
+                pass  # fail open — reminder may fire again, no functional harm
 
         # Combine all pre-reflection messages (outcome + promotion + consolidation + guard notices)
-        # Note: decay_messages already included via decay_prefix in reflection
+        # Note: decay_messages already included via decay_prefix in reflection.
+        # `reflection` may be empty when memory_reminder_shown is already True
+        # for this session (post-first-Stop) — only join with separator if both
+        # halves have content.
         prepend_messages = outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages
-        if prepend_messages:
+        if prepend_messages and reflection:
             final_message = "\n".join(prepend_messages) + "\n\n" + reflection
+        elif prepend_messages:
+            final_message = "\n".join(prepend_messages)
         else:
             final_message = reflection
 

--- a/scenarios/crew/01-end-to-end-feature.md
+++ b/scenarios/crew/01-end-to-end-feature.md
@@ -125,7 +125,7 @@ phases/clarify/complexity.md containing:
 ```
 
 **With wicked-search available**:
-- Dispatches to `/wicked-garden:search:code "OAuth2 implementation patterns passport.js"`
+- Dispatches to `wicked-brain:search "OAuth2 implementation patterns passport.js"`
 - Finds existing auth patterns in codebase
 
 **Without wicked-search (standalone)**:

--- a/scenarios/search/code-only-search.md
+++ b/scenarios/search/code-only-search.md
@@ -65,7 +65,7 @@ EOF
 
 2. Search code only for "cache":
    ```
-   /wicked-garden:search:code cache
+   wicked-brain:search cache
    ```
 
 3. Compare with unified search:

--- a/scenarios/search/docs-only-search.md
+++ b/scenarios/search/docs-only-search.md
@@ -77,7 +77,7 @@ EOF
 
 2. Search docs only for "password":
    ```
-   /wicked-garden:search:docs password
+   wicked-brain:search password
    ```
 
 3. Compare with unified search:

--- a/scenarios/search/incremental-indexing.md
+++ b/scenarios/search/incremental-indexing.md
@@ -75,7 +75,7 @@ EOF
 
 5. Search for the new method:
    ```
-   /wicked-garden:search:code cancel_order
+   wicked-brain:search cancel_order
    ```
 
 6. Check updated stats:

--- a/scenarios/search/onboarding-unfamiliar-codebase.md
+++ b/scenarios/search/onboarding-unfamiliar-codebase.md
@@ -181,7 +181,7 @@ EOF
 
 6. Search documentation for "User Management":
    ```
-   /wicked-garden:search:docs "User Management"
+   wicked-brain:search "User Management"
    ```
 
 7. Find what code implements user management:
@@ -198,7 +198,7 @@ EOF
 
 9. Find UserAPI implementation:
    ```
-   /wicked-garden:search:code UserAPI
+   wicked-brain:search UserAPI
    ```
 
 10. Understand dependencies of UserAPI:
@@ -215,7 +215,7 @@ EOF
 
 12. Find existing auth-related code:
     ```
-    /wicked-garden:search:code "auth"
+    wicked-brain:search "auth"
     ```
 
 13. Understand UserService dependencies before adding password reset:

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -321,6 +321,20 @@ class SessionState:
     # don't warrant individual dataclass fields.
     extras: dict | None = None
 
+    # Hook-reminder latches (v9.2.2 — per-session noise suppression).
+    # SessionState.update silently drops unknown keys, so prior to v9.2.2
+    # the latches below were write-only — the hooks SET them but the values
+    # never persisted, causing the reminders they were meant to gate to fire
+    # every time. Declaring the fields here turns the writes into reads on
+    # the next Stop / PostToolUse and the latches actually take.
+    #
+    # instruction_sync_fired: list of filenames (CLAUDE.md / AGENTS.md) for
+    #   which the [Sync] reminder has already fired this session.
+    # memory_reminder_shown: True when stop.py's [Memory] reminder has
+    #   already fired once this session — replaces the prior every-turn fire.
+    instruction_sync_fired: list | None = None
+    memory_reminder_shown: bool = False
+
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------

--- a/scripts/smaht/context_package.py
+++ b/scripts/smaht/context_package.py
@@ -58,10 +58,10 @@ PLUGIN_SKILL_MAP = {
         "wicked-brain:memory (store mode) — persist a decision or learning for future sessions",
     ],
     "search": [
-        "/wicked-garden:search:code — find code symbols (functions, classes, methods)",
+        "wicked-brain:search — find code symbols (functions, classes, methods)",
         "/wicked-garden:search:refs — find where a symbol is referenced",
         "/wicked-garden:search:blast-radius — analyze what changing a symbol affects",
-        "/wicked-garden:search:docs — search documents (PDF, markdown, Office)",
+        "wicked-brain:search — search documents (PDF, markdown, Office)",
     ],
     "tasks": [
         "TaskCreate/TaskUpdate/TaskList/TaskGet — native Claude Code task tools; metadata validated by PreToolUse",


### PR DESCRIPTION
Fixes friction inventory item 11 (the `[Memory] REQUIRED` reminder firing every turn) and the recurring hook reminders that flooded every session in this conversation. Three orthogonal bugs surfaced:

1. **Latch fields silently dropped** — `instruction_sync_fired` and `scenario_stale_warned` weren't declared in SessionState. Same anti-pattern class as v9.2.0/9.2.1.
2. **`[Memory] REQUIRED: Session ending` had no latch** — fired every Stop hook. Latched + copy rewritten.
3. **`[Scenarios] Command/skill changed` was low-signal** — dropped entirely.

Plus 16 files swept for stale `/wicked-garden:search:code` and `:search:docs` references that v9.1.5 missed (only scanned `skills/`).

Patch — zero behavior change visible to features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)