### PR TITLE
v9.2.11 — delete every-10-turn [Memory] Checkpoint nudge + dead _MEMORY_INSTRUCTIONS constant

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.10",
+  "version": "9.2.11",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [9.2.11] - 2026-05-06
+
+**Delete the every-10-turn `[Memory] Checkpoint` nudge + delete the dead `_MEMORY_INSTRUCTIONS` constant.**
+
+The v9.2.10 bootstrap quietening cleared four bootstrap notices but missed a separate `UserPromptSubmit` periodic emitter. v9.2.11 closes the gap.
+
+### Periodic `[Memory]` checkpoint nudge removed
+
+`hooks/scripts/prompt_submit.py` fired `[Memory] Checkpoint: store decisions/gotchas with wicked-brain:memory.` every 10 turns (`turn_count > 0 and turn_count % 10 == 0`). The nudge surfaced on every prompt submit at turn 10, 20, 30, ... regardless of whether the session had produced anything worth checkpointing — exactly the false-urgency anti-pattern called out in the v9.2.6 [silent-contract-drift] wiki article.
+
+CLAUDE.md tells Claude how to use `wicked-brain:memory` (the "Memory Management" override block); the `wicked-brain-session-teardown` agent is the proper end-of-session synthesis checkpoint. A turn-counter timer added no signal beyond what those two mechanisms already provide. Removed.
+
+### Dead constant `_MEMORY_INSTRUCTIONS` deleted
+
+v9.2.10 stopped APPENDING the constant to the briefing but kept it defined as a silent-contract-drift defence in case any other module imported it. v9.2.11 grepped `hooks/`, `scripts/`, `tests/`, `commands/` — zero imports — and deleted it.
+
+The v9.2.10 `test_memory_instructions_constant_still_defined` test became its own anti-pattern: a constant kept alive only by a test that asserts it exists is a tautology. Same shape as the v9.2.10 `TestCrewYoloAliasStub` deletion — a defence test for code that has no actual consumers is dead weight.
+
+The test now asserts the **absence** of the constant (`test_memory_instructions_constant_removed`). Adding `_MEMORY_INSTRUCTIONS` back would surface as a regression.
+
+### Tests
+
+- 8/8 bootstrap-notice-gating tests passing (the new negative-assertion test replaces the old defence test).
+- 230/230 v10 surface + hook + bootstrap + smaht + session_state smoke tests passing.
+- 35/35 wicked-testing probe + drift tests passing.
+- Relevance lint deny-default clean.
+
+### Plugin version
+
+9.2.10 → 9.2.11 (patch — periodic noise removal + dead-constant cleanup; no behaviour change).
+
 ## [9.2.10] - 2026-05-06
 
 **Bootstrap quietening — gate informational notices on actual condition + delete defunct yolo test class.**

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -488,20 +488,12 @@ def _read_config():
         return None
 
 
-# ---------------------------------------------------------------------------
-# Memory behavior instructions (injected every session)
-# ---------------------------------------------------------------------------
-
-_MEMORY_INSTRUCTIONS = (
-    "[Memory] This project uses wicked-garden memory for persistence. "
-    "Never write to MEMORY.md directly — use wicked-brain:memory to store decisions. "
-    "MEMORY.md is auto-generated and read-only. "
-    "When editing CLAUDE.md or AGENTS.md, keep both files in sync — "
-    "a PostToolUse hook will remind you. "
-    "Memory uses 3 tiers: semantic (durable project knowledge, prioritized in recall), "
-    "episodic (sprint-level patterns), working (transient session context, auto-consolidated). "
-    "Use --tier semantic for decisions and permanent knowledge."
-)
+# v9.2.11 deleted _MEMORY_INSTRUCTIONS. v9.2.10 stopped APPENDING it to the
+# briefing (CLAUDE.md "Memory Management" section already overrides the
+# system-level auto-memory instructions); v9.2.11 confirmed zero imports
+# across hooks/, scripts/, tests/, commands/ and removed the dead constant.
+# Same cleanup pattern as the v9.2.10 yolo test deletion — a constant kept
+# alive only by a test that asserts it exists is a tautology.
 
 _DANGEROUS_MODE_WARNING = (
     "[Question Mode] Dangerous mode is active (skipDangerousModePermissionPrompt). "
@@ -1510,12 +1502,10 @@ def main():
         if decay_summary:
             briefing_parts.append(f"[Memory] {decay_summary}")
 
-        # NOTE (v9.2.10): _MEMORY_INSTRUCTIONS used to be appended here every
-        # session. CLAUDE.md's "Memory Management" section already overrides
-        # the system-level auto-memory instructions and tells Claude to use
-        # wicked-brain:memory. Emitting the same guidance every session was
-        # redundant noise. The string constant is preserved below for
-        # backwards reference but no longer appended to the briefing.
+        # NOTE (v9.2.10): the per-session _MEMORY_INSTRUCTIONS append was
+        # removed. CLAUDE.md's "Memory Management" section already covers
+        # what the briefing was telling Claude. v9.2.11 deleted the constant
+        # itself after confirming zero imports.
 
         if dangerous_mode:
             briefing_parts.append(_DANGEROUS_MODE_WARNING)

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -10,9 +10,14 @@ architecture. The hook is now responsible only for session-level concerns:
   - Session goal capture (turns 1-2)
   - HOT fast-exit on continuation tokens
   - Pull-model directive injection (tiny, ~60-150 chars)
-  - Memory nudge (every 10 turns)
-  - Jam / discovery suggestion
+  - Jam / discovery suggestion (signal-gated)
   - Output formatting
+
+v9.2.11 removed the periodic [Memory] nudge that fired every 10 turns.
+Periodic reminders without a real signal are noise — Claude knows about
+wicked-brain:memory from CLAUDE.md and uses it when there is something
+to checkpoint. The proper checkpoint is the wicked-brain-session-teardown
+agent at session end, not a 10-turn timer.
 
 Subagents pull context on demand via wicked-brain:search/query and
 wicked-garden:search rather than having a briefing pushed every turn.
@@ -1208,12 +1213,14 @@ def main():
         if intent_directive:
             all_parts.append(intent_directive)
 
-        # Periodic memory storage nudge (every 10 turns)
-        _STORAGE_NUDGE_INTERVAL = 10
-        if turn_count > 0 and turn_count % _STORAGE_NUDGE_INTERVAL == 0:
-            all_parts.append(
-                "[Memory] Checkpoint: store decisions/gotchas with wicked-brain:memory."
-            )
+        # NOTE (v9.2.11): the periodic [Memory] checkpoint nudge that fired
+        # every 10 turns was removed. It surfaced on every prompt submit at
+        # turns 10, 20, 30 ... regardless of whether the session had produced
+        # anything worth checkpointing — exactly the false-urgency anti-
+        # pattern the v9.2.6 "silent contract drift" wiki article warns
+        # against. CLAUDE.md tells Claude how to use wicked-brain:memory; the
+        # session-teardown agent handles end-of-session synthesis. A turn-
+        # counter timer added no signal.
 
         # Jam suggestion: when ambiguity signals present
         jam_hint = _suggest_jam(prompt, state)

--- a/tests/test_bootstrap_notice_gating.py
+++ b/tests/test_bootstrap_notice_gating.py
@@ -126,12 +126,17 @@ def test_critical_skills_silent_when_present():
     )
 
 
-def test_memory_instructions_constant_still_defined():
-    """v9.2.10 stopped APPENDING _MEMORY_INSTRUCTIONS to the briefing but
-    kept the constant defined for backwards reference. Removing the
-    constant is a follow-up cleanup; deleting it in this PR would be a
-    silent contract drift if any other module imports it."""
+def test_memory_instructions_constant_removed():
+    """v9.2.11 deleted _MEMORY_INSTRUCTIONS entirely. v9.2.10 only stopped
+    APPENDING it to the briefing; the constant was preserved as a silent-
+    contract-drift defence in case any other module imported it. v9.2.11
+    confirmed zero imports across hooks/, scripts/, tests/, commands/ and
+    removed the dead constant. This test now asserts the absence — adding
+    it back is a regression."""
     import bootstrap
 
-    assert hasattr(bootstrap, "_MEMORY_INSTRUCTIONS")
-    assert "wicked-brain:memory" in bootstrap._MEMORY_INSTRUCTIONS
+    assert not hasattr(bootstrap, "_MEMORY_INSTRUCTIONS"), (
+        "_MEMORY_INSTRUCTIONS was deleted in v9.2.11 because it had zero "
+        "consumers. If you need this constant, prefer adding the guidance "
+        "to CLAUDE.md (which is loaded into context by Claude Code itself)."
+    )


### PR DESCRIPTION
## Summary

v9.2.10 cleared four bootstrap notices but missed a separate `UserPromptSubmit` periodic emitter:

```
[Memory] Checkpoint: store decisions/gotchas with wicked-brain:memory.
```

Fired every 10 turns regardless of session content — false-urgency anti-pattern (the v9.2.6 silent-contract-drift wiki article).

## Changes

| Item | Before | After |
|---|---|---|
| `[Memory] Checkpoint` nudge | Every 10 turns (turn 10, 20, 30, ...) | Removed — CLAUDE.md + session-teardown agent already cover this |
| `_MEMORY_INSTRUCTIONS` constant | Preserved in v9.2.10 as silent-drift defence | Deleted — zero imports confirmed across hooks/scripts/tests/commands |
| `test_memory_instructions_constant_still_defined` | Asserted constant exists (tautology) | Replaced with `test_memory_instructions_constant_removed` (negative assertion blocks regression) |

## Why now

This session has been progressively reducing the "every-turn fires regardless of state" anti-pattern. The chain so far:
- v9.2.2 — silenced recurring hook noise + sweep stale slash refs
- v9.2.10 — gated `[Setup]` and `[Quick Start]` per-project; dropped `[Memory]` and `[Skills]` happy-path
- **v9.2.11** — extends the same principle to the `UserPromptSubmit` path

## Test plan

- [x] 8/8 bootstrap-notice-gating tests (negative-assertion test replaces defence test)
- [x] 230/230 v10 surface + hook + bootstrap + smaht + session_state smoke
- [x] 35/35 wicked-testing probe + drift
- [x] Relevance lint deny-default clean
- [x] No tests reference the deleted nudge string

## No behaviour change beyond suppression

The capability is preserved — Claude calls `wicked-brain:memory` when there is something to checkpoint, just as it always has. The session-teardown agent (`wicked-brain-session-teardown`) is the proper end-of-session synthesis trigger. The 10-turn timer was redundant scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)