### PR TITLE
fix(smaht): wire active_chain_id producer for chain-aware scoring (v9.2.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.3",
+  "version": "9.2.4",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [9.2.4] - 2026-05-06
+
+**Wire the `active_chain_id` producer that v9.2.3 declared but didn't write.**
+
+v9.2.3 declared `active_chain_id` to close a silent contract drift, but the bigger underlying bug — there's no producer, so smaht chain-aware scoring is degraded — remained as a follow-on. v9.2.4 wires the producer.
+
+### What changed
+
+`hooks/scripts/bootstrap.py` now writes `active_chain_id` next to `active_project_id` whenever the SessionStart hook resolves the active crew project. Same is_active gate (skip when phase is `""` / `complete` / `done` / `archived`). Format mirrors the `chain_id` convention documented in CLAUDE.md "Native Tasks as Dual-Purpose Event Queue":
+
+| Project state | active_chain_id value |
+|---|---|
+| Active, in clarify phase | `{slug}.root` |
+| Active, in any other phase | `{slug}.{phase}` |
+| Inactive / archived | `None` |
+
+### Effect
+
+The smaht events_adapter's `_chain_boost` function now actually receives a non-None chain id when a crew project is running, and events whose chain_id matches the active one (or are descendants of it) get the documented 0.8+ boost instead of the silent 0.1 baseline. Chain-aware event ranking is restored on every SessionStart.
+
+### Tests
+
+- 94/94 v10-surface tests still pass
+- Drift test confirms `active_chain_id` references in the events adapter resolve to the now-declared+written field
+- Smoke test of bootstrap.py on the wicked-garden repo: no active project → `active_chain_id: None` (correct no-op)
+
+### Plugin version
+
+9.2.3 → 9.2.4 (patch — single-line wire-up of an already-declared field).
+
 ## [9.2.3] - 2026-05-06
 
 **Cleanup — fix the root cause that bit us 3× this session: declare 6 more SessionState fields, add CI test that prevents regression.**

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -1385,6 +1385,22 @@ def main():
                 is_active = active_phase not in ("", "complete", "done", "archived")
                 state.update(active_project_id=project_name if is_active else None)
 
+                # v9.2.4: also write active_chain_id so smaht's chain-aware
+                # event scoring (CLAUDE.md "Chain-aware smaht scoring") actually
+                # works. Field declared in v9.2.3, producer was missing — events
+                # got the 0.1 baseline instead of the documented 0.8+ chain
+                # boost. Format mirrors the chain_id convention in CLAUDE.md
+                # "Native Tasks as Dual-Purpose Event Queue":
+                #   {slug}.root            for the root chain
+                #   {slug}.{phase}         per active phase
+                # Cleared (set None) when the project is not active so events
+                # in unrelated sessions don't accidentally inherit the chain.
+                if is_active:
+                    chain_id = f"{project_name}.{active_phase}" if active_phase != "clarify" else f"{project_name}.root"
+                    state.update(active_chain_id=chain_id)
+                else:
+                    state.update(active_chain_id=None)
+
                 # #459 telemetry producer: anchor complexity_at_session_open
                 # from the active project's complexity_score so session-close
                 # drift capture has a delta baseline.  Only set when not


### PR DESCRIPTION
v9.2.3 declared `active_chain_id` to close the silent contract drift; this wires the missing producer so smaht chain-aware event scoring actually works.

Bootstrap.py now writes `active_chain_id` next to `active_project_id` whenever SessionStart resolves an active crew project:
- Active, clarify phase → `{slug}.root`
- Active, any other phase → `{slug}.{phase}`
- Inactive / archived → `None`

**Effect**: smaht events_adapter._chain_boost now actually receives a non-None chain id when a crew project is running. Events get the documented 0.8+ chain boost instead of the silent 0.1 baseline.

94/94 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)