### PR TITLE
fix(#847): scope-delta trigger for clarify HITL gate

### DIFF
--- a/scripts/crew/scope_delta.py
+++ b/scripts/crew/scope_delta.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""scope_delta.py — Compute scope-delta metrics for the clarify HITL gate.
+
+Issue #847: the facilitator's clarify HITL gate previously fired only on
+intent ambiguity (the six triggers in ``skills/propose-process/refs/
+ambiguity.md``). It missed the failure where the rubric silently
+expanded a 24-issue wave plan to absorb a 1M-insertion sibling project
+because no trigger looked at scope-size deltas.
+
+This helper computes the four scope-delta metrics that drive the
+seventh trigger added in #847:
+
+- ``new_items``: items in the proposed plan not present in the
+  baseline plan (matched by id).
+- ``oversize_factor``: ratio of the largest new item's size to the
+  median size of items already in the baseline plan. Trips the trigger
+  at >= 3.0.
+- ``total_size_ratio``: total proposed-plan size / baseline-plan size.
+  Trips the trigger at >= 2.0.
+- ``epic_or_project_added``: True iff any new item carries a label
+  matching the epic/project regex.
+
+Stdlib-only; designed for the propose-process facilitator agent or
+the slim caller to consume programmatically. Returns a dict; the
+facilitator agent should surface the trigger as a clarifying question
+when any threshold is crossed (per ambiguity.md trigger #7).
+
+The "size" of an item is whatever the caller measures consistently —
+LOC, file count, sub-task count, or a fused score. The helper does not
+prescribe a unit; it just compares apples to apples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any, Dict, Iterable, List, Optional
+
+
+# Issue #847: items labeled with these patterns are project-sized by
+# convention and must not be silently absorbed into a wave plan.
+EPIC_LABEL_PATTERNS = (
+    re.compile(r"^epic$", re.IGNORECASE),
+    re.compile(r"^project$", re.IGNORECASE),
+    re.compile(r"^large$", re.IGNORECASE),
+    re.compile(r"^xlarge$", re.IGNORECASE),
+    re.compile(r"^xxl$", re.IGNORECASE),
+)
+
+# Threshold defaults — surfaced as constants so callers can override
+# but the trigger doctrine in ambiguity.md stays in sync.
+DEFAULT_OVERSIZE_FACTOR_TRIP = 3.0
+DEFAULT_TOTAL_SIZE_RATIO_TRIP = 2.0
+
+
+def _median(values: List[float]) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    mid = len(sorted_values) // 2
+    if len(sorted_values) % 2 == 1:
+        return float(sorted_values[mid])
+    return (sorted_values[mid - 1] + sorted_values[mid]) / 2.0
+
+
+def _has_epic_label(labels: Optional[Iterable[str]]) -> bool:
+    if not labels:
+        return False
+    for label in labels:
+        if not isinstance(label, str):
+            continue
+        for pattern in EPIC_LABEL_PATTERNS:
+            if pattern.match(label.strip()):
+                return True
+    return False
+
+
+def _normalize_item(raw: Any) -> Dict[str, Any]:
+    """Coerce a raw item entry to the canonical shape.
+
+    Accepts either a dict ({"id", "size", "labels"}) or a bare string
+    (treated as id with size=1, no labels). Anything else is dropped.
+    """
+    if isinstance(raw, dict):
+        item_id = raw.get("id") or raw.get("name") or raw.get("title")
+        size = raw.get("size", 1)
+        labels = raw.get("labels", [])
+        if item_id is None:
+            return {}
+        try:
+            size = float(size)
+        except (TypeError, ValueError):
+            size = 1.0
+        return {"id": str(item_id), "size": size,
+                "labels": list(labels) if labels else []}
+    if isinstance(raw, str):
+        return {"id": raw, "size": 1.0, "labels": []}
+    return {}
+
+
+def compute_scope_delta(
+    baseline: List[Any],
+    proposed: List[Any],
+    *,
+    oversize_factor_trip: float = DEFAULT_OVERSIZE_FACTOR_TRIP,
+    total_size_ratio_trip: float = DEFAULT_TOTAL_SIZE_RATIO_TRIP,
+) -> Dict[str, Any]:
+    """Compute scope-delta metrics for the clarify HITL gate (#847).
+
+    Args:
+        baseline: List of items the user explicitly named in the
+            original ask. Each entry is a dict
+            ``{"id": str, "size": float, "labels": [str]}`` or a bare
+            string id.
+        proposed: List of items in the proposed plan, same shape.
+        oversize_factor_trip: Threshold at or above which the
+            oversize_factor trips the trigger (default 3.0).
+        total_size_ratio_trip: Threshold at or above which the
+            total_size_ratio trips the trigger (default 2.0).
+
+    Returns:
+        Dict with:
+          - ``new_items``: list of {id, size, labels} for items in
+            proposed but not baseline.
+          - ``baseline_median_size`` / ``baseline_total_size``.
+          - ``proposed_total_size``.
+          - ``oversize_factor``: max(new_item.size) / baseline_median_size,
+            or None when baseline_median_size is 0.
+          - ``total_size_ratio``: proposed_total / baseline_total, or
+            None when baseline_total is 0.
+          - ``epic_or_project_added``: True iff any new item has an
+            epic-class label.
+          - ``triggers``: ordered list of human-readable strings naming
+            which thresholds tripped. Empty list = no trigger fired.
+
+    The trigger fires whenever ``triggers`` is non-empty.
+    """
+    base = [it for it in (_normalize_item(x) for x in baseline) if it]
+    prop = [it for it in (_normalize_item(x) for x in proposed) if it]
+
+    base_ids = {it["id"] for it in base}
+    new_items = [it for it in prop if it["id"] not in base_ids]
+
+    baseline_sizes = [it["size"] for it in base]
+    baseline_median = _median(baseline_sizes)
+    baseline_total = sum(baseline_sizes)
+    proposed_total = sum(it["size"] for it in prop)
+
+    if new_items and baseline_median > 0:
+        max_new_size = max(it["size"] for it in new_items)
+        oversize_factor = max_new_size / baseline_median
+    else:
+        oversize_factor = None
+
+    if baseline_total > 0:
+        total_size_ratio = proposed_total / baseline_total
+    else:
+        total_size_ratio = None
+
+    epic_added = any(_has_epic_label(it.get("labels")) for it in new_items)
+
+    triggers: List[str] = []
+    if oversize_factor is not None and oversize_factor >= oversize_factor_trip:
+        triggers.append(
+            f"oversize-factor: largest new item is {oversize_factor:.1f}x "
+            f"the baseline median (trip threshold: {oversize_factor_trip}x)"
+        )
+    if total_size_ratio is not None and total_size_ratio >= total_size_ratio_trip:
+        triggers.append(
+            f"total-size-ratio: proposed plan is {total_size_ratio:.1f}x "
+            f"the baseline total size (trip threshold: {total_size_ratio_trip}x)"
+        )
+    if epic_added:
+        epic_ids = [
+            it["id"] for it in new_items if _has_epic_label(it.get("labels"))
+        ]
+        triggers.append(
+            f"epic-or-project-label: new item(s) {epic_ids} carry an "
+            "epic/project-class label and should be planned separately"
+        )
+
+    return {
+        "new_items": new_items,
+        "baseline_median_size": baseline_median,
+        "baseline_total_size": baseline_total,
+        "proposed_total_size": proposed_total,
+        "oversize_factor": oversize_factor,
+        "total_size_ratio": total_size_ratio,
+        "epic_or_project_added": epic_added,
+        "triggers": triggers,
+    }
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute scope-delta metrics for the clarify HITL gate "
+            "(Issue #847). Pass --baseline and --proposed as JSON file "
+            "paths or '-' to read from stdin."
+        )
+    )
+    parser.add_argument("--baseline", required=True,
+                        help="Path to JSON file with baseline items, or '-' for stdin.")
+    parser.add_argument("--proposed", required=True,
+                        help="Path to JSON file with proposed items, or '-' for stdin.")
+    parser.add_argument("--oversize-factor-trip", type=float,
+                        default=DEFAULT_OVERSIZE_FACTOR_TRIP,
+                        help=f"Override oversize-factor trip (default {DEFAULT_OVERSIZE_FACTOR_TRIP}).")
+    parser.add_argument("--total-size-ratio-trip", type=float,
+                        default=DEFAULT_TOTAL_SIZE_RATIO_TRIP,
+                        help=f"Override total-size-ratio trip (default {DEFAULT_TOTAL_SIZE_RATIO_TRIP}).")
+    parser.add_argument("--exit-nonzero-on-trip", action="store_true",
+                        help="Exit 1 if any trigger fires.")
+    args = parser.parse_args()
+
+    def _load(path: str) -> List[Any]:
+        if path == "-":
+            return json.loads(sys.stdin.read())
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    baseline = _load(args.baseline)
+    proposed = _load(args.proposed)
+    if not isinstance(baseline, list) or not isinstance(proposed, list):
+        print("Error: baseline and proposed must each be a JSON array.",
+              file=sys.stderr)
+        sys.exit(2)
+
+    result = compute_scope_delta(
+        baseline, proposed,
+        oversize_factor_trip=args.oversize_factor_trip,
+        total_size_ratio_trip=args.total_size_ratio_trip,
+    )
+    json.dump(result, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")
+    if args.exit_nonzero_on_trip and result["triggers"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/scripts/crew/scope_delta.py
+++ b/scripts/crew/scope_delta.py
@@ -93,8 +93,17 @@ def _normalize_item(raw: Any) -> Dict[str, Any]:
             size = float(size)
         except (TypeError, ValueError):
             size = 1.0
-        return {"id": str(item_id), "size": size,
-                "labels": list(labels) if labels else []}
+        # Labels normalization (Gemini PR #860 review): a bare string must
+        # become a single-element list, not be decomposed by list("epic")
+        # into ['e','p','i','c']. A non-iterable type (int, None, etc.)
+        # falls back to []. Only str/list/tuple yield meaningful labels.
+        if isinstance(labels, str):
+            labels_list = [labels]
+        elif isinstance(labels, (list, tuple)):
+            labels_list = list(labels)
+        else:
+            labels_list = []
+        return {"id": str(item_id), "size": size, "labels": labels_list}
     if isinstance(raw, str):
         return {"id": raw, "size": 1.0, "labels": []}
     return {}

--- a/scripts/crew/scope_delta.py
+++ b/scripts/crew/scope_delta.py
@@ -213,7 +213,7 @@ def _cli() -> None:
     parser.add_argument("--baseline", required=True,
                         help="Path to JSON file with baseline items, or '-' for stdin.")
     parser.add_argument("--proposed", required=True,
-                        help="Path to JSON file with proposed items, or '-' for stdin.")
+                        help="Path to JSON file with proposed items, or '-' for stdin (mutually exclusive with --baseline -).")
     parser.add_argument("--oversize-factor-trip", type=float,
                         default=DEFAULT_OVERSIZE_FACTOR_TRIP,
                         help=f"Override oversize-factor trip (default {DEFAULT_OVERSIZE_FACTOR_TRIP}).")
@@ -229,6 +229,18 @@ def _cli() -> None:
             return json.loads(sys.stdin.read())
         with open(path, "r", encoding="utf-8") as fh:
             return json.load(fh)
+
+    # Copilot PR #860 review: stdin can only be consumed once. Reject the
+    # ambiguous '--baseline - --proposed -' case explicitly so a second
+    # empty read doesn't surface as a confusing JSONDecodeError.
+    if args.baseline == "-" and args.proposed == "-":
+        print(
+            "Error: --baseline and --proposed cannot BOTH be '-'. "
+            "stdin can only be consumed once. Pass at most one of them as "
+            "'-' and the other as a file path.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     baseline = _load(args.baseline)
     proposed = _load(args.proposed)

--- a/skills/propose-process/refs/ambiguity.md
+++ b/skills/propose-process/refs/ambiguity.md
@@ -30,8 +30,8 @@ Any of:
    the trigger:
    - A single new GitHub issue, file path, or task is **3× or more the size** of
      the median item already in scope (LOC, files touched, or sub-task count).
-   - Total LOC / file-count delta from baseline plan to proposed plan exceeds
-     **2× the original**.
+   - Total proposed plan size is at least **2× the baseline plan total**
+     (i.e. the proposed plan absorbs as much new work as the original ask).
    - A new GitHub issue is labeled `epic`, `project`, or appears in another active
      project — it is its own project and should not be silently bundled.
    - User said "small change" or "fix" but the plan now spans **>3 phases** or

--- a/skills/propose-process/refs/ambiguity.md
+++ b/skills/propose-process/refs/ambiguity.md
@@ -24,6 +24,23 @@ Any of:
    memory entries from similar projects.
 6. **Compliance implied but not stated**. E.g. "let users download their data" — GDPR
    scope is implied but the user may not realize it.
+7. **Scope creep / project-sized addition** (Issue #847). The plan absorbs an item
+   the user did not name in the original ask, AND that item is materially larger
+   than the median item in the planned scope. Concrete heuristics — any one trips
+   the trigger:
+   - A single new GitHub issue, file path, or task is **3× or more the size** of
+     the median item already in scope (LOC, files touched, or sub-task count).
+   - Total LOC / file-count delta from baseline plan to proposed plan exceeds
+     **2× the original**.
+   - A new GitHub issue is labeled `epic`, `project`, or appears in another active
+     project — it is its own project and should not be silently bundled.
+   - User said "small change" or "fix" but the plan now spans **>3 phases** or
+     **>10 tasks**.
+
+   This catches the failure where the facilitator silently expanded a 24-issue
+   wave plan to absorb a 1M-insertion sibling project. **Use the
+   `scripts/crew/scope_delta.py` helper** to compute the numbers when wave
+   planning so the trigger fires on data, not vibes.
 
 Two or more triggers → mandatory stop. One trigger → facilitator judgment (lean toward
 stopping when rigor_tier would be `full`).

--- a/skills/propose-process/refs/ambiguity.md
+++ b/skills/propose-process/refs/ambiguity.md
@@ -32,8 +32,9 @@ Any of:
      the median item already in scope (LOC, files touched, or sub-task count).
    - Total proposed plan size is at least **2× the baseline plan total**
      (i.e. the proposed plan absorbs as much new work as the original ask).
-   - A new GitHub issue is labeled `epic`, `project`, or appears in another active
-     project — it is its own project and should not be silently bundled.
+   - A new GitHub issue carries an epic/project-class size label
+     (`epic`, `project`, `large`, `xlarge`, or `xxl`), or appears in another
+     active project — it is its own project and should not be silently bundled.
    - User said "small change" or "fix" but the plan now spans **>3 phases** or
      **>10 tasks**.
 

--- a/tests/crew/test_scope_delta.py
+++ b/tests/crew/test_scope_delta.py
@@ -16,10 +16,16 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
-# Ensure scripts/ is importable
+# Ensure scripts/ is importable. Copilot PR #860 review: append rather
+# than insert, and keep scripts/ ahead of scripts/crew/ so crew.py-style
+# names don't shadow the crew/ package for later-collected tests.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_REPO_ROOT / "scripts"))
-sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+_SCRIPTS = str(_REPO_ROOT / "scripts")
+_CREW = str(_REPO_ROOT / "scripts" / "crew")
+if _SCRIPTS not in sys.path:
+    sys.path.append(_SCRIPTS)
+if _CREW not in sys.path:
+    sys.path.append(_CREW)
 
 import scope_delta as sd  # noqa: E402
 
@@ -240,6 +246,35 @@ class TestCLI(unittest.TestCase):
             baseline, baseline, "--exit-nonzero-on-trip",
             expect_returncode=0,
         )
+
+    def test_cli_rejects_both_stdin(self):
+        """Copilot PR #860 review: --baseline - --proposed - cannot
+        both consume stdin. Reject explicitly with exit 2."""
+        scope_delta_path = _REPO_ROOT / "scripts" / "crew" / "scope_delta.py"
+        result = subprocess.run(
+            [sys.executable, str(scope_delta_path),
+             "--baseline", "-", "--proposed", "-"],
+            input="[]", capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cannot BOTH be '-'", result.stderr)
+
+
+class TestEpicLabelExtraSizes(unittest.TestCase):
+    """Copilot PR #860 review: doctrine now lists large/xlarge/xxl in
+    addition to epic/project. Verify the implementation matches."""
+
+    def test_large_label_trips_epic_class(self):
+        baseline = [{"id": "i-1", "size": 10}]
+        proposed = baseline + [{"id": "n-1", "size": 1, "labels": ["large"]}]
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertTrue(result["epic_or_project_added"])
+
+    def test_xxl_label_trips_epic_class(self):
+        baseline = [{"id": "i-1", "size": 10}]
+        proposed = baseline + [{"id": "n-1", "size": 1, "labels": ["xxl"]}]
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertTrue(result["epic_or_project_added"])
 
 
 if __name__ == "__main__":

--- a/tests/crew/test_scope_delta.py
+++ b/tests/crew/test_scope_delta.py
@@ -41,6 +41,36 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(sd._normalize_item(42), {})
         self.assertEqual(sd._normalize_item(None), {})
 
+    def test_labels_string_becomes_single_element_list(self):
+        # Gemini PR #860 review: a bare string label must NOT be
+        # decomposed by list("epic") into ['e','p','i','c'].
+        item = sd._normalize_item({"id": "i-1", "size": 1, "labels": "epic"})
+        self.assertEqual(item["labels"], ["epic"])
+
+    def test_labels_non_iterable_defaults_to_empty(self):
+        # Non-iterable labels (int, dict, etc.) must not crash with
+        # TypeError — fall back to [].
+        for bad in (42, 3.14, {"k": "v"}, True):
+            item = sd._normalize_item({"id": "i-1", "size": 1, "labels": bad})
+            self.assertEqual(item["labels"], [],
+                             f"non-iterable labels {bad!r} should default to []")
+
+    def test_labels_string_label_still_detects_epic(self):
+        """End-to-end guard: a string-typed labels field with value 'epic'
+        flows through normalization and still trips the epic-class trigger."""
+        baseline = [{"id": "i-1", "size": 10}]
+        proposed = baseline + [
+            # NB: labels passed as bare string, not list — pre-fix this would
+            # decompose into ['e','p','i','c'] and the epic trigger would
+            # silently miss.
+            {"id": "ep-1", "size": 1, "labels": "epic"},
+        ]
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertTrue(result["epic_or_project_added"])
+        self.assertTrue(any(
+            "epic-or-project-label" in t for t in result["triggers"]
+        ))
+
 
 class TestEpicLabelDetection(unittest.TestCase):
     def test_epic_match_case_insensitive(self):

--- a/tests/crew/test_scope_delta.py
+++ b/tests/crew/test_scope_delta.py
@@ -1,0 +1,216 @@
+"""Tests for scripts/crew/scope_delta.py — Issue #847.
+
+Covers compute_scope_delta() and the CLI shim. The trigger doctrine
+lives in skills/propose-process/refs/ambiguity.md trigger #7; this
+suite enforces the numerical contract the doctrine references.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure scripts/ is importable
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "crew"))
+
+import scope_delta as sd  # noqa: E402
+
+
+class TestNormalize(unittest.TestCase):
+    def test_dict_passthrough(self):
+        item = sd._normalize_item({"id": "i-1", "size": 5, "labels": ["bug"]})
+        self.assertEqual(item, {"id": "i-1", "size": 5.0, "labels": ["bug"]})
+
+    def test_string_becomes_id(self):
+        item = sd._normalize_item("i-1")
+        self.assertEqual(item, {"id": "i-1", "size": 1.0, "labels": []})
+
+    def test_invalid_size_falls_back_to_one(self):
+        item = sd._normalize_item({"id": "i-1", "size": "huge"})
+        self.assertEqual(item["size"], 1.0)
+
+    def test_unknown_shape_dropped(self):
+        self.assertEqual(sd._normalize_item(42), {})
+        self.assertEqual(sd._normalize_item(None), {})
+
+
+class TestEpicLabelDetection(unittest.TestCase):
+    def test_epic_match_case_insensitive(self):
+        self.assertTrue(sd._has_epic_label(["EPIC"]))
+        self.assertTrue(sd._has_epic_label(["epic"]))
+        self.assertTrue(sd._has_epic_label(["project"]))
+
+    def test_substring_does_not_match(self):
+        # 'epic-feature' is not the bare 'epic' label
+        self.assertFalse(sd._has_epic_label(["epic-feature"]))
+
+    def test_no_labels_false(self):
+        self.assertFalse(sd._has_epic_label([]))
+        self.assertFalse(sd._has_epic_label(None))
+
+
+class TestComputeScopeDeltaTriggers(unittest.TestCase):
+    """The seventh ambiguity trigger fires whenever scope_delta returns a
+    non-empty triggers list. These tests pin the threshold semantics."""
+
+    def test_no_change_no_trigger(self):
+        baseline = [{"id": "i-1", "size": 10}, {"id": "i-2", "size": 12}]
+        result = sd.compute_scope_delta(baseline, baseline)
+        self.assertEqual(result["triggers"], [])
+        self.assertEqual(result["new_items"], [])
+
+    def test_oversize_factor_trips_at_3x_median(self):
+        # Median of 10/12/14 = 12.0; new item size 36 → 3.0x
+        baseline = [
+            {"id": "i-1", "size": 10},
+            {"id": "i-2", "size": 12},
+            {"id": "i-3", "size": 14},
+        ]
+        proposed = baseline + [{"id": "new-big", "size": 36}]
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertAlmostEqual(result["oversize_factor"], 3.0)
+        self.assertTrue(any("oversize-factor" in t for t in result["triggers"]))
+
+    def test_oversize_factor_does_not_trip_below_3x(self):
+        baseline = [{"id": "i-1", "size": 10}, {"id": "i-2", "size": 12}]
+        proposed = baseline + [{"id": "new-mid", "size": 25}]  # ~2.27x
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertLess(result["oversize_factor"], 3.0)
+        self.assertFalse(any("oversize-factor" in t for t in result["triggers"]))
+
+    def test_total_size_ratio_trips_at_2x(self):
+        baseline = [{"id": "i-1", "size": 10}]
+        # Two new items each size 5 brings total to 20 → 2.0x. Each new item
+        # is 0.5x median (10) so oversize-factor will not also trip.
+        proposed = baseline + [
+            {"id": "n-1", "size": 5},
+            {"id": "n-2", "size": 5},
+        ]
+        result = sd.compute_scope_delta(baseline, proposed)
+        self.assertAlmostEqual(result["total_size_ratio"], 2.0)
+        self.assertTrue(any("total-size-ratio" in t for t in result["triggers"]))
+
+    def test_epic_label_trips_independently(self):
+        baseline = [{"id": "i-1", "size": 10}]
+        proposed = baseline + [{"id": "ep-1", "size": 1, "labels": ["epic"]}]
+        result = sd.compute_scope_delta(baseline, proposed)
+        # size is tiny, so oversize-factor + total-size-ratio do NOT trip
+        self.assertTrue(result["epic_or_project_added"])
+        self.assertTrue(any("epic-or-project-label" in t for t in result["triggers"]))
+
+    def test_dogfood_scenario_jagan_ciq(self):
+        """Issue #847 dogfood: baseline 24 normal-sized issues, plan
+        absorbs a 1M-insertion sibling project. Verify the trigger fires
+        even when the small items have label-only signal."""
+        baseline = [{"id": f"i-{i}", "size": 100} for i in range(24)]
+        # 1M-insertion absorbed item at scale 1_040_000
+        proposed = baseline + [
+            {"id": "jagan-ciq",
+             "size": 1_040_000,
+             "labels": ["epic", "project"]},
+        ]
+        result = sd.compute_scope_delta(baseline, proposed)
+        # All three triggers should fire on this scenario
+        trips = " ".join(result["triggers"])
+        self.assertIn("oversize-factor", trips)
+        self.assertIn("total-size-ratio", trips)
+        self.assertIn("epic-or-project-label", trips)
+
+    def test_baseline_empty_does_not_explode(self):
+        """When baseline is empty (greenfield plan), oversize_factor and
+        total_size_ratio are None — no division-by-zero — and the
+        epic-label trigger still fires when applicable."""
+        proposed = [{"id": "n-1", "size": 5, "labels": ["epic"]}]
+        result = sd.compute_scope_delta([], proposed)
+        self.assertIsNone(result["oversize_factor"])
+        self.assertIsNone(result["total_size_ratio"])
+        self.assertTrue(result["epic_or_project_added"])
+
+    def test_overrideable_thresholds(self):
+        baseline = [{"id": "i-1", "size": 10}]
+        proposed = baseline + [{"id": "n-1", "size": 25}]  # 2.5x median
+        # Default 3.0 → no trip
+        self.assertFalse(any(
+            "oversize-factor" in t
+            for t in sd.compute_scope_delta(baseline, proposed)["triggers"]
+        ))
+        # Tighten to 2.0 → trips
+        triggers = sd.compute_scope_delta(
+            baseline, proposed, oversize_factor_trip=2.0
+        )["triggers"]
+        self.assertTrue(any("oversize-factor" in t for t in triggers))
+
+
+class TestCLI(unittest.TestCase):
+    """The CLI is the surface the propose-process facilitator agent
+    invokes. Verify it reads/writes JSON cleanly and honors --exit-
+    nonzero-on-trip."""
+
+    def _run_cli(self, baseline, proposed, *extra_args, expect_returncode=0):
+        scope_delta_path = _REPO_ROOT / "scripts" / "crew" / "scope_delta.py"
+        # Pass via stdin: baseline first, then proposed via temp file
+        import tempfile
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False
+        ) as base_fh:
+            json.dump(baseline, base_fh)
+            base_path = base_fh.name
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False
+        ) as prop_fh:
+            json.dump(proposed, prop_fh)
+            prop_path = prop_fh.name
+        cmd = [
+            sys.executable, str(scope_delta_path),
+            "--baseline", base_path,
+            "--proposed", prop_path,
+            *extra_args,
+        ]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=15
+        )
+        Path(base_path).unlink()
+        Path(prop_path).unlink()
+        self.assertEqual(
+            result.returncode, expect_returncode,
+            f"stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+        return result
+
+    def test_cli_outputs_json_with_triggers(self):
+        baseline = [{"id": "i-1", "size": 10}, {"id": "i-2", "size": 12}]
+        proposed = baseline + [{"id": "big", "size": 50}]
+        result = self._run_cli(baseline, proposed)
+        payload = json.loads(result.stdout)
+        self.assertIn("triggers", payload)
+        self.assertTrue(any(
+            "oversize-factor" in t for t in payload["triggers"]
+        ))
+
+    def test_cli_exit_nonzero_on_trip(self):
+        baseline = [{"id": "i-1", "size": 10}, {"id": "i-2", "size": 12}]
+        proposed = baseline + [{"id": "big", "size": 50}]
+        self._run_cli(
+            baseline, proposed, "--exit-nonzero-on-trip",
+            expect_returncode=1,
+        )
+
+    def test_cli_exit_zero_when_no_trip(self):
+        baseline = [{"id": "i-1", "size": 10}, {"id": "i-2", "size": 12}]
+        # Same plan — no triggers fire → exit 0 even with --exit-nonzero-on-trip
+        self._run_cli(
+            baseline, baseline, "--exit-nonzero-on-trip",
+            expect_returncode=0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #847.

## Summary
- Clarify HITL gate fired only on intent ambiguity. It missed the failure where the rubric silently expanded a 24-issue wave plan to absorb a 1M-insertion sibling project (#732, jagan-ciq).
- Added ambiguity trigger #7 — **"Scope creep / project-sized addition"** — to `skills/propose-process/refs/ambiguity.md` with four concrete heuristics:
  - Oversize-factor: largest new item ≥ **3× baseline median size**.
  - Total-size-ratio: proposed plan total ≥ **2× baseline total**.
  - Epic/project-class label on any new item.
  - "Small change" framing contradicted by plan size (>3 phases or >10 tasks).
- Added `scripts/crew/scope_delta.py` — stdlib-only helper. Exposes `compute_scope_delta(baseline, proposed)` for programmatic use and a JSON-in/JSON-out CLI with `--exit-nonzero-on-trip` for shell integration. Default thresholds match the doctrine; callers may override per-project.

## Dogfood regression test

The exact #732 absorption case is locked in: when a 1M-insertion epic-labeled item lands in a plan of 24 normal-sized items, all three numerical triggers fire.

## Test plan
- [x] `tests/crew/test_scope_delta.py` — 18 new tests:
  - `TestNormalize` (4) — dict/string/invalid input shapes.
  - `TestEpicLabelDetection` (3) — case-insensitive match, substring rejection, empty fallback.
  - `TestComputeScopeDeltaTriggers` (8) — boundary at 3× median, boundary at 2× total, epic-label independent trip, overridable thresholds, empty-baseline path, no-change no-trip, dogfood `jagan-ciq` regression.
  - `TestCLI` (3) — JSON output, `--exit-nonzero-on-trip` semantics on trip and no-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)