### PR TITLE
fix(#846): hydrate phase_plan/complexity/rigor from process-plan.json

### DIFF
--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -994,8 +994,126 @@ def get_project_dir(project_name: str) -> Path:
     return project_dir
 
 
+def _hydrate_from_process_plan(state: ProjectState) -> bool:
+    """Hydrate phase_plan / complexity_score / rigor_tier / specialists from
+    ``process-plan.json`` when the DomainStore record left them empty.
+
+    Issue #846: ``propose-process`` writes the canonical plan to
+    ``process-plan.json`` but did not always reach the DomainStore record
+    via ``phase_manager update`` — leaving ``phase_manager status`` to
+    return ``phase_plan: []`` even though the plan existed on disk.
+    Treat ``process-plan.json`` as the source of truth for these fields
+    and populate the state in place. When both sources have values and
+    they disagree, prefer ``process-plan.json`` and emit a stderr warning
+    so the drift is visible.
+
+    Returns True iff any field was hydrated. Fail-open on parse errors
+    or missing files — never raises out of this helper. The intent is
+    "if the plan exists on disk, surface it"; surfacing a partial state
+    is better than masking it.
+    """
+    try:
+        project_dir = get_project_dir(state.name)
+    except Exception:
+        return False
+
+    plan_json = project_dir / "process-plan.json"
+    if not plan_json.exists():
+        return False
+
+    try:
+        plan = json.loads(plan_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug(
+            "[hydrate] process-plan.json unreadable for project %s: %s",
+            state.name, exc,
+        )
+        return False
+
+    hydrated = False
+
+    # phase_plan from plan["phases"][...]["name"]
+    plan_phases = plan.get("phases")
+    if isinstance(plan_phases, list) and plan_phases:
+        plan_phase_names = [
+            resolve_phase(p["name"])
+            for p in plan_phases
+            if isinstance(p, dict) and isinstance(p.get("name"), str)
+        ]
+        if plan_phase_names:
+            if not state.phase_plan:
+                state.phase_plan = plan_phase_names
+                hydrated = True
+            elif state.phase_plan != plan_phase_names:
+                logger.warning(
+                    "[hydrate] DomainStore phase_plan %s disagrees with "
+                    "process-plan.json %s for project %s — preferring "
+                    "process-plan.json (Issue #846).",
+                    state.phase_plan, plan_phase_names, state.name,
+                )
+                state.phase_plan = plan_phase_names
+                hydrated = True
+
+    # complexity_score from plan["complexity"]
+    plan_complexity = plan.get("complexity")
+    if isinstance(plan_complexity, int):
+        if state.complexity_score == 0:
+            state.complexity_score = plan_complexity
+            hydrated = True
+        elif state.complexity_score != plan_complexity:
+            logger.warning(
+                "[hydrate] DomainStore complexity_score %s disagrees with "
+                "process-plan.json %s for project %s — preferring "
+                "process-plan.json.",
+                state.complexity_score, plan_complexity, state.name,
+            )
+            state.complexity_score = plan_complexity
+            hydrated = True
+
+    # rigor_tier lives in extras to match v6 storage convention
+    plan_rigor = plan.get("rigor_tier")
+    if isinstance(plan_rigor, str) and plan_rigor in {"minimal", "standard", "full"}:
+        existing_rigor = (state.extras or {}).get("rigor_tier")
+        if not existing_rigor:
+            state.extras["rigor_tier"] = plan_rigor
+            hydrated = True
+        elif existing_rigor != plan_rigor:
+            logger.warning(
+                "[hydrate] DomainStore rigor_tier %r disagrees with "
+                "process-plan.json %r for project %s — preferring "
+                "process-plan.json.",
+                existing_rigor, plan_rigor, state.name,
+            )
+            state.extras["rigor_tier"] = plan_rigor
+            hydrated = True
+
+    # specialists_recommended from plan["specialists"][...]["name"]
+    plan_specialists = plan.get("specialists")
+    if isinstance(plan_specialists, list) and plan_specialists:
+        names = [
+            s["name"] for s in plan_specialists
+            if isinstance(s, dict) and isinstance(s.get("name"), str)
+        ]
+        if names and not state.specialists_recommended:
+            state.specialists_recommended = names
+            hydrated = True
+
+    return hydrated
+
+
 def load_project_state(project_name: str) -> Optional[ProjectState]:
-    """Load project state from DomainStore."""
+    """Load project state from DomainStore.
+
+    Issue #846: After loading the DomainStore record, attempt to hydrate
+    phase_plan, complexity_score, rigor_tier, and specialists from
+    ``process-plan.json`` when the record left them empty. The plan file
+    is the canonical artifact written by propose-process; the
+    DomainStore record can drift behind it when a caller wrote the plan
+    but never made the corresponding ``phase_manager update`` call.
+    Hydration is read-only at load time — see ``_hydrate_from_process_plan``
+    for the drift-warning behavior. Persist via ``save_project_state``
+    if the caller wants the hydrated state to stick.
+    """
     if not project_name or not is_safe_project_name(project_name):
         return None
 
@@ -1005,7 +1123,23 @@ def load_project_state(project_name: str) -> Optional[ProjectState]:
         project_dir = get_project_dir(project_name)
         project_md = project_dir / "project.md"
         if project_md.exists():
-            return load_from_markdown(project_md)
+            state = load_from_markdown(project_md)
+            if state is not None:
+                _hydrate_from_process_plan(state)
+            return state
+        # No DomainStore record — try hydrating a minimal state purely
+        # from process-plan.json so callers can still see the plan that
+        # was authored. This is the case the user hit in #846.
+        plan_json = project_dir / "process-plan.json"
+        if plan_json.exists():
+            stub = ProjectState(
+                name=project_name,
+                current_phase="clarify",
+                created_at=get_utc_timestamp(),
+                version="v3-capability-based",
+            )
+            if _hydrate_from_process_plan(stub):
+                return stub
         return None
 
     phases = {}
@@ -1034,7 +1168,7 @@ def load_project_state(project_name: str) -> Optional[ProjectState]:
     }
     extras = {k: v for k, v in data.items() if k not in known_keys}
 
-    return ProjectState(
+    state = ProjectState(
         name=data.get("name", project_name),
         current_phase=resolve_phase(data.get("current_phase", "clarify")),
         created_at=data.get("created_at", get_utc_timestamp()),
@@ -1047,6 +1181,11 @@ def load_project_state(project_name: str) -> Optional[ProjectState]:
         cp_project_id=data.get("cp_project_id"),
         extras=extras,
     )
+    # Issue #846: hydrate from process-plan.json when the DomainStore
+    # record is missing fields the plan defines. Read-only at load time;
+    # callers wanting persistence call save_project_state separately.
+    _hydrate_from_process_plan(state)
+    return state
 
 
 def _load_from_markdown_simple(project_md: Path) -> Optional[ProjectState]:

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -956,6 +956,151 @@ class TestAutoReevalStub(unittest.TestCase):
             )
 
 
+class TestHydrateFromProcessPlan(unittest.TestCase):
+    """Issue #846 — load_project_state hydrates phase_plan / complexity /
+    rigor_tier / specialists from process-plan.json when the DomainStore
+    record is empty. Drift between the two sources logs a warning and
+    prefers process-plan.json.
+    """
+
+    def _write_plan(self, project_dir, *, phases=None, complexity=3,
+                    rigor_tier="standard", specialists=None):
+        plan = {
+            "phases": phases or [
+                {"name": "clarify", "why": "x", "primary": []},
+                {"name": "design", "why": "x", "primary": []},
+                {"name": "build", "why": "x", "primary": []},
+            ],
+            "complexity": complexity,
+            "rigor_tier": rigor_tier,
+            "specialists": specialists or [
+                {"name": "engineering", "why": "x"},
+                {"name": "qe", "why": "x"},
+            ],
+        }
+        project_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "process-plan.json").write_text(json.dumps(plan))
+
+    def _empty_state(self, name="hydrate-proj"):
+        s = pm.ProjectState(
+            name=name, current_phase="clarify",
+            created_at="2026-01-01T00:00:00Z",
+        )
+        s.phase_plan = []  # explicit empty for hydration tests
+        return s
+
+    def test_hydrates_empty_phase_plan(self):
+        state = self._empty_state()
+        self.assertEqual(state.phase_plan, [])
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir)
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                changed = pm._hydrate_from_process_plan(state)
+        self.assertTrue(changed)
+        self.assertEqual(state.phase_plan, ["clarify", "design", "build"])
+
+    def test_hydrates_complexity_and_rigor(self):
+        state = self._empty_state()
+        self.assertEqual(state.complexity_score, 0)
+        self.assertNotIn("rigor_tier", state.extras)
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir, complexity=5, rigor_tier="full")
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                pm._hydrate_from_process_plan(state)
+        self.assertEqual(state.complexity_score, 5)
+        self.assertEqual(state.extras.get("rigor_tier"), "full")
+
+    def test_hydrates_specialists_only_when_empty(self):
+        state = self._empty_state()
+        state.specialists_recommended = ["pre-existing"]
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir)
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                pm._hydrate_from_process_plan(state)
+        # Existing specialists list survives — only fill on empty
+        self.assertEqual(state.specialists_recommended, ["pre-existing"])
+
+    def test_drift_logs_warning_and_prefers_plan(self):
+        state = self._empty_state()
+        state.phase_plan = ["clarify", "test"]  # disagrees with plan
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir)
+            with patch.object(pm, "get_project_dir", return_value=project_dir), \
+                 patch.object(pm.logger, "warning") as mock_warn:
+                pm._hydrate_from_process_plan(state)
+        self.assertEqual(state.phase_plan, ["clarify", "design", "build"])
+        # Warning emitted naming the drift
+        self.assertTrue(mock_warn.called)
+        warned = " ".join(str(c) for c in mock_warn.call_args_list)
+        self.assertIn("disagrees", warned)
+        self.assertIn("#846", warned)
+
+    def test_no_plan_file_is_noop(self):
+        state = self._empty_state()
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            project_dir.mkdir(parents=True)
+            # No process-plan.json written
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                changed = pm._hydrate_from_process_plan(state)
+        self.assertFalse(changed)
+        self.assertEqual(state.phase_plan, [])
+
+    def test_malformed_plan_fail_open(self):
+        state = self._empty_state()
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            project_dir.mkdir(parents=True)
+            (project_dir / "process-plan.json").write_text("{not valid json")
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                changed = pm._hydrate_from_process_plan(state)
+        self.assertFalse(changed)
+        self.assertEqual(state.phase_plan, [])
+
+    def test_invalid_rigor_tier_skipped(self):
+        state = self._empty_state()
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir, rigor_tier="ludicrous")
+            with patch.object(pm, "get_project_dir", return_value=project_dir):
+                pm._hydrate_from_process_plan(state)
+        self.assertNotIn("rigor_tier", state.extras)
+
+    def test_load_project_state_hydrates_when_record_empty(self):
+        """End-to-end: load_project_state returns a state with phase_plan
+        populated from process-plan.json when the DomainStore record had
+        none."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir)
+            stored = {"name": "hydrate-proj", "current_phase": "clarify",
+                      "created_at": "2026-05-07T00:00:00Z", "phases": {}}
+            with patch.object(pm._sm, "get", return_value=stored), \
+                 patch.object(pm, "get_project_dir", return_value=project_dir):
+                state = pm.load_project_state("hydrate-proj")
+        self.assertIsNotNone(state)
+        self.assertEqual(state.phase_plan, ["clarify", "design", "build"])
+        self.assertEqual(state.complexity_score, 3)
+        self.assertEqual(state.extras.get("rigor_tier"), "standard")
+
+    def test_load_project_state_hydrates_stub_when_no_record_but_plan_exists(self):
+        """If DomainStore has no record AND process-plan.json exists,
+        return a stub state hydrated from the plan."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "hydrate-proj"
+            self._write_plan(project_dir)
+            with patch.object(pm._sm, "get", return_value=None), \
+                 patch.object(pm, "get_project_dir", return_value=project_dir):
+                state = pm.load_project_state("hydrate-proj")
+        self.assertIsNotNone(state)
+        self.assertEqual(state.phase_plan, ["clarify", "design", "build"])
+        self.assertEqual(state.complexity_score, 3)
+
+
 class TestStatusJsonFieldParity(unittest.TestCase):
     """Issue #494: `phase_manager.py status --json` surfaces rigor_tier,
     complexity_score, and is_complete alongside the existing fields."""


### PR DESCRIPTION
Closes #846.

## Summary
- `phase_manager status` returned `phase_plan: []` (and `complexity: 0`, `rigor_tier: null`) even when propose-process had written a complete `process-plan.json`. The DomainStore record and the on-disk plan were two state machines that didn't talk to each other — the rubric wrote the plan, but if the caller didn't make a followup `phase_manager update` call, the state record stayed empty.
- `load_project_state` now hydrates `phase_plan`, `complexity_score`, `rigor_tier`, and `specialists_recommended` from `process-plan.json` when the DomainStore record left them empty. The plan file is the explicit deliverable from propose-process, so it is the source of truth when present.
- Drift between the two sources logs a warning naming Issue #846 and prefers `process-plan.json`. Read-only at load time; callers wanting persistence call `save_project_state` separately.

## Edge cases

| Situation                                          | Behavior                              |
|----------------------------------------------------|---------------------------------------|
| DomainStore record missing + plan present          | Return stub state hydrated from plan  |
| DomainStore record present + plan missing          | Unchanged (pure load)                 |
| Malformed plan JSON                                | Fail-open (returns False, state unchanged) |
| Invalid `rigor_tier` value                         | Skipped (only `minimal/standard/full` hydrate) |
| `specialists_recommended` already non-empty        | Preserved (session-scoped overrides survive) |
| Drift between record and plan                      | Plan wins; stderr warning names #846  |

## Test plan
- [x] `tests/crew/test_phase_manager.py::TestHydrateFromProcessPlan` — 9 new tests covering empty hydration, complexity+rigor, specialists-no-overwrite, drift warning + plan-wins, no-plan no-op, malformed JSON fail-open, invalid rigor tier skipped, end-to-end `load_project_state` with stored record, end-to-end `load_project_state` with no record but plan present.
- [x] Full `tests/crew/test_phase_manager.py` suite — 75 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)