### PR TITLE
v9.2.8 — bump wicked_testing_version ^0.2.0 → ^0.3.0; compile silent-contract-drift wiki

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.7",
+  "version": "9.2.8",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
-  "wicked_testing_version": "^0.2.0",
+  "wicked_testing_version": "^0.3.0",
   "author": {
     "name": "Mike Parcewski"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [9.2.8] - 2026-05-06
+
+**Quick cleanup — bump `wicked_testing_version` pin + compile silent-contract-drift wiki.**
+
+### `wicked_testing_version` range bump
+
+- `plugin.json:wicked_testing_version` was `^0.2.0`. wicked-testing has shipped 0.3.x for some time, and `^0.2.0` per caret semver = `>=0.2.0 <0.3.0` rejects everything 0.3+. The result: every session bootstrap surfaced `[wicked-testing] wicked-testing 0.3.3 does not satisfy required range ^0.2.0` as a warning even though no integration was actually broken.
+- Bumped to `^0.3.0` (=`>=0.3.0 <0.4.0`). Accepts current 0.3.x patches; still alerts on a future 0.4.x major bump.
+- README "Version pinning" section updated to match (was still claiming "^0.2.0 for v7.1.x" — three minor versions stale).
+- 32/32 wicked-testing probe tests pass with the new pin. No code change in `scripts/_wicked_testing_probe.py` — the probe always evaluated `is_version_in_range(installed, pin)` correctly; the bug was the pin value, not the probe logic.
+
+### `wiki/concepts/silent-contract-drift.md` synthesised
+
+The v9.2.6 consolidation pass flagged a four-memory cluster around the same pattern — behaviour that LOOKS like working code but silently no-ops or silently degrades, with a failure mode indistinguishable from intentional behaviour. The cluster bit wicked-garden three times in one session (v9.2.0 `pull_*` orphans, v9.2.2 `instruction_sync_fired`, v9.2.3 `active_chain_id` et al), each time fixed only because a mechanical CI test scanned both halves of the contract.
+
+`wicked-brain:agent` (consolidate) compiled the cluster into `wiki/concepts/silent-contract-drift.md` (953 words, 6 indexed chunks). Article structure:
+- Pattern definition: what makes a bug "silent contract drift" — three flavours (orphan dead writes, defensive `try/except` + INFO-finding cadence, lookalike mechanisms serving different concerns).
+- Detection pattern: mechanical CI test scans BOTH halves (declared-not-written + used-not-declared). `tests/test_session_state_field_drift.py` is the canonical example.
+- Backlinks to all four source memories: `silent-info-finding-as-disguised-bug`, `subagent-skill-loading-is-feature-not-bug`, `dispatch-log-precedes-reviewer-do-not-move-to-post-hook`, `v10-native-task-store-audit-trail-decision`.
+
+The wiki article only lives in the brain index — not committed to the wicked-garden repo. The brain is the system of record for synthesised knowledge; this PR contains no wiki/ files. Followers can read it via `wicked-brain:read /path/to/silent-contract-drift.md` or `wicked-brain:search "silent contract drift"`.
+
+### Plugin version
+
+9.2.7 → 9.2.8 (patch — config bump + wiki synthesis; no behaviour change).
+
 ## [9.2.7] - 2026-05-06
 
 **Phase 2C — slim `commands/crew/execute.md` (the deferred final cleanup).**

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ wicked-garden runs standalone with local JSON storage and grep fallback when opt
 
 ### Version pinning
 
-`plugin.json:wicked_testing_version` pins a caret-range (`^0.2.0` for v7.1.x). Patch releases are backward-compatible bug fixes. Minor releases may add new Tier-1 agents (additive only). A wicked-testing major bump requires a coordinated wicked-garden major release. See [INTEGRATION.md §8](https://github.com/mikeparcewski/wicked-testing/blob/main/docs/INTEGRATION.md#8-version--compatibility).
+`plugin.json:wicked_testing_version` pins a caret-range (`^0.3.0` for v9.2.x). Patch releases are backward-compatible bug fixes. Minor releases may add new Tier-1 agents (additive only). A wicked-testing major bump requires a coordinated wicked-garden major release. See [INTEGRATION.md §8](https://github.com/mikeparcewski/wicked-testing/blob/main/docs/INTEGRATION.md#8-version--compatibility).
 
 ---
 


### PR DESCRIPTION
## Summary

- Bump `plugin.json:wicked_testing_version` from `^0.2.0` → `^0.3.0` to match shipped wicked-testing major line.
- Update README "Version pinning" section (was three minor versions stale).
- Companion: `wiki/concepts/silent-contract-drift.md` synthesised by `wicked-brain` consolidate agent (953 words, 6 chunks, 4 source memories). Lives in the brain index only — not in the repo.

## Why

Every session bootstrap surfaced this warning:

```
[wicked-testing] wicked-testing 0.3.3 does not satisfy required range ^0.2.0.
wicked-testing required — run: npx wicked-testing install
```

`^0.2.0` per caret semver = `>=0.2.0 <0.3.0`. wicked-testing has shipped 0.3.x for some time. The pin rejected the entire 0.3.x line even when no integration was actually broken — chronic noise in every session.

## Test plan

- [x] 32/32 wicked-testing probe tests passing
- [x] 3/3 SessionState field-drift tests passing
- [x] `is_version_in_range("0.3.3", "^0.3.0")` → `True` (accepts current)
- [x] `is_version_in_range("0.4.0", "^0.3.0")` → `False` (still alerts on major bump)
- [x] No code change in `scripts/_wicked_testing_probe.py` — pin value was the bug, not the probe

## No behaviour change

The probe always evaluated `is_version_in_range(installed, pin)` correctly. The pin value was simply stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)