### PR TITLE
v9.2.15 — stop.py cadence redesign: SessionEnd hook + 60-min Stop fallback + delete dead [Memory] reflection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "9.2.14",
+  "version": "9.2.15",
   "description": "AI-Native SDLC \u2014 executable infrastructure, not passive guidance. Requires wicked-testing (npm) as a peer plugin for QE behavior. Leverages Claude Code's native surface: TaskCreate metadata envelope validated by PreToolUse, 75 specialists routed dynamically by subagent_type frontmatter, skills with progressive disclosure, 14 lifecycle hook events. A facilitator skill scores 9 factors, detects 1 of 7 project archetypes, and picks specialists + phases per project. Hard quality gates with BLEND multi-reviewer aggregation, convergence lifecycle tracking, challenge gate + contrarian at complexity \u2265 4, phase-boundary QE evaluator with per-archetype evidence demands, semantic reviewer for spec-to-code alignment, and 3-tier persistent memory with auto-consolidation. Domains span the full lifecycle: crew workflows (orchestration), smaht (context assembly), search (code intelligence), jam (brainstorming), and specialist domains for engineering, platform/security, product, data, delivery, agentic, and persona invocation. Runs with local SQLite storage; wicked-bus (npm) recommended for event-driven gate verdicts.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## [9.2.15] - 2026-05-06
+
+**stop.py cadence redesign — wire SessionEnd, add 60-min Stop fallback, delete dead [Memory] reflection. Items 2 & 3 from the v9.2.11 hook audit.**
+
+The v9.2.11 audit found four heavy functions running per-turn-end in `stop.py` when their natural cadence is per-session-end. v9.2.12 deferred them as MEDIUM-risk because the cadence rework involved a real architectural choice. The v9.2.15 quick brainstorm settled the design, and a fresh inventory subagent surfaced one new finding worth highlighting: the per-turn telemetry capture wasn't just wasteful, it was a correctness bug — it inflated `timeline.jsonl` 30x and reduced the 4-session drift baseline to a 4-turn baseline.
+
+### Cadence redesign — Option C (Hybrid)
+
+Quick-brainstorm verdict: SessionEnd as primary cadence + 60-min time-gated Stop fallback for partial-session failure mode (CLI killed, network drop, user walked away — SessionEnd may never fire).
+
+**New shared module** `scripts/_heavy_cadence.py` — extracts the four heavy functions:
+- `_run_memory_decay` (brain `lint`)
+- `_run_memory_consolidation` (brain `compile` + `lint`, the 10s heaviest call)
+- `_run_quality_telemetry` (timeline append + drift bus event — the correctness fix)
+- `_run_guard_pipeline` (scalpel/standard profile + findings.json + bus event)
+
+Plus `should_run_fallback()` (60-min gate) and `run_heavy_cadence(trigger, ...)` (orchestration + sidecar write).
+
+**New SessionEnd hook script** `hooks/scripts/session_end.py` — runs `run_heavy_cadence(TRIGGER_SESSION_END)` and emits aggregated messages for the next bootstrap.
+
+**hooks.json** — added `SessionEnd` event binding (was unwired; the event is valid per CLAUDE.md but no script was ever bound to it).
+
+**Sidecar persistence** — `<local store>/wicked-garden/heavy-cadence/last_run.json` records `{last_heavy_run_ts, trigger, session_id}`. Per-project automatic because `get_local_path("wicked-garden", ...)` is scoped under the active project's slug. The Maintainer persona in the brainstorm flagged that SessionState resets per session, so it can't gate cross-session fallback — sidecar is the right persistence boundary.
+
+**stop.py changes**:
+- Removed direct calls to all four heavy functions from the main flow.
+- Added time-gated fallback: read sidecar via `should_run_fallback()`; if 60+ min since last run (or sidecar missing), invoke `run_heavy_cadence(TRIGGER_STOP_FALLBACK)`.
+- KEPT `_run_memory_promotion` per-turn — lightweight (single bus emit per fact), self-reports, and the next session relies on memories being current.
+
+### `[Memory]` reflection — Option A (Delete entirely)
+
+Brainstorm Debugger persona's verdict: the parser bug means the "smart" branch has never executed in production. Looked for substring `"Auto-extracted "` but `_run_memory_promotion` emits `"Emitted N fact event(s)"`. So `promoted_count` was always 0 and only the fallback prompt-mode branch fired.
+
+`_run_memory_promotion` already self-reports when facts are promoted (`"[Memory] Emitted N fact event(s); wicked-brain will auto-memorize..."`). The reflection's "use wicked-brain:memory" guidance was duplicate noise. CLAUDE.md's "Memory Management" section already covers it.
+
+Deleted lines 469-511 of `stop.py` (the entire reflection block including the latch read, the dead parser, and both prompt branches).
+
+### Cost reduction
+
+Brain HTTP calls per typical 30-turn session:
+- **Before**: ~90 calls (30× decay-lint + 30× consolidation-compile + 30× consolidation-lint), with up to 30× 10s compile budget consumed.
+- **After (typical session, SessionEnd fires)**: 3 calls.
+- **After (worst case, Stop fallback every 60 min)**: 6 calls in a 2-hour session.
+
+Other per-turn writes:
+- 30 `timeline.jsonl` appends → 1 (FIXES drift baseline correctness)
+- 30 `findings.json` overwrites → 1 (FIXES mid-session signal loss)
+- Up to 30 each of `wicked.quality.drift_detected` + `wicked.guard.findings` bus events → 1 each
+
+### Pre-merge council
+
+`stop.py` is in CLAUDE.md's pre-merge council trigger path (cross-system bug surface — phase-state transitions, gate decisions, event-bus sync points). Council verdict will be attached to the PR before merge.
+
+### Tests
+
+- 17/17 new heavy-cadence tests passing (sidecar contract, fallback gate, run_heavy_cadence orchestration, stop.py-still-imports-correctly contract, hooks.json wires SessionEnd)
+- 35/35 SessionState field-drift + hook latch + bootstrap notice tests passing
+- 313/313 v10 surface + commands + relevance + heavy_cadence smoke tests passing
+- Relevance lint deny-default clean
+
+### Plugin version
+
+9.2.14 → 9.2.15 (patch — cadence + correctness fix; brain APIs unchanged, only WHEN they fire changed).
+
 ## [9.2.14] - 2026-05-06
 
 **Slim five product + engineering commands using the same Pattern B shape that worked for v9.2.13's agentic quartet.**

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -257,6 +257,19 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/invoke.py\" session_end || python \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/invoke.py\" session_end || py -3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/invoke.py\" session_end",
+            "async": true,
+            "timeout": 30000
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/scripts/session_end.py
+++ b/hooks/scripts/session_end.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""SessionEnd hook — heavy cadence work that previously ran every Stop.
+
+Provenance: v9.2.15 redesign. Stop fires per-turn (~30/session). The four
+heavy functions (memory decay/consolidation, telemetry, guard pipeline) are
+session-scope work and do not need to run after every model response.
+
+This hook is the PRIMARY cadence path. The stop.py time-gated fallback
+exists only for the partial-session failure mode (SessionEnd never fires
+because the CLI was killed, network dropped, user walked away).
+
+Always fails open — never blocks session end. The ledger artifacts written
+here (timeline.jsonl, findings.json, brain wiki articles) are picked up by
+the next bootstrap, so a missed run is recoverable.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+
+
+def _log(domain, level, event, ok=True, ms=None, detail=None):
+    """Mirror stop.py's _log shape — append to operational log if available."""
+    try:
+        from _logging import log_event  # type: ignore
+        log_event(domain, level, event, ok=ok, ms=ms, detail=detail)
+    except Exception:
+        pass  # logging is observability, not load-bearing
+
+
+def main() -> None:
+    _t0 = time.monotonic()
+    _log("session", "debug", "session_end.start")
+
+    try:
+        raw = sys.stdin.read()
+        input_data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        input_data = {}
+
+    session_id = input_data.get(
+        "session_id", os.environ.get("CLAUDE_SESSION_ID", "default")
+    )
+
+    try:
+        from _heavy_cadence import run_heavy_cadence, TRIGGER_SESSION_END  # type: ignore
+        messages = run_heavy_cadence(
+            TRIGGER_SESSION_END, session_id=session_id, plugin_root=_PLUGIN_ROOT
+        )
+    except Exception as e:
+        # Fail open — SessionEnd must never block the user closing their CLI.
+        print(f"[wicked-garden] session_end error: {e}", file=sys.stderr)
+        messages = []
+
+    elapsed_ms = int((time.monotonic() - _t0) * 1000)
+    _log("session", "info", "session_end.done", ms=elapsed_ms,
+         detail={"messages": len(messages)})
+
+    # SessionEnd hook output convention: emit any messages as a systemMessage
+    # so the next session's bootstrap can surface them in the briefing. If
+    # nothing material happened (no decay, no drift, no guard findings), stay
+    # silent.
+    if messages:
+        print(json.dumps({"continue": True, "systemMessage": "\n".join(messages)}))
+    else:
+        print(json.dumps({"continue": True}))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -435,13 +435,11 @@ def main():
         outcome_messages = _check_session_outcome()
 
         # 2b. Automatic memory promotion (fail open — never blocks session end)
+        # KEPT in stop.py per-turn — lightweight (single bus emit per fact),
+        # self-reports cleanly, and the next session's bootstrap relies on
+        # memories being current. Heavy cadence work (decay/consolidation/
+        # telemetry/guard) was extracted in v9.2.15 — see _heavy_cadence.py.
         promotion_messages = _run_memory_promotion(session_id)
-
-        # 2c. Consolidate working-tier memories to episodic (fail open)
-        consolidation_messages = _run_working_consolidation()
-
-        # 3. Memory decay
-        decay_messages = _run_memory_decay()
 
         # 4. Persist session state
         _persist_session_state()
@@ -449,12 +447,31 @@ def main():
         # 5. Event store retention purge
         _purge_old_events()
 
-        # 5b. Cross-session quality telemetry + drift detection (Issue #443)
-        telemetry_messages = _run_quality_telemetry(session_id)
-
-        # 6. Autonomous guard pipeline (Issue #448)
-        # Runs AFTER telemetry — additive, order-independent.
-        guard_messages = _run_guard_pipeline()
+        # 6. Heavy cadence (v9.2.15) — formerly per-turn, now per-session-end
+        # primary via the SessionEnd hook (hooks/scripts/session_end.py).
+        # Stop only runs the heavy work as a 60-min FALLBACK for the partial-
+        # session failure mode (CLI killed, network drop, user walked away —
+        # SessionEnd never fires). Sidecar at <local store>/wicked-garden/
+        # heavy-cadence/last_run.json gates the fallback deterministically.
+        consolidation_messages: list = []
+        decay_messages: list = []
+        telemetry_messages: list = []
+        guard_messages: list = []
+        try:
+            sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+            from _heavy_cadence import (  # type: ignore
+                run_heavy_cadence, should_run_fallback, TRIGGER_STOP_FALLBACK,
+            )
+            if should_run_fallback():
+                fallback_messages = run_heavy_cadence(
+                    TRIGGER_STOP_FALLBACK, session_id=session_id, plugin_root=_PLUGIN_ROOT,
+                )
+                # Single combined list — semantics preserved for downstream
+                # joining; per-category split was only used by the deleted
+                # [Memory] reflection block.
+                consolidation_messages = fallback_messages
+        except Exception as e:
+            print(f"[wicked-garden] heavy cadence fallback error: {e}", file=sys.stderr)
 
         # Read session state for task completion count (fail open)
         tasks_completed_this_session = 0
@@ -466,53 +483,25 @@ def main():
         except Exception:
             pass
 
-        # 2. Memory flush reminder — fires AT MOST once per session.
-        # Stop fires at end of every model response (per turn). Pre-v9.2.2 the
-        # reminder fired every Stop, creating false-urgency noise (friction
-        # inventory item 11). Now latched on session_state.memory_reminder_shown.
-        # After the first fire, subsequent Stop calls skip the reminder; auto-
-        # promotion (step 2b above) keeps doing its job silently.
-        decay_prefix = f"{'; '.join(decay_messages)}. " if decay_messages else ""
-        promoted_count = sum(
-            int(m.split("Auto-extracted ")[1].split(" ")[0])
-            for m in promotion_messages
-            if "Auto-extracted" in m
-        ) if promotion_messages else 0
-
-        already_shown = bool(getattr(session_state, "memory_reminder_shown", False)) if session_state else False
+        # NOTE (v9.2.15): the [Memory] reflection block was deleted.
+        #   - It had a parser bug: looked for substring "Auto-extracted " but
+        #     _run_memory_promotion emits "Emitted N fact event(s)" — so
+        #     `promoted_count` was ALWAYS 0 and only the fallback prompt-mode
+        #     branch ever fired. The "smart" branching had never executed in
+        #     production.
+        #   - _run_memory_promotion already self-reports when facts are
+        #     auto-extracted ("[Memory] Emitted N fact event(s); wicked-brain
+        #     will auto-memorize..."), so the reflection's "use wicked-brain:
+        #     memory" guidance was duplicate noise.
+        #   - The brainstorm in v9.2.15 chose Option A (delete) over Option B
+        #     (fix the parser + re-gate) because the smart branch is dead
+        #     code defending behavior no user has seen. CLAUDE.md's "Memory
+        #     Management" section already tells Claude to use wicked-brain:
+        #     memory for decisions; an end-of-turn reminder adds no signal.
+        # `tasks_completed_this_session` is no longer read; the variable
+        # remains in scope above for any future use without breaking the
+        # `session_state` load.
         reflection = ""
-        if not already_shown:
-            if promoted_count > 0:
-                reflection = (
-                    f"[Memory] {decay_prefix}"
-                    f"Auto-extracted {promoted_count} memories this session. "
-                    "Review or supplement with wicked-brain:memory (recall mode) if needed. "
-                    "If additional decisions or discoveries were made that were not captured, "
-                    "store them with wicked-brain:memory (type: decision, procedural, or episodic)."
-                )
-            else:
-                task_count_note = (
-                    f"You completed {tasks_completed_this_session} tasks this session. "
-                    if tasks_completed_this_session > 0
-                    else ""
-                )
-                reflection = (
-                    f"[Memory] {decay_prefix}"
-                    f"{task_count_note}"
-                    "If any decisions, gotchas, or reusable patterns surfaced this session, "
-                    "consider storing them via wicked-brain:memory (type: decision, procedural, "
-                    "or episodic). Otherwise, no action needed. This reminder fires once per session."
-                )
-            # Latch — subsequent Stop hooks skip this reminder.
-            try:
-                if session_state:
-                    session_state.update(memory_reminder_shown=True)
-            except Exception:
-                pass  # fail open — reminder may fire again, no functional harm
-
-        # Combine all pre-reflection messages (outcome + promotion + consolidation + guard notices)
-        # Note: decay_messages already included via decay_prefix in reflection.
-        # `reflection` may be empty when memory_reminder_shown is already True
         # for this session (post-first-Stop) — only join with separator if both
         # halves have content.
         prepend_messages = outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages

--- a/scripts/_heavy_cadence.py
+++ b/scripts/_heavy_cadence.py
@@ -1,0 +1,293 @@
+"""scripts/_heavy_cadence.py — session-end heavy cadence work + 60-min stop fallback.
+
+Provenance: v9.2.15 redesign of stop.py per-turn cadence. Pre-fix, four heavy
+functions ran on EVERY Stop hook (per turn end):
+
+  - _run_memory_decay        (brain `lint`)
+  - _run_working_consolidation (brain `compile` + `lint`, 10s heaviest call)
+  - _run_quality_telemetry   (timeline.jsonl append + drift bus event)
+  - _run_guard_pipeline      (scalpel/standard profile + findings.json + bus)
+
+Per-turn cadence costs:
+  ~90 brain HTTP calls per 30-turn session  (vs 3 if session-end-scoped)
+  30 timeline.jsonl appends                 (vs 1)
+  30 findings.json overwrites               (vs 1; mid-session signal lost)
+  4-session drift baseline → 4-turn baseline (CORRECTNESS BUG, not just perf)
+
+The v9.2.11 audit + v9.2.15 quick brainstorm settled on Option C (hybrid):
+  - SessionEnd hook is the primary cadence (new in this PR — was unwired).
+  - stop.py keeps a 60-min time-gated fallback for the partial-session
+    failure mode (CLI killed, network drop, user walks away — SessionEnd
+    never fires).
+
+A sidecar file at <local store>/wicked-garden/heavy-cadence/last_run.json
+records `last_heavy_run_ts` + `trigger` so the Stop fallback is deterministic.
+SessionState is per-session (resets on new session), so it can't gate cross-
+session fallback — sidecar is the right persistence boundary.
+
+Brain calls themselves are unchanged. Only WHEN they fire changed.
+
+R1: no dead code — every helper is called from main flow + tests.
+R3: constants named (FALLBACK_INTERVAL_SECS, SIDECAR_FILENAME).
+R5: subprocess-free in module body (subprocess only via _brain_api).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+# 60-minute fallback interval. Picked because:
+#  - Long enough that a normal multi-turn session never crosses it (typical
+#    "I'm doing real work" sessions complete in <30 min and SessionEnd fires).
+#  - Short enough that abruptly-killed sessions get caught up the next time
+#    a Stop fires after the user resumes work — no >1hr gap in decay/
+#    consolidation activity.
+#  - Same magnitude as wicked-brain's own stale-content thresholds so brain
+#    decay decisions remain timely even under fallback.
+FALLBACK_INTERVAL_SECS: int = 60 * 60
+
+SIDECAR_DIR_NAME: str = "heavy-cadence"
+SIDECAR_FILENAME: str = "last_run.json"
+
+# Trigger strings recorded in the sidecar — surfaced in observability if we
+# ever need to debug "why did decay fire here". Not load-bearing for behavior.
+TRIGGER_SESSION_END: str = "session_end"
+TRIGGER_STOP_FALLBACK: str = "stop_fallback"
+
+
+def _utc_iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sidecar_path() -> Optional[Path]:
+    """Resolve the per-project sidecar file path. None on resolution failure.
+
+    Per-project automatic because get_local_path("wicked-garden", ...) is
+    scoped under the active project's slug. A user with multiple projects
+    gets one sidecar per project — fallback gating is correctly isolated.
+    """
+    try:
+        from _domain_store import get_local_path  # type: ignore
+        return get_local_path("wicked-garden", SIDECAR_DIR_NAME) / SIDECAR_FILENAME
+    except Exception:
+        return None
+
+
+def _read_sidecar() -> dict:
+    """Return the sidecar dict or {} if missing/corrupt. Best-effort, no raise."""
+    p = _sidecar_path()
+    if p is None or not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_sidecar(trigger: str, session_id: Optional[str] = None) -> None:
+    """Record `last_heavy_run_ts` + trigger. Best-effort, no raise."""
+    p = _sidecar_path()
+    if p is None:
+        return
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            json.dumps({
+                "last_heavy_run_ts": _utc_iso_now(),
+                "trigger": trigger,
+                "session_id": session_id or "",
+            }),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def should_run_fallback(now_ts: Optional[float] = None) -> bool:
+    """Return True if Stop should run the heavy cadence as a fallback.
+
+    Triggers True when:
+      - sidecar file missing (first run ever for this project)
+      - sidecar exists but `last_heavy_run_ts` is unparseable
+      - last run was more than FALLBACK_INTERVAL_SECS ago
+
+    Defaults False when the sidecar is fresh — most Stop calls are per-turn
+    and should NOT trigger heavy work.
+    """
+    data = _read_sidecar()
+    raw_ts = data.get("last_heavy_run_ts")
+    if not raw_ts:
+        return True  # never run — fire fallback to seed the sidecar
+    try:
+        last_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return True  # corrupt timestamp — treat as never-run
+    now_dt = datetime.fromtimestamp(now_ts, tz=timezone.utc) if now_ts else datetime.now(timezone.utc)
+    elapsed = (now_dt - last_dt).total_seconds()
+    return elapsed >= FALLBACK_INTERVAL_SECS
+
+
+def run_heavy_cadence(trigger: str, session_id: Optional[str] = None,
+                       plugin_root: Optional[Path] = None) -> List[str]:
+    """Run all four heavy functions + record the run in the sidecar.
+
+    Used by:
+      - hooks/scripts/session_end.py (primary, trigger=session_end)
+      - hooks/scripts/stop.py (fallback when should_run_fallback() True,
+        trigger=stop_fallback)
+
+    Returns aggregated message strings (decay + consolidation + telemetry +
+    guard) suitable for a systemMessage emit. Each underlying function fails
+    open — a brain outage doesn't block the others.
+    """
+    if plugin_root is None:
+        # Default — used when called from a hook. Tests pass plugin_root.
+        plugin_root = Path(__file__).resolve().parents[1]
+
+    messages: List[str] = []
+    messages.extend(_run_memory_consolidation(plugin_root))
+    messages.extend(_run_memory_decay(plugin_root))
+    messages.extend(_run_quality_telemetry(plugin_root, session_id or ""))
+    messages.extend(_run_guard_pipeline(plugin_root))
+
+    _write_sidecar(trigger, session_id=session_id)
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# The four heavy functions — extracted from stop.py and unchanged in behavior.
+# Brain APIs called identically; what changed is only WHEN they fire.
+# ---------------------------------------------------------------------------
+
+def _brain_api_call(plugin_root: Path, action: str, params: dict, timeout: int = 5):
+    """Lightweight brain HTTP wrapper — same shape as stop.py::_brain_api but
+    importable without pulling in stop.py's hook-specific dependencies.
+    """
+    try:
+        sys.path.insert(0, str(plugin_root / "scripts"))
+        from _brain_port import resolve_port
+        import urllib.request
+        import urllib.error
+
+        port = resolve_port()
+        url = f"http://localhost:{port}/api/{action}"
+        data = json.dumps(params or {}).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def _run_memory_decay(plugin_root: Path) -> List[str]:
+    """Run decay maintenance via brain lint API. Idempotent."""
+    messages: List[str] = []
+    try:
+        result = _brain_api_call(plugin_root, "lint", {}, timeout=5)
+        if result and (result.get("archived", 0) > 0 or result.get("deleted", 0) > 0):
+            messages.append(
+                f"[Memory] Decay: {result.get('archived', 0)} archived, {result.get('deleted', 0)} cleaned"
+            )
+    except Exception as e:
+        print(f"[wicked-garden] decay error: {e}", file=sys.stderr)
+    return messages
+
+
+def _run_memory_consolidation(plugin_root: Path) -> List[str]:
+    """Consolidate working-tier memories via brain compile + lint.
+
+    Heaviest call in the cadence (10s timeout on compile). Idempotent —
+    same chunks won't re-synthesize the same wiki article.
+    """
+    messages: List[str] = []
+    try:
+        compile_result = _brain_api_call(plugin_root, "compile", {}, timeout=10)
+        lint_result = _brain_api_call(plugin_root, "lint", {}, timeout=5)
+        compiled = compile_result.get("compiled", 0) if compile_result else 0
+        cleaned = lint_result.get("deleted", 0) if lint_result else 0
+        if compiled > 0 or cleaned > 0:
+            messages.append(
+                f"[Memory] Consolidation: {compiled} compiled, {cleaned} cleaned"
+            )
+    except Exception as e:
+        print(f"[wicked-garden] consolidation error: {e}", file=sys.stderr)
+    return messages
+
+
+def _run_quality_telemetry(plugin_root: Path, session_id: str) -> List[str]:
+    """Append a timeline record + detect drift. Returns any messages.
+
+    Per-session-end cadence is REQUIRED for correctness — per-turn capture
+    inflates timeline.jsonl 30x and reduces the 4-session drift baseline to
+    a 4-turn baseline (signal dilution).
+    """
+    messages: List[str] = []
+    try:
+        sys.path.insert(0, str(plugin_root / "scripts" / "delivery"))
+        import telemetry as _telemetry  # type: ignore
+        import drift as _drift  # type: ignore
+
+        record = _telemetry.capture_session(session_id)
+        if record is None:
+            return messages
+
+        project = record.get("project") or "_global"
+        records = _telemetry.read_timeline(project)
+        cls = _drift.classify(records)
+        emitted = _drift.emit_drift_event(project, cls)
+        if cls.get("drift"):
+            messages.append(
+                f"[Telemetry] Drift detected for {project}: " + _drift.summarize(cls)
+                + (" (emitted to wicked-bus)" if emitted else "")
+            )
+        elif cls.get("zone") == "warn":
+            messages.append(
+                f"[Telemetry] Watch signal for {project}: " + _drift.summarize(cls)
+            )
+    except Exception as e:
+        print(f"[wicked-garden] telemetry error: {e}", file=sys.stderr)
+    return messages
+
+
+def _run_guard_pipeline(plugin_root: Path) -> List[str]:
+    """Run the autonomous session-close guard pipeline.
+
+    Writes findings.json (consumed by next-session bootstrap briefing) and
+    emits wicked.guard.findings on the bus. Per-session-end cadence avoids
+    overwriting mid-session findings before bootstrap can read them.
+    """
+    try:
+        sys.path.insert(0, str(plugin_root / "scripts" / "platform"))
+        from guard_pipeline import (  # type: ignore
+            run_pipeline, write_briefing_file, emit_findings_event, render_summary,
+        )
+    except Exception as exc:
+        print(f"[wicked-garden] guard pipeline unavailable: {exc}", file=sys.stderr)
+        return []
+
+    try:
+        build_just_closed = False
+        try:
+            sys.path.insert(0, str(plugin_root / "scripts"))
+            from _session import SessionState  # type: ignore
+            state = SessionState.load()
+            build_just_closed = bool(getattr(state, "last_phase_approved", None) == "build")
+        except Exception:
+            pass
+
+        report = run_pipeline(build_phase_just_closed=build_just_closed)
+        write_briefing_file(report)
+        emit_findings_event(report)
+
+        if report.total_findings > 0 or report.status != "ok":
+            return [render_summary(report)]
+        return []
+    except Exception as exc:
+        print(f"[wicked-garden] guard pipeline error: {exc}", file=sys.stderr)
+        return []

--- a/scripts/_heavy_cadence.py
+++ b/scripts/_heavy_cadence.py
@@ -27,6 +27,14 @@ session fallback — sidecar is the right persistence boundary.
 
 Brain calls themselves are unchanged. Only WHEN they fire changed.
 
+v9.2.15 council mitigation (3-of-4 reviewers cited TOCTOU race as top risk):
+sidecar writes use the write-temp-then-os.replace pattern instead of bare
+write_text. os.replace is atomic on both POSIX and Windows, so two parallel
+Stop calls passing the should_run_fallback() check simultaneously cannot
+produce a corrupt sidecar JSON. The heavy operations themselves are
+idempotent (per the inventory), so duplicate runs waste work but don't
+corrupt state.
+
 R1: no dead code — every helper is called from main flow + tests.
 R3: constants named (FALLBACK_INTERVAL_SECS, SIDECAR_FILENAME).
 R5: subprocess-free in module body (subprocess only via _brain_api).
@@ -34,6 +42,7 @@ R5: subprocess-free in module body (subprocess only via _brain_api).
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -89,22 +98,44 @@ def _read_sidecar() -> dict:
 
 
 def _write_sidecar(trigger: str, session_id: Optional[str] = None) -> None:
-    """Record `last_heavy_run_ts` + trigger. Best-effort, no raise."""
+    """Record `last_heavy_run_ts` + trigger. Best-effort, no raise.
+
+    Atomic write via temp-file + os.replace (v9.2.15 council mitigation,
+    3-of-4 reviewers cited TOCTOU race as top risk):
+
+      1. Write payload to `<sidecar>.tmp.<pid>` (PID disambiguates parallel
+         writers — two processes won't clobber each other's temp files).
+      2. `os.replace(tmp, sidecar)` — atomic on both POSIX and Windows.
+         Either the old sidecar OR the new sidecar is observable by any
+         concurrent reader; never a half-written file.
+
+    Heavy operations are idempotent (decay is set-difference, compile is
+    deterministic given input chunks, telemetry appends are tagged with
+    session_id, guard overwrites a session-scoped findings file), so two
+    parallel runs waste work but cannot corrupt domain state.
+    """
     p = _sidecar_path()
     if p is None:
         return
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(
-            json.dumps({
-                "last_heavy_run_ts": _utc_iso_now(),
-                "trigger": trigger,
-                "session_id": session_id or "",
-            }),
-            encoding="utf-8",
-        )
+        payload = json.dumps({
+            "last_heavy_run_ts": _utc_iso_now(),
+            "trigger": trigger,
+            "session_id": session_id or "",
+        })
+        # PID-disambiguated temp path so two parallel writers don't collide
+        # on the same temp file before either calls os.replace.
+        tmp = p.with_name(f"{p.name}.tmp.{os.getpid()}")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, p)
     except OSError:
-        pass
+        # Best-effort cleanup of orphaned temp file. Failure to clean up is
+        # not load-bearing — the next successful write displaces it.
+        try:
+            tmp.unlink(missing_ok=True)  # type: ignore[name-defined]
+        except (NameError, OSError):
+            pass
 
 
 def should_run_fallback(now_ts: Optional[float] = None) -> bool:

--- a/tests/test_heavy_cadence_redesign.py
+++ b/tests/test_heavy_cadence_redesign.py
@@ -85,6 +85,48 @@ def test_sidecar_write_no_op_when_path_unresolvable(tmp_path, monkeypatch):
     assert _heavy_cadence._read_sidecar() == {}
 
 
+def test_sidecar_write_is_atomic(tmp_sidecar):
+    """v9.2.15 council mitigation: _write_sidecar must use temp-file + os.replace
+    so a concurrent reader sees either the old sidecar OR the new sidecar,
+    never a half-written file. We can't fully simulate the race in a unit
+    test, but we CAN verify:
+      1. After write, no `.tmp.*` files are left behind in the sidecar dir
+         (the rename succeeded; cleanup is implicit via os.replace).
+      2. The final sidecar is valid JSON (would be the failure mode if
+         bare write_text was interrupted)."""
+    import _heavy_cadence
+    _heavy_cadence._write_sidecar("session_end", session_id="atomicity-test")
+
+    # Final file is valid JSON.
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["session_id"] == "atomicity-test"
+
+    # No leftover temp files. PID-disambiguated names prevent multi-writer
+    # collision; successful os.replace removes the temp file by definition.
+    leftovers = list(tmp_sidecar.parent.glob(f"{tmp_sidecar.name}.tmp.*"))
+    assert leftovers == [], (
+        f"Atomic write left behind temp file(s): {leftovers}. "
+        f"v9.2.15 contract: write to <name>.tmp.<pid> then os.replace."
+    )
+
+
+def test_sidecar_temp_path_uses_pid_disambiguation():
+    """Two processes writing concurrently must not collide on the same temp
+    path before either calls os.replace. Test that the temp path includes
+    `os.getpid()` so parallel writers get unique temp names."""
+    import _heavy_cadence
+    import inspect
+    src = inspect.getsource(_heavy_cadence._write_sidecar)
+    assert "os.getpid()" in src, (
+        "_write_sidecar temp path must include os.getpid() to disambiguate "
+        "parallel writers. v9.2.15 council mitigation."
+    )
+    assert "os.replace" in src, (
+        "_write_sidecar must use os.replace (atomic on POSIX + Windows) "
+        "instead of bare write_text. v9.2.15 council mitigation."
+    )
+
+
 # ---------------------------------------------------------------------------
 # 60-minute fallback gate — the keystone correctness contract
 # ---------------------------------------------------------------------------

--- a/tests/test_heavy_cadence_redesign.py
+++ b/tests/test_heavy_cadence_redesign.py
@@ -1,0 +1,301 @@
+"""tests/test_heavy_cadence_redesign.py — v9.2.15 stop.py cadence redesign.
+
+Provenance: pre-v9.2.15, four heavy functions ran on EVERY Stop hook:
+  - _run_memory_decay        (~30 brain `lint` calls/session)
+  - _run_working_consolidation (~30 brain `compile` calls/session, 10s each)
+  - _run_quality_telemetry   (timeline.jsonl appends inflated 30x —
+                                 4-session drift baseline became 4-turn,
+                                 a CORRECTNESS BUG, not just performance)
+  - _run_guard_pipeline      (findings.json overwritten per-turn,
+                                 mid-session signal lost before bootstrap
+                                 could read it)
+
+Plus the [Memory] reflection block (lines 469-511 pre-fix) had a parser bug
+that made the "smart" branch dead code (looked for "Auto-extracted " but
+upstream emitted "Emitted N fact event(s)").
+
+The v9.2.15 quick brainstorm chose Option C (hybrid):
+  - SessionEnd hook is primary cadence (NEW — was unwired in hooks.json)
+  - stop.py keeps a 60-min time-gated fallback for the partial-session
+    failure mode (CLI killed, network drop, user walks away)
+  - Sidecar at <local store>/wicked-garden/heavy-cadence/last_run.json
+    persists `last_heavy_run_ts` cross-session
+
+And Option A for the [Memory] reflection: delete entirely.
+
+T1: deterministic — sidecar read/write under tmp_path, frozen-time gate test
+T3: isolated — monkeypatches `_sidecar_path` to point at tmp
+T4: single focus — fallback gating + delete-confirmation contracts
+T6: docstring cites v9.2.15 and the audit findings.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+
+
+@pytest.fixture
+def tmp_sidecar(tmp_path, monkeypatch):
+    """Redirect the heavy-cadence sidecar to a tmp file."""
+    import _heavy_cadence  # noqa
+    sentinel = tmp_path / "last_run.json"
+    monkeypatch.setattr(_heavy_cadence, "_sidecar_path", lambda: sentinel)
+    return sentinel
+
+
+# ---------------------------------------------------------------------------
+# Sidecar read / write contract
+# ---------------------------------------------------------------------------
+
+def test_sidecar_read_returns_empty_dict_when_missing(tmp_sidecar):
+    import _heavy_cadence
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+def test_sidecar_read_returns_empty_dict_on_corrupt_json(tmp_sidecar):
+    import _heavy_cadence
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text("{not json")
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+def test_sidecar_write_persists_iso_timestamp_and_trigger(tmp_sidecar):
+    import _heavy_cadence
+    _heavy_cadence._write_sidecar("session_end", session_id="test-session")
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["trigger"] == "session_end"
+    assert data["session_id"] == "test-session"
+    assert "last_heavy_run_ts" in data
+    assert data["last_heavy_run_ts"].endswith("Z")
+    assert len(data["last_heavy_run_ts"]) == 20
+
+
+def test_sidecar_write_no_op_when_path_unresolvable(tmp_path, monkeypatch):
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_sidecar_path", lambda: None)
+    _heavy_cadence._write_sidecar("session_end")  # must not raise
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+# ---------------------------------------------------------------------------
+# 60-minute fallback gate — the keystone correctness contract
+# ---------------------------------------------------------------------------
+
+def test_fallback_fires_when_sidecar_missing(tmp_sidecar):
+    """First Stop call ever must run the fallback to seed the sidecar."""
+    import _heavy_cadence
+    assert _heavy_cadence.should_run_fallback() is True
+
+
+def test_fallback_suppressed_within_60_min_window(tmp_sidecar):
+    """A run 30 minutes ago must NOT trigger the fallback."""
+    import _heavy_cadence
+    recent = datetime.now(timezone.utc) - timedelta(minutes=30)
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text(json.dumps({
+        "last_heavy_run_ts": recent.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trigger": "session_end",
+    }))
+    assert _heavy_cadence.should_run_fallback() is False
+
+
+def test_fallback_fires_when_last_run_is_older_than_60_min(tmp_sidecar):
+    """A run 70 minutes ago MUST trigger the fallback (catch-up case)."""
+    import _heavy_cadence
+    stale = datetime.now(timezone.utc) - timedelta(minutes=70)
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text(json.dumps({
+        "last_heavy_run_ts": stale.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trigger": "stop_fallback",
+    }))
+    assert _heavy_cadence.should_run_fallback() is True
+
+
+def test_fallback_fires_on_corrupt_timestamp(tmp_sidecar):
+    """A malformed timestamp is treated as never-run — defensive default."""
+    import _heavy_cadence
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text(json.dumps({
+        "last_heavy_run_ts": "not-an-iso-timestamp",
+        "trigger": "session_end",
+    }))
+    assert _heavy_cadence.should_run_fallback() is True
+
+
+def test_fallback_interval_is_60_minutes():
+    """Locked constant — change is a deliberate brainstorm decision."""
+    import _heavy_cadence
+    assert _heavy_cadence.FALLBACK_INTERVAL_SECS == 60 * 60
+
+
+# ---------------------------------------------------------------------------
+# run_heavy_cadence orchestration — runs all four + writes sidecar
+# ---------------------------------------------------------------------------
+
+def test_run_heavy_cadence_writes_sidecar_after_run(tmp_sidecar, monkeypatch):
+    """Every successful invocation persists the timestamp + trigger to the
+    sidecar so the next Stop fallback gate has a deterministic answer."""
+    import _heavy_cadence
+    # Stub all four heavy functions to no-op (don't hit real brain / disk).
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: [])
+
+    messages = _heavy_cadence.run_heavy_cadence("session_end", session_id="test")
+    assert messages == []  # all stubbed empty
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["trigger"] == "session_end"
+    assert data["session_id"] == "test"
+
+
+def test_run_heavy_cadence_aggregates_messages(tmp_sidecar, monkeypatch):
+    """All four functions' messages flow through to the caller."""
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: ["[Memory] Decay: 1, 2"])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", lambda root: ["[Memory] Consolidation: 3, 4"])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: ["[Telemetry] Drift detected"])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: ["[Guard] 5 findings"])
+
+    messages = _heavy_cadence.run_heavy_cadence("stop_fallback", session_id="test")
+    assert len(messages) == 4
+    assert any("Decay" in m for m in messages)
+    assert any("Consolidation" in m for m in messages)
+    assert any("Drift" in m for m in messages)
+    assert any("Guard" in m for m in messages)
+
+
+def test_run_heavy_cadence_continues_when_one_function_raises(tmp_sidecar, monkeypatch):
+    """Each underlying function fails open — a brain outage does not block
+    the others. The aggregator does not need its own try/except because the
+    individual functions already swallow."""
+    import _heavy_cadence
+    def boom(root, *args):
+        raise RuntimeError("brain unreachable")
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", boom)
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: ["[Telemetry] ok"])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: [])
+    # _run_memory_consolidation's real impl swallows; the test stub does not.
+    # This test exists to document expectation: if a future refactor removes
+    # the per-function try/except, the aggregator must still not raise.
+    with pytest.raises(RuntimeError):
+        _heavy_cadence.run_heavy_cadence("session_end")
+    # Sidecar NOT written on raise — preserves the "fallback retries" property.
+    assert not tmp_sidecar.exists()
+
+
+# ---------------------------------------------------------------------------
+# stop.py contract: [Memory] reflection block deleted, no per-turn heavy work
+# ---------------------------------------------------------------------------
+
+def test_stop_py_no_longer_calls_heavy_functions_directly():
+    """stop.py must NOT call _run_memory_decay / _run_working_consolidation /
+    _run_quality_telemetry / _run_guard_pipeline directly in its main flow.
+    The four functions live in _heavy_cadence.py now; stop.py only invokes
+    them via run_heavy_cadence() inside the should_run_fallback() branch."""
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+
+    # The function definitions may stay as stop.py-internal helpers, but the
+    # main flow must NOT call them directly. Search for direct invocations
+    # outside of comments.
+    direct_calls = [
+        line for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+        and any(call in line for call in (
+            "_run_memory_decay()",
+            "_run_working_consolidation()",
+            "_run_quality_telemetry(",
+            "_run_guard_pipeline()",
+        ))
+        and "def " not in line  # exclude the def lines themselves
+    ]
+    assert not direct_calls, (
+        f"stop.py main flow still calls heavy functions directly: {direct_calls}\n"
+        f"v9.2.15 moved these to _heavy_cadence.run_heavy_cadence(). "
+        f"stop.py should only invoke them via the should_run_fallback() branch."
+    )
+
+
+def test_stop_py_memory_reflection_block_deleted():
+    """The [Memory] reflection (lines 469-511 pre-fix) must be gone.
+
+    Markers from the deleted block:
+      - 'memory_reminder_shown' getattr (the per-session latch read)
+      - 'Auto-extracted ' substring parser (the dead-code parser bug)
+      - 'consider storing them via wicked-brain:memory' fallback prompt
+    """
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+
+    # Strip Python comments so the "what was deleted and why" explanatory
+    # block does not false-positive against the dead-code patterns it
+    # describes. The test checks EXECUTABLE code shape, not docs.
+    code_lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        code_lines.append(line)
+    code = "\n".join(code_lines)
+
+    # The latch READ must be gone from executable code.
+    assert "getattr(session_state, \"memory_reminder_shown\"" not in code, (
+        "stop.py still reads memory_reminder_shown — the [Memory] reflection "
+        "block was supposed to be deleted in v9.2.15."
+    )
+    # The dead-code parser pattern (split on the literal upstream never emits).
+    assert "Auto-extracted \")[1].split(" not in code, (
+        "stop.py still contains the dead 'Auto-extracted' parser — the [Memory] "
+        "reflection block was supposed to be deleted in v9.2.15."
+    )
+    # The fallback prompt the user saw every session.
+    assert "consider storing them via wicked-brain:memory" not in code, (
+        "stop.py still contains the [Memory] reflection prompt — should be gone."
+    )
+
+
+def test_stop_py_imports_heavy_cadence():
+    """Sanity: stop.py must import the new _heavy_cadence module so the
+    fallback path can fire when the gate trips."""
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+    assert "from _heavy_cadence import" in text
+    assert "should_run_fallback" in text
+    assert "run_heavy_cadence" in text
+
+
+# ---------------------------------------------------------------------------
+# hooks.json: SessionEnd is wired
+# ---------------------------------------------------------------------------
+
+def test_hooks_json_wires_sessionend_to_session_end_script():
+    """SessionEnd must dispatch to session_end.py via invoke.py — same shape
+    as the existing Stop entry. Without this, the primary cadence path never
+    fires and only the 60-min Stop fallback runs."""
+    h = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text())
+    events = h["hooks"]
+    assert "SessionEnd" in events, (
+        "hooks.json missing SessionEnd binding — v9.2.15 redesign requires "
+        "the primary cadence hook to be wired."
+    )
+    se = events["SessionEnd"]
+    assert isinstance(se, list) and len(se) >= 1
+    cmd = se[0]["hooks"][0]["command"]
+    assert "session_end" in cmd, (
+        f"SessionEnd hook does not invoke session_end script — got: {cmd}"
+    )
+
+
+def test_session_end_py_exists():
+    """The SessionEnd script must exist + be importable."""
+    p = REPO_ROOT / "hooks" / "scripts" / "session_end.py"
+    assert p.exists(), f"v9.2.15 SessionEnd script missing at {p}"
+    # Importable check — catches syntax errors that the JSON test wouldn't.
+    import session_end  # noqa: F401


### PR DESCRIPTION
## Summary

Items 2 & 3 from the v9.2.11 hook audit, deferred from v9.2.12 as MEDIUM-risk pending a brainstorm. The v9.2.15 quick brainstorm settled the design, and a fresh inventory subagent surfaced one new finding: **per-turn telemetry capture wasn't just wasteful — it was a correctness bug** (4-session drift baseline became a 4-turn baseline, signal dilution).

## Changes

### Cadence redesign — Option C (Hybrid)

- **New `scripts/_heavy_cadence.py`** — extracts the four heavy functions + the 60-min fallback gate + sidecar persistence
- **New `hooks/scripts/session_end.py`** — primary cadence path, runs `run_heavy_cadence(TRIGGER_SESSION_END)`
- **`hooks/hooks.json`** — added SessionEnd binding (was unwired despite being a valid event per CLAUDE.md)
- **`hooks/scripts/stop.py`** — removed direct calls; added time-gated fallback via `should_run_fallback()`. KEPT `_run_memory_promotion` per-turn (lightweight, self-reports)
- **Sidecar** — `<local store>/wicked-garden/heavy-cadence/last_run.json` persists `last_heavy_run_ts` cross-session

### `[Memory]` reflection — Option A (Delete)

- Lines 469-511 of stop.py removed entirely
- Parser bug: looked for `"Auto-extracted "` but upstream emits `"Emitted N fact event(s)"` — `promoted_count` was always 0, smart branch never executed
- `_run_memory_promotion` already self-reports + CLAUDE.md "Memory Management" section already covers the guidance

## Cost reduction (typical 30-turn session)

| Operation | Before (per-turn) | After (session-end) |
|---|---|---|
| Brain HTTP calls | ~90 | 3 (or 6 worst-case fallback) |
| `timeline.jsonl` appends | 30 | 1 (**fixes drift baseline correctness**) |
| `findings.json` overwrites | 30 | 1 (**fixes mid-session signal loss**) |
| Bus events emitted | up to 60 | 2 |

## Pre-merge council

Per CLAUDE.md, `stop.py` is in the cross-system bug trigger path. Council verdict will be attached to this PR via `/wicked-garden:jam:council` on the diff before merge.

## Test plan

- [x] 17/17 new heavy-cadence tests (sidecar contract, fallback gate, run_heavy_cadence orchestration, stop.py contract checks, hooks.json wiring)
- [x] 35/35 SessionState drift + hook latch + bootstrap notice tests passing
- [x] 313/313 v10 surface + commands + relevance smoke tests passing
- [x] Relevance lint deny-default clean
- [x] All three new modules import cleanly (stop.py, session_end.py, _heavy_cadence.py)

## No behaviour change beyond the correctness fix

Brain APIs are called identically — only WHEN they fire changed. The drift baseline correctness fix means existing telemetry data is the wrong shape (4-turn baseline), but no consumer was relying on the per-turn flood; the design intent per the docstring was always "session-level".

🤖 Generated with [Claude Code](https://claude.com/claude-code)