### PR TITLE
chore: fix 'declared but no producer' drift + CI guard (v9.2.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.4",
+  "version": "9.2.5",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [9.2.5] - 2026-05-06
+
+**Cleanup — fix the OTHER half of the SessionState drift bug class + extend the CI drift test.**
+
+v9.2.3 / v9.2.4 caught fields declared without writers via the audit. v9.2.5 surfaces and fixes more producer gaps, plus extends the CI drift test to catch this class going forward.
+
+### Producer gaps fixed
+
+- **`active_project`** — read by `post_tool.py` (QE change-tracking nudge) and `pre_compact.py` (WIP recovery dump's "Active Project" section). Both consumers expected the dict snapshot. Producer was missing — both silently fell through to default branches. Wired in `bootstrap.py` as `state.update(active_project=dict(project_data))` next to the existing `active_chain_id` writer. Same is_active gate.
+
+- **`crew_project`** — was declared in v9.2.3 only because we noticed the `getattr(state, "crew_project", None)` read in `post_tool.py:352`. Audit confirmed nothing ever wrote it. Replaced the read with `getattr(state, "active_project_id", None)` (same intent, real producer) and removed the field declaration.
+
+### Producer gap acknowledged but deferred
+
+- **`last_reeval_ts` / `last_reeval_task_count`** — read by `scripts/crew/phase_start_gate.py` via `prompt_submit.py`'s re-eval context dict. No producer exists. **Phase_start_gate has been silently treating every check as "first time"** because both fields stay at default. The fix is feature work (find where re-eval finishes, wire the writer); deferred from this cleanup release. Tracked in `KNOWN_PRODUCER_GAPS` in the new drift test.
+
+### Extended drift test (`tests/test_session_state_field_drift.py`)
+
+New test: `test_every_declared_field_has_a_producer`. Catches "declared and read by hooks but never written" — exactly the bug class that bit `active_chain_id` (v9.2.4) and `active_project` (v9.2.5).
+
+The test detects writers via four patterns, with explicit allowlists for false positives:
+- `KNOWN_DICT_UNPACK_WRITERS`: fields written via `**updates` (regex can't reliably detect; allowlist is small and reviewable).
+- `KNOWN_PRODUCER_GAPS`: documented producer gaps that are tracked as separate work (currently `last_reeval_ts` / `last_reeval_task_count`).
+
+The audit now scans both `hooks/` AND `scripts/` for writer patterns — needed because `scripts/crew/phase_manager.py` writes `last_phase_approved` and `skip_reeval_count` via a `sess.update(...)` alias my v9.2.3 audit missed.
+
+### Plugin version
+
+9.2.4 → 9.2.5 (patch — declarative + producer wiring + test extension; zero behavior change visible to features beyond restoring the silently-degraded ones).
+
+### Cumulative drift class fixed
+
+| Surface | First broken | Fixed in | Now caught by |
+|---|---|---|---|
+| Field used but not declared (silent-drop) | v9.2.0 (5 fields) → v9.2.3 (8 fields total) | v9.2.0 / v9.2.2 / v9.2.3 | `test_every_hook_state_reference_matches_a_declared_field` |
+| Field declared but no producer (silent default) | v9.2.4 (1) → v9.2.5 (2 more) | v9.2.4 / v9.2.5 | `test_every_declared_field_has_a_producer` (NEW) |
+
+The drift class is now mechanically detected on both halves. Adding a SessionState field to either half going forward will fail CI rather than silently no-op.
+
 ## [9.2.4] - 2026-05-06
 
 **Wire the `active_chain_id` producer that v9.2.3 declared but didn't write.**

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -1401,6 +1401,20 @@ def main():
                 else:
                     state.update(active_chain_id=None)
 
+                # v9.2.5: also write active_project (the dict snapshot, distinct
+                # from active_project_id which is the slug). Read by:
+                #   - post_tool.py:1428-1431 (tracks current_phase + current_specialist
+                #     for QE change-tracking nudge)
+                #   - pre_compact.py (WIP recovery dump shows "Active Project" section)
+                # Producer was missing — both consumers got None and silently fell
+                # through their default branches. Same bug class as active_chain_id
+                # (declared, read, never written). Same fix: write in bootstrap when
+                # the project is active.
+                if is_active:
+                    state.update(active_project=dict(project_data))
+                else:
+                    state.update(active_project=None)
+
                 # #459 telemetry producer: anchor complexity_at_session_open
                 # from the active project's complexity_score so session-close
                 # drift capture has a delta baseline.  Only set when not

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -349,7 +349,10 @@ def _track_qe_change(file_path: str):
             state.update(qe_nudged=True)
 
             # Check if a crew project is active — if so, crew handles QE via execute.md
-            has_crew = bool(getattr(state, "crew_project", None))
+            # v9.2.5: replaced a getattr on a phantom field with active_project_id
+            # which is the slug bootstrap actually writes when a crew project is
+            # active. Same intent ("is a crew project active?"), real producer.
+            has_crew = bool(getattr(state, "active_project_id", None))
             if has_crew:
                 return (
                     f"[QE] {unique_count} files changed this session. "

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -346,9 +346,10 @@ class SessionState:
     #   was never wired — the smaht scoring has been silently degraded. The
     #   field declaration here makes the read return None cleanly until a
     #   producer is added.
-    # crew_project: dict snapshot of the active crew project (slug + phase).
-    #   Read by post_tool.py QE check to skip the change-tracking nudge when
-    #   crew is handling QE. Read-only currently; declaring as None default.
+    # crew_project: REMOVED in v9.2.5. The single read site in post_tool.py
+    #   was a phantom — nothing ever wrote the field. Replaced the read with
+    #   `getattr(state, "active_project_id", None)` which is the same intent
+    #   ("is a crew project active?") and has a real producer in bootstrap.
     # last_reeval_ts / last_reeval_task_count: read by prompt_submit when
     #   building re-evaluation context. Currently read-only; declared so the
     #   read returns the documented default rather than via getattr fallback.
@@ -359,7 +360,6 @@ class SessionState:
     #   whose readiness probe failed. Was a write-only orphan; declaration
     #   makes it persistable.
     active_chain_id: str | None = None
-    crew_project: dict | None = None
     last_reeval_ts: str = ""
     last_reeval_task_count: int = 0
     legacy_reeval_entries_detected: bool = False

--- a/tests/test_session_state_field_drift.py
+++ b/tests/test_session_state_field_drift.py
@@ -104,3 +104,111 @@ def test_session_state_declares_at_least_60_fields():
         f"SessionState only has {len(declared)} declared fields; "
         f"expected ~62 after v9.2.3. Did the dataclass shrink unexpectedly?"
     )
+
+
+# ---------------------------------------------------------------------------
+# v9.2.5 — extend the test to the OTHER half of the drift class:
+# fields declared and read but NEVER written. v9.2.4 surfaced this when
+# `active_chain_id` was found to have no producer (smaht chain-aware scoring
+# silently degraded). v9.2.5 surfaced two more: `active_project` and
+# `crew_project` (plus `last_reeval_ts` / `last_reeval_task_count` which are
+# known-incomplete and tracked separately).
+#
+# A field declared and read but never written is the same severity as the
+# v9.2.0–v9.2.3 drift class — the consumer always sees the dataclass default,
+# silently. The test catches that mechanically.
+# ---------------------------------------------------------------------------
+
+# Producers that the audit regex doesn't reliably detect — written via
+# `**dict_unpack` patterns or via non-state variables. Listed explicitly so
+# someone reading this list can confirm each one has a real producer.
+KNOWN_DICT_UNPACK_WRITERS = {
+    "complexity_at_session_open",  # bootstrap.py:~1411 — `updates = {"complexity_at_session_open": ...}` then state.update(**updates)
+    "complexity_score",            # same call site as above
+    "extras",                      # bootstrap.py — written via `state.update(**extras_dict)` pattern
+    "turn_count",                  # _session.py::increment_turn does direct attribute assign + save
+}
+
+# Fields with KNOWN producer gaps tracked as separate work — declared and
+# read by consumers but no writer exists. Each produces silent degradation
+# that's understood and tracked, not a regression to fix in this test.
+# Removing an entry from this set means a producer is now wired.
+KNOWN_PRODUCER_GAPS = {
+    # `last_reeval_*` are read by phase_start_gate via prompt_submit context;
+    # writer is supposed to fire after each re-eval completes (per docstring
+    # in scripts/crew/phase_start_gate.py). Phase_start_gate has been silently
+    # treating every check as "first time" because both fields stay at default.
+    # Producer wiring is feature work, deferred from cleanup releases — see
+    # the open follow-on issue for tracking.
+    "last_reeval_ts",
+    "last_reeval_task_count",
+}
+
+
+def _writer_field_names() -> set[str]:
+    """Detect ALL fields written by any producer pattern.
+
+    Patterns this catches (best-effort, not exhaustive):
+    - `state.update(field=value, ...)` — explicit kwarg
+    - `sess.update(field=value, ...)` — alias variable in scripts/crew
+    - `session_state.update(field=value, ...)` — alias variable in stop.py
+    - `state.field = value` / `state.field += value` — direct attribute write
+    - `field=` inside any update() call body (multi-line tolerant)
+    - `**dict_unpack` — captured via the KNOWN_DICT_UNPACK_WRITERS allowlist
+    """
+    written: set[str] = set()
+    for f in (HOOKS_DIR.rglob("*.py")):
+        text = f.read_text(encoding="utf-8")
+        # Catch all `name=` inside any update(...) call (multi-line OK).
+        for m in re.finditer(r"\.update\(([^)]*)\)", text, re.DOTALL):
+            for kw in re.finditer(r"([a-z_][a-z_0-9]*)\s*=", m.group(1)):
+                written.add(kw.group(1))
+        # Catch direct attribute writes on state-like vars.
+        for m in re.finditer(
+            r"(?:state|sess|session_state)\.([a-z_][a-z_0-9]*)\s*[+\-*/]?=(?!=)",
+            text,
+        ):
+            written.add(m.group(1))
+    # Also walk scripts/ for sess.update(...) producers (e.g. phase_manager.py
+    # writes last_phase_approved + skip_reeval_count via `sess.update(...)`).
+    scripts_root = REPO_ROOT / "scripts"
+    for f in scripts_root.rglob("*.py"):
+        if "tests" in f.parts:
+            continue
+        text = f.read_text(encoding="utf-8")
+        for m in re.finditer(r"\.update\(([^)]*)\)", text, re.DOTALL):
+            for kw in re.finditer(r"([a-z_][a-z_0-9]*)\s*=", m.group(1)):
+                written.add(kw.group(1))
+    return written
+
+
+def test_every_declared_field_has_a_producer():
+    """v9.2.5 contract: every declared SessionState field that ANY hook reads
+    must have at least one producer (some piece of code that writes it).
+
+    A field declared + read but never written is silently degraded — consumers
+    always see the dataclass default. v9.2.4 surfaced this for `active_chain_id`
+    (smaht chain-aware scoring); v9.2.5 fixed it for `active_project` and
+    removed `crew_project` (phantom field).
+
+    Failure means a NEW field has the same bug. Either wire a producer or
+    document the gap explicitly in KNOWN_PRODUCER_GAPS with a comment.
+    """
+    declared = _declared_fields()
+    written = _writer_field_names()
+    read_by_hooks = _used_fields_in_hooks()
+
+    # Only declared fields that are READ matter — a field declared but nobody
+    # reads is its own dead-code class (rare, not load-bearing).
+    declared_and_read = declared & read_by_hooks
+    no_producer = declared_and_read - written - KNOWN_DICT_UNPACK_WRITERS - KNOWN_PRODUCER_GAPS
+
+    assert not no_producer, (
+        f"SessionState producer gap — {len(no_producer)} field(s) declared "
+        f"and read by hooks but never written by any producer:\n"
+        f"  {sorted(no_producer)}\n"
+        f"Either wire a producer (preferred — see active_chain_id in "
+        f"hooks/scripts/bootstrap.py for the canonical pattern) or add to "
+        f"KNOWN_PRODUCER_GAPS with a comment explaining why the gap is "
+        f"acceptable (e.g. tracked as a separate issue)."
+    )


### PR DESCRIPTION
Fixes the OTHER half of the SessionState drift class and extends the CI test to catch it mechanically going forward.

**Producer gaps fixed**:
- `active_project`: read by post_tool + pre_compact, never written. Wired in bootstrap.py.
- `crew_project`: phantom field — removed declaration; replaced read with `active_project_id`.

**Deferred**: `last_reeval_ts` / `last_reeval_task_count` — feature work to wire producer; tracked in KNOWN_PRODUCER_GAPS allowlist.

**CI guard added**: `test_every_declared_field_has_a_producer` catches "declared and read by hooks but never written." Would have caught `active_chain_id` automatically.

3/3 drift tests + 95/95 v10-surface tests pass. The drift class is now mechanically detected on both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)