### PR TITLE
fix(#850): document gate-result canonical fields + alias deprecated names

### DIFF
--- a/agents/crew/qe-orchestrator.md
+++ b/agents/crew/qe-orchestrator.md
@@ -115,15 +115,21 @@ Skill descriptions get injected into context; full skill bodies do not unless
 explicitly invoked. The contract below is the authoritative shape callers
 (phase_manager, gate_dispatch) consume — do not defer to a skill ref for it.
 
-Your final message MUST end with a fenced JSON block of this shape:
+Your final message MUST end with a fenced JSON block matching the canonical
+gate-result schema validated by `scripts/crew/gate_result_schema.py`. Field
+names below are exact — `gate_result_schema.py::validate_gate_result` enforces
+them and rejects on missing or wrong-named required fields. Issue #850 added
+soft aliases (`decision`→`verdict`, `timestamp`→`recorded_at`) that emit a
+deprecation warning; do not rely on them.
 
 ```json
 {
   "gate": "value | strategy | execution",
   "target": "<file path or task id>",
-  "decision": "APPROVE | CONDITIONAL | REJECT",
+  "verdict": "APPROVE | CONDITIONAL | REJECT",
   "score": 0.85,
   "reviewer": "qe-orchestrator",
+  "recorded_at": "2026-05-07T22:30:00Z",
   "reviewers_dispatched": ["wicked-testing:test-strategist", "wicked-testing:risk-assessor"],
   "dispatch_mode": "parallel | serial",
   "serial_reason": null,
@@ -138,6 +144,13 @@ Your final message MUST end with a fenced JSON block of this shape:
   "evidence_artifact": "phases/{phase}/{gate}-gate-{TIMESTAMP}.md"
 }
 ```
+
+Required fields enforced by the validator:
+
+- `verdict` (or `result`) — one of `APPROVE | CONDITIONAL | REJECT`.
+- `reviewer` — string; not a banned auto-approve identity.
+- `recorded_at` — ISO-8601 timestamp (e.g. `"2026-05-07T22:30:00Z"`).
+- `score` — numeric in `[0.0, 1.0]`.
 
 Invariants:
 - APPROVE → `conditions: []` AND `blockers: []` AND `score >= 0.70`.

--- a/scripts/crew/gate_result_schema.py
+++ b/scripts/crew/gate_result_schema.py
@@ -498,6 +498,37 @@ def _check_per_reviewer_verdicts(verdicts: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
+_FIELD_ALIASES: Dict[str, str] = {
+    # Issue #850 — accept the legacy field names that the qe-orchestrator
+    # contract example documented for years before the validator was added.
+    # Coerce in place to the canonical name so downstream readers see the
+    # validated shape. Each coercion emits a stderr deprecation so subagent
+    # authors notice and migrate. Mapping: alias -> canonical.
+    "timestamp": "recorded_at",
+    "decision": "verdict",
+}
+
+
+def _coerce_field_aliases(data: Dict[str, Any]) -> None:
+    """Copy legacy alias keys onto canonical names when the canonical is
+    absent. Mutates ``data`` in place so the validated/parsed dict the
+    caller receives carries the canonical fields.
+
+    Steering, not blocking: aliases survive validation but emit a
+    stderr deprecation. The qe-orchestrator agent doc is the source of
+    truth for canonical names; aliases are the soak-in path.
+    """
+    for alias, canonical in _FIELD_ALIASES.items():
+        if alias in data and canonical not in data:
+            data[canonical] = data[alias]
+            print(
+                f"[gate-result-schema] DEPRECATED: field '{alias}' is a legacy "
+                f"alias for '{canonical}' and will be removed in a future "
+                "release. Update reviewer output to use the canonical name.",
+                file=sys.stderr,
+            )
+
+
 def validate_gate_result(data: Any) -> None:
     """Validate a parsed gate-result dict. Raises on any violation.
 
@@ -505,9 +536,12 @@ def validate_gate_result(data: Any) -> None:
 
     - ``data`` must be a ``dict``. Anything else raises.
     - At least one of ``verdict`` or ``result`` must be present and a
-      valid enum member.
+      valid enum member. Legacy field name ``decision`` is accepted as
+      an alias for ``verdict`` (deprecation warned).
     - ``reviewer`` required; string; within char cap; not banned.
-    - ``recorded_at`` required; ISO-8601 parseable.
+    - ``recorded_at`` required; ISO-8601 parseable. Legacy field name
+      ``timestamp`` is accepted as an alias (deprecation warned).
+    - ``score`` required; numeric.
     - Field length caps enforced via ``FIELD_CAPS`` table.
     - ``conditions`` list cap + per-entry byte cap.
     - ``rubric_breakdown`` dict cap + per-``notes`` byte cap.
@@ -528,6 +562,12 @@ def validate_gate_result(data: Any) -> None:
             offending_field="<root>",
             violation_class="schema",
         )
+
+    # Issue #850: coerce legacy aliases (timestamp -> recorded_at,
+    # decision -> verdict) before required-field checks so a subagent
+    # following the older qe-orchestrator example doesn't get rejected
+    # purely on field-name drift.
+    _coerce_field_aliases(data)
 
     # AC-1: verdict / result enum. At least one must be present.
     has_verdict = "verdict" in data

--- a/tests/crew/test_gate_result_schema.py
+++ b/tests/crew/test_gate_result_schema.py
@@ -125,6 +125,84 @@ class RequiredFields(unittest.TestCase):
         self.assertEqual(cm.exception.reason, "invalid-timestamp:recorded_at")
 
 
+class FieldAliasCoercion(unittest.TestCase):
+    """Issue #850 — accept legacy field names from older qe-orchestrator
+    contract examples (``timestamp``, ``decision``) by coercing them to
+    canonical names. Each coercion is a deprecation that survives
+    validation but emits a stderr warning."""
+
+    def _capture_stderr(self):
+        import io, contextlib
+        buf = io.StringIO()
+        return buf, contextlib.redirect_stderr(buf)
+
+    def test_timestamp_alias_coerces_to_recorded_at(self):
+        payload = _valid_gate_result()
+        payload["timestamp"] = payload.pop("recorded_at")
+        buf, ctx = self._capture_stderr()
+        with ctx:
+            validate_gate_result(payload)
+        self.assertEqual(payload.get("recorded_at"), "2026-04-19T10:00:00+00:00")
+        self.assertIn("DEPRECATED", buf.getvalue())
+        self.assertIn("timestamp", buf.getvalue())
+        self.assertIn("recorded_at", buf.getvalue())
+
+    def test_decision_alias_coerces_to_verdict(self):
+        payload = _valid_gate_result()
+        payload["decision"] = payload.pop("verdict")
+        buf, ctx = self._capture_stderr()
+        with ctx:
+            validate_gate_result(payload)
+        self.assertEqual(payload.get("verdict"), "APPROVE")
+        self.assertIn("DEPRECATED", buf.getvalue())
+        self.assertIn("decision", buf.getvalue())
+
+    def test_canonical_wins_when_both_present(self):
+        # Canonical present → alias is ignored, no coercion, no warning.
+        payload = _valid_gate_result()
+        payload["timestamp"] = "WRONG-VALUE-SHOULD-NOT-WIN"
+        buf, ctx = self._capture_stderr()
+        with ctx:
+            validate_gate_result(payload)
+        self.assertEqual(payload["recorded_at"], "2026-04-19T10:00:00+00:00")
+        # No deprecation emitted because canonical was already present
+        self.assertNotIn("DEPRECATED", buf.getvalue())
+
+    def test_aliased_invalid_timestamp_still_validated(self):
+        # After coercion, the canonical field must still pass downstream
+        # checks. Bad timestamp under the alias name should still raise
+        # invalid-timestamp:recorded_at, not pass silently.
+        payload = _valid_gate_result()
+        payload.pop("recorded_at")
+        payload["timestamp"] = "not-a-date"
+        buf, ctx = self._capture_stderr()
+        with ctx, self.assertRaises(GateResultSchemaError) as cm:
+            validate_gate_result(payload)
+        self.assertEqual(cm.exception.reason, "invalid-timestamp:recorded_at")
+
+    def test_aliased_invalid_verdict_still_validated(self):
+        payload = _valid_gate_result()
+        payload.pop("verdict")
+        payload["decision"] = "MAYBE"
+        buf, ctx = self._capture_stderr()
+        with ctx, self.assertRaises(GateResultSchemaError) as cm:
+            validate_gate_result(payload)
+        self.assertTrue(
+            cm.exception.reason.startswith("invalid-verdict-enum"),
+            f"unexpected reason: {cm.exception.reason!r}",
+        )
+
+    def test_unknown_alias_does_not_coerce(self):
+        # Only mapped aliases are honored; arbitrary keys must not become
+        # canonical-name shadows.
+        payload = _valid_gate_result()
+        payload.pop("recorded_at")
+        payload["recordedAt"] = "2026-04-19T10:00:00+00:00"  # unmapped name
+        with self.assertRaises(GateResultSchemaError) as cm:
+            validate_gate_result(payload)
+        self.assertEqual(cm.exception.reason, "missing-required-field:recorded_at")
+
+
 class FieldSizeCaps(unittest.TestCase):
     def test_reason_oversize_raises(self):
         oversized = "a" * (MAX_REASON_BYTES + 1)


### PR DESCRIPTION
Closes #850.

## Summary
- `agents/crew/qe-orchestrator.md` example schema documented `decision` and omitted `recorded_at`. The validator at `scripts/crew/gate_result_schema.py` required `verdict` (or `result`) plus `recorded_at`. Subagents following the agent's example produced gate-result.json files that failed validation.
- Updated the agent doc to list the canonical required fields (`verdict`, `reviewer`, `recorded_at`, `score`) with an exact example, cross-referenced to the validator.
- Added soft alias coercion in `validate_gate_result`: `timestamp` → `recorded_at`, `decision` → `verdict`. Each coercion mutates the parsed dict in place and emits a stderr deprecation. Steering, not blocking.
- After coercion, downstream validation is unchanged — a bogus value under the alias still raises the canonical error (`invalid-timestamp:recorded_at`, not `:timestamp`).

## Test plan
- [x] `tests/crew/test_gate_result_schema.py::FieldAliasCoercion` — 6 new tests:
  - timestamp → recorded_at coercion + deprecation warning
  - decision → verdict coercion + deprecation warning
  - canonical wins when both present (no warning, alias ignored)
  - aliased bogus timestamp still fails canonical validator
  - aliased bogus verdict still fails canonical validator
  - unmapped alias names (e.g. `recordedAt`) do not coerce
- [x] Full `tests/crew/test_gate_result_schema.py` suite — 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)