### PR TITLE
feat(v11): work-shape archetypes — catalog + detector + steering engine

### DIFF
--- a/.claude-plugin/archetypes.json
+++ b/.claude-plugin/archetypes.json
@@ -1,0 +1,150 @@
+{
+  "$schema_version": "v11.0.0",
+  "$comment": "Work-shape archetypes (v11). Each archetype is a complete unit with its own phases, produces, HITL discipline, and cost band. No universal pipeline. Detector classifies a prompt into one or more archetypes; steering emits per-archetype directives. v6.3 archetype detection (code-repo / docs-only / etc.) was about target *kind*; this is about work *shape*.",
+  "archetypes": {
+    "triage": {
+      "description": "Classify the work and route to the right archetype. The entry shape for any prompt that hasn't been routed yet.",
+      "phases": ["classify"],
+      "produces": ["routing-decision"],
+      "hitl": "none",
+      "cost_band": "negligible",
+      "maturity": "production",
+      "signals": {
+        "always_on": true
+      },
+      "next_archetypes": "any",
+      "min_complexity": 0
+    },
+    "explore": {
+      "description": "Diverge then converge on options when the problem space is open. Produces an option set or hypothesis, not a decision.",
+      "phases": ["frame", "diverge", "converge"],
+      "produces": ["option-set", "hypothesis"],
+      "hitl": "continuous",
+      "cost_band": "low",
+      "maturity": "research",
+      "signals": {
+        "novelty_high": true,
+        "open_ended_phrasing": ["what should", "how might", "explore", "options for", "should we"],
+        "ambiguity_high": true
+      },
+      "next_archetypes": ["specify", "decide", "build"],
+      "min_complexity": 0
+    },
+    "specify": {
+      "description": "Turn an ask into structured, testable acceptance criteria.",
+      "phases": ["elicit", "structure", "validate"],
+      "produces": ["smart-acceptance-criteria"],
+      "hitl": "discrete:validate-gate",
+      "cost_band": "low",
+      "maturity": "piloted",
+      "signals": {
+        "spec_ambiguity_high": true,
+        "phrases": ["acceptance criteria", "requirements", "user story", "spec"],
+        "scope_unclear": true
+      },
+      "next_archetypes": ["build", "decide"],
+      "min_complexity": 0
+    },
+    "decide": {
+      "description": "Pick between options with an ADR-shaped artifact. Used when 2+ paths are viable and the choice is load-bearing.",
+      "phases": ["brief", "options", "score", "record"],
+      "produces": ["adr", "decision-artifact"],
+      "hitl": "discrete:select-gate",
+      "cost_band": "medium",
+      "maturity": "piloted",
+      "signals": {
+        "phrases": ["should we use", "x or y", "adr", "decision", "trade-off"],
+        "multiple_viable_options": true,
+        "reversibility_medium_or_low": true
+      },
+      "next_archetypes": ["build", "migrate", "ship"],
+      "min_complexity": 2
+    },
+    "ship": {
+      "description": "Roll out an already-built change with progressively widening blast radius.",
+      "phases": ["canary", "ramp", "full", "soak"],
+      "produces": ["rollout-verdict", "slo-snapshot"],
+      "hitl": "discrete:ramp-gates",
+      "cost_band": "medium",
+      "maturity": "piloted",
+      "signals": {
+        "phrases": ["deploy", "release", "rollout", "cutover", "ramp"],
+        "blast_radius_high": true,
+        "post_build": true
+      },
+      "next_archetypes": ["review"],
+      "min_complexity": 2
+    },
+    "review": {
+      "description": "Independent assessment of an artifact (code / spec / design / incident response). Hard verdict at the end — APPROVE / CONDITIONAL / REJECT — with a remediation list when not APPROVE.",
+      "phases": ["scope", "assess", "findings", "remediate-or-accept"],
+      "produces": ["verdict", "remediation-list"],
+      "hitl": "hard:final-verdict",
+      "cost_band": "medium",
+      "maturity": "piloted",
+      "signals": {
+        "phrases": ["review", "audit", "evaluate", "verdict", "code review", "design review"],
+        "independent_assessment_needed": true
+      },
+      "next_archetypes": ["build", "migrate", "ship", "incident"],
+      "min_complexity": 1
+    },
+    "incident": {
+      "description": "Live-fire response to a production failure. Mitigate first, RCA second, follow-up third.",
+      "phases": ["triage", "investigate", "mitigate", "resolve", "followup"],
+      "produces": ["mitigation", "rca", "followup-list"],
+      "hitl": "hard:mitigate",
+      "cost_band": "variable",
+      "maturity": "production",
+      "signals": {
+        "phrases": ["down", "outage", "incident", "broken in prod", "post-mortem", "5xx", "error rate"],
+        "production_impact": true
+      },
+      "next_archetypes": ["build", "migrate", "review"],
+      "min_complexity": 0
+    },
+    "build": {
+      "description": "Implement and ship a new feature or fix. The most common archetype. Test rigor scales with complexity / blast_radius / novelty.",
+      "phases": ["plan", "implement", "test", "review"],
+      "produces": ["shipped-code", "test-report"],
+      "hitl": "discrete:review-gate",
+      "cost_band": "high",
+      "maturity": "research",
+      "signals": {
+        "phrases": ["implement", "add", "build", "feature", "fix", "create"],
+        "code_change": true
+      },
+      "next_archetypes": ["ship", "review"],
+      "min_complexity": 0,
+      "test_rigor_scales_with": ["complexity", "blast_radius", "novelty"]
+    },
+    "migrate": {
+      "description": "Shape change that requires forward + rollback proof. Schema migrations, data backfills, breaking-API rollouts. Expand-contract pattern.",
+      "phases": ["plan", "expand", "backfill", "cutover", "contract"],
+      "produces": ["shape-change", "rollback-proof"],
+      "hitl": "hard:cutover-gate",
+      "cost_band": "high",
+      "maturity": "research",
+      "signals": {
+        "phrases": ["migration", "migrate", "schema change", "backfill", "cutover", "rename column", "drop column", "breaking change"],
+        "state_complexity_high": true,
+        "reversibility_low": true
+      },
+      "next_archetypes": ["ship", "review"],
+      "min_complexity": 2
+    }
+  },
+  "$detector_notes": [
+    "Archetypes are NOT mutually exclusive. A schema-changing feature is build + migrate. A risky deploy is ship + review.",
+    "triage is the entry archetype — it always fires first to classify.",
+    "Signals come from the prompt text + the propose-process 9-factor scoring. The detector is allowed to be confident (>0.7) on a single archetype OR return a small set.",
+    "When no archetype scores > 0.5, return ['triage'] and ask a clarifying question.",
+    "The phase shapes are EACH archetype's own. There is no universal pipeline. A 'build' that needs a 'specify' first chains: specify -> build, NOT specify-as-build's-clarify-phase."
+  ],
+  "$hitl_levels": {
+    "none": "No human checkpoint. Fires and is done.",
+    "continuous": "Human is a participant throughout. Brainstorm-style.",
+    "discrete:<gate>": "Hard stop at the named gate; human approves before proceeding.",
+    "hard:<gate>": "Same as discrete but the gate cannot be auto-approved or bypassed without explicit override audit log."
+  }
+}

--- a/scripts/crew/archetypes_v11.py
+++ b/scripts/crew/archetypes_v11.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""archetypes_v11.py — Work-shape archetype detection + steering engine.
+
+v11 reframes the crew workflow: instead of a fixed
+clarify->design->build->test->review pipeline with a "rigor tier" dial,
+each prompt is classified into one or more **work-shape archetypes**
+(triage / explore / specify / decide / ship / review / incident /
+build / migrate). Each archetype owns its own phase shape, produces,
+HITL discipline, and cost band. Steering directives fire per archetype,
+not per fixed-pipeline phase.
+
+This is the v6.3 archetype-detect's spiritual successor — but v6.3
+classified the *target kind* (code-repo / docs-only / config-infra /
+multi-repo / etc.) and used it to pick gate thresholds. v11 classifies
+the *work shape* and uses it to pick the entire workflow.
+
+The two coexist during transition:
+  * scripts/crew/archetype_detect.py — v6.3 target-kind classifier,
+    consumed by gate-adjudicator.
+  * scripts/crew/archetypes_v11.py    — v11 work-shape classifier,
+    consumed by steering-aware skills.
+
+Stdlib-only. CLI shim at bottom of file.
+
+Usage (library):
+    from archetypes_v11 import detect_archetypes, steering_directives
+
+    matches = detect_archetypes(
+        prompt="add caching to the dashboard",
+        signals={"complexity": 3, "blast_radius": "low"},
+    )
+    # matches -> [("build", 0.85, ["phrase: add"])]
+
+    directives = steering_directives(matches, signals)
+    # directives -> [{"archetype": "build", "phases": [...], "next_action": ...}]
+
+Usage (CLI):
+    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \\
+      "${CLAUDE_PLUGIN_ROOT}/scripts/crew/archetypes_v11.py" \\
+      detect --prompt "add caching to the dashboard"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+_THIS_DIR = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _THIS_DIR.parents[1]
+_CATALOG_PATH = _PLUGIN_ROOT / ".claude-plugin" / "archetypes.json"
+
+
+# Confidence thresholds — kept as named constants so callers can grep
+# for the doctrine and tests can lock them.
+HIGH_CONFIDENCE = 0.7
+MEDIUM_CONFIDENCE = 0.5
+LOW_CONFIDENCE = 0.3
+
+
+def load_catalog(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Return the archetype catalog dict. Raises FileNotFoundError when
+    the catalog isn't present — callers should not silently fall back."""
+    catalog_path = path or _CATALOG_PATH
+    return json.loads(catalog_path.read_text(encoding="utf-8"))
+
+
+def _phrase_score(prompt_lower: str, phrases: List[str]) -> Tuple[float, List[str]]:
+    """Score how strongly the prompt matches a phrase list.
+
+    First match scores 0.55 (above MEDIUM_CONFIDENCE so a single strong
+    keyword trips a directive). Each additional match adds 0.2 up to a
+    0.9 cap. Returns (score, hits) so the steering directive can name
+    the matched phrases.
+
+    Calibration rationale: archetype phrases are *category words* like
+    'implement' / 'outage' / 'migrate' — they are intentionally
+    high-signal. One should be enough to fire 'suggest' strength; two
+    should escalate to 'recommend'.
+    """
+    hits: List[str] = []
+    for phrase in phrases:
+        # Word-boundary match for short phrases; substring for multi-word
+        # (multi-word phrases are inherently boundary-safe).
+        if " " in phrase:
+            if phrase in prompt_lower:
+                hits.append(phrase)
+        else:
+            pattern = re.compile(rf"\b{re.escape(phrase)}\b", re.IGNORECASE)
+            if pattern.search(prompt_lower):
+                hits.append(phrase)
+    if not hits:
+        return 0.0, []
+    score = 0.55 + 0.2 * (len(hits) - 1)
+    return min(score, 0.9), hits
+
+
+def _signal_score(
+    archetype_signals: Dict[str, Any],
+    signals: Dict[str, Any],
+) -> Tuple[float, List[str]]:
+    """Score how the caller-provided signals agree with the archetype's
+    declared signals. Each agreement adds 0.3 capped at 0.9.
+
+    Recognized boolean signal flags (any subset is fine):
+      - novelty_high, blast_radius_high, ambiguity_high,
+        spec_ambiguity_high, scope_unclear, multiple_viable_options,
+        reversibility_medium_or_low, reversibility_low,
+        state_complexity_high, post_build, code_change,
+        production_impact, independent_assessment_needed.
+
+    Boolean True in the archetype declaration is a *requirement* —
+    if the caller didn't pass that signal it scores 0.
+    """
+    hits: List[str] = []
+    score = 0.0
+    for key, declared in archetype_signals.items():
+        if key in ("phrases", "always_on"):
+            continue
+        if declared is True and signals.get(key) is True:
+            score += 0.3
+            hits.append(f"signal: {key}")
+    return min(score, 0.9), hits
+
+
+def _detect_one_archetype(
+    name: str,
+    archetype: Dict[str, Any],
+    prompt_lower: str,
+    signals: Dict[str, Any],
+) -> Tuple[float, List[str]]:
+    """Score a single archetype against the prompt + signals.
+
+    Returns (combined_score, evidence). Combined score is the max of
+    phrase score and signal score plus 0.1 if both are non-zero
+    (concordance bonus), capped at 1.0.
+    """
+    arch_signals = archetype.get("signals") or {}
+    if arch_signals.get("always_on"):
+        return 1.0, ["always_on"]
+
+    phrase_list = list(arch_signals.get("phrases") or [])
+    p_score, p_hits = _phrase_score(prompt_lower, phrase_list)
+    s_score, s_hits = _signal_score(arch_signals, signals)
+
+    if p_score == 0 and s_score == 0:
+        return 0.0, []
+
+    combined = max(p_score, s_score)
+    if p_score > 0 and s_score > 0:
+        combined = min(combined + 0.1, 1.0)
+    return combined, p_hits + s_hits
+
+
+def detect_archetypes(
+    prompt: str,
+    signals: Optional[Dict[str, Any]] = None,
+    *,
+    catalog: Optional[Dict[str, Any]] = None,
+    threshold: float = MEDIUM_CONFIDENCE,
+) -> List[Tuple[str, float, List[str]]]:
+    """Classify a prompt into one or more work-shape archetypes.
+
+    Args:
+        prompt: User prompt or task description.
+        signals: Optional dict with the boolean signal flags listed in
+            ``_signal_score``. Typically populated from the
+            propose-process 9-factor scoring or from runtime hooks.
+        catalog: Override catalog (testing).
+        threshold: Drop archetypes scoring below this. Default
+            MEDIUM_CONFIDENCE (0.5).
+
+    Returns:
+        List of ``(archetype_name, score, evidence)`` tuples sorted by
+        score descending. Always includes ``triage`` at the end as the
+        fallback when no other archetype scores >= threshold.
+
+    The triage archetype is special: it is always present in the result
+    so callers always have a routing target. When triage is the only
+    item returned, the caller should ask a clarifying question rather
+    than dispatch.
+    """
+    catalog = catalog or load_catalog()
+    archetypes = catalog.get("archetypes", {})
+    prompt_lower = (prompt or "").lower()
+    signals = signals or {}
+
+    matches: List[Tuple[str, float, List[str]]] = []
+    for name, archetype in archetypes.items():
+        if name == "triage":
+            continue  # always-on; appended last
+        score, evidence = _detect_one_archetype(
+            name, archetype, prompt_lower, signals,
+        )
+        if score >= threshold:
+            matches.append((name, round(score, 3), evidence))
+
+    matches.sort(key=lambda m: m[1], reverse=True)
+
+    if not matches:
+        # No clear shape — return triage so caller knows to clarify
+        return [("triage", 1.0, ["no_other_archetype_above_threshold"])]
+
+    matches.append(("triage", 1.0, ["always_on"]))
+    return matches
+
+
+def steering_directives(
+    matches: List[Tuple[str, float, List[str]]],
+    signals: Optional[Dict[str, Any]] = None,
+    *,
+    catalog: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Turn a match list into actionable steering directives.
+
+    Each directive is a dict the caller emits as a system reminder,
+    a TaskCreate, or a hook output. Shape:
+
+        {
+          "archetype": "build",
+          "score": 0.85,
+          "evidence": ["phrase: add", "signal: code_change"],
+          "phases": ["plan", "implement", "test", "review"],
+          "produces": ["shipped-code", "test-report"],
+          "hitl": "discrete:review-gate",
+          "cost_band": "high",
+          "maturity": "research",
+          "next_action": "Run `wicked-garden:engineering:implement` ...",
+          "strength": "recommend"  # suggest | recommend | require
+        }
+
+    Strength escalates with score:
+        score >= HIGH_CONFIDENCE   -> "recommend"
+        score >= MEDIUM_CONFIDENCE -> "suggest"
+        else                       -> "suggest" (informational)
+
+    triage at the bottom of the match list adds an informational
+    directive only if it is the *sole* match (no clear shape detected).
+    """
+    catalog = catalog or load_catalog()
+    archetypes = catalog.get("archetypes", {})
+    signals = signals or {}
+    sole_match = len(matches) == 1 and matches[0][0] == "triage"
+
+    directives: List[Dict[str, Any]] = []
+    for name, score, evidence in matches:
+        if name == "triage" and not sole_match:
+            continue
+        archetype = archetypes.get(name, {})
+        if score >= HIGH_CONFIDENCE:
+            strength = "recommend"
+        else:
+            strength = "suggest"
+        directives.append({
+            "archetype": name,
+            "score": score,
+            "evidence": evidence,
+            "phases": list(archetype.get("phases", [])),
+            "produces": list(archetype.get("produces", [])),
+            "hitl": archetype.get("hitl"),
+            "cost_band": archetype.get("cost_band"),
+            "maturity": archetype.get("maturity"),
+            "next_action": _next_action_for(name, archetype, signals),
+            "strength": strength,
+        })
+    return directives
+
+
+def _next_action_for(
+    name: str,
+    archetype: Dict[str, Any],
+    signals: Dict[str, Any],
+) -> str:
+    """Render the recommended next-action string for an archetype.
+
+    Kept centralized here so the wording is consistent across system
+    reminders, hook output, and CLI display.
+    """
+    first_phase = (archetype.get("phases") or ["?"])[0]
+    return (
+        f"Enter '{name}' archetype at phase '{first_phase}'. "
+        f"Phases: {' -> '.join(archetype.get('phases', []))}. "
+        f"Produces: {', '.join(archetype.get('produces', []))}. "
+        f"HITL: {archetype.get('hitl', 'none')}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(
+        description="v11 work-shape archetype detector + steering engine."
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    detect = sub.add_parser("detect", help="Detect archetypes from prompt + signals.")
+    detect.add_argument("--prompt", required=True)
+    detect.add_argument("--signals", default=None,
+                        help="JSON object of boolean signal flags.")
+    detect.add_argument("--threshold", type=float, default=MEDIUM_CONFIDENCE)
+    detect.add_argument("--steering", action="store_true",
+                        help="Also emit the per-archetype steering directives.")
+
+    catalog_cmd = sub.add_parser("catalog",
+                                 help="Print the archetype catalog as JSON.")
+    catalog_cmd.add_argument("--name", default=None,
+                             help="Print only one archetype by name.")
+
+    args = parser.parse_args()
+
+    if args.action == "detect":
+        signals = json.loads(args.signals) if args.signals else {}
+        matches = detect_archetypes(args.prompt, signals,
+                                    threshold=args.threshold)
+        result: Dict[str, Any] = {
+            "matches": [
+                {"archetype": n, "score": s, "evidence": e}
+                for n, s, e in matches
+            ]
+        }
+        if args.steering:
+            result["directives"] = steering_directives(matches, signals)
+        json.dump(result, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    if args.action == "catalog":
+        catalog = load_catalog()
+        if args.name:
+            archetype = catalog.get("archetypes", {}).get(args.name)
+            if archetype is None:
+                print(f"Unknown archetype: {args.name}", file=sys.stderr)
+                sys.exit(1)
+            json.dump({args.name: archetype}, sys.stdout, indent=2)
+        else:
+            json.dump(catalog, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tests/crew/test_archetypes_v11.py
+++ b/tests/crew/test_archetypes_v11.py
@@ -1,0 +1,253 @@
+"""Tests for scripts/crew/archetypes_v11.py — v11 work-shape archetype
+detection + steering directives."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = str(_REPO_ROOT / "scripts")
+_CREW = str(_REPO_ROOT / "scripts" / "crew")
+if _SCRIPTS not in sys.path:
+    sys.path.append(_SCRIPTS)
+if _CREW not in sys.path:
+    sys.path.append(_CREW)
+
+import archetypes_v11 as av  # noqa: E402
+
+
+class TestCatalogShape(unittest.TestCase):
+    """Lock the v11 catalog contract — 9 archetypes, all carrying the
+    required fields. Adding a 10th is fine; dropping or renaming one is
+    a breaking change that should fail this test loudly."""
+
+    REQUIRED_KEYS = {
+        "description", "phases", "produces", "hitl", "cost_band",
+        "maturity", "signals", "next_archetypes", "min_complexity",
+    }
+    EXPECTED_NAMES = {
+        "triage", "explore", "specify", "decide", "ship", "review",
+        "incident", "build", "migrate",
+    }
+
+    def test_all_nine_archetypes_present(self):
+        catalog = av.load_catalog()
+        names = set(catalog.get("archetypes", {}).keys())
+        self.assertEqual(self.EXPECTED_NAMES, names)
+
+    def test_required_fields_on_every_archetype(self):
+        catalog = av.load_catalog()
+        for name, archetype in catalog["archetypes"].items():
+            missing = self.REQUIRED_KEYS - set(archetype.keys())
+            self.assertFalse(missing, f"{name} missing keys: {missing}")
+            self.assertIsInstance(archetype["phases"], list)
+            self.assertGreater(len(archetype["phases"]), 0,
+                               f"{name} must declare at least one phase")
+
+
+class TestDetectionPositive(unittest.TestCase):
+    """Each archetype's positive case — phrases or signals fire it."""
+
+    def test_build_fires_on_implement_phrase(self):
+        matches = av.detect_archetypes("implement caching for the dashboard")
+        names = [n for n, _, _ in matches]
+        self.assertIn("build", names)
+
+    def test_migrate_fires_on_schema_change_phrase(self):
+        matches = av.detect_archetypes(
+            "we need a schema change to drop the legacy_id column",
+            signals={"reversibility_low": True, "state_complexity_high": True},
+        )
+        top = matches[0]
+        self.assertEqual(top[0], "migrate")
+        self.assertGreaterEqual(top[1], av.HIGH_CONFIDENCE)
+
+    def test_incident_fires_on_outage_phrase(self):
+        matches = av.detect_archetypes(
+            "checkout is down — 5xx error rate spiking",
+            signals={"production_impact": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("incident", names)
+
+    def test_specify_fires_on_acceptance_criteria_phrase(self):
+        matches = av.detect_archetypes(
+            "write acceptance criteria for the export feature",
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("specify", names)
+
+    def test_explore_fires_on_open_ended_phrasing(self):
+        matches = av.detect_archetypes(
+            "what should we do about the rate-limit story?",
+            signals={"novelty_high": True, "ambiguity_high": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("explore", names)
+
+    def test_decide_fires_on_x_or_y(self):
+        matches = av.detect_archetypes(
+            "should we use redis or memcached for the session store?",
+            signals={"multiple_viable_options": True,
+                     "reversibility_medium_or_low": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("decide", names)
+
+    def test_ship_fires_on_rollout_phrase(self):
+        matches = av.detect_archetypes(
+            "kick off the canary rollout for the new pricing logic",
+            signals={"blast_radius_high": True, "post_build": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("ship", names)
+
+    def test_review_fires_on_review_phrase(self):
+        matches = av.detect_archetypes(
+            "code review the new auth middleware",
+            signals={"independent_assessment_needed": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("review", names)
+
+
+class TestDetectionTriageFallback(unittest.TestCase):
+    """When nothing scores >= threshold, triage is the sole match."""
+
+    def test_unknown_intent_returns_only_triage(self):
+        matches = av.detect_archetypes("hmm")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0][0], "triage")
+
+    def test_triage_always_appended_when_other_matches_present(self):
+        matches = av.detect_archetypes("implement caching")
+        names = [n for n, _, _ in matches]
+        # build matched -> triage still appended at end
+        self.assertEqual(names[-1], "triage")
+        self.assertGreater(len(matches), 1)
+
+
+class TestDetectionMultiArchetype(unittest.TestCase):
+    """Archetypes are NOT mutually exclusive — a schema-changing feature
+    is build + migrate."""
+
+    def test_schema_change_feature_returns_both_build_and_migrate(self):
+        matches = av.detect_archetypes(
+            "implement schema change to add a tenant_id column with backfill",
+            signals={"state_complexity_high": True, "reversibility_low": True,
+                     "code_change": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("build", names)
+        self.assertIn("migrate", names)
+
+
+class TestSignalScoring(unittest.TestCase):
+    """Confirm that signal-only inputs (no phrase match) can still trip
+    an archetype above threshold."""
+
+    def test_signal_only_path_works(self):
+        # No phrase like "deploy" / "rollout" but blast_radius signal alone
+        matches = av.detect_archetypes(
+            "ok",
+            signals={"blast_radius_high": True, "post_build": True},
+        )
+        names = [n for n, _, _ in matches]
+        self.assertIn("ship", names)
+
+    def test_concordance_bonus_when_phrase_and_signal_both_match(self):
+        # Phrase + signal yields higher score than phrase alone
+        score_phrase_only = av._detect_one_archetype(
+            "build",
+            av.load_catalog()["archetypes"]["build"],
+            "implement caching",
+            {},
+        )[0]
+        score_phrase_and_signal = av._detect_one_archetype(
+            "build",
+            av.load_catalog()["archetypes"]["build"],
+            "implement caching",
+            {"code_change": True},
+        )[0]
+        self.assertGreater(score_phrase_and_signal, score_phrase_only)
+
+
+class TestSteeringDirectives(unittest.TestCase):
+    """Steering directives carry archetype metadata + strength keyed
+    off score."""
+
+    def test_directive_includes_phase_shape_and_next_action(self):
+        matches = av.detect_archetypes("implement caching",
+                                       signals={"code_change": True})
+        directives = av.steering_directives(matches)
+        build = next(d for d in directives if d["archetype"] == "build")
+        self.assertEqual(build["phases"],
+                         ["plan", "implement", "test", "review"])
+        self.assertIn("plan", build["next_action"])
+        self.assertIn("implement", build["next_action"])
+
+    def test_high_score_yields_recommend_strength(self):
+        matches = [("build", 0.85, ["x"]), ("triage", 1.0, ["always_on"])]
+        directives = av.steering_directives(matches)
+        build = next(d for d in directives if d["archetype"] == "build")
+        self.assertEqual(build["strength"], "recommend")
+
+    def test_medium_score_yields_suggest_strength(self):
+        matches = [("build", 0.55, ["x"]), ("triage", 1.0, ["always_on"])]
+        directives = av.steering_directives(matches)
+        build = next(d for d in directives if d["archetype"] == "build")
+        self.assertEqual(build["strength"], "suggest")
+
+    def test_triage_only_sole_match_emits_directive(self):
+        matches = [("triage", 1.0, ["fallback"])]
+        directives = av.steering_directives(matches)
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(directives[0]["archetype"], "triage")
+
+    def test_triage_skipped_when_other_archetypes_match(self):
+        matches = [("build", 0.85, ["x"]), ("triage", 1.0, ["always_on"])]
+        directives = av.steering_directives(matches)
+        names = [d["archetype"] for d in directives]
+        self.assertIn("build", names)
+        self.assertNotIn("triage", names)
+
+
+class TestCLI(unittest.TestCase):
+    """End-to-end CLI smoke."""
+
+    def _run(self, *args, expect_returncode=0):
+        path = _REPO_ROOT / "scripts" / "crew" / "archetypes_v11.py"
+        result = subprocess.run(
+            [sys.executable, str(path), *args],
+            capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, expect_returncode,
+                         f"stdout={result.stdout!r} stderr={result.stderr!r}")
+        return result
+
+    def test_detect_outputs_matches(self):
+        result = self._run("detect", "--prompt", "implement caching")
+        payload = json.loads(result.stdout)
+        names = [m["archetype"] for m in payload["matches"]]
+        self.assertIn("build", names)
+
+    def test_detect_with_steering_emits_directives(self):
+        result = self._run("detect", "--prompt", "implement caching",
+                           "--steering")
+        payload = json.loads(result.stdout)
+        self.assertIn("directives", payload)
+        self.assertGreater(len(payload["directives"]), 0)
+
+    def test_catalog_lists_all_archetypes(self):
+        result = self._run("catalog")
+        payload = json.loads(result.stdout)
+        names = set(payload.get("archetypes", {}).keys())
+        self.assertEqual(names, TestCatalogShape.EXPECTED_NAMES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**v11 reframe.** Stop forcing every prompt through the same `clarify → design → test-strategy → challenge → build → test → review` pipeline. Each prompt is classified into one or more **work-shape archetypes**, each with its own phase shape, produces, HITL discipline, and cost band.

## The 9 archetypes

| Archetype | Phases                                       | Produces                       | HITL                  | Cost      | Maturity   |
|-----------|----------------------------------------------|--------------------------------|-----------------------|-----------|------------|
| triage    | classify                                     | routing decision               | none                  | negligible| production |
| explore   | frame → diverge → converge                   | option set · hypothesis        | continuous            | low       | research   |
| specify   | elicit → structure → validate                | SMART acceptance criteria      | discrete:validate     | low       | piloted    |
| decide    | brief → options → score → record             | ADR · decision artifact        | discrete:select       | medium    | piloted    |
| ship      | canary → ramp → full → soak                  | rollout verdict · SLO snapshot | discrete:ramp         | medium    | piloted    |
| review    | scope → assess → findings → remediate        | verdict · remediation list     | hard:final-verdict    | medium    | piloted    |
| incident  | triage → investigate → mitigate → resolve → followup | mitigation · RCA · followup | hard:mitigate     | variable  | production |
| build     | plan → implement → test → review             | shipped code · test report     | discrete:review       | high      | research   |
| migrate   | plan → expand → backfill → cutover → contract | shape change · rollback proof  | hard:cutover          | high      | research   |

## Pieces shipped

1. `.claude-plugin/archetypes.json` — catalog. Phases / produces / hitl / cost_band / maturity + detection signals (phrase list + boolean flags) per archetype.
2. `scripts/crew/archetypes_v11.py` — detector (`detect_archetypes`) + steering engine (`steering_directives`) + CLI. Stdlib-only.
3. `tests/crew/test_archetypes_v11.py` — 23 tests: catalog shape, all 9 archetype positive paths, multi-archetype detection (build + migrate co-fire on schema-changing features), triage fallback, signal-only path, concordance bonus, strength tiers, CLI smoke.

## Coexists with v6.3 archetypes

v6.3 `archetype_detect.py` classifies *target kind* (code-repo / docs-only / config-infra / multi-repo / ...) and feeds `gate-adjudicator`. v11 classifies *work shape*. Different questions; both stay.

## What this is NOT (yet)

This PR is the foundation. NOT included:
- Wiring into `prompt_submit.py` (next PR)
- Per-archetype skills/agents that own phase shapes
- Dissolving crew's fixed pipeline into per-archetype phase machines

This is the structural reframe the seven dogfood PRs (#854–#860) pointed at — they were surface fixes to a pipeline whose shape was the deeper problem.

## Smoke tests (real prompts)

```
$ archetypes_v11.py detect --prompt "drop the legacy_id column from orders" \
  --signals '{"reversibility_low": true, "state_complexity_high": true}'
→ migrate (0.8), triage (always)

$ archetypes_v11.py detect --prompt "checkout is down — 5xx spiking" \
  --signals '{"production_impact": true}'
→ incident (1.0), triage (always)

$ archetypes_v11.py detect --prompt "should we use redis or memcached"
→ decide (0.55), triage (always)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)