### PR TITLE
v9.2.10 — bootstrap quietening + delete defunct yolo test

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.9",
+  "version": "9.2.10",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [9.2.10] - 2026-05-06
+
+**Bootstrap quietening — gate informational notices on actual condition + delete defunct yolo test class.**
+
+Every session bootstrap surfaced four notices that fired regardless of state:
+
+```
+[Skills] Critical v6 skills are present on disk. If Skill() returns 'Unknown skill: ...', run /reload-plugins
+[Memory] This project uses wicked-garden memory for persistence. Never write to MEMORY.md directly...
+[Setup] Run `/wicked-garden:setup --reconfigure` to change connection or re-onboard.
+[Quick Start] Available commands for this project: ...
+```
+
+None of them were gated on actual problem state. v9.2.10 fixes each per its real semantics.
+
+### `[Skills]` happy-path message dropped (`_check_critical_skills`)
+
+The function used to emit a one-liner on every healthy session — *"skills are present; if Skill() fails run /reload-plugins"*. That message has zero signal when nothing's broken. A user who has hit a cache-stale failure once knows the fix; emitting it on every healthy session adds no value.
+
+`_check_critical_skills` now returns `None` when all critical skills are present. The real problem case (missing skill files on disk) still surfaces a directive with the install fix.
+
+### `[Memory]` reminder removed from briefing
+
+`_MEMORY_INSTRUCTIONS` was appended to the briefing every session — a 95-character block telling Claude to use `wicked-brain:memory` instead of writing `MEMORY.md`. CLAUDE.md's "Memory Management" section already overrides the system-level auto-memory instructions and tells Claude exactly the same thing. The briefing reminder was redundant prompt budget.
+
+The constant `_MEMORY_INSTRUCTIONS` is preserved (in case any other module imports it — silent contract drift defence per the v9.2.6 wiki article) but no longer appended to the briefing. A future cleanup can delete the constant entirely once a sweep confirms no consumers.
+
+### `[Setup]` and `[Quick Start]` gated on first-session-per-project
+
+Both notices are useful exactly once per project. v9.2.10 adds a per-project sentinel file:
+
+- `_notice_path()` resolves to `<local store>/wicked-garden/bootstrap-notices/shown.json`. The path is per-project automatically because `get_local_path("wicked-garden", ...)` is scoped under the active project's slug.
+- `_notice_already_shown(notice_id)` reads the sentinel; returns False if missing or absent from the file.
+- `_record_notice_shown(notice_id)` writes `{notice_id: {shown_at: ISO-8601-UTC}}`. Best-effort — bootstrap stays fail-open if the local store is unreachable.
+- Briefing emit checks `_notice_already_shown` before appending each notice and records on emission.
+
+Same anti-pattern as the v9.2.6 [Memory] reminder that v9.2.2 first attempted to latch and got bit by SessionState being per-session. v9.2.10 fixes it correctly via cross-session per-project storage.
+
+### `TestCrewYoloAliasStub` deleted (#603 followup)
+
+`commands/crew/yolo.md` was deleted in PR #603 (v9-PR-2 surface cuts) when the CLI compatibility shim moved into `scripts/crew/autonomy.py`. `--yolo` now resolves to `--autonomy=full` via `get_mode()` and emits a one-shot deprecation warning — there is no markdown alias file anymore.
+
+The `TestCrewYoloAliasStub` class kept asserting `commands/crew/yolo.md must still exist for backward compatibility`. That test has been failing since #603 — three test failures with no signal. Class removed; sibling classes (`TestCrewAutoApproveCanonical`, `TestPhaseManagerYoloAction`) remain because their contracts still hold.
+
+### Tests
+
+- 8/8 new bootstrap-notice-gating tests added (`tests/test_bootstrap_notice_gating.py`):
+  - first show records, subsequent shows suppress, multiple notices track independently, ISO timestamp persisted, unresolvable path fails open, corrupt JSON treated as empty, `[Skills]` silent when present, `_MEMORY_INSTRUCTIONS` constant still defined.
+- 230/230 v10 surface + hook + session_state smoke tests passing.
+- 35/35 wicked-testing probe + drift tests passing.
+- Relevance lint (deny default from v9.2.9) clean.
+
+### Plugin version
+
+9.2.9 → 9.2.10 (patch — bootstrap noise reduction; no behaviour change beyond suppression of redundant notices).
+
 ## [9.2.9] - 2026-05-06
 
 **Issue #725 bulk-pass — relevance frontmatter on the remaining 384 commands/skills + lint flips to deny.**

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Add shared scripts directory to path so hook can import shared modules
@@ -726,6 +727,60 @@ _CRITICAL_V6_SKILLS = (
 )
 
 
+# v9.2.10 — first-session-per-project gating for informational briefing notices.
+# Both `[Setup]` and `[Quick Start]` are useful exactly once per project; on
+# every subsequent session they are pure noise. The sentinel file lives under
+# the wicked-garden local store (per-project automatically because
+# `get_local_path` resolves under the active project's slug), so a fresh
+# project sees the notices on its first session and never again.
+
+_BOOTSTRAP_NOTICE_FILE = "shown.json"
+_NOTICE_SETUP = "setup_reconfigure"
+_NOTICE_QUICK_START = "quick_start"
+
+
+def _notice_path() -> "Path | None":
+    """Resolve the per-project sentinel file path. None on resolution failure."""
+    try:
+        # Lazy import — keeps bootstrap fail-open if scripts/ is unreachable.
+        sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+        from _domain_store import get_local_path  # type: ignore
+        return get_local_path("wicked-garden", "bootstrap-notices") / _BOOTSTRAP_NOTICE_FILE
+    except Exception:
+        return None
+
+
+def _notice_already_shown(notice_id: str) -> bool:
+    """Return True if `notice_id` has been emitted for this project before."""
+    p = _notice_path()
+    if p is None or not p.exists():
+        return False
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return notice_id in data
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
+def _record_notice_shown(notice_id: str) -> None:
+    """Record `notice_id` as shown. Best-effort; failures don't block bootstrap."""
+    p = _notice_path()
+    if p is None:
+        return
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        data = {}
+        if p.exists():
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                data = {}
+        data[notice_id] = {"shown_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}
+        p.write_text(json.dumps(data), encoding="utf-8")
+    except OSError:
+        pass  # fail open
+
+
 def _check_critical_skills() -> str | None:
     """Verify critical v6 skill files are present in the plugin root.
 
@@ -735,9 +790,14 @@ def _check_critical_skills() -> str | None:
     can check the files exist on disk and emit a diagnostic directive so an
     "Unknown skill" error surfaces a fix path instead of being cryptic.
 
-    Returns a directive string (shown in the briefing) when any critical skill
-    is missing from disk, OR a 1-liner when all files are present that tells
-    Claude how to handle a cache-stale Skill() failure. Fails open on errors.
+    Returns a directive string ONLY when one or more critical skills are
+    missing from disk (a real install problem). The previous "happy path"
+    message — "skills are present; if Skill() fails, run /reload-plugins" —
+    fired every session even with a clean install and was chronic noise. A
+    user who has hit a cache-stale failure once knows the fix; emitting it
+    on every healthy session adds no signal. v9.2.10 dropped that branch.
+
+    Fails open on errors.
     """
     try:
         plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
@@ -745,17 +805,13 @@ def _check_critical_skills() -> str | None:
             return None
         root = Path(plugin_root)
         missing = [s for s in _CRITICAL_V6_SKILLS if not (root / s).exists()]
-        if missing:
-            return (
-                "[Skills] Critical v6 skill files are missing from the plugin root:\n"
-                + "\n".join(f"  - {s}" for s in missing)
-                + "\nThe plugin install is incomplete. Reinstall with "
-                "`claude plugin install wicked-garden --scope project`."
-            )
+        if not missing:
+            return None  # healthy install — nothing to say
         return (
-            "[Skills] Critical v6 skills are present on disk. "
-            "If Skill() returns 'Unknown skill: wicked-garden:crew:*', the plugin "
-            "cache is stale — run `/reload-plugins` once, then retry."
+            "[Skills] Critical v6 skill files are missing from the plugin root:\n"
+            + "\n".join(f"  - {s}" for s in missing)
+            + "\nThe plugin install is incomplete. Reinstall with "
+            "`claude plugin install wicked-garden --scope project`."
         )
     except Exception:
         return None  # fail open — never block bootstrap
@@ -1454,22 +1510,35 @@ def main():
         if decay_summary:
             briefing_parts.append(f"[Memory] {decay_summary}")
 
-        # --- Internal instructions for Claude ---
-        briefing_parts.append(_MEMORY_INSTRUCTIONS)
+        # NOTE (v9.2.10): _MEMORY_INSTRUCTIONS used to be appended here every
+        # session. CLAUDE.md's "Memory Management" section already overrides
+        # the system-level auto-memory instructions and tells Claude to use
+        # wicked-brain:memory. Emitting the same guidance every session was
+        # redundant noise. The string constant is preserved below for
+        # backwards reference but no longer appended to the briefing.
 
         if dangerous_mode:
             briefing_parts.append(_DANGEROUS_MODE_WARNING)
 
+        # [Setup] and [Quick Start] are first-session-per-project notices.
+        # Once shown for a project, they are recorded in the per-project
+        # sentinel file and suppressed on every subsequent bootstrap. v9.2.10.
         if not onboarding_directive:
-            briefing_parts.append(
-                "[Setup] Run `/wicked-garden:setup --reconfigure` to change connection or re-onboard."
-            )
+            if not _notice_already_shown(_NOTICE_SETUP):
+                briefing_parts.append(
+                    "[Setup] Run `/wicked-garden:setup --reconfigure` to change connection or re-onboard."
+                )
+                _record_notice_shown(_NOTICE_SETUP)
 
-        # Discovery: show 2-3 contextual command suggestions based on project files
+        # Discovery: show 2-3 contextual command suggestions based on project files.
+        # Also gated on first-session-per-project since the suggestions don't change
+        # session-to-session.
         if not onboarding_directive and has_memories:
-            discovery_lines = _suggest_commands_for_project()
-            if discovery_lines:
-                briefing_parts.append(discovery_lines)
+            if not _notice_already_shown(_NOTICE_QUICK_START):
+                discovery_lines = _suggest_commands_for_project()
+                if discovery_lines:
+                    briefing_parts.append(discovery_lines)
+                    _record_notice_shown(_NOTICE_QUICK_START)
 
         # Facilitator context: surface aging action items from process_memory.
         # Additive briefing line (issue #461) — runs last of the informational

--- a/tests/test_bootstrap_notice_gating.py
+++ b/tests/test_bootstrap_notice_gating.py
@@ -1,0 +1,137 @@
+"""tests/test_bootstrap_notice_gating.py — first-session-per-project gating
+for [Setup] and [Quick Start] briefing notices (v9.2.10).
+
+Provenance: every session of every wicked-garden user emitted
+
+  [Setup] Run `/wicked-garden:setup --reconfigure` to change connection or re-onboard.
+  [Quick Start] Available commands for this project: ...
+
+These notices are useful exactly once per project. Emitting them on every
+session is chronic noise — same anti-pattern as the v9.2.6 [Memory] reminder
+that v9.2.2 first attempted to latch (and got bit by SessionState being
+per-session). v9.2.10 fixes it correctly via a per-project sentinel file
+under the wicked-garden local store, which is naturally scoped per project
+because `get_local_path("wicked-garden", ...)` resolves under the active
+project's slug.
+
+T1: deterministic — uses a tmp_path-redirected sentinel file.
+T3: isolated — monkeypatches `_notice_path` to point at tmp.
+T4: single focus — the notice-shown contract.
+T6: docstring cites v9.2.10 (this PR).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+@pytest.fixture
+def tmp_notice_path(tmp_path, monkeypatch):
+    """Redirect the bootstrap notice sentinel to a tmp file."""
+    import bootstrap  # noqa: F401  — module loaded with sys.path adjustments above
+    sentinel = tmp_path / "shown.json"
+    monkeypatch.setattr(bootstrap, "_notice_path", lambda: sentinel)
+    return sentinel
+
+
+def test_first_show_records_notice(tmp_notice_path):
+    """First call emits (returns False from _notice_already_shown)
+    and recording marks it as shown."""
+    import bootstrap
+
+    notice_id = "setup_reconfigure"
+    assert bootstrap._notice_already_shown(notice_id) is False
+    bootstrap._record_notice_shown(notice_id)
+    assert bootstrap._notice_already_shown(notice_id) is True
+
+
+def test_subsequent_calls_see_notice_as_shown(tmp_notice_path):
+    """After a notice is recorded, subsequent _notice_already_shown calls
+    return True so the briefing logic suppresses the line."""
+    import bootstrap
+
+    bootstrap._record_notice_shown("quick_start")
+    # Multiple checks all return True — sticky across reads.
+    assert bootstrap._notice_already_shown("quick_start") is True
+    assert bootstrap._notice_already_shown("quick_start") is True
+    assert bootstrap._notice_already_shown("quick_start") is True
+
+
+def test_two_notices_track_independently(tmp_notice_path):
+    """Recording one notice does not mark another as shown."""
+    import bootstrap
+
+    bootstrap._record_notice_shown("setup_reconfigure")
+    assert bootstrap._notice_already_shown("setup_reconfigure") is True
+    assert bootstrap._notice_already_shown("quick_start") is False
+
+
+def test_record_persists_iso_timestamp(tmp_notice_path):
+    """Each entry stores `shown_at` as an ISO-8601 UTC string for forensics."""
+    import bootstrap
+
+    bootstrap._record_notice_shown("setup_reconfigure")
+    data = json.loads(tmp_notice_path.read_text())
+    assert "setup_reconfigure" in data
+    assert "shown_at" in data["setup_reconfigure"]
+    ts = data["setup_reconfigure"]["shown_at"]
+    # Z-suffix UTC timestamp, length 20 (e.g. "2026-05-06T14:23:45Z").
+    assert ts.endswith("Z")
+    assert len(ts) == 20
+
+
+def test_unresolvable_path_fails_open(tmp_path, monkeypatch):
+    """If `_notice_path` returns None (e.g. local store unreachable),
+    _notice_already_shown returns False and _record_notice_shown is a no-op
+    rather than raising. Bootstrap must never hard-fail on this."""
+    import bootstrap
+
+    monkeypatch.setattr(bootstrap, "_notice_path", lambda: None)
+    assert bootstrap._notice_already_shown("anything") is False
+    # Must not raise.
+    bootstrap._record_notice_shown("anything")
+    assert bootstrap._notice_already_shown("anything") is False
+
+
+def test_corrupt_json_treated_as_empty(tmp_notice_path):
+    """A malformed sentinel file behaves like an empty one — first-show
+    semantics are preserved rather than raising."""
+    import bootstrap
+
+    tmp_notice_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_notice_path.write_text("{not json")
+    assert bootstrap._notice_already_shown("setup_reconfigure") is False
+    # Recording overwrites the corrupt content with a fresh dict.
+    bootstrap._record_notice_shown("setup_reconfigure")
+    assert bootstrap._notice_already_shown("setup_reconfigure") is True
+
+
+def test_critical_skills_silent_when_present():
+    """v9.2.10: the [Skills] happy-path message was dropped. When all
+    critical v6 skills exist on disk, _check_critical_skills returns None
+    rather than the chronic 'present on disk' notice."""
+    import bootstrap
+
+    result = bootstrap._check_critical_skills()
+    # All critical skills exist in the wicked-garden repo by construction.
+    assert result is None, (
+        f"_check_critical_skills should return None when skills present; got: {result!r}"
+    )
+
+
+def test_memory_instructions_constant_still_defined():
+    """v9.2.10 stopped APPENDING _MEMORY_INSTRUCTIONS to the briefing but
+    kept the constant defined for backwards reference. Removing the
+    constant is a follow-up cleanup; deleting it in this PR would be a
+    silent contract drift if any other module imports it."""
+    import bootstrap
+
+    assert hasattr(bootstrap, "_MEMORY_INSTRUCTIONS")
+    assert "wicked-brain:memory" in bootstrap._MEMORY_INSTRUCTIONS

--- a/tests/test_command_aliases.py
+++ b/tests/test_command_aliases.py
@@ -4,10 +4,15 @@ tests/test_command_aliases.py
 Regression suite for command aliases introduced in v6.3.3 hygiene bundle (#533).
 
 Asserts:
-- The crew:yolo alias stub still exists (backward compat).
-- The yolo stub redirects to crew:auto-approve (mentions auto-approve).
 - The canonical auto-approve command exists with full content.
 - The phase_manager.py 'yolo' action subcommand name is preserved (no runtime rename).
+
+Historical note (v9.2.10): the `TestCrewYoloAliasStub` class was removed
+because `commands/crew/yolo.md` was deleted in PR #603 (v9-PR-2 surface
+cuts). The CLI compatibility shim now lives in `scripts/crew/autonomy.py`
+— `--yolo` resolves to `--autonomy=full` via `get_mode()` and emits a
+one-shot deprecation warning. There is no markdown alias file anymore;
+the contract `TestCrewYoloAliasStub` asserted has not held since #603.
 """
 
 from pathlib import Path
@@ -16,34 +21,6 @@ import pytest
 REPO = Path(__file__).parent.parent
 COMMANDS_CREW = REPO / "commands" / "crew"
 SCRIPTS_CREW = REPO / "scripts" / "crew"
-
-
-class TestCrewYoloAliasStub:
-    """crew:yolo must remain as a stub that redirects to crew:auto-approve."""
-
-    def test_yolo_md_exists(self):
-        """commands/crew/yolo.md must still exist for backward compatibility."""
-        assert (COMMANDS_CREW / "yolo.md").exists(), (
-            "commands/crew/yolo.md was deleted. It must remain as an alias stub "
-            "so that existing /wicked-garden:crew:yolo invocations continue to work."
-        )
-
-    def test_yolo_md_is_short_stub(self):
-        """yolo.md must be short (stub-only, not full command spec)."""
-        content = (COMMANDS_CREW / "yolo.md").read_text(encoding="utf-8")
-        lines = [l for l in content.splitlines() if l.strip()]
-        assert len(lines) <= 20, (
-            f"commands/crew/yolo.md has {len(lines)} non-empty lines — expected a short alias "
-            f"stub (<=20 lines). It may have been reverted to the full command spec."
-        )
-
-    def test_yolo_stub_references_auto_approve(self):
-        """yolo.md must reference crew:auto-approve so users know where the canonical command is."""
-        content = (COMMANDS_CREW / "yolo.md").read_text(encoding="utf-8")
-        assert "auto-approve" in content, (
-            "commands/crew/yolo.md stub must reference 'auto-approve' to redirect users "
-            "to the canonical command. Got:\n" + content[:300]
-        )
 
 
 class TestCrewAutoApproveCanonical:


### PR DESCRIPTION
## Summary

Every session bootstrap fires four informational notices regardless of state:

```
[Skills] Critical v6 skills are present on disk. If Skill() returns 'Unknown skill: ...', run /reload-plugins
[Memory] This project uses wicked-garden memory for persistence. Never write to MEMORY.md directly...
[Setup] Run `/wicked-garden:setup --reconfigure` to change connection or re-onboard.
[Quick Start] Available commands for this project: ...
```

None gated on actual problem state. v9.2.10 fixes each per its real semantics.

## Changes

| Notice | Before | After |
|---|---|---|
| `[Skills]` (happy path) | Every session | Silent when all critical skills present (real failure case unchanged) |
| `[Memory]` | Every session | Removed — CLAUDE.md "Memory Management" already overrides system-level auto-memory |
| `[Setup]` | Every session | First-session-per-project (sentinel file) |
| `[Quick Start]` | Every session | First-session-per-project (sentinel file) |

Sentinel: `<local store>/wicked-garden/bootstrap-notices/shown.json`. Per-project automatic because `get_local_path("wicked-garden", ...)` resolves under the active project's slug.

## Defunct test deleted

`TestCrewYoloAliasStub` asserted `commands/crew/yolo.md must still exist for backward compatibility`. The file was deleted in PR #603 when the `--yolo` CLI shim moved into `scripts/crew/autonomy.py`. The test has been failing since — three failing tests with no signal. Class removed.

## Test plan

- [x] 8/8 new bootstrap-notice-gating tests (`tests/test_bootstrap_notice_gating.py`)
- [x] 230/230 v10 surface + hook + session_state smoke
- [x] 35/35 wicked-testing probe + drift
- [x] Relevance lint deny mode clean

## No behaviour change beyond suppression

The notices remain available — they just emit when meaningful instead of every session. A user installing wicked-garden on a fresh project still sees `[Setup]` and `[Quick Start]` once. After that, the briefing stays focused on session-specific signal (active project, decay summary, dangerous mode, facilitator context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)