### PR TITLE
chore: 6 SessionState fields + CI drift test (v9.2.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [9.2.3] - 2026-05-06
+
+**Cleanup — fix the root cause that bit us 3× this session: declare 6 more SessionState fields, add CI test that prevents regression.**
+
+### What this fixes
+
+`SessionState.update(**kwargs)` silently drops unknown keys. v9.2.0, v9.2.2, and now v9.2.3 each surfaced field-name mismatches caused by this. A complete audit of `state.update(X=...)` and `getattr(state, "X", ...)` call sites in `hooks/scripts/` against the SessionState dataclass declaration found **6 more undeclared fields** that this session hadn't yet caught:
+
+| Field | Status before v9.2.3 | Impact |
+|---|---|---|
+| `active_chain_id` | Read by smaht events_adapter for chain-aware scoring; never declared, never written | **Smaht chain-aware scoring has been silently degraded** — every event got the 0.1 baseline instead of the documented 0.8+ chain boost |
+| `crew_project` | Read by post_tool QE check (`getattr(state, "crew_project", None)`); never declared | QE nudge always assumed no crew active |
+| `last_reeval_ts` / `last_reeval_task_count` | Read by prompt_submit re-evaluation context; never declared | Re-eval context built with default values |
+| `legacy_reeval_entries_detected` | Written by bootstrap.py:1215; never declared | Migration-detection signal never persisted |
+| `unready_plugins` | Written by bootstrap.py:1279; never declared | Plugin-readiness state never persisted |
+
+All six declared in `scripts/_session.py` with documentation explaining each one's role and producer/consumer.
+
+### CI guard added
+
+`tests/test_session_state_field_drift.py` (NEW) walks `hooks/scripts/` and asserts every `state.update(X=...)` and `getattr(state, "X", ...)` reference resolves to a declared SessionState field. Future drift fails CI rather than silently no-op in production.
+
+False-positive guard: `KNOWN_NON_SESSIONSTATE_FIELDS = {"name", "chain_id", "topics"}` — these names appear on other state objects (`ProjectState` in `scripts/crew/phase_manager.py` and `solo_mode.py`) and the audit grep can't disambiguate scope. Documented inline in the test.
+
+### Plugin version
+
+9.2.2 → 9.2.3 (patch — pure declarative cleanup + test).
+
+### The pattern, finally locked in
+
+| Anti-pattern | First surfaced | Fixed in | Now caught by |
+|---|---|---|---|
+| Orphan dead writes | v9.0.0 → v9.2.0 (-80 lines `pull_*`) | v9.2.0 | "every read is a write expression" heuristic |
+| Disguised silent failure | v9.2.1 (`run_semantic_review` import) | v9.2.1 | "constant-cadence INFO finding" heuristic |
+| Latch-field silently dropped | v9.2.2 + v9.2.3 (8 fields total) | v9.2.2 / v9.2.3 | **CI drift test** (new this release) |
+
+The CI test is the durable closure — the heuristic is now mechanical instead of relying on someone running an audit grep. 94/94 v10-surface tests + 2/2 drift tests pass.
+
 ## [9.2.2] - 2026-05-06
 
 **Cleanup — silence the recurring hook reminders that flooded every session.**

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -335,6 +335,36 @@ class SessionState:
     instruction_sync_fired: list | None = None
     memory_reminder_shown: bool = False
 
+    # v9.2.3 — fields previously USED via getattr/state.update but NEVER
+    # declared. Each was silently failing because update() drops unknown keys.
+    # Audit ran 2026-05-06 against all `state.update(X=...)` and
+    # `getattr(state, "X", ...)` call sites in hooks/ and scripts/.
+    #
+    # active_chain_id: string identifier of the active crew chain (e.g.
+    #   "{slug}.root" or "{slug}.{phase}"). Read by smaht events_adapter for
+    #   chain-aware scoring (CLAUDE.md "Chain-aware smaht scoring"). Producer
+    #   was never wired — the smaht scoring has been silently degraded. The
+    #   field declaration here makes the read return None cleanly until a
+    #   producer is added.
+    # crew_project: dict snapshot of the active crew project (slug + phase).
+    #   Read by post_tool.py QE check to skip the change-tracking nudge when
+    #   crew is handling QE. Read-only currently; declaring as None default.
+    # last_reeval_ts / last_reeval_task_count: read by prompt_submit when
+    #   building re-evaluation context. Currently read-only; declared so the
+    #   read returns the documented default rather than via getattr fallback.
+    # legacy_reeval_entries_detected: written by bootstrap.py:1215 when a
+    #   project has pre-v6 re-eval entries needing migration. Was a write-
+    #   only orphan; declaration makes it persistable.
+    # unready_plugins: written by bootstrap.py:1279 with names of plugins
+    #   whose readiness probe failed. Was a write-only orphan; declaration
+    #   makes it persistable.
+    active_chain_id: str | None = None
+    crew_project: dict | None = None
+    last_reeval_ts: str = ""
+    last_reeval_task_count: int = 0
+    legacy_reeval_entries_detected: bool = False
+    unready_plugins: list | None = None
+
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------

--- a/tests/test_session_state_field_drift.py
+++ b/tests/test_session_state_field_drift.py
@@ -1,0 +1,106 @@
+"""tests/test_session_state_field_drift.py — prevent silent SessionState drops.
+
+Provenance: this test was added in v9.2.3 after a single cleanup pass found
+SIX undeclared SessionState fields that hooks were `state.update(...)`-ing
+or `getattr(state, ...)`-reading without the field being declared in the
+dataclass. `SessionState.update(**kwargs)` silently drops unknown keys, so
+every one of those was a write-only orphan or a constant-default read.
+
+The drift bit us three times in this same session before being fixed:
+  v9.2.0 — pull_phase / pull_count / unpulled_ok / corrections / pull_regress_at
+  v9.2.2 — instruction_sync_fired (`[Sync]` reminder latch)
+  v9.2.3 — active_chain_id, crew_project, last_reeval_ts, last_reeval_task_count,
+           legacy_reeval_entries_detected, unready_plugins
+
+Same anti-pattern class as v9.2.1's `run_semantic_review` ImportError —
+silent contract drift that nobody noticed because the failure was indistinguishable
+from intentional behavior.
+
+This test scans the hooks directory and asserts every SessionState field
+reference resolves to a declared field. Adding a `state.update(new_field=...)`
+or `getattr(state, "new_field", ...)` call without declaring `new_field`
+in `SessionState` will now fail CI rather than silently no-op in production.
+
+T1: deterministic — pure file scanning, no I/O on SessionState
+T3: isolated — reads files only, no fixtures
+T4: single focus — the SessionState/hook field-name contract
+T6: docstring cites v9.2.3 (this PR) and the historical regressions
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# False-positive guard. Some scripts use `state` to refer to a non-SessionState
+# object (crew project state, dataclass instances of other shapes). Field
+# names on those don't need to match SessionState. Listed explicitly so a
+# reviewer adding a new field can see why it's exempt.
+KNOWN_NON_SESSIONSTATE_FIELDS = {
+    "name",       # ProjectState.name in scripts/crew/phase_manager.py + solo_mode.py
+    "chain_id",   # ProjectState.chain_id in scripts/crew/phase_manager.py
+    "topics",     # `state.topics` in prompt_submit's session-goal capture (different state object)
+}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SESSION_FILE = REPO_ROOT / "scripts" / "_session.py"
+HOOKS_DIR = REPO_ROOT / "hooks" / "scripts"
+
+
+def _declared_fields() -> set[str]:
+    """Parse SessionState dataclass field declarations."""
+    text = SESSION_FILE.read_text(encoding="utf-8")
+    fields = set()
+    # Match dataclass field lines: "    name: type = value" or "    name: type"
+    for m in re.finditer(r"^    ([a-z_][a-z_0-9]*)\s*:\s*[^#=]", text, re.MULTILINE):
+        fields.add(m.group(1))
+    return fields
+
+
+def _used_fields_in_hooks() -> set[str]:
+    """Walk hook scripts, return all field names referenced via
+    `state.update(name=...)` or `getattr(state, "name", ...)`.
+
+    Hooks are the canonical SessionState consumers — scripts/ has more noise
+    from non-SessionState `state` references (ProjectState, dataclass
+    parameters), so this scan is hooks-only by design.
+    """
+    used = set()
+    for f in HOOKS_DIR.rglob("*.py"):
+        text = f.read_text(encoding="utf-8")
+        for m in re.finditer(r"state\.update\(([a-z_][a-z_0-9]*)\s*=", text):
+            used.add(m.group(1))
+        for m in re.finditer(r"""getattr\(state,\s*['"]([a-z_][a-z_0-9]*)['"]""", text):
+            used.add(m.group(1))
+    return used
+
+
+def test_every_hook_state_reference_matches_a_declared_field():
+    """v9.2.3 contract: every `state.update(X=...)` or `getattr(state, "X", ...)`
+    in hook scripts must reference a declared SessionState field.
+
+    Failure means the same anti-pattern that bit v9.2.0 / v9.2.2 / v9.2.3 has
+    re-shipped. Add the field to SessionState in scripts/_session.py — or, if
+    `state` here is a different state object, add the name to
+    KNOWN_NON_SESSIONSTATE_FIELDS above with a comment explaining why.
+    """
+    declared = _declared_fields()
+    used = _used_fields_in_hooks()
+    drift = used - declared - KNOWN_NON_SESSIONSTATE_FIELDS
+    assert not drift, (
+        f"SessionState field drift detected — {len(drift)} field(s) referenced "
+        f"in hook scripts but not declared in scripts/_session.py:\n"
+        f"  {sorted(drift)}\n"
+        f"Either declare the field in SessionState (preferred — silent-drop "
+        f"is the bug) or add to KNOWN_NON_SESSIONSTATE_FIELDS with a comment."
+    )
+
+
+def test_session_state_declares_at_least_60_fields():
+    """Sanity check — if someone deletes the SessionState dataclass, the
+    drift test would pass vacuously. Anchor on the field count expected
+    after v9.2.3 (62 fields)."""
+    declared = _declared_fields()
+    assert len(declared) >= 60, (
+        f"SessionState only has {len(declared)} declared fields; "
+        f"expected ~62 after v9.2.3. Did the dataclass shrink unexpectedly?"
+    )


### PR DESCRIPTION
Same anti-pattern that bit us in v9.2.0 / v9.2.2 — `SessionState.update(**kwargs)` silently drops unknown keys. A complete audit found 6 more undeclared fields:

| Field | Impact |
|---|---|
| `active_chain_id` | **Load-bearing.** Smaht chain-aware scoring has been silently degraded (every event got the 0.1 baseline, not the documented 0.8+ boost) because the producer was never wired AND the field was undeclared |
| `crew_project` | post_tool QE nudge assumed no crew active (read-only, default None) |
| `last_reeval_ts` / `last_reeval_task_count` | re-eval context used defaults |
| `legacy_reeval_entries_detected` | bootstrap migration signal never persisted (write-only orphan) |
| `unready_plugins` | bootstrap readiness state never persisted (write-only orphan) |

**CI guard** (the durable fix): `tests/test_session_state_field_drift.py` scans `hooks/scripts/` and asserts every `state.update(X=...)` / `getattr(state, "X")` reference matches a declared SessionState field. Future drift fails CI.

The CI test is the closure for the entire anti-pattern class — the heuristic is now mechanical. 94/94 v10-surface tests + 2/2 new drift tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)