### PR TITLE
v9.2.9 — Issue #725 bulk-pass: relevance frontmatter on 384 commands/skills + lint flips to deny

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.8",
+  "version": "9.2.9",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [9.2.9] - 2026-05-06
+
+**Issue #725 bulk-pass — relevance frontmatter on the remaining 384 commands/skills + lint flips to deny.**
+
+The `phase_relevance` / `archetype_relevance` frontmatter contract introduced with the context-aware `crew:guide` (Issue #725) shipped on a curated 15-command subset and deliberately deferred the remaining ~384 commands/skills to a follow-up PR. `WG_RELEVANCE_LINT=warn` was the bridge — it flagged the gap on every plugin load (`WARN: missing relevance frontmatter — 384 files: ... (and 379 more)`) but didn't block. v9.2.9 closes the bridge.
+
+### Bulk-pass
+
+`scripts/wg/_relevance_bulkadd.py` walks every command/skill missing one or both of the required frontmatter fields and inserts directory-derived defaults. Every domain gets a value that reflects the work it does, not blanket `["*"]`:
+
+| Domain | `phase_relevance` |
+|---|---|
+| `commands/platform/`, `skills/platform/`, `skills/delivery/` | `["build", "review", "operate"]` |
+| `commands/product/`, `skills/product/` | `["clarify", "design", "review"]` |
+| `commands/engineering/`, `skills/engineering/`, `commands/data/`, `skills/data/` | `["design", "build"]` |
+| `commands/jam/`, `skills/jam/`, `skills/multi-model/`, `skills/deliberate/` | `["clarify", "design"]` |
+| `commands/agentic/`, `skills/agentic/` | `["design", "review"]` |
+| `skills/propose-process/`, `skills/integration-discovery/` | `["bootstrap"]` |
+| `skills/worktrees/` | `["build"]` |
+| `commands/crew/`, `commands/search/`, `commands/smaht/`, `commands/persona/`, `commands/<top>/`, all cross-cutting skills | `["*"]` |
+
+`archetype_relevance` is `["*"]` everywhere at the bulk-pass stage. Future per-file scoping (e.g. narrowing `commands/data/*` to `["code-repo"]`) is a per-file judgment that doesn't add value at this scale.
+
+The bulk-add tool is preserved at `scripts/wg/_relevance_bulkadd.py` for one release in case a follow-up domain pass reuses the per-domain map. Safe to delete in a future cleanup.
+
+**Result**: 384 files edited, 17 already had frontmatter (the curated subset shipped in #725 + the v10 phase-2 work). Every command/skill now declares both fields. The bootstrap warning that fired on every plugin load is gone.
+
+### Lint default flip: `warn` → `deny`
+
+`scripts/wg/check_relevance_frontmatter.py` previously defaulted to `WG_RELEVANCE_LINT=warn`. The script's own docstring committed to the flip: "The next release flips the default after the bulk-pass follow-up PR ships." This PR is that release.
+
+- New default: `WG_RELEVANCE_LINT=deny`. Adding a new command or skill without `phase_relevance` + `archetype_relevance` now fails CI rather than emitting a warning everyone learned to ignore.
+- `warn` mode kept as a temporary opt-out during refactors that intentionally add files without frontmatter.
+- `off` mode kept as a rollback lever for emergencies.
+
+The flip is the lock that keeps the bulk-pass meaningful. Without it, this PR silences the existing warns but the next person to add a command without frontmatter re-introduces the noise.
+
+### Tests
+
+- 7/7 relevance lint tests passing.
+- 35/35 wicked-testing probe + drift tests passing.
+- All three lint modes verified: `deny` (default) → exit 0 clean; `warn` → exit 0; `off` → exit 0.
+- Pre-existing test failure: `test_yolo_md_exists` — references a deleted alias file, unrelated to this PR. Tracked separately.
+
+### Plugin version
+
+9.2.8 → 9.2.9 (patch — frontmatter bulk-pass + lint default flip; no behaviour change).
+
 ## [9.2.8] - 2026-05-06
 
 **Quick cleanup — bump `wicked_testing_version` pin + compile silent-contract-drift wiki.**

--- a/commands/agentic/audit.md
+++ b/commands/agentic/audit.md
@@ -1,6 +1,8 @@
 ---
 description: Deep trust and safety audit for agentic systems with risk classification and compliance validation
 argument-hint: "[path] [--output FILE] [--standard GDPR|HIPAA|SOC2] [--scenarios]"
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:agentic:audit

--- a/commands/agentic/design.md
+++ b/commands/agentic/design.md
@@ -1,6 +1,8 @@
 ---
 description: Interactive agentic architecture design guidance with pattern recommendations and safety validation
 argument-hint: "[problem description] [--output FILE]"
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:agentic:design

--- a/commands/agentic/frameworks.md
+++ b/commands/agentic/frameworks.md
@@ -4,6 +4,8 @@ description: |
   use case — gets latest ecosystem context via Context7. NOT for reviewing existing agentic code
   (use agentic:review) or architecture design (use agentic:design).
 argument-hint: "[--compare fw1,fw2,...] [--language python|typescript] [--use-case TYPE]"
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:agentic:frameworks

--- a/commands/agentic/review.md
+++ b/commands/agentic/review.md
@@ -1,6 +1,8 @@
 ---
 description: Full agentic codebase review with framework detection, agent topology analysis, and remediation roadmap
 argument-hint: "[path] [--quick] [--framework NAME] [--output FILE]"
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:agentic:review

--- a/commands/crew/activity.md
+++ b/commands/crew/activity.md
@@ -1,6 +1,8 @@
 ---
 description: "Query the unified event log for cross-domain activity"
 argument-hint: "[--domain D] [--project P] [--since 7d] [--fts 'search terms'] [--action A] [--limit N]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:activity

--- a/commands/crew/archive.md
+++ b/commands/crew/archive.md
@@ -3,6 +3,8 @@ description: |
   Use when a crew project is done and you want to remove it from active listings without deleting it.
   NOT for deleting projects (use reset) or checking project status (use crew:status).
 argument-hint: "<project-name> [--unarchive]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:archive

--- a/commands/crew/auto-approve.md
+++ b/commands/crew/auto-approve.md
@@ -1,6 +1,8 @@
 ---
 description: Grant or revoke auto-approve (APPROVE-verdict fast-lane) for a crew project
 argument-hint: "<project-name> --approve --justification \"<text>\" | --revoke | --status"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:auto-approve

--- a/commands/crew/convergence.md
+++ b/commands/crew/convergence.md
@@ -1,6 +1,8 @@
 ---
 description: Show artifact convergence lifecycle — states, stalls, and gate verdict
 argument-hint: "[status|record|stall|verify-gate] [--project P] [--artifact A]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:convergence

--- a/commands/crew/evidence.md
+++ b/commands/crew/evidence.md
@@ -1,6 +1,8 @@
 ---
 description: Show evidence summary for a task or project
 argument-hint: "[task-id] [--project project-id]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:evidence

--- a/commands/crew/explain.md
+++ b/commands/crew/explain.md
@@ -1,6 +1,8 @@
 ---
 description: Translate jargon-heavy crew output into plain, grade-8 English
 argument-hint: "<text-or-path-to-explain> [--style paired|plain-only]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:explain

--- a/commands/crew/feedback.md
+++ b/commands/crew/feedback.md
@@ -1,6 +1,8 @@
 ---
 description: Capture user or stakeholder feedback linked to the current crew project
 argument-hint: "<feedback-text> [--source user|stakeholder|team|monitoring] [--sentiment positive|neutral|negative]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:feedback

--- a/commands/crew/gate.md
+++ b/commands/crew/gate.md
@@ -1,6 +1,8 @@
 ---
 description: Run QE analysis on a target with configurable rigor
 argument-hint: "[target] [--gate value|strategy|execution] [--rigor quick|standard]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:gate

--- a/commands/crew/incident.md
+++ b/commands/crew/incident.md
@@ -3,6 +3,8 @@ description: |
   Use when logging a production incident that needs traceability back to an active crew project's requirements and code.
   NOT for live incident triage (use platform:incident) or post-mortems without a crew project.
 argument-hint: "<description> [--severity critical|high|medium|low] [--components comp1,comp2]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:incident

--- a/commands/crew/just-finish.md
+++ b/commands/crew/just-finish.md
@@ -1,6 +1,8 @@
 ---
 description: Execute remaining work with maximum autonomy and guardrails
 argument-hint: "[--autonomy=ask|balanced|full] [--justification \"<text>\"]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:just-finish

--- a/commands/crew/operate.md
+++ b/commands/crew/operate.md
@@ -1,6 +1,8 @@
 ---
 description: Enter and manage the operate phase for the current crew project
 argument-hint: "[--status]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:operate

--- a/commands/crew/profile.md
+++ b/commands/crew/profile.md
@@ -3,6 +3,8 @@ description: |
   Use when adjusting how wicked-crew engages — autonomy level, verbosity, or plan mode — before starting or mid-project.
   NOT for project-level configuration (use crew:start) or gate configuration (use crew:gate).
 argument-hint: "[--autonomy ask-first|balanced|just-finish] [--style verbose|balanced|concise] [--plan-mode on|off]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:profile

--- a/commands/crew/reconcile.md
+++ b/commands/crew/reconcile.md
@@ -1,6 +1,8 @@
 ---
 description: Diagnose drift between native TaskList and garden chain (read-only)
 argument-hint: "[--project=<slug> | --all] [--json]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:reconcile

--- a/commands/crew/retro.md
+++ b/commands/crew/retro.md
@@ -1,6 +1,8 @@
 ---
 description: Generate a retrospective from operate phase data
 argument-hint: "[--project project-name]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:retro

--- a/commands/crew/swarm.md
+++ b/commands/crew/swarm.md
@@ -1,5 +1,7 @@
 ---
 description: Check for quality crisis swarm trigger and recommend coalition response
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:swarm

--- a/commands/data/analyze.md
+++ b/commands/data/analyze.md
@@ -1,6 +1,8 @@
 ---
 description: Start interactive data analysis session for CSV/Excel files
 argument-hint: "<file-path> [--focus <type>] [--context <file>] [--refresh] [--scenarios]"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:analyze

--- a/commands/data/data.md
+++ b/commands/data/data.md
@@ -4,6 +4,8 @@ description: |
   report (completeness, uniqueness, validity). NOT for interactive SQL queries (use data:analyze)
   or ML pipeline work (use data:ml).
 argument-hint: "<subcommand> [args...] — profile <path> | validate --schema <schema> --data <path> | quality <path>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:data

--- a/commands/data/ml.md
+++ b/commands/data/ml.md
@@ -1,6 +1,8 @@
 ---
 description: "ML model review and training pipeline design"
 argument-hint: "<subcommand> [args...] — review <path> | pipeline --type <classification|regression|ranking>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:ml

--- a/commands/data/ontology.md
+++ b/commands/data/ontology.md
@@ -1,6 +1,8 @@
 ---
 description: Sample a dataset and recommend public or custom ontologies based on the data
 argument-hint: "<file-path>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:ontology

--- a/commands/data/pipeline.md
+++ b/commands/data/pipeline.md
@@ -1,6 +1,8 @@
 ---
 description: "Data pipeline design and review"
 argument-hint: "<subcommand> [args...] — design --source <src> --target <tgt> [--frequency <freq>] | review <path>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:pipeline

--- a/commands/deliberate.md
+++ b/commands/deliberate.md
@@ -9,6 +9,8 @@ allowed-tools:
   - AskUserQuestion
 description: "Critically analyze any work request before implementation — challenge assumptions, find root causes, identify opportunities, and propose better approaches."
 argument-hint: "<description or GH#number> [--deep] [--batch]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:deliberate

--- a/commands/delivery/experiment.md
+++ b/commands/delivery/experiment.md
@@ -1,6 +1,8 @@
 ---
 description: "Design statistically rigorous A/B test experiments"
 argument-hint: "<description> — describe what you want to test"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:delivery:experiment

--- a/commands/delivery/process-health.md
+++ b/commands/delivery/process-health.md
@@ -1,6 +1,8 @@
 ---
 description: Surface process memory — kaizen status, unresolved action items, aging alerts, and SPC drift
 argument-hint: "[--project name] [--format text|json|both] [--spc]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:delivery:process-health

--- a/commands/delivery/report.md
+++ b/commands/delivery/report.md
@@ -1,6 +1,8 @@
 ---
 description: Generate multi-perspective delivery reports from project data
 argument-hint: "<file> [--personas <list>] [--all] [--output <dir>]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:delivery:report

--- a/commands/delivery/rollout.md
+++ b/commands/delivery/rollout.md
@@ -1,6 +1,8 @@
 ---
 description: "Plan progressive feature rollouts with risk assessment"
 argument-hint: "<description> — describe the feature to roll out"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:delivery:rollout

--- a/commands/delivery/setup.md
+++ b/commands/delivery/setup.md
@@ -4,6 +4,8 @@ description: |
   commentary sensitivity. NOT for generating reports (use delivery:report) or reviewing process health (use delivery:process-health).
 argument-hint: "[--reset]"
 allowed-tools: ["Read", "Write", "AskUserQuestion"]
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:delivery:setup

--- a/commands/engineering/add-field.md
+++ b/commands/engineering/add-field.md
@@ -1,5 +1,7 @@
 ---
 description: Add a field to an entity/class and propagate to all affected files
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:add-field

--- a/commands/engineering/apply.md
+++ b/commands/engineering/apply.md
@@ -1,5 +1,7 @@
 ---
 description: Apply patches from a saved JSON file
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:apply

--- a/commands/engineering/arch.md
+++ b/commands/engineering/arch.md
@@ -4,6 +4,8 @@ description: |
   violations, or recommending design patterns. Outputs ADR-style analysis with trade-offs.
   NOT for greenfield design (use the architecture skill) or code-level review (use engineering:review).
 argument-hint: "[component or system] [--scope module|service|system]"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:arch

--- a/commands/engineering/debug.md
+++ b/commands/engineering/debug.md
@@ -4,6 +4,8 @@ description: |
   root cause, reproduction steps, fix, and prevention. NOT for code review (use engineering:review)
   or architecture analysis (use engineering:arch).
 argument-hint: "<error message, symptom, or issue description>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:debug

--- a/commands/engineering/docs.md
+++ b/commands/engineering/docs.md
@@ -3,6 +3,8 @@ description: |
   Use when generating API docs, READMEs, guides, or inline comments from existing code, or improving
   documentation that has drifted from implementation. NOT for architecture docs (use engineering:arch).
 argument-hint: "<file or component> [--type api|readme|guide|inline]"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:docs

--- a/commands/engineering/new-generator.md
+++ b/commands/engineering/new-generator.md
@@ -1,5 +1,7 @@
 ---
 description: Create a new language generator for wicked-patch with scaffolding, tests, and validation
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:new-generator

--- a/commands/engineering/patch-plan.md
+++ b/commands/engineering/patch-plan.md
@@ -1,5 +1,7 @@
 ---
 description: Show what would be affected by a change without generating patches
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:plan

--- a/commands/engineering/plan.md
+++ b/commands/engineering/plan.md
@@ -4,6 +4,8 @@ description: |
   changes, risk assessment, and test recommendations — before writing any code.
   NOT for free-form planning (use native Task planning) or architecture decisions (use engineering:arch).
 argument-hint: "<change request or issue description>"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:plan

--- a/commands/engineering/remove.md
+++ b/commands/engineering/remove.md
@@ -1,5 +1,7 @@
 ---
 description: Remove a field and all its usages from the codebase
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:remove

--- a/commands/engineering/rename.md
+++ b/commands/engineering/rename.md
@@ -1,5 +1,7 @@
 ---
 description: Rename a field/symbol across all usages in the codebase
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:engineering:rename

--- a/commands/jam/brainstorm.md
+++ b/commands/jam/brainstorm.md
@@ -1,6 +1,8 @@
 ---
 description: Start a new brainstorm session with dynamic focus groups
 argument-hint: "<topic> [--personas list] [--rounds n] [--converge fast]"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:brainstorm

--- a/commands/jam/council.md
+++ b/commands/jam/council.md
@@ -1,6 +1,8 @@
 ---
 description: Structured multi-model evaluation using external LLM CLIs for independent perspectives
 argument-hint: "<topic>" --options "A, B, C" [--criteria "perf, cost, risk"]
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:council

--- a/commands/jam/persona.md
+++ b/commands/jam/persona.md
@@ -3,6 +3,8 @@ description: |
   Use when you want to quote or trace a specific persona's position across all rounds of a brainstorm —
   e.g., "what did the Security Reviewer say across each round?" NOT for full session transcript (use jam:transcript).
 argument-hint: "<persona-name> [--session-id ID] [--json]"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:persona

--- a/commands/jam/perspectives.md
+++ b/commands/jam/perspectives.md
@@ -1,6 +1,8 @@
 ---
 description: Get multiple perspectives on a decision without synthesis
 argument-hint: "<decision or question>"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:perspectives

--- a/commands/jam/revisit.md
+++ b/commands/jam/revisit.md
@@ -1,6 +1,8 @@
 ---
 description: Revisit a past brainstorm decision and record its outcome
 argument-hint: "<topic or decision keyword>"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:revisit

--- a/commands/jam/thinking.md
+++ b/commands/jam/thinking.md
@@ -3,6 +3,8 @@ description: |
   Use when you want the raw pre-synthesis perspectives from a brainstorm — minority views, strong dissents,
   and nuances that synthesis may have compressed. NOT for the full session (use jam:transcript).
 argument-hint: "[--session-id ID] [--json]"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:thinking

--- a/commands/jam/transcript.md
+++ b/commands/jam/transcript.md
@@ -1,6 +1,8 @@
 ---
 description: View the full conversation transcript from a jam brainstorm or council session
 argument-hint: "[--session-id ID] [--json]"
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:jam:transcript

--- a/commands/persona/define.md
+++ b/commands/persona/define.md
@@ -1,6 +1,8 @@
 ---
 description: Create or update a custom persona for on-demand invocation
 argument-hint: "<name> --focus \"<focus>\" [--traits \"<t1,t2>\"] [--role <role>] [--save]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:persona:define

--- a/commands/persona/list.md
+++ b/commands/persona/list.md
@@ -1,6 +1,8 @@
 ---
 description: List all available personas with their focus and invocation syntax
 argument-hint: "[--role <role>]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:persona:list

--- a/commands/persona/submit.md
+++ b/commands/persona/submit.md
@@ -3,6 +3,8 @@ description: |
   Use when you want to contribute a locally-defined custom persona back to the wicked-garden repository
   as a built-in specialist. NOT for creating a persona (use persona:define) or invoking one (use persona:as).
 argument-hint: "<persona-name>"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:persona:submit

--- a/commands/platform/actions.md
+++ b/commands/platform/actions.md
@@ -1,6 +1,8 @@
 ---
 description: GitHub Actions workflow generation and optimization
 argument-hint: "<generate|optimize|troubleshoot> [workflow file]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:actions

--- a/commands/platform/assert.md
+++ b/commands/platform/assert.md
@@ -1,5 +1,7 @@
 ---
 description: Run contract assertions against plugin subprocess outputs
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:assert

--- a/commands/platform/audit.md
+++ b/commands/platform/audit.md
@@ -4,6 +4,8 @@ description: |
   artifacts, verifies state, and generates compliance reports. NOT for defining compliance policies
   (use platform:compliance) or ad hoc security checks (use platform:security).
 argument-hint: "<framework: soc2|hipaa|gdpr|pci> [control ID]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:audit

--- a/commands/platform/compliance.md
+++ b/commands/platform/compliance.md
@@ -1,6 +1,8 @@
 ---
 description: Regulatory compliance check (SOC2, HIPAA, GDPR, PCI)
 argument-hint: "<framework: soc2|hipaa|gdpr|pci> [path]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:compliance

--- a/commands/platform/gh.md
+++ b/commands/platform/gh.md
@@ -4,6 +4,8 @@ description: |
   or release automation — that go beyond what a plain `gh` man-page example covers.
   NOT for simple git operations (use Bash) or repo health (use platform:health).
 argument-hint: "<operation: workflows|prs|releases|repo> [args]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:gh

--- a/commands/platform/health.md
+++ b/commands/platform/health.md
@@ -4,6 +4,8 @@ description: |
   covers health probes, error pattern detection, and multi-service observability in one command.
   NOT for plugin-level diagnostics (use platform:plugin-health) or distributed tracing (use platform:traces).
 argument-hint: "[service name or 'all' for full assessment]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:health

--- a/commands/platform/incident.md
+++ b/commands/platform/incident.md
@@ -1,6 +1,8 @@
 ---
 description: Incident response and triage
 argument-hint: "<error message, alert, or symptom description>"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:incident

--- a/commands/platform/infra.md
+++ b/commands/platform/infra.md
@@ -4,6 +4,8 @@ description: |
   or security posture. NOT for application architecture review (use engineering:arch) or
   active incident response (use platform:incident).
 argument-hint: "<path to IaC files or 'scan' for discovery>"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:infra

--- a/commands/platform/plugin-health.md
+++ b/commands/platform/plugin-health.md
@@ -4,6 +4,8 @@ description: |
   queries hook traces, or adjusts log verbosity. Single entry point for all plugin-level diagnostics.
   NOT for distributed tracing (use platform:traces) or system-wide health (use platform:health).
 argument-hint: "[--plugin name] [--retry-auth] [--json]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:health

--- a/commands/platform/security.md
+++ b/commands/platform/security.md
@@ -1,6 +1,8 @@
 ---
 description: Security review and vulnerability assessment
 argument-hint: "<path, PR, or 'full' for comprehensive scan> [--scenarios]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:security

--- a/commands/platform/toolchain.md
+++ b/commands/platform/toolchain.md
@@ -1,5 +1,7 @@
 ---
 description: Discover and query engineer monitoring tools (APM, logging, metrics, cloud)
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:toolchain

--- a/commands/platform/traces.md
+++ b/commands/platform/traces.md
@@ -1,6 +1,8 @@
 ---
 description: Distributed tracing analysis for latency and dependencies
 argument-hint: "[service name, trace ID, or 'slow' for latency investigation]"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:platform:traces

--- a/commands/product/a11y.md
+++ b/commands/product/a11y.md
@@ -1,6 +1,8 @@
 ---
 description: Accessibility audit — WCAG 2.1 AA compliance, keyboard navigation, screen reader support, color contrast
 argument-hint: "<target> [--level A|AA|AAA] [--quick]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:a11y

--- a/commands/product/align.md
+++ b/commands/product/align.md
@@ -3,6 +3,8 @@ description: |
   Use when you have divergent stakeholder positions on scope, priority, or direction and need to surface
   concerns, map them to trade-offs, and build consensus. NOT for requirements elicitation (use product:elicit)
   or UX design (use product:ux).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:align

--- a/commands/product/analyze.md
+++ b/commands/product/analyze.md
@@ -2,6 +2,8 @@
 description: Analyze customer feedback for themes, sentiment, and trends
 argument-hint: "[--theme X] [--sentiment pos|neg] [--trend period]"
 next-step: "product:synthesize"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:analyze

--- a/commands/product/elicit.md
+++ b/commands/product/elicit.md
@@ -2,6 +2,8 @@
 description: |
   Use when turning a vague idea or stakeholder ask into structured user stories with acceptance criteria.
   NOT for requirements traceability graphs (use the requirements-graph skill) or UX flows (use product:ux).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:elicit

--- a/commands/product/listen.md
+++ b/commands/product/listen.md
@@ -2,6 +2,8 @@
 description: Aggregate customer feedback from available sources
 argument-hint: "[--capability type] [--days N] [--tags x,y]"
 next-step: "product:analyze"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:listen

--- a/commands/product/mockup.md
+++ b/commands/product/mockup.md
@@ -3,6 +3,8 @@ description: |
   Use when you need a quick ASCII wireframe or HTML mockup in-chat without Figma overhead.
   NOT for production design work — use the figma plugin for that.
 argument-hint: "<description-or-target> [--format ascii|html|spec] [--fidelity low|medium|high]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:mockup

--- a/commands/product/screenshot.md
+++ b/commands/product/screenshot.md
@@ -1,6 +1,8 @@
 ---
 description: Screenshot-based UI review using Claude's multimodal vision — analyze layout, color, typography, and consistency from image files
 argument-hint: "<image-path> [<reference-path>]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:screenshot

--- a/commands/product/strategy.md
+++ b/commands/product/strategy.md
@@ -1,6 +1,8 @@
 ---
 description: Strategic analysis - ROI, value proposition, market, competitive
 argument-hint: "<target> [--focus roi|value|market|competitive|all]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:strategy

--- a/commands/product/synthesize.md
+++ b/commands/product/synthesize.md
@@ -2,6 +2,8 @@
 description: Generate actionable recommendations from customer feedback insights
 argument-hint: "[--priority high|medium|low] [--feature X] [--format brief|detailed]"
 next-step: null
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:synthesize

--- a/commands/product/ux-review.md
+++ b/commands/product/ux-review.md
@@ -4,6 +4,8 @@ description: |
   design system adherence, spacing/typography/color, component patterns, and research quality.
   NOT for generating UX flows (use product:ux) or accessibility code audits (use product:a11y).
 argument-hint: "<target> [--focus flows|ui|a11y|research|all] [--quick]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:ux-review

--- a/commands/product/ux.md
+++ b/commands/product/ux.md
@@ -3,6 +3,8 @@ description: |
   Use when creating or analyzing user flows, information architecture, and interaction patterns — in-chat,
   without a design tool. NOT for production visual design (use figma plugin) or accessibility audits (use product:a11y).
 argument-hint: "<target-or-description> [--mode create|analyze]"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:product:ux

--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -8,6 +8,8 @@ allowed_tools:
   - Grep
   - AskUserQuestion
   - Skill
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:report-issue

--- a/commands/reset.md
+++ b/commands/reset.md
@@ -2,6 +2,8 @@
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 description: "Reset wicked-garden to a clean state — choose which data to clear"
 argument-hint: "[--all] [--only domain1,domain2] [--keep domain] [--force] [--list-projects] [--all-projects]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:reset

--- a/commands/search/categories.md
+++ b/commands/search/categories.md
@@ -4,6 +4,8 @@ description: |
   and how they relate across architectural layers. Unique graph-shape output from the wicked-garden index.
   NOT for finding a specific symbol (use wicked-brain:search) or counting files (use Bash).
 argument-hint: "[--project <name>]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:categories

--- a/commands/search/coverage.md
+++ b/commands/search/coverage.md
@@ -4,6 +4,8 @@ description: |
   with no upstream or downstream connections. Unique to the wicked-garden graph index.
   NOT for general code search (use wicked-brain:search) or impact analysis (use search:blast-radius).
 argument-hint: "[--type <symbol_type>] [--show-orphans]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:coverage

--- a/commands/search/index.md
+++ b/commands/search/index.md
@@ -1,6 +1,8 @@
 ---
 description: Build unified index for code and documents in a directory
 argument-hint: "<path>"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:index

--- a/commands/search/lineage.md
+++ b/commands/search/lineage.md
@@ -1,6 +1,8 @@
 ---
 description: Trace data lineage from source to sink (UI → DB or reverse)
 argument-hint: "<symbol> [--direction upstream|downstream|both] [--depth N]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:lineage

--- a/commands/search/quality.md
+++ b/commands/search/quality.md
@@ -4,6 +4,8 @@ description: |
   and auto-fill the index until >=95% accuracy. NOT for one-time validation checks (use search:validate)
   or browsing index contents (use wicked-brain:search).
 argument-hint: "[--max-iterations N]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:quality

--- a/commands/search/service-map.md
+++ b/commands/search/service-map.md
@@ -1,6 +1,8 @@
 ---
 description: Detect and visualize the service architecture from infrastructure and code patterns
 argument-hint: "[project_root] [--format table|json|mermaid]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:service-map

--- a/commands/search/sources.md
+++ b/commands/search/sources.md
@@ -1,6 +1,8 @@
 ---
 description: Manage external content sources for the search index
 argument-hint: "list | add | remove <name> | refresh [--force]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:sources

--- a/commands/search/validate.md
+++ b/commands/search/validate.md
@@ -3,6 +3,8 @@ description: |
   Use when you need a quick consistency check on the brain index before relying on it for impact analysis.
   NOT for repairing index gaps (use search:quality) or browsing indexed content (use wicked-brain:search).
 argument-hint: "[--sample-size N] [--format table|json]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:search:validate

--- a/commands/smaht/briefing.md
+++ b/commands/smaht/briefing.md
@@ -3,6 +3,8 @@ description: |
   Use when starting a new session and you want to know what happened since the last one — recent events,
   active crew projects, and memory updates. NOT for live session state inspection (use smaht:state).
 argument-hint: "[--days N] [--project name]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:smaht:briefing

--- a/commands/smaht/events-import.md
+++ b/commands/smaht/events-import.md
@@ -1,6 +1,8 @@
 ---
 description: "Import existing domain JSON records into the unified event log"
 argument-hint: "[--domain D] [--dry-run]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:smaht:events-import

--- a/commands/smaht/propose-skills.md
+++ b/commands/smaht/propose-skills.md
@@ -3,6 +3,8 @@ description: |
   Mine recent Claude Code session transcripts to propose skills that would
   automate repetitive patterns. Read-only MVP — outputs a markdown report only.
 argument-hint: "[--project=SLUG] [--limit=N] [--json]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:smaht:propose-skills

--- a/commands/smaht/state.md
+++ b/commands/smaht/state.md
@@ -3,6 +3,8 @@ description: |
   Use when you need to inspect live SessionState, adapter outputs, or smaht directive settings.
   NOT for what-happened-since-last-session (use smaht:briefing).
 argument-hint: "[--state] [--events N] [--json]"
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:smaht:state

--- a/scripts/wg/_relevance_bulkadd.py
+++ b/scripts/wg/_relevance_bulkadd.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""scripts/wg/_relevance_bulkadd.py — Issue #725 bulk-pass tooling.
+
+One-shot script that adds `phase_relevance` and `archetype_relevance`
+frontmatter fields to every command/skill that lacks them. Directory-derived
+defaults — every file gets a value that reflects its purpose rather than a
+blanket `["*"]`.
+
+This file lives under `scripts/wg/` (the dev-tools tree). After the bulk pass
+ships and `WG_RELEVANCE_LINT` flips to `deny`, this script becomes legacy —
+it's safe to delete in a future cleanup. We keep it for one release in case
+a follow-up domain pass reuses the per-domain map.
+
+Usage:
+    sh scripts/_python.sh scripts/wg/_relevance_bulkadd.py [--dry-run]
+
+R1: no dead code — each helper is called from main().
+R3: constants named (DEFAULTS_BY_DOMAIN, REQUIRED_FIELDS).
+R5: subprocess-free — pure stdlib.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Per-domain phase defaults. Archetype is "*" everywhere — narrowing per
+# directory adds no signal at the bulk-pass stage.
+DEFAULTS_BY_DOMAIN: dict[tuple[str, str], list[str]] = {
+    # commands/
+    ("commands", "<top>"): ["*"],
+    ("commands", "crew"): ["*"],
+    ("commands", "platform"): ["build", "review", "operate"],
+    ("commands", "product"): ["clarify", "design", "review"],
+    ("commands", "engineering"): ["design", "build"],
+    ("commands", "search"): ["*"],
+    ("commands", "jam"): ["clarify", "design"],
+    ("commands", "delivery"): ["build", "review", "operate"],
+    ("commands", "data"): ["design", "build"],
+    ("commands", "agentic"): ["design", "review"],
+    ("commands", "smaht"): ["*"],
+    ("commands", "persona"): ["*"],
+    ("commands", "mem"): ["*"],
+    # skills/
+    ("skills", "engineering"): ["design", "build"],
+    ("skills", "product"): ["clarify", "design", "review"],
+    ("skills", "platform"): ["build", "review", "operate"],
+    ("skills", "agentic"): ["design", "review"],
+    ("skills", "propose-process"): ["bootstrap", "clarify"],
+    ("skills", "multi-model"): ["clarify", "design"],
+    ("skills", "deliberate"): ["clarify", "design"],
+    ("skills", "crew"): ["*"],
+    ("skills", "delivery"): ["build", "review", "operate"],
+    ("skills", "wickedizer"): ["*"],
+    ("skills", "workflow"): ["*"],
+    ("skills", "data"): ["design", "build"],
+    ("skills", "integration-discovery"): ["bootstrap"],
+    ("skills", "smaht"): ["*"],
+    ("skills", "jam"): ["clarify", "design"],
+    ("skills", "worktrees"): ["build"],
+    ("skills", "search"): ["*"],
+    ("skills", "runtime-exec"): ["*"],
+    ("skills", "ground"): ["*"],
+    ("skills", "facilitator-score"): ["clarify"],
+    ("skills", "persona"): ["*"],
+}
+
+DEFAULT_ARCHETYPE: list[str] = ["*"]
+REQUIRED_FIELDS: tuple[str, ...] = ("phase_relevance", "archetype_relevance")
+_FRONTMATTER_BLOCK = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+def _domain_key(path: Path) -> tuple[str, str]:
+    """Return (root, domain) for a command/skill path. Top-level files
+    under commands/ get domain "<top>"."""
+    parts = path.parts
+    if len(parts) >= 3:
+        return (parts[0], parts[1])
+    return (parts[0], "<top>")
+
+
+def _phase_for(path: Path) -> list[str]:
+    key = _domain_key(path)
+    return DEFAULTS_BY_DOMAIN.get(key, ["*"])
+
+
+def _has_field(text: str, field: str) -> bool:
+    m = _FRONTMATTER_BLOCK.match(text)
+    if not m:
+        return False
+    block = m.group(1)
+    pat = re.compile(rf"^{re.escape(field)}\s*:", re.MULTILINE)
+    return bool(pat.search(block))
+
+
+def _format_list(values: list[str]) -> str:
+    return "[" + ", ".join(f'"{v}"' for v in values) + "]"
+
+
+def _insert_fields(text: str, phase_values: list[str]) -> str:
+    """Insert missing fields before the closing `---` of the frontmatter
+    block. If no frontmatter exists, prepend a new one."""
+    new_lines: list[str] = []
+    if not _has_field(text, "phase_relevance"):
+        new_lines.append(f"phase_relevance: {_format_list(phase_values)}")
+    if not _has_field(text, "archetype_relevance"):
+        new_lines.append(f"archetype_relevance: {_format_list(DEFAULT_ARCHETYPE)}")
+
+    if not new_lines:
+        return text  # nothing to add — both fields already present
+
+    m = _FRONTMATTER_BLOCK.match(text)
+    if m:
+        # Insert before the closing ---. Frontmatter ends at m.end().
+        # The closing fence is the second "---". m.end() includes it.
+        # We want to insert the new lines RIGHT before the closing fence.
+        inner = m.group(1)
+        # Find offset of closing ---. m.end() points to char after the
+        # closing ---, but text[m.start():m.end()] = "---\n<inner>\n---".
+        # Easiest: rebuild the frontmatter from inner + new + closing fence.
+        rebuilt = "---\n" + inner.rstrip() + "\n" + "\n".join(new_lines) + "\n---"
+        return rebuilt + text[m.end():]
+    # No frontmatter at all — prepend a new block.
+    return "---\n" + "\n".join(new_lines) + "\n---\n" + text
+
+
+def _iter_targets(repo_root: Path) -> list[Path]:
+    out: list[Path] = []
+    for sub in ("commands", "skills"):
+        root = repo_root / sub
+        if root.is_dir():
+            out.extend(sorted(root.rglob("*.md")))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    dry_run = "--dry-run" in argv
+
+    targets = _iter_targets(repo_root)
+    edited = 0
+    skipped = 0
+    for path in targets:
+        rel = path.relative_to(repo_root)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as e:
+            sys.stderr.write(f"WARN: cannot read {rel}: {e}\n")
+            continue
+
+        if _has_field(text, "phase_relevance") and _has_field(text, "archetype_relevance"):
+            skipped += 1
+            continue
+
+        new_text = _insert_fields(text, _phase_for(rel))
+        if new_text == text:
+            skipped += 1
+            continue
+
+        if not dry_run:
+            path.write_text(new_text, encoding="utf-8")
+        edited += 1
+
+    label = "WOULD EDIT" if dry_run else "EDITED"
+    sys.stdout.write(
+        f"{label}: {edited} files; SKIPPED (already complete): {skipped} files\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/wg/check_relevance_frontmatter.py
+++ b/scripts/wg/check_relevance_frontmatter.py
@@ -6,17 +6,13 @@ Scans ``commands/**/*.md`` and ``skills/**/*.md`` for the
 Issue #725 reframe (context-aware ``crew:guide``).
 
 Modes (env: ``WG_RELEVANCE_LINT``)
-  - ``warn`` (default for this release): emit a single WARN line listing the
-    first ``MAX_LISTED`` offending paths and exit 0. Allows the curated
-    15-command subset to land without forcing a 240-file bulk pass.
-  - ``deny``: same scan, but exit non-zero so CI fails. The next release flips
-    the default after the bulk-pass follow-up PR ships.
+  - ``deny`` (default since v9.2.9): same scan, but exit non-zero so CI fails.
+    The bulk-pass PR (#834, v9.2.9) added frontmatter to the remaining 384
+    commands/skills, so the lint can now block regressions.
+  - ``warn``: emit a single WARN line listing the first ``MAX_LISTED`` offending
+    paths and exit 0. Useful as a temporary opt-out during a refactor that
+    intentionally adds files without frontmatter.
   - ``off``: skip the scan entirely (rollback lever for emergencies).
-
-Why warn-only this release: the reframe ships frontmatter on a CURATED
-15-command subset (the daily-driver list). Bulk-editing the remaining ~225
-commands/skills is intentionally deferred to a follow-up PR so reviewers can
-audit one diff at a time. Once that PR lands, flip the default to ``deny``.
 
 R1: no dead code — every helper is called from main().
 R3: constants named (``MAX_LISTED``, ``ENV_MODE`` etc.).
@@ -38,7 +34,7 @@ ENV_MODE: str = "WG_RELEVANCE_LINT"
 MODE_WARN: str = "warn"
 MODE_DENY: str = "deny"
 MODE_OFF: str = "off"
-DEFAULT_MODE: str = MODE_WARN
+DEFAULT_MODE: str = MODE_DENY
 VALID_MODES: tuple[str, ...] = (MODE_WARN, MODE_DENY, MODE_OFF)
 MAX_LISTED: int = 5
 
@@ -140,8 +136,8 @@ def main(argv: list[str]) -> int:
     )
     if mode == MODE_WARN:
         sys.stdout.write(
-            f"NOTE: {ENV_MODE}={MODE_WARN} (warn-only this release; flips to "
-            f"{MODE_DENY!r} after the bulk-pass follow-up PR — Issue #725).\n"
+            f"NOTE: {ENV_MODE}={MODE_WARN} (default since v9.2.9 is "
+            f"{MODE_DENY!r}; warn mode is the temporary opt-out).\n"
         )
         return 0
     return 1

--- a/skills/agentic/agentic-patterns/SKILL.md
+++ b/skills/agentic/agentic-patterns/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Runtime → Governance) for separating concerns in production-grade agentic systems.
   NOT for reviewing existing agentic code (use review-methodology) or framework selection (use the frameworks skill).
 portability: portable
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Agentic Patterns

--- a/skills/agentic/agentic-patterns/refs/anti-patterns-design.md
+++ b/skills/agentic/agentic-patterns/refs/anti-patterns-design.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Anti-Patterns in Agentic Systems: Design
 
 Common design mistakes in agentic systems and how to fix them. Covers God Agent, Tight Coupling, Missing Guardrails, Deep Nesting, and No Observability.

--- a/skills/agentic/agentic-patterns/refs/anti-patterns-operational.md
+++ b/skills/agentic/agentic-patterns/refs/anti-patterns-operational.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Anti-Patterns in Agentic Systems: Operational
 
 Operational anti-patterns including Sequential Bottleneck, Context Bloat, Redundant Agents, Hardcoded Prompts, and Missing Timeouts.

--- a/skills/agentic/agentic-patterns/refs/pattern-catalog.md
+++ b/skills/agentic/agentic-patterns/refs/pattern-catalog.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Pattern Catalog
 
 Detailed reference for agentic architecture patterns with implementation guidance.

--- a/skills/agentic/context-engineering/SKILL.md
+++ b/skills/agentic/context-engineering/SKILL.md
@@ -7,6 +7,8 @@ description: |
   scope for short / long-term / episodic state, or applying a context-loading
   strategy (anticipatory / JIT / hybrid).
 portability: portable
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Context Engineering

--- a/skills/agentic/context-engineering/refs/caching-and-optimization.md
+++ b/skills/agentic/context-engineering/refs/caching-and-optimization.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Caching, Batching & Cost Optimization
 
 Advanced strategies for reducing API costs through caching, batching, and intelligent model selection.

--- a/skills/agentic/context-engineering/refs/compression-techniques.md
+++ b/skills/agentic/context-engineering/refs/compression-techniques.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Context Optimization Techniques
 
 Advanced strategies for minimizing token usage while maximizing context quality.

--- a/skills/agentic/context-engineering/refs/cost-calculation-budget.md
+++ b/skills/agentic/context-engineering/refs/cost-calculation-budget.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Token Cost Models and Budgeting
 
 Comprehensive guide to calculating, tracking, and optimizing token costs in agentic systems.

--- a/skills/agentic/context-engineering/refs/cost-optimization-reporting.md
+++ b/skills/agentic/context-engineering/refs/cost-optimization-reporting.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Cost Optimization & Reporting
 
 Strategies for estimating, optimizing, and reporting on token costs in agentic systems.

--- a/skills/agentic/context-engineering/refs/selective-loading.md
+++ b/skills/agentic/context-engineering/refs/selective-loading.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Selective Loading & Token-Aware Prompting
 
 Strategies for loading only relevant context and adapting prompts to available token budgets.

--- a/skills/agentic/frameworks/SKILL.md
+++ b/skills/agentic/frameworks/SKILL.md
@@ -5,6 +5,8 @@ description: |
   curated comparison by use case, language, and maturity. Gets latest context via Context7 when available.
   NOT for reviewing existing agentic code (use review-methodology) or architecture patterns (use agentic-patterns).
 portability: portable
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Agentic Frameworks

--- a/skills/agentic/frameworks/refs/framework-profiles-1.md
+++ b/skills/agentic/frameworks/refs/framework-profiles-1.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Framework Detailed Profiles
 
 In-depth analysis of top 6 agentic frameworks.

--- a/skills/agentic/frameworks/refs/framework-profiles-2.md
+++ b/skills/agentic/frameworks/refs/framework-profiles-2.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Framework Profiles (Part 2)
 
 Detailed profiles of AutoGen, Pydantic AI, and LlamaIndex Agents.

--- a/skills/agentic/frameworks/refs/migration-patterns-paths.md
+++ b/skills/agentic/frameworks/refs/migration-patterns-paths.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Framework Migration Patterns: Common Paths
 
 Why to migrate, general strategy, and common migration paths between agentic frameworks.

--- a/skills/agentic/frameworks/refs/migration-patterns-testing.md
+++ b/skills/agentic/frameworks/refs/migration-patterns-testing.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Framework Migration Patterns: Testing, Rollback & Advanced Paths
 
 Migration testing strategy, rollback planning, advanced migration paths, effort estimates, and when not to migrate.

--- a/skills/agentic/review-methodology/SKILL.md
+++ b/skills/agentic/review-methodology/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Reliable → Production → Optimized) for assessing production readiness.
   NOT for architecture design (use agentic-patterns) or live agentic review with a subagent (use agentic:review command).
 portability: portable
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Agentic Review Methodology

--- a/skills/agentic/review-methodology/refs/deliverable-templates.md
+++ b/skills/agentic/review-methodology/refs/deliverable-templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Review Deliverable Templates
 
 Complete templates for all review report types.

--- a/skills/agentic/review-methodology/refs/issue-taxonomy-quality-testing.md
+++ b/skills/agentic/review-methodology/refs/issue-taxonomy-quality-testing.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Issue Taxonomy: Performance, Quality, Observability & Testing
 
 Issue categories for agentic system reviews covering performance, code quality, observability, testing, and severity guidelines.

--- a/skills/agentic/review-methodology/refs/issue-taxonomy-reliability-safety.md
+++ b/skills/agentic/review-methodology/refs/issue-taxonomy-reliability-safety.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Issue Taxonomy: Reliability, Security & Safety
 
 Complete reference of issue categories for agentic system reviews covering reliability, security, safety, and cost issues.

--- a/skills/agentic/trust-and-safety/SKILL.md
+++ b/skills/agentic/trust-and-safety/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Use when: designing guardrails or human-in-the-loop gates for an agent, or
   hardening an agentic system against prompt injection.
 portability: portable
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Trust and Safety

--- a/skills/agentic/trust-and-safety/refs/guardrails-actions.md
+++ b/skills/agentic/trust-and-safety/refs/guardrails-actions.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Guardrail Implementation - Actions and Approvals
 
 Action whitelisting, pre-flight validation, sandboxed execution, and approval workflows.

--- a/skills/agentic/trust-and-safety/refs/guardrails-input-output.md
+++ b/skills/agentic/trust-and-safety/refs/guardrails-input-output.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Guardrail Implementation - Input and Output Patterns
 
 Input validation, sanitization, prompt injection detection, and output filtering patterns.

--- a/skills/agentic/trust-and-safety/refs/guardrails-resources.md
+++ b/skills/agentic/trust-and-safety/refs/guardrails-resources.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Guardrail Implementation - Resources and Monitoring
 
 Resource limiting, adaptive rate limiting, anomaly detection, and complete guardrail system architecture.

--- a/skills/agentic/trust-and-safety/refs/safety-checklist-advanced.md
+++ b/skills/agentic/trust-and-safety/refs/safety-checklist-advanced.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Safety Checklist: Advanced
 
 Advanced safety checklist covering monitoring, incident response, testing, and operational safety.

--- a/skills/agentic/trust-and-safety/refs/safety-checklist-core.md
+++ b/skills/agentic/trust-and-safety/refs/safety-checklist-core.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "review"]
+archetype_relevance: ["*"]
+---
 # Safety Checklist: Core
 
 Use this checklist to assess core safety of agentic systems covering input, output, action, auth, and privacy.

--- a/skills/crew/adaptive/SKILL.md
+++ b/skills/crew/adaptive/SKILL.md
@@ -6,6 +6,8 @@ description: |
 
   Use when: setting or changing autonomy level (just-finish / balanced / ask-first),
   adjusting communication style, or applying a saved engagement preference profile.
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Adaptive Engagement Skill

--- a/skills/crew/change-type-detector/SKILL.md
+++ b/skills/crew/change-type-detector/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "detect change type", "classify files", "what kind of change",
   "ui or api change", "change-type detection", or before creating test tasks.
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Change Type Detector Skill

--- a/skills/crew/change-type-detector/refs/file-classification-rules.md
+++ b/skills/crew/change-type-detector/refs/file-classification-rules.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # File Classification Rules
 
 Complete extension tables, path segment tables, and keyword lists for the

--- a/skills/crew/crew-qe-gate/SKILL.md
+++ b/skills/crew/crew-qe-gate/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: running a value / strategy / execution gate at a crew checkpoint,
   validating phase-transition readiness, or asking "is this ready to advance".
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Crew QE Gate Skill

--- a/skills/crew/evidence-validation/SKILL.md
+++ b/skills/crew/evidence-validation/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: validating a TaskUpdate description before marking complete, or
   checking that evidence fields match the task's complexity tier.
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Evidence Validation Skill

--- a/skills/crew/evidence-validation/refs/evidence-schema.md
+++ b/skills/crew/evidence-validation/refs/evidence-schema.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Evidence Schema
 
 Full field definitions with natural language detection indicators per tier.

--- a/skills/crew/evidence-validation/refs/test-evidence-requirements.md
+++ b/skills/crew/evidence-validation/refs/test-evidence-requirements.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Test Evidence Requirements
 
 QE artifact requirements per test type. Used by the evidence-validation skill

--- a/skills/crew/explain/SKILL.md
+++ b/skills/crew/explain/SKILL.md
@@ -12,6 +12,8 @@ description: |
   crew jargon into language a non-practitioner can act on. Also used
   automatically by the orchestrator when `crew.output_style = paired` or
   `plain-only` — the skill produces the `**Plain:**` line.
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:crew:explain

--- a/skills/crew/issue-reporting/SKILL.md
+++ b/skills/crew/issue-reporting/SKILL.md
@@ -10,6 +10,8 @@ description: |
   Use when: "file a bug", "report issue", "something went wrong", "not working as expected",
   "create issue", reporting UX friction, logging unmet outcomes, or investigating tool failures.
 user-invocable: false
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Issue Reporting

--- a/skills/crew/issue-reporting/refs/templates.md
+++ b/skills/crew/issue-reporting/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Issue Templates Reference
 
 Body templates used by both auto-reporting hooks and the manual `/wicked-garden:report-issue` command.

--- a/skills/crew/test-task-factory/SKILL.md
+++ b/skills/crew/test-task-factory/SKILL.md
@@ -8,6 +8,8 @@ description: |
   Use when: creating test tasks after change-type detection, QE task generation,
   "test task factory", "create test tasks", "generate QE tasks", or after
   change-type-detector classifies files as ui/api/both.
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Test Task Factory Skill

--- a/skills/crew/test-task-factory/refs/test-evidence-taxonomy.md
+++ b/skills/crew/test-task-factory/refs/test-evidence-taxonomy.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Test Evidence Taxonomy
 
 Canonical evidence requirements per test type. Used to populate task metadata

--- a/skills/crew/test-task-factory/refs/test-task-templates.md
+++ b/skills/crew/test-task-factory/refs/test-task-templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Test Task Templates
 
 Full description templates per test type. These are filled by substituting

--- a/skills/data/analysis/SKILL.md
+++ b/skills/data/analysis/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when exploring a dataset for patterns, trends, and business insights — EDA, segmentation,
   anomaly detection, and visualization guidance. Generates the Observation → Insight → Action chain.
   NOT for schema validation or data quality scoring (use the data/data skill) or SQL queries (use data:analyze).
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Data Analysis Skill

--- a/skills/data/analysis/refs/templates.md
+++ b/skills/data/analysis/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Analysis Output Templates
 
 Standard templates for data analysis reports.

--- a/skills/data/data/SKILL.md
+++ b/skills/data/data/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when profiling a dataset's structure, validating it against a schema, or generating a data quality
   report (completeness, uniqueness, validity constraints). Runs the data_profiler.py and schema_validator.py scripts.
   NOT for exploratory pattern analysis (use data/analysis) or SQL queries (use data:analyze).
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Data Engineering Skill

--- a/skills/data/data/refs/examples.md
+++ b/skills/data/data/refs/examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Data Engineering Examples
 
 Detailed examples for data profiling, schema validation, and quality assessment.

--- a/skills/data/ml/SKILL.md
+++ b/skills/data/ml/SKILL.md
@@ -10,6 +10,8 @@ description: |
   - "how should I deploy this model"
   - "feature engineering advice"
   - "ML architecture guidance"
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # ML Engineering Skill

--- a/skills/data/ml/refs/templates.md
+++ b/skills/data/ml/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # ML Output Templates
 
 Standard templates for ML model reviews and documentation.

--- a/skills/data/pipeline/SKILL.md
+++ b/skills/data/pipeline/SKILL.md
@@ -13,6 +13,8 @@ description: |
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: ["**/dags/**", "**/pipelines/**", "**/etl/**", "**/airflow/**", "**/prefect/**"]
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Pipeline Engineering Skill

--- a/skills/data/pipeline/refs/templates.md
+++ b/skills/data/pipeline/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Pipeline Output Templates
 
 Standard templates for pipeline design and review documentation.

--- a/skills/deliberate/SKILL.md
+++ b/skills/deliberate/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: challenging assumptions before implementation, reframing a stated
   problem, or asking whether the right thing is being asked at all.
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # Deliberate

--- a/skills/deliberate/refs/architecture-lens.md
+++ b/skills/deliberate/refs/architecture-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Architecture Lens
 
 Additional questions for the five lenses when the work involves system architecture.

--- a/skills/deliberate/refs/assumptions-lens.md
+++ b/skills/deliberate/refs/assumptions-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Assumptions Lens
 
 Additional questions for the five lenses that surface hidden assumptions and

--- a/skills/deliberate/refs/code-lens.md
+++ b/skills/deliberate/refs/code-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Code Lens
 
 Additional questions for the five lenses when the work involves code changes.

--- a/skills/deliberate/refs/content-lens.md
+++ b/skills/deliberate/refs/content-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Content Lens
 
 Additional questions for the five lenses when the work involves content, docs, or copy.

--- a/skills/deliberate/refs/data-lens.md
+++ b/skills/deliberate/refs/data-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Data Lens
 
 Additional questions for the five lenses when the work involves data pipelines,

--- a/skills/deliberate/refs/design-lens.md
+++ b/skills/deliberate/refs/design-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Design Lens
 
 Additional questions for the five lenses when the work involves UX, UI, or design.

--- a/skills/deliberate/refs/opportunity-patterns.md
+++ b/skills/deliberate/refs/opportunity-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Opportunity Patterns
 
 Common patterns where a single issue reveals broader improvement opportunities.

--- a/skills/deliberate/refs/ops-lens.md
+++ b/skills/deliberate/refs/ops-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Ops Lens
 
 Additional questions for the five lenses when the work involves infrastructure,

--- a/skills/deliberate/refs/product-lens.md
+++ b/skills/deliberate/refs/product-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Product Lens
 
 Additional questions for the five lenses when the work involves features, user needs,

--- a/skills/deliberate/refs/rethink-framework.md
+++ b/skills/deliberate/refs/rethink-framework.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Rethink Framework
 
 When to step back from fixing and consider redesigning. Not every issue needs a

--- a/skills/deliberate/refs/security-lens.md
+++ b/skills/deliberate/refs/security-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Security Lens
 
 Additional questions for the five lenses when the work involves authentication,

--- a/skills/deliberate/refs/testing-lens.md
+++ b/skills/deliberate/refs/testing-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Testing Lens
 
 Additional questions for the five lenses when the work involves test failures,

--- a/skills/deliberate/refs/timing-lens.md
+++ b/skills/deliberate/refs/timing-lens.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Timing Lens
 
 Additional questions for the five lenses that challenge WHEN to act, not just

--- a/skills/delivery/design/SKILL.md
+++ b/skills/delivery/design/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "design experiment", "A/B test", "hypothesis", "sample size",
   "what metrics", "test my feature", "should we experiment"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Design Skill

--- a/skills/delivery/design/refs/output-template.md
+++ b/skills/delivery/design/refs/output-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Experiment Design Output Template
 
 Markdown template for the experiment design output emitted by the `delivery:design` skill. Substitute the placeholders with values from the hypothesis, metrics, sample-size, and instrumentation steps.

--- a/skills/delivery/design/refs/statistics.md
+++ b/skills/delivery/design/refs/statistics.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Statistical Concepts for Experiments
 
 Deep dive into the statistical foundations of A/B testing.

--- a/skills/delivery/onboarding-guide/SKILL.md
+++ b/skills/delivery/onboarding-guide/SKILL.md
@@ -9,6 +9,8 @@ description: |
 
   Use when: "onboard a new developer", "getting-started guide", "team
   orientation for new hire", "first week plan", "day-one productivity".
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Onboarding Guide

--- a/skills/delivery/onboarding-guide/refs/plan-template.md
+++ b/skills/delivery/onboarding-guide/refs/plan-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Onboarding Guide — Output Template
 
 ## Onboarding Plan for {developer_name}

--- a/skills/delivery/reporting/SKILL.md
+++ b/skills/delivery/reporting/SKILL.md
@@ -9,6 +9,8 @@ description: |
 
   Enhanced with:
   - wicked-brain:memory Stores insights across sessions
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Reporting Skill

--- a/skills/delivery/reporting/refs/integration.md
+++ b/skills/delivery/reporting/refs/integration.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Integration Details
 
 Report structure, caching, storage, and validation patterns.

--- a/skills/delivery/reporting/refs/personas.md
+++ b/skills/delivery/reporting/refs/personas.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Persona Details
 
 Detailed configuration and generation patterns for report personas.

--- a/skills/delivery/rollout/SKILL.md
+++ b/skills/delivery/rollout/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "roll out feature", "progressive rollout", "canary deployment",
   "feature flag", "rollback plan", "launch feature", "deploy gradually"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Rollout Skill

--- a/skills/delivery/rollout/refs/output-template.md
+++ b/skills/delivery/rollout/refs/output-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Rollout Plan Output Template
 
 Markdown template for the rollout plan returned by `/wicked-garden:delivery:rollout`. Substitute the placeholders with values from the risk assessment, strategy, and capability-discovery results.

--- a/skills/delivery/rollout/refs/strategies-core.md
+++ b/skills/delivery/rollout/refs/strategies-core.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Rollout Strategies: Core Approaches
 
 Core rollout strategy guidance: Big Bang, Progressive, and Canary rollouts.

--- a/skills/delivery/rollout/refs/strategies-operations.md
+++ b/skills/delivery/rollout/refs/strategies-operations.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Rollout Strategies: Operations & Communication
 
 Dark launch, feature flags, monitoring, rollback procedures, communication templates, and post-rollout learning.

--- a/skills/engineering/architecture/SKILL.md
+++ b/skills/engineering/architecture/SKILL.md
@@ -7,6 +7,8 @@ description: |
   Use when: "design the architecture", "what's the overall structure",
   "architecture patterns", "technology stack", "system architecture"
 portability: portable
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Architecture Skill

--- a/skills/engineering/architecture/refs/adr-template.md
+++ b/skills/engineering/architecture/refs/adr-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # ADR Template
 
 Use this template for Architectural Decision Records (ADRs).

--- a/skills/engineering/architecture/refs/architecture-template-deployment.md
+++ b/skills/engineering/architecture/refs/architecture-template-deployment.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architecture Document Template: Deployment & Operations
 
 Deployment architecture, release process, quality attributes, risks, future considerations, and template usage tips.

--- a/skills/engineering/architecture/refs/architecture-template-design.md
+++ b/skills/engineering/architecture/refs/architecture-template-design.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architecture Document Template: Design
 
 Template for system overview, architecture style, components, data architecture, technology stack, and cross-cutting concerns.

--- a/skills/engineering/architecture/refs/examples-ecommerce-analytics.md
+++ b/skills/engineering/architecture/refs/examples-ecommerce-analytics.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architecture Examples - E-Commerce and Analytics
 
 Real-world architecture examples with complete ADRs and diagrams for e-commerce and analytics platforms.

--- a/skills/engineering/architecture/refs/examples-saas-trading.md
+++ b/skills/engineering/architecture/refs/examples-saas-trading.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architecture Examples - SaaS and Trading
 
 Real-world architecture examples with complete ADRs and diagrams for multi-tenant SaaS and financial trading platforms, plus pattern matching guide.

--- a/skills/engineering/architecture/refs/patterns-advanced.md
+++ b/skills/engineering/architecture/refs/patterns-advanced.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architectural Patterns: Advanced & Selection Guide
 
 Serverless, Clean Architecture, CQRS, Service Mesh, pattern selection guide, and evolution strategy.

--- a/skills/engineering/architecture/refs/patterns-structural.md
+++ b/skills/engineering/architecture/refs/patterns-structural.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Architectural Patterns: Structural
 
 Detailed guide to structural architectural patterns with trade-offs and when to use them.

--- a/skills/engineering/backend/SKILL.md
+++ b/skills/engineering/backend/SKILL.md
@@ -8,6 +8,8 @@ description: |
   "backend performance", "REST endpoint", "query optimization",
   "server-side architecture"
 portability: portable
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Backend Skill

--- a/skills/engineering/backend/refs/checklists.md
+++ b/skills/engineering/backend/refs/checklists.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Backend Review Checklists
 
 ## API Quality Checklist

--- a/skills/engineering/backend/refs/patterns.md
+++ b/skills/engineering/backend/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Backend Code Patterns
 
 ## API Endpoint Pattern

--- a/skills/engineering/debugging/SKILL.md
+++ b/skills/engineering/debugging/SKILL.md
@@ -12,6 +12,8 @@ agent: debugger
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: ["**/*.log", "**/error*.ts", "**/error*.py", "**/*debug*"]
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Debugging Skill

--- a/skills/engineering/debugging/refs/patterns.md
+++ b/skills/engineering/debugging/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Debugging Code Patterns
 
 ## Binary Search Debugging

--- a/skills/engineering/debugging/refs/process.md
+++ b/skills/engineering/debugging/refs/process.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Debugging Process & Checklists
 
 ## Systematic Debugging Process

--- a/skills/engineering/docs/SKILL.md
+++ b/skills/engineering/docs/SKILL.md
@@ -5,6 +5,8 @@ description: |
   code-doc drift after a refactor. Covers generate (API docs, READMEs), audit (coverage metrics,
   undocumented exports), and sync (stale docs detection) in one skill.
   NOT for architecture documentation (use the architecture skill) or product requirements (use product/requirements-analysis).
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Documentation Engineering Skill

--- a/skills/engineering/engineering/SKILL.md
+++ b/skills/engineering/engineering/SKILL.md
@@ -5,6 +5,8 @@ description: |
   code for R1-R6 standards violations (dead code, bare panics, magic values, swallowed errors,
   unbounded ops, god functions) or getting cross-cutting implementation advice.
   NOT for architecture decisions (use the architecture skill) or debugging (use the debugging skill).
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Engineering Skill

--- a/skills/engineering/engineering/refs/checklists.md
+++ b/skills/engineering/engineering/refs/checklists.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Engineering Review Checklists
 
 ## Structure Checklist

--- a/skills/engineering/engineering/refs/templates.md
+++ b/skills/engineering/engineering/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Engineering Output Templates
 
 ## Implementation Guidance Template

--- a/skills/engineering/frontend/SKILL.md
+++ b/skills/engineering/frontend/SKILL.md
@@ -11,6 +11,8 @@ portability: portable
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: ["**/*.tsx", "**/*.jsx", "**/*.css", "**/*.scss", "**/components/**"]
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Frontend Skill

--- a/skills/engineering/frontend/refs/checklists.md
+++ b/skills/engineering/frontend/refs/checklists.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Frontend Review Checklists
 
 ## Component Quality Checklist

--- a/skills/engineering/frontend/refs/patterns.md
+++ b/skills/engineering/frontend/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Frontend Code Patterns
 
 ## Component Structure Pattern

--- a/skills/engineering/integration/SKILL.md
+++ b/skills/engineering/integration/SKILL.md
@@ -7,6 +7,8 @@ description: |
   Use when: "API design", "service integration", "how do these communicate",
   "API contract", "integration pattern", "REST API", "GraphQL", "event schema"
 portability: portable
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Integration Skill

--- a/skills/engineering/integration/refs/error-handling-best-practices.md
+++ b/skills/engineering/integration/refs/error-handling-best-practices.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Error Handling Guide: Best Practices
 
 ## Best Practices

--- a/skills/engineering/integration/refs/error-handling-error-classes-typescript.md
+++ b/skills/engineering/integration/refs/error-handling-error-classes-typescript.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Error Handling Guide: Error Classes (TypeScript)
 
 ## Error Classes (TypeScript)

--- a/skills/engineering/integration/refs/error-handling-error-response-format.md
+++ b/skills/engineering/integration/refs/error-handling-error-response-format.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Error Handling Guide: Error Response Format
 
 ## Error Response Format

--- a/skills/engineering/integration/refs/error-handling-retry-strategies.md
+++ b/skills/engineering/integration/refs/error-handling-retry-strategies.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Error Handling Guide: Retry Strategies
 
 ## Retry Strategies

--- a/skills/engineering/integration/refs/event-schemas-best-practices.md
+++ b/skills/engineering/integration/refs/event-schemas-best-practices.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Event Schema Design Guide: Best Practices
 
 ## Best Practices

--- a/skills/engineering/integration/refs/event-schemas-event-naming-conventions.md
+++ b/skills/engineering/integration/refs/event-schemas-event-naming-conventions.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Event Schema Design Guide: Event Naming Conventions
 
 ## Event Naming Conventions

--- a/skills/engineering/integration/refs/event-schemas-event-structure.md
+++ b/skills/engineering/integration/refs/event-schemas-event-structure.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Event Schema Design Guide: Event Structure
 
 ## Event Structure

--- a/skills/engineering/integration/refs/graphql-best-practices.md
+++ b/skills/engineering/integration/refs/graphql-best-practices.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # GraphQL API Design Guide: Best Practices
 
 ## Best Practices

--- a/skills/engineering/integration/refs/graphql-error-handling.md
+++ b/skills/engineering/integration/refs/graphql-error-handling.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # GraphQL API Design Guide: Error Handling
 
 ## Error Handling

--- a/skills/engineering/integration/refs/graphql-graphql-basics.md
+++ b/skills/engineering/integration/refs/graphql-graphql-basics.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # GraphQL API Design Guide: GraphQL Basics
 
 ## GraphQL Basics

--- a/skills/engineering/integration/refs/graphql-query-examples.md
+++ b/skills/engineering/integration/refs/graphql-query-examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # GraphQL API Design Guide: Query Examples
 
 ## Query Examples

--- a/skills/engineering/integration/refs/graphql-schema-design-patterns.md
+++ b/skills/engineering/integration/refs/graphql-schema-design-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # GraphQL API Design Guide: Schema Design Patterns
 
 ## Schema Design Patterns

--- a/skills/engineering/integration/refs/grpc-grpc-overview.md
+++ b/skills/engineering/integration/refs/grpc-grpc-overview.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # gRPC API Design Guide: gRPC Overview
 
 ## gRPC Overview

--- a/skills/engineering/integration/refs/grpc-implementation-examples.md
+++ b/skills/engineering/integration/refs/grpc-implementation-examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # gRPC API Design Guide: Implementation Examples
 
 ## Implementation Examples

--- a/skills/engineering/integration/refs/grpc-metadata-headers.md
+++ b/skills/engineering/integration/refs/grpc-metadata-headers.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # gRPC API Design Guide: Metadata (Headers)
 
 ## Metadata (Headers)

--- a/skills/engineering/integration/refs/grpc-testing.md
+++ b/skills/engineering/integration/refs/grpc-testing.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # gRPC API Design Guide: Testing
 
 ## Testing

--- a/skills/engineering/integration/refs/resilience-best-practices.md
+++ b/skills/engineering/integration/refs/resilience-best-practices.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Resilience Patterns Guide: Best Practices
 
 ## Best Practices

--- a/skills/engineering/integration/refs/resilience-circuit-breaker-pattern.md
+++ b/skills/engineering/integration/refs/resilience-circuit-breaker-pattern.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Resilience Patterns Guide: Circuit Breaker Pattern
 
 ## Circuit Breaker Pattern

--- a/skills/engineering/integration/refs/resilience-rate-limiting.md
+++ b/skills/engineering/integration/refs/resilience-rate-limiting.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Resilience Patterns Guide: Rate Limiting
 
 ## Rate Limiting

--- a/skills/engineering/integration/refs/resilience-timeout-pattern.md
+++ b/skills/engineering/integration/refs/resilience-timeout-pattern.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Resilience Patterns Guide: Timeout Pattern
 
 ## Timeout Pattern

--- a/skills/engineering/integration/refs/rest-api-fundamentals.md
+++ b/skills/engineering/integration/refs/rest-api-fundamentals.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # REST API Design - Fundamentals
 
 Core principles, resource design, HTTP methods, and query parameters for RESTful APIs.

--- a/skills/engineering/integration/refs/rest-api-responses-security.md
+++ b/skills/engineering/integration/refs/rest-api-responses-security.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # REST API Design - Responses, Headers, Security, and Best Practices
 
 Response formats, status codes, headers, advanced patterns, security, and best practices.

--- a/skills/engineering/integration/refs/versioning-breaking-changes.md
+++ b/skills/engineering/integration/refs/versioning-breaking-changes.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # API Versioning Guide: Breaking Changes
 
 ## Breaking Changes

--- a/skills/engineering/integration/refs/versioning-migration-strategies.md
+++ b/skills/engineering/integration/refs/versioning-migration-strategies.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # API Versioning Guide: Migration Strategies
 
 ## Migration Strategies

--- a/skills/engineering/integration/refs/versioning-versioning-strategies.md
+++ b/skills/engineering/integration/refs/versioning-versioning-strategies.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # API Versioning Guide: Versioning Strategies
 
 ## Versioning Strategies

--- a/skills/engineering/patch/SKILL.md
+++ b/skills/engineering/patch/SKILL.md
@@ -7,6 +7,8 @@ description: |
   "propagate change", "generate migration", "update all references".
 
   This is the CODE MUTATION counterpart to wicked-garden:search (which is read-only).
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # wicked-patch

--- a/skills/engineering/system-design/SKILL.md
+++ b/skills/engineering/system-design/SKILL.md
@@ -5,6 +5,8 @@ description: |
   contracts — the "how do we slice this?" question at design time.
   NOT for reviewing an existing system's health (use the architecture skill or engineering:arch).
 portability: portable
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # System Design Skill

--- a/skills/engineering/system-design/refs/anti-patterns-big-ball-of-mud.md
+++ b/skills/engineering/system-design/refs/anti-patterns-big-ball-of-mud.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Anti-Patterns: Big Ball of Mud
 
 ## Big Ball of Mud

--- a/skills/engineering/system-design/refs/anti-patterns-circular-dependencies.md
+++ b/skills/engineering/system-design/refs/anti-patterns-circular-dependencies.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Anti-Patterns: Circular Dependencies
 
 ## Circular Dependencies

--- a/skills/engineering/system-design/refs/anti-patterns-feature-envy.md
+++ b/skills/engineering/system-design/refs/anti-patterns-feature-envy.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Anti-Patterns: Feature Envy
 
 ## Feature Envy

--- a/skills/engineering/system-design/refs/anti-patterns-god-object.md
+++ b/skills/engineering/system-design/refs/anti-patterns-god-object.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Anti-Patterns: God Object
 
 ## God Object

--- a/skills/engineering/system-design/refs/component-template-lifecycle.md
+++ b/skills/engineering/system-design/refs/component-template-lifecycle.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Documentation Template - Operations
 
 Operational aspects of component documentation: performance, security, monitoring, testing, deployment, and disaster recovery.

--- a/skills/engineering/system-design/refs/component-template-maintenance.md
+++ b/skills/engineering/system-design/refs/component-template-maintenance.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Documentation Template - Maintenance
 
 Change log, references, contact info, example auth component, and template usage tips.

--- a/skills/engineering/system-design/refs/component-template-structure.md
+++ b/skills/engineering/system-design/refs/component-template-structure.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Documentation Template - Structure
 
 Template for documenting individual system components with clear structure and interfaces.

--- a/skills/engineering/system-design/refs/dependencies-best-practices.md
+++ b/skills/engineering/system-design/refs/dependencies-best-practices.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Dependency Management Guide: Best Practices
 
 ## Best Practices

--- a/skills/engineering/system-design/refs/dependencies-dependency-principles.md
+++ b/skills/engineering/system-design/refs/dependencies-dependency-principles.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Dependency Management Guide: Dependency Principles
 
 ## Dependency Principles

--- a/skills/engineering/system-design/refs/dependencies-dependency-tracking.md
+++ b/skills/engineering/system-design/refs/dependencies-dependency-tracking.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Dependency Management Guide: Dependency Tracking
 
 ## Dependency Tracking

--- a/skills/engineering/system-design/refs/interface-template-lifecycle.md
+++ b/skills/engineering/system-design/refs/interface-template-lifecycle.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Interface Documentation Template - Operations
 
 Testing, examples, client libraries, monitoring, migration guides, and changelog.

--- a/skills/engineering/system-design/refs/interface-template-maintenance.md
+++ b/skills/engineering/system-design/refs/interface-template-maintenance.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Interface Documentation Template - Examples and Tips
 
 Complete User Service interface example and tips for documenting interfaces.

--- a/skills/engineering/system-design/refs/interface-template-structure.md
+++ b/skills/engineering/system-design/refs/interface-template-structure.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Interface Documentation Template - Structure
 
 Template for documenting component interfaces, contracts, and integration points. Covers overview, contracts, operations, data types, error handling, and auth.

--- a/skills/engineering/system-design/refs/patterns-dependency-injection.md
+++ b/skills/engineering/system-design/refs/patterns-dependency-injection.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Design Patterns: Dependency Injection
 
 ## Dependency Injection

--- a/skills/engineering/system-design/refs/patterns-facade-pattern.md
+++ b/skills/engineering/system-design/refs/patterns-facade-pattern.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Design Patterns: Facade Pattern
 
 ## Facade Pattern

--- a/skills/engineering/system-design/refs/patterns-layered-pattern.md
+++ b/skills/engineering/system-design/refs/patterns-layered-pattern.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Design Patterns: Layered Pattern
 
 ## Layered Pattern

--- a/skills/engineering/system-design/refs/patterns-plugin-architecture.md
+++ b/skills/engineering/system-design/refs/patterns-plugin-architecture.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
+---
 # Component Design Patterns: Plugin Architecture
 
 ## Plugin Architecture

--- a/skills/engineering/unit-test-quality/SKILL.md
+++ b/skills/engineering/unit-test-quality/SKILL.md
@@ -13,6 +13,8 @@ description: |
   coverage but low confidence, or pairing a regression test with a bug fix.
 status: stable
 portability: portable
+phase_relevance: ["design", "build"]
+archetype_relevance: ["*"]
 ---
 
 # Unit Test Quality

--- a/skills/facilitator-score/SKILL.md
+++ b/skills/facilitator-score/SKILL.md
@@ -11,6 +11,8 @@ description: |
 portability: portable
 allowed-tools:
   - wicked-garden:ground
+phase_relevance: ["clarify"]
+archetype_relevance: ["*"]
 ---
 
 # wicked-garden:facilitator-score — Questionnaire Scorer

--- a/skills/ground/SKILL.md
+++ b/skills/ground/SKILL.md
@@ -11,6 +11,8 @@ description: |
   codebase exploration (use Agent(Explore)), or fetching specific symbols (use
   wicked-brain:search directly).
 portability: portable
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # wicked-garden:ground — Steer Yourself

--- a/skills/integration-discovery/SKILL.md
+++ b/skills/integration-discovery/SKILL.md
@@ -9,6 +9,8 @@ description: |
   agents fit a task, or discovering installed CLIs / MCP servers.
 user-invocable: false
 status: experimental
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
 ---
 
 # Capability Router

--- a/skills/integration-discovery/refs/capabilities.md
+++ b/skills/integration-discovery/refs/capabilities.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
+---
 # Capability Definitions
 
 Detailed patterns for discovering integrations by capability category.

--- a/skills/integration-discovery/refs/cli-detection.md
+++ b/skills/integration-discovery/refs/cli-detection.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
+---
 # CLI Detection
 
 How to discover CLI tools available in the user's PATH, decide which to use, and store preferences.

--- a/skills/integration-discovery/refs/discovery-sources.md
+++ b/skills/integration-discovery/refs/discovery-sources.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
+---
 # Discovery Sources
 
 Where to look for capabilities and how to check each source.

--- a/skills/integration-discovery/refs/task-patterns.md
+++ b/skills/integration-discovery/refs/task-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap"]
+archetype_relevance: ["*"]
+---
 # Task Patterns
 
 Common task types and their typical capability mappings. Use as starting points—always verify availability.

--- a/skills/jam/SKILL.md
+++ b/skills/jam/SKILL.md
@@ -7,6 +7,8 @@ description: |
   Use when: "brainstorm this", "explore ideas", "get different perspectives",
   "focus group", "what do you think about", "pros and cons", "quick check".
 context: fork
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # Brainstorming Skill

--- a/skills/jam/refs/facilitation-patterns.md
+++ b/skills/jam/refs/facilitation-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Facilitation Patterns
 
 Match persona archetypes to problem types for effective brainstorming sessions.

--- a/skills/jam/refs/synthesis-patterns.md
+++ b/skills/jam/refs/synthesis-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Synthesis Patterns
 
 How to transform raw persona discussions into actionable outcomes.

--- a/skills/multi-model/SKILL.md
+++ b/skills/multi-model/SKILL.md
@@ -10,6 +10,8 @@ description: |
   Use when: running a council session across multiple LLM CLIs, getting a
   second opinion from a different model on a decision, or doing a cross-model
   code or architecture review.
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
 ---
 
 # Multi-Model Collaboration Skill

--- a/skills/multi-model/refs/aichat.md
+++ b/skills/multi-model/refs/aichat.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # aichat CLI — Usage Patterns
 
 `aichat` is an all-in-one LLM CLI written in Rust — fast, pipe-native, multi-provider. Covers OpenAI, Anthropic, Gemini, Mistral, Groq, Ollama, and more via a single YAML config.

--- a/skills/multi-model/refs/aider.md
+++ b/skills/multi-model/refs/aider.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Aider CLI — Usage Patterns
 
 Aider is an AI pair-programmer designed to edit code inside a git repo. For council use it runs in a restricted one-shot mode: no git, no commits, no file edits — just an answer to the scaffold prompt.

--- a/skills/multi-model/refs/auditability.md
+++ b/skills/multi-model/refs/auditability.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Auditability: Tracking AI Conversations
 
 How to maintain audit trails for multi-AI conversations. Essential for compliance, team visibility, and learning from past decisions.

--- a/skills/multi-model/refs/codex.md
+++ b/skills/multi-model/refs/codex.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Codex CLI — Usage Patterns
 
 OpenAI Codex CLI for AI-assisted coding, code review, and multi-model collaboration.

--- a/skills/multi-model/refs/context.md
+++ b/skills/multi-model/refs/context.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Context: Maintaining AI Conversation State
 
 How to maintain context across AI sessions, manage context windows, and decide when to continue vs. start fresh.

--- a/skills/multi-model/refs/copilot.md
+++ b/skills/multi-model/refs/copilot.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Copilot CLI — Usage Patterns
 
 GitHub Copilot CLI for AI-assisted coding, code review, and multi-model collaboration.

--- a/skills/multi-model/refs/examples.md
+++ b/skills/multi-model/refs/examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Examples: Multi-AI Conversation Patterns
 
 Real-world examples and templates for multi-model collaboration.

--- a/skills/multi-model/refs/gemini.md
+++ b/skills/multi-model/refs/gemini.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Gemini CLI — Usage Patterns
 
 Google Gemini CLI for AI-assisted tasks, long-context analysis, and multi-model collaboration.

--- a/skills/multi-model/refs/goose.md
+++ b/skills/multi-model/refs/goose.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Goose CLI — Usage Patterns
 
 Block's open-source AI agent. Goose is designed to *do things* — run tools, execute commands, read files — not just answer questions. In council mode it operates as a read-only responder via `goose run -i -`.

--- a/skills/multi-model/refs/llm.md
+++ b/skills/multi-model/refs/llm.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # llm CLI — Usage Patterns
 
 Simon Willison's `llm` — a pipe-native multi-provider aggregator. One command, many providers, everything via plugins. Ideal fit for council scaffolds: `cat scaffold | llm "prompt"` just works.

--- a/skills/multi-model/refs/opencode.md
+++ b/skills/multi-model/refs/opencode.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # OpenCode CLI — Usage Patterns
 
 OpenCode CLI for AI-assisted coding with multiple providers. Supports OpenAI, Anthropic,

--- a/skills/multi-model/refs/orchestration.md
+++ b/skills/multi-model/refs/orchestration.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Multi-Model Orchestration Patterns
 
 Patterns for coordinating multiple AI models via external CLI dispatch.

--- a/skills/multi-model/refs/pi.md
+++ b/skills/multi-model/refs/pi.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design"]
+archetype_relevance: ["*"]
+---
 # Pi CLI — Usage Patterns
 
 `pi` is a coding-agent CLI (`@mariozechner/pi-coding-agent` on npm). Configurable across Google, OpenAI, Anthropic, and more; works as a council member via non-interactive `-p` mode with `@file` attachments.

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -5,6 +5,8 @@ description: |
   Use when: invoking a named persona via persona:as, defining or listing
   personas, or reviewing work through a specific role's perspective.
 disable-model-invocation: true
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Persona System

--- a/skills/platform/audit/SKILL.md
+++ b/skills/platform/audit/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "audit trail", "collect evidence", "audit report",
   "control testing", "compliance documentation"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Audit Skill

--- a/skills/platform/audit/refs/checklists-evidence-operations.md
+++ b/skills/platform/audit/refs/checklists-evidence-operations.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Audit Evidence: Collection, Organization & Readiness
 
 Evidence collection scripts, organization structure, gap tracking, and audit readiness checklists.

--- a/skills/platform/audit/refs/checklists-gdpr-pci-evidence.md
+++ b/skills/platform/audit/refs/checklists-gdpr-pci-evidence.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Audit Evidence Checklists: GDPR & PCI DSS
 
 Checklists for GDPR and PCI DSS audit evidence collection.

--- a/skills/platform/audit/refs/checklists-soc2-hipaa.md
+++ b/skills/platform/audit/refs/checklists-soc2-hipaa.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Audit Evidence Checklists: SOC2 & HIPAA
 
 Comprehensive checklists for collecting SOC2 Type II and HIPAA audit evidence.

--- a/skills/platform/audit/refs/frameworks-gdpr-pci.md
+++ b/skills/platform/audit/refs/frameworks-gdpr-pci.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Audit Framework Control Mappings: GDPR & PCI DSS
 
 Framework-specific control testing and evidence requirements for GDPR and PCI DSS.

--- a/skills/platform/audit/refs/frameworks-soc2-hipaa.md
+++ b/skills/platform/audit/refs/frameworks-soc2-hipaa.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Audit Framework Control Mappings: SOC2 & HIPAA
 
 Framework-specific control testing and evidence requirements for SOC2 Type II and HIPAA.

--- a/skills/platform/compliance/SKILL.md
+++ b/skills/platform/compliance/SKILL.md
@@ -7,6 +7,8 @@ description: |
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: ["**/compliance/**", "**/audit/**", "**/policy/**", "**/.hipaa*", "**/.gdpr*"]
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Compliance Skill

--- a/skills/platform/compliance/refs/checklists.md
+++ b/skills/platform/compliance/refs/checklists.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Compliance Checklists
 
 Detailed verification checklists for each framework.

--- a/skills/platform/compliance/refs/frameworks.md
+++ b/skills/platform/compliance/refs/frameworks.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Compliance Frameworks Reference
 
 Detailed framework-specific requirements and controls.

--- a/skills/platform/errors/SKILL.md
+++ b/skills/platform/errors/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when investigating a production error spike or pattern across services — aggregates errors from
   discovered tracking sources, correlates with deployments, and assesses user impact.
   NOT for general observability (use platform/observability) or tracing latency (use the platform:traces command).
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Error Analysis Skill

--- a/skills/platform/errors/refs/patterns.md
+++ b/skills/platform/errors/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Error Pattern Analysis Guide
 
 Detailed investigation guides for common error patterns.

--- a/skills/platform/errors/refs/severity.md
+++ b/skills/platform/errors/refs/severity.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Error Severity Classification
 
 Guidelines for classifying error severity and determining appropriate response.

--- a/skills/platform/gate-benchmark-rebaseline/SKILL.md
+++ b/skills/platform/gate-benchmark-rebaseline/SKILL.md
@@ -11,6 +11,8 @@ description: |
   "p95 benchmark baseline out of date", "update benchmark_baseline.json",
   "benchmark.yml failure", "gate-result p95 exceeds 2x baseline",
   "rebaseline procedure", or `AC-11` baseline drift.
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Gate-Result Benchmark Re-baseline

--- a/skills/platform/gh-cli/SKILL.md
+++ b/skills/platform/gh-cli/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when you need gh CLI patterns beyond the basics — debugging failed workflow runs, bulk PR operations,
   release automation, or repo health checks. Provides composable gh invocations for power users.
   NOT for simple git commands (use Bash) or GitLab (use the glab-cli skill).
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # GitHub CLI Power Utilities

--- a/skills/platform/gh-cli/refs/automation.md
+++ b/skills/platform/gh-cli/refs/automation.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # CI/CD Integration Examples
 
 Integrate gh_ops.py into your automation workflows.

--- a/skills/platform/gh-cli/refs/gh-ops.md
+++ b/skills/platform/gh-cli/refs/gh-ops.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # gh_ops.py Reference
 
 Unified GitHub operations CLI with intelligent features.

--- a/skills/platform/gh-cli/refs/patterns.md
+++ b/skills/platform/gh-cli/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Common gh CLI Patterns
 
 Quick reference for common GitHub CLI operations.

--- a/skills/platform/github-actions/SKILL.md
+++ b/skills/platform/github-actions/SKILL.md
@@ -10,6 +10,8 @@ portability: portable
 # TODO #339: When Claude Code supports 'paths' in skill frontmatter for
 # file-context auto-activation, add:
 #   paths: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml", ".github/actions/**"]
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # GitHub Actions Workflow Writing

--- a/skills/platform/github-actions/refs/security.md
+++ b/skills/platform/github-actions/refs/security.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitHub Actions Security Reference
 
 ## Permissions

--- a/skills/platform/github-actions/refs/templates.md
+++ b/skills/platform/github-actions/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitHub Actions Templates
 
 Copy-paste templates with security and optimization built in.

--- a/skills/platform/github-actions/refs/troubleshooting.md
+++ b/skills/platform/github-actions/refs/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitHub Actions Troubleshooting
 
 Common errors and fixes.

--- a/skills/platform/gitlab-ci/SKILL.md
+++ b/skills/platform/gitlab-ci/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Use when: "create CI/CD pipeline", "GitLab CI config", "fix pipeline",
   ".gitlab-ci.yml", "configure runners", "pipeline optimization"
 portability: portable
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # GitLab CI/CD Pipeline Writing

--- a/skills/platform/gitlab-ci/refs/templates.md
+++ b/skills/platform/gitlab-ci/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitLab CI Templates
 
 Copy-paste templates with optimization built in.

--- a/skills/platform/gitlab-ci/refs/troubleshooting.md
+++ b/skills/platform/gitlab-ci/refs/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitLab CI Troubleshooting
 
 Common errors and fixes.

--- a/skills/platform/glab-cli/SKILL.md
+++ b/skills/platform/glab-cli/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when you need glab CLI patterns for GitLab — pipeline debugging, MR management, or release
   automation. Provides composable glab invocations for power users.
   NOT for GitHub (use the gh-cli skill) or simple git commands (use Bash).
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # GitLab CLI Power Utilities

--- a/skills/platform/glab-cli/refs/ci-debugging.md
+++ b/skills/platform/glab-cli/refs/ci-debugging.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # GitLab CI Pipeline Debugging
 
 Quick reference for debugging GitLab CI/CD failures.

--- a/skills/platform/glab-cli/refs/glab-ops.md
+++ b/skills/platform/glab-cli/refs/glab-ops.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # glab_ops.py Reference
 
 GitLab operations CLI with intelligent features.

--- a/skills/platform/glab-cli/refs/patterns.md
+++ b/skills/platform/glab-cli/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Common glab CLI Patterns
 
 Quick reference for GitLab CLI operations.

--- a/skills/platform/health/SKILL.md
+++ b/skills/platform/health/SKILL.md
@@ -8,6 +8,8 @@ description: |
   Use when: checking aggregated system health, validating a post-deployment
   state, or correlating production status with recent changes.
 portability: portable
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Health Aggregation Skill

--- a/skills/platform/health/refs/sources.md
+++ b/skills/platform/health/refs/sources.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Observability Capability Discovery Patterns
 
 Detailed patterns for discovering and integrating with observability capabilities.

--- a/skills/platform/observability/SKILL.md
+++ b/skills/platform/observability/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when monitoring or diagnosing the wicked-garden plugin ecosystem — health probes, contract assertions,
   hook traces, error pattern detection, and APM/logging/metrics toolchain discovery.
   NOT for distributed tracing across services (use the platform:traces command) or audit evidence (use platform/audit).
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Observability Skill

--- a/skills/platform/observability/refs/toolchain-discovery.md
+++ b/skills/platform/observability/refs/toolchain-discovery.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Toolchain Discovery: Monitoring CLI Detection Patterns
 
 Detection patterns and usage examples for monitoring CLIs in the engineer's environment.

--- a/skills/platform/prereq-doctor/SKILL.md
+++ b/skills/platform/prereq-doctor/SKILL.md
@@ -5,6 +5,8 @@ description: |
 
   Use when: "command not found", "ModuleNotFoundError", "missing tool",
   "install dependency", "prereq check", "setup validation"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
 ---
 
 # Prereq Doctor

--- a/skills/platform/prereq-doctor/refs/tool-registry.md
+++ b/skills/platform/prereq-doctor/refs/tool-registry.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
 # Tool Registry
 
 Maps tool names to install commands per platform. Used by `prereq_doctor.py`.

--- a/skills/product/acceptance-criteria/SKILL.md
+++ b/skills/product/acceptance-criteria/SKILL.md
@@ -6,6 +6,8 @@ description: |
 
   Use when: "define acceptance criteria", "how do we know it's done",
   "what should QE test", "definition of done"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Acceptance Criteria Skill

--- a/skills/product/acceptance-criteria/refs/ac-anti-patterns.md
+++ b/skills/product/acceptance-criteria/refs/ac-anti-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Acceptance Criteria Anti-Patterns
 
 Common mistakes to avoid when writing acceptance criteria.

--- a/skills/product/acceptance-criteria/refs/ac-examples.md
+++ b/skills/product/acceptance-criteria/refs/ac-examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Acceptance Criteria Examples
 
 Comprehensive examples of well-written acceptance criteria across different domains.

--- a/skills/product/accessibility/SKILL.md
+++ b/skills/product/accessibility/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when auditing code for WCAG 2.1 AA compliance — keyboard navigation, ARIA patterns, color contrast,
   and semantic HTML. Produces prioritized remediation with code-level fixes.
   NOT for running automated a11y tools (use product:a11y command) or visual design review (use product/visual-review).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Accessibility Skill

--- a/skills/product/accessibility/refs/aria-patterns-basics.md
+++ b/skills/product/accessibility/refs/aria-patterns-basics.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # ARIA Patterns - Basics and Attributes
 
 ARIA fundamentals, common attributes, labeling, states, relationships, and live regions.

--- a/skills/product/accessibility/refs/aria-patterns-dynamic.md
+++ b/skills/product/accessibility/refs/aria-patterns-dynamic.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # ARIA Patterns - Dynamic Content and Best Practices
 
 Combobox, alerts, tooltips, live regions, and best practices.

--- a/skills/product/accessibility/refs/aria-patterns-interactive.md
+++ b/skills/product/accessibility/refs/aria-patterns-interactive.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # ARIA Patterns - Interactive Widgets
 
 Tabs, modal dialogs, and dropdown menus.

--- a/skills/product/accessibility/refs/audit-report-findings.md
+++ b/skills/product/accessibility/refs/audit-report-findings.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Accessibility Audit Report: Findings Template
 
 Template for executive summary, methodology, and detailed findings sections of an accessibility audit.

--- a/skills/product/accessibility/refs/audit-report-results.md
+++ b/skills/product/accessibility/refs/audit-report-results.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Accessibility Audit Report: Results & Recommendations
 
 Test results by component, automated scan results, screen reader testing, keyboard navigation, recommendations, and checklists.

--- a/skills/product/accessibility/refs/common-violations-html-css.md
+++ b/skills/product/accessibility/refs/common-violations-html-css.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Common Accessibility Violations: HTML & CSS
 
 Quick reference for the most frequent WCAG violations with before/after examples. Covers images, forms, contrast, semantics, and focus.

--- a/skills/product/accessibility/refs/common-violations-interactive.md
+++ b/skills/product/accessibility/refs/common-violations-interactive.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Common Accessibility Violations: Interactive Components
 
 Violations in custom components, forms, keyboard navigation, dynamic content, and headings with fixes.

--- a/skills/product/accessibility/refs/keyboard-testing-basics.md
+++ b/skills/product/accessibility/refs/keyboard-testing-basics.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Keyboard Testing Guide: Basics
 
 Core keyboard navigation testing for WCAG 2.1 compliance.

--- a/skills/product/accessibility/refs/keyboard-testing-patterns.md
+++ b/skills/product/accessibility/refs/keyboard-testing-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Keyboard Testing Guide: Patterns & Tools
 
 Testing workflows, common violations with fixes, tools, and quick reference.

--- a/skills/product/accessibility/refs/screen-reader-testing-advanced.md
+++ b/skills/product/accessibility/refs/screen-reader-testing-advanced.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Screen Reader Testing: Advanced Tests & Workflow
 
 ARIA testing, navigation, tables, dynamic content, focus management, common issues, and testing workflow.

--- a/skills/product/accessibility/refs/screen-reader-testing-commands.md
+++ b/skills/product/accessibility/refs/screen-reader-testing-commands.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Screen Reader Testing: Commands & Setup
 
 Comprehensive guide to screen reader commands and setup for WCAG 2.1 compliance.

--- a/skills/product/accessibility/refs/wcag-checklist.md
+++ b/skills/product/accessibility/refs/wcag-checklist.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # WCAG 2.1 Level AA Complete Checklist
 
 Comprehensive checklist for WCAG 2.1 Level AA compliance.

--- a/skills/product/analyze/SKILL.md
+++ b/skills/product/analyze/SKILL.md
@@ -5,6 +5,8 @@ description: |
 
   Use when: analyzing customer feedback for sentiment, extracting themes from
   support or survey data, or detecting trends in voice-of-customer signal.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Analyze Skill

--- a/skills/product/analyze/refs/algorithms.md
+++ b/skills/product/analyze/refs/algorithms.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Analysis Algorithms
 
 Detailed algorithms for sentiment, theme extraction, and trend detection.

--- a/skills/product/analyze/refs/sentiment-patterns.md
+++ b/skills/product/analyze/refs/sentiment-patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Sentiment Analysis Patterns
 
 Common patterns and indicators for sentiment classification.

--- a/skills/product/imagery/SKILL.md
+++ b/skills/product/imagery/SKILL.md
@@ -6,6 +6,8 @@ description: |
 
   Use when: generating, editing, analyzing, or reviewing an image — routes to
   the appropriate sub-skill (create / alter / review).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Imagery: Visual Asset Lifecycle

--- a/skills/product/imagery/alter/SKILL.md
+++ b/skills/product/imagery/alter/SKILL.md
@@ -5,6 +5,8 @@ description: |
   Requires a provider that supports editing operations.
 
   Use when: "edit image", "modify image", "change image", "inpaint", "img2img"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Image Alteration

--- a/skills/product/imagery/alter/refs/editing-reference.md
+++ b/skills/product/imagery/alter/refs/editing-reference.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Image Editing Reference
 
 Comprehensive reference for image modification techniques, provider-specific commands, and refinement strategies.

--- a/skills/product/imagery/create/SKILL.md
+++ b/skills/product/imagery/create/SKILL.md
@@ -5,6 +5,8 @@ description: |
   Supports 5 providers: cstudio, vertex-curl, OpenAI, Stability AI, Replicate.
 
   Use when: "generate image", "create image", "text to image", "new visual"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Image Creation

--- a/skills/product/imagery/create/refs/prompt-engineering.md
+++ b/skills/product/imagery/create/refs/prompt-engineering.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Prompt Engineering for Image Generation
 
 Guidance on crafting effective prompts that produce high-quality, predictable image outputs.

--- a/skills/product/imagery/create/refs/provider-reference.md
+++ b/skills/product/imagery/create/refs/provider-reference.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Provider Reference
 
 Detailed documentation for each supported image generation provider.

--- a/skills/product/imagery/review/SKILL.md
+++ b/skills/product/imagery/review/SKILL.md
@@ -7,6 +7,8 @@ description: |
   Use when: reviewing an image for visual quality, brand-guideline adherence,
   or accessibility before production use.
 portability: portable
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Image Review & Analysis

--- a/skills/product/imagery/review/refs/analysis-lenses.md
+++ b/skills/product/imagery/review/refs/analysis-lenses.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Visual Analysis Lenses
 
 Four complementary lenses for comprehensive image analysis. Apply one or more depending on the task.

--- a/skills/product/imagery/review/refs/quality-gates.md
+++ b/skills/product/imagery/review/refs/quality-gates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Quality Gates Reference
 
 Four review gates ensure visual assets are "Business Ready" before delivery. Each gate produces a PASS/FAIL verdict with actionable feedback.

--- a/skills/product/listen/SKILL.md
+++ b/skills/product/listen/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: aggregating customer feedback from discovered sources, gathering
   voice-of-customer data, or surveying sentiment across channels.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Listen Skill

--- a/skills/product/listen/refs/channels.md
+++ b/skills/product/listen/refs/channels.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Capability Integration Patterns
 
 Detailed integration patterns for customer voice capabilities.

--- a/skills/product/mockup/SKILL.md
+++ b/skills/product/mockup/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when you need a quick ASCII wireframe or HTML mockup in-chat without Figma overhead.
   NOT for production design work — use the figma plugin for that.
 portability: portable
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Mockup Skill

--- a/skills/product/mockup/refs/templates.md
+++ b/skills/product/mockup/refs/templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Mockup Templates
 
 Copy-paste templates for three common mockup deliverables: HTML/CSS preview, component spec, and handoff notes. See the SKILL.md selection table for when to use each output format.

--- a/skills/product/product-management/SKILL.md
+++ b/skills/product/product-management/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: planning a roadmap, prioritizing a backlog, or defining scope and
   stakeholder alignment for an upcoming feature.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Product Management Skill

--- a/skills/product/product-management/refs/acceptance-criteria-guide-examples.md
+++ b/skills/product/product-management/refs/acceptance-criteria-guide-examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Acceptance Criteria Guide: Domain Examples & Integration
 
 Domain-specific examples, non-functional requirements, common mistakes, testing integration, and review process.

--- a/skills/product/product-management/refs/acceptance-criteria-guide-fundamentals.md
+++ b/skills/product/product-management/refs/acceptance-criteria-guide-fundamentals.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Acceptance Criteria Guide: Fundamentals
 
 What acceptance criteria are, the Given/When/Then format, basic examples, coverage requirements, and writing guidelines.

--- a/skills/product/product-management/refs/user-story-template.md
+++ b/skills/product/product-management/refs/user-story-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # User Story Template
 
 Standard template for creating well-formed user stories with complete traceability.

--- a/skills/product/requirements-analysis/SKILL.md
+++ b/skills/product/requirements-analysis/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when turning a vague idea or stakeholder ask into structured user stories with acceptance criteria
   and a requirements graph. For complexity >= 3 or compliance projects, defaults to graph mode.
   NOT for navigating an existing requirements graph (use requirements-navigate) or stakeholder alignment (use product:align).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Requirements Analysis Skill

--- a/skills/product/requirements-analysis/refs/requirements-example-auth.md
+++ b/skills/product/requirements-analysis/refs/requirements-example-auth.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Requirements Output: Authentication Example
 
 Full domain-specific example of requirements analysis output for an authentication feature.

--- a/skills/product/requirements-analysis/refs/requirements-example-export-integration.md
+++ b/skills/product/requirements-analysis/refs/requirements-example-export-integration.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Requirements Output: Minimal Example & Integration Points
 
 Minimal format example and integration points for requirements analysis output.

--- a/skills/product/requirements-analysis/refs/requirements-output-format-template.md
+++ b/skills/product/requirements-analysis/refs/requirements-output-format-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Requirements Output Format: Templates
 
 Standard format template and minimal format for documenting requirements analysis results.

--- a/skills/product/requirements-analysis/refs/user-story-guide.md
+++ b/skills/product/requirements-analysis/refs/user-story-guide.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # User Story Writing Guide
 
 Comprehensive guide to writing effective user stories.

--- a/skills/product/requirements-graph/SKILL.md
+++ b/skills/product/requirements-graph/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: defining requirements as a filesystem graph of atomic ACs, eliciting
   user stories, or laying out acceptance criteria with traceable edges.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Requirements Graph

--- a/skills/product/requirements-graph/refs/examples.md
+++ b/skills/product/requirements-graph/refs/examples.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Requirements Graph: Worked Examples
 
 ## Example 1: Authentication Feature

--- a/skills/product/requirements-graph/refs/schema.md
+++ b/skills/product/requirements-graph/refs/schema.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Requirements Graph: Frontmatter Schema Reference
 
 Complete field reference for all requirement node types.

--- a/skills/product/requirements-migrate/SKILL.md
+++ b/skills/product/requirements-migrate/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "migrate requirements", "convert to graph",
   "split requirements", "restructure requirements"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Requirements Migrate

--- a/skills/product/requirements-navigate/SKILL.md
+++ b/skills/product/requirements-navigate/SKILL.md
@@ -6,6 +6,8 @@ description: |
 
   Use when: navigating or querying a requirements graph, generating a coverage
   report, refreshing meta.md, or linting graph structure for gaps.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Requirements Navigate

--- a/skills/product/requirements-navigate/refs/meta-templates.md
+++ b/skills/product/requirements-navigate/refs/meta-templates.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # meta.md Templates
 
 Copy-paste templates for each level of the requirements graph.

--- a/skills/product/screenshot/SKILL.md
+++ b/skills/product/screenshot/SKILL.md
@@ -8,6 +8,8 @@ description: |
   Use when: reviewing a UI screenshot for visual design, comparing rendered
   output against design system rules, or auditing layout from an image file.
 portability: portable
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Screenshot Skill

--- a/skills/product/strategy/SKILL.md
+++ b/skills/product/strategy/SKILL.md
@@ -6,6 +6,8 @@ description: |
 
   Use when: building a business case for a technical investment, evaluating
   ROI or value proposition, or doing competitive positioning analysis.
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Strategy Skill

--- a/skills/product/strategy/refs/frameworks.md
+++ b/skills/product/strategy/refs/frameworks.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Strategic Analysis Frameworks
 
 Reference guide for business analysis frameworks used in product.

--- a/skills/product/strategy/refs/templates-competitive-market.md
+++ b/skills/product/strategy/refs/templates-competitive-market.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Strategic Analysis Templates: Competitive & Market Analysis
 
 Competitive analysis, market analysis, and quick decision templates for business strategy.

--- a/skills/product/strategy/refs/templates-roi-value.md
+++ b/skills/product/strategy/refs/templates-roi-value.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Strategic Analysis Templates: ROI & Value Proposition
 
 ROI analysis and value proposition templates for business strategy.

--- a/skills/product/synthesize/SKILL.md
+++ b/skills/product/synthesize/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use when: "recommendations from feedback", "translate feedback to priorities",
   "feature priorities from customer data", "synthesize feedback into action"
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Synthesize Skill

--- a/skills/product/synthesize/refs/journey-mapping.md
+++ b/skills/product/synthesize/refs/journey-mapping.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Customer Journey Mapping
 
 Map feedback to customer lifecycle stages for holistic insights.

--- a/skills/product/synthesize/refs/prioritization.md
+++ b/skills/product/synthesize/refs/prioritization.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
+---
 # Prioritization Framework
 
 Detailed framework for translating customer voice into feature priorities.

--- a/skills/product/ux-review/SKILL.md
+++ b/skills/product/ux-review/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Use when evaluating UX quality — user flows, information architecture, user research synthesis,
   personas, and usability assessment. Also covers generative UX flow design from requirements.
   NOT for visual design consistency (use visual-review) or accessibility code audits (use product/accessibility).
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # UX Review Skill

--- a/skills/product/visual-review/SKILL.md
+++ b/skills/product/visual-review/SKILL.md
@@ -5,6 +5,8 @@ description: |
   scale, color palette, component patterns, and responsive polish. Structured checklist + scoring.
   NOT for UX flows or user research (use ux-review) or accessibility code audits (use product/accessibility).
 portability: portable
+phase_relevance: ["clarify", "design", "review"]
+archetype_relevance: ["*"]
 ---
 
 # Visual Review Skill

--- a/skills/propose-process/refs/ambiguity.md
+++ b/skills/propose-process/refs/ambiguity.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Ambiguity — when to stop and ask
 
 The facilitator's worst failure mode is confidently planning the wrong thing. When the

--- a/skills/propose-process/refs/challenge-gate.md
+++ b/skills/propose-process/refs/challenge-gate.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Challenge Gate (Issue #442)
 
 Persistent contrarian review. The facilitator auto-inserts the `challenge`

--- a/skills/propose-process/refs/dispatch-example.md
+++ b/skills/propose-process/refs/dispatch-example.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Concrete Dispatch Example
 
 Concrete Task() dispatch example for the `crew:start` Step 5 call. The abstract template (with all `{token}` placeholders) lives in SKILL.md; this version has the *top-level documented inputs* substituted with realistic values so callers can see the expected shape.

--- a/skills/propose-process/refs/evidence-framing.md
+++ b/skills/propose-process/refs/evidence-framing.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Evidence Framing (functional, not coverage)
 
 Evidence is about proving the task did what it claims. Coverage percentages are gate

--- a/skills/propose-process/refs/factor-definitions.md
+++ b/skills/propose-process/refs/factor-definitions.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Factor Definitions (with calibration examples)
 
 Nine factors. For each: what it means, what LOW / MEDIUM / HIGH look like, and the

--- a/skills/propose-process/refs/gate-policy.md
+++ b/skills/propose-process/refs/gate-policy.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Gate Policy — Human-Readable Description
 
 **This file is documentation only.** The runtime source of truth is

--- a/skills/propose-process/refs/inputs.md
+++ b/skills/propose-process/refs/inputs.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Inputs — priors fetch and session-state reads
 
 The facilitator runs inside a Claude session with access to:

--- a/skills/propose-process/refs/interaction-mode.md
+++ b/skills/propose-process/refs/interaction-mode.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Interaction mode — yolo / `/wicked-garden:crew:just-finish`
 
 **Interaction mode is orthogonal to phase plan, specialist selection, rigor tier, and

--- a/skills/propose-process/refs/output-schema.md
+++ b/skills/propose-process/refs/output-schema.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Output Schema (for measurement)
 
 When the facilitator is invoked with `output=json` (set by

--- a/skills/propose-process/refs/phase-catalog.md
+++ b/skills/propose-process/refs/phase-catalog.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Phase Catalog (templates, soft dependencies)
 
 Phases are templates, not laws. The facilitator picks what applies for THIS work and

--- a/skills/propose-process/refs/plan-template.md
+++ b/skills/propose-process/refs/plan-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # `process-plan.md` template
 
 Write this artifact to the project directory (typically

--- a/skills/propose-process/refs/process-memory.md
+++ b/skills/propose-process/refs/process-memory.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Process memory — first-class context at session start
 
 Issue #447 adds a persistent per-project process memory. The facilitator reads this at every session start so retro observations, kaizen hypotheses, and unresolved action items don't evaporate between sessions.

--- a/skills/propose-process/refs/re-eval-addendum-schema.md
+++ b/skills/propose-process/refs/re-eval-addendum-schema.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Re-Evaluation Addendum JSONL Schema (D2, D8)
 
 This file is the authoritative human-readable description of the re-eval addendum

--- a/skills/propose-process/refs/re-evaluation.md
+++ b/skills/propose-process/refs/re-evaluation.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Re-Evaluation Mode (Bidirectional, v6)
 
 The facilitator runs at every phase boundary — not just at `crew:start`. Two modes:

--- a/skills/propose-process/refs/spec-quality-rubric.md
+++ b/skills/propose-process/refs/spec-quality-rubric.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Spec Quality Rubric — Human-Readable Description
 
 **This file is documentation.** The runtime source of truth is

--- a/skills/propose-process/refs/specialist-selection.md
+++ b/skills/propose-process/refs/specialist-selection.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["bootstrap", "clarify"]
+archetype_relevance: ["*"]
+---
 # Specialist Selection (~70-agent roster map)
 
 Discover at call time via `Glob agents/**/*.md` and read the `description:` +

--- a/skills/runtime-exec/SKILL.md
+++ b/skills/runtime-exec/SKILL.md
@@ -4,6 +4,8 @@ description: |
   Smart runtime execution for Python and Node scripts with automatic package manager detection.
   Invoked by other skills and agents when scripts need execution with correct runtime resolution.
 user-invocable: false
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Runtime Execution Skill

--- a/skills/search/codebase-narrator/SKILL.md
+++ b/skills/search/codebase-narrator/SKILL.md
@@ -12,6 +12,8 @@ description: |
   Use when: "give me an architecture walkthrough", "narrate this codebase",
   "explain how this project is organized", "code navigation", "where should
   I start reading".
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Codebase Narrator

--- a/skills/search/codebase-narrator/refs/output-template.md
+++ b/skills/search/codebase-narrator/refs/output-template.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Codebase Narrator — Output Template
 
 ## Codebase Narrative: {project_name}

--- a/skills/smaht/SKILL.md
+++ b/skills/smaht/SKILL.md
@@ -9,6 +9,8 @@ description: |
   Use when: gathering a context briefing before a task, resuming work after
   a session break, or assembling background on an unfamiliar area.
 user-invocable: true
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Context Assembly (v6 pull-model)

--- a/skills/smaht/discovery/SKILL.md
+++ b/skills/smaht/discovery/SKILL.md
@@ -5,6 +5,8 @@ description: |
   Discovers relationships dynamically from command/skill content, not a static map.
   Invoked by the Stop hook and smaht:briefing to surface one relevant suggestion.
 user-invocable: false
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Contextual Discovery

--- a/skills/smaht/intent/SKILL.md
+++ b/skills/smaht/intent/SKILL.md
@@ -9,6 +9,8 @@ description: |
   Use when: "set intent", "intent override", "/wicked-garden:intent",
   "make the framework quiet", "force rigor", "what's my intent".
 user-invocable: true
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:intent

--- a/skills/smaht/propose-skills/SKILL.md
+++ b/skills/smaht/propose-skills/SKILL.md
@@ -10,6 +10,8 @@ description: |
   skills from my sessions", "mine my history for skill ideas",
   "session-mined skill builder", "skill discovery from past usage".
 user-invocable: true
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Propose Skills (session-mined, MVP)

--- a/skills/wickedizer/SKILL.md
+++ b/skills/wickedizer/SKILL.md
@@ -7,6 +7,8 @@ description: |
   message, or aligning written output to team voice.
 portability: portable
 status: experimental
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Wickedizer: Clear, Credible, Human Writing

--- a/skills/wickedizer/refs/artifact-types.md
+++ b/skills/wickedizer/refs/artifact-types.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Artifact Types: Mode-Specific Guidance
 
 Different document types have different constraints. This reference provides specific guidance for each artifact type wickedizer handles.

--- a/skills/wickedizer/refs/complexity.md
+++ b/skills/wickedizer/refs/complexity.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Complexity: Keep It Simple
 
 Writing complexity is cognitive load on the reader. Every unnecessary word, section, or concept is debt they pay to understand you.

--- a/skills/wickedizer/refs/de-ai-pass.md
+++ b/skills/wickedizer/refs/de-ai-pass.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # De-AI Pass: Removing AI-Generated Tells
 
 This reference covers identifying and removing patterns that signal AI-generated content. The goal isn't to hide AI involvement - it's to remove artifacts that damage trust and clarity.

--- a/skills/wickedizer/refs/failure-modes.md
+++ b/skills/wickedizer/refs/failure-modes.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Failure Modes: What to Watch For
 
 This reference catalogs common failure modes in rewritten content. Use it as a checklist or debugging guide when output doesn't feel right.

--- a/skills/wickedizer/refs/patterns.md
+++ b/skills/wickedizer/refs/patterns.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Patterns: Reusable Writing Structures
 
 Patterns are proven structures for common writing situations. Don't reinvent—adapt.

--- a/skills/wickedizer/refs/review.md
+++ b/skills/wickedizer/refs/review.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Review: Quality Validation
 
 How do you know writing is done? This reference provides review criteria and checklists for validating writing quality.

--- a/skills/wickedizer/refs/structure.md
+++ b/skills/wickedizer/refs/structure.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Structure: Document Architecture
 
 How you organize content determines whether readers find what they need. Structure is invisible when done well—readers just "get it."

--- a/skills/wickedizer/refs/voice-profile.md
+++ b/skills/wickedizer/refs/voice-profile.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Voice Profile: Team Writing Style
 
 This reference defines the default voice for wickedizer output. Apply these characteristics unless the context requires a different tone (e.g., marketing copy, legal docs). Teams can customize this profile in their local settings.

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -9,6 +9,8 @@ context: fork
 
 **Plain:** wicked-crew v6 — propose-process rubric picks phases and rigor tier;
 gates are hard enforcement; two interaction modes (normal / yolo).
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
 ---
 
 # Workflow Skill (v6)

--- a/skills/workflow/refs/archetype-adjustments.md
+++ b/skills/workflow/refs/archetype-adjustments.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Archetype Adjustments
 
 11 project archetypes with detection keywords and scoring adjustments.

--- a/skills/workflow/refs/evidence.md
+++ b/skills/workflow/refs/evidence.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Evidence Tracking
 
 Crew gate decisions and phase artifacts are tracked as evidence to support

--- a/skills/workflow/refs/integration.md
+++ b/skills/workflow/refs/integration.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Utility Plugin Integration
 
 How wicked-crew integrates with utility plugins (graceful degradation).

--- a/skills/workflow/refs/risk-dimension-signals.md
+++ b/skills/workflow/refs/risk-dimension-signals.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Risk Dimension Signals
 
 Seven independent risk dimensions computed from text analysis. Each dimension

--- a/skills/workflow/refs/scoring-rubric.md
+++ b/skills/workflow/refs/scoring-rubric.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Scoring Rubric (HISTORICAL — v5)
 
 **Status**: Deprecated. This file describes the v5 weighted-sum complexity-scoring

--- a/skills/workflow/refs/signal-keywords.md
+++ b/skills/workflow/refs/signal-keywords.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Signal Keywords
 
 All 16 signal categories with keyword lists and specialist routing.

--- a/skills/workflow/refs/specialist-routing-rules.md
+++ b/skills/workflow/refs/specialist-routing-rules.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["*"]
+archetype_relevance: ["*"]
+---
 # Specialist Routing Rules
 
 Signal-to-specialist mapping, complexity thresholds, fallback agents,

--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -12,6 +12,8 @@ description: |
   in main?", verifying agent-claimed commits actually landed, planning multi-agent
   parallel work in worktrees.
 status: stable
+phase_relevance: ["build"]
+archetype_relevance: ["*"]
 ---
 
 # Worktrees

--- a/skills/worktrees/refs/recipes.md
+++ b/skills/worktrees/refs/recipes.md
@@ -1,3 +1,7 @@
+---
+phase_relevance: ["build"]
+archetype_relevance: ["*"]
+---
 # Worktree Recipes
 
 Detection, salvage, and verification commands for the three worktree failure modes.


### PR DESCRIPTION
## Summary

Closes the Issue #725 bridge. The `phase_relevance` / `archetype_relevance` frontmatter contract introduced with context-aware `crew:guide` shipped on a curated 15-command subset and deferred the rest. Every plugin load surfaced `WARN: missing relevance frontmatter — 384 files: ... (and 379 more)`.

This PR:
1. Adds frontmatter to the 384 missing commands/skills with directory-derived defaults (real signal, not blanket `["*"]`).
2. Flips `WG_RELEVANCE_LINT` default from `warn` to `deny` per the script's own committed plan.

## Per-domain phase mapping

| Domain | `phase_relevance` |
|---|---|
| `platform/`, `delivery/` | `["build", "review", "operate"]` |
| `product/` | `["clarify", "design", "review"]` |
| `engineering/`, `data/` | `["design", "build"]` |
| `jam/`, `multi-model/`, `deliberate/` | `["clarify", "design"]` |
| `agentic/` | `["design", "review"]` |
| `propose-process/`, `integration-discovery/` | `["bootstrap"]` |
| `worktrees/` | `["build"]` |
| `crew/`, `search/`, `smaht/`, `persona/`, cross-cutting | `["*"]` |

`archetype_relevance` is `["*"]` everywhere at the bulk-pass stage.

## Lint flip rationale

The script's docstring committed to the flip: *"The next release flips the default after the bulk-pass follow-up PR ships."* This is that release.

Without the flip, this PR silences existing warns but the next person to add a command without frontmatter re-introduces the noise. The flip is the lock that keeps the bulk-pass meaningful.

- `deny` (new default): CI fails on missing frontmatter
- `warn`: temporary opt-out during a refactor that intentionally adds files without frontmatter
- `off`: rollback lever for emergencies

## Test plan

- [x] 7/7 relevance lint tests passing
- [x] 35/35 wicked-testing probe + drift tests passing
- [x] 225/225 v10-surface + hook + smaht + relevance smoke tests passing
- [x] All three lint modes verified clean (`deny` exit 0, `warn` exit 0, `off` exit 0)
- [x] Spot-check: every edited file has valid YAML, multiline `description: |` preserved
- [x] 0 broken frontmatter blocks across 401 commands+skills

## No behaviour change

This is a config + frontmatter sweep. No code logic touched in commands/skills/agents/hooks. The frontmatter is read by `crew:guide` (Issue #725) — the field values now declare what was previously implicit.

## Pre-existing failure noted

`test_yolo_md_exists` references a deleted alias file. Unrelated to this PR; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)