### PR TITLE
feat(v11): per-archetype skill family with 9 playbooks

### DIFF
--- a/skills/archetype/SKILL.md
+++ b/skills/archetype/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: wicked-garden:archetype
+description: |
+  v11 work-shape archetype runner. When a prompt has been routed to one
+  of the 9 archetypes (triage, explore, specify, decide, ship, review,
+  incident, build, migrate), this skill is the entry point. It picks
+  the right per-archetype playbook from refs/ and executes the phase
+  shape declared in `.claude-plugin/archetypes.json`.
+
+  Use when: a `<wg archetype="X">` or `<wg archetypes>` system-reminder
+  tag appears, an explicit "let's run the X archetype" request, or
+  when one of the per-archetype slash commands resolves to this skill.
+allowed-tools: ["*"]
+---
+
+# /wicked-garden:archetype
+
+v11 entry point for **work-shape archetypes**. Each archetype is a complete
+unit with its own phase shape, produces, HITL discipline, and cost band.
+There is no universal pipeline.
+
+## When to use this skill
+
+Invoke when:
+- A `<wg archetype="X">` or `<wg archetypes>` system-reminder tag appears
+  (emitted by the v11 prompt hook).
+- The user explicitly asks to "run the {archetype} archetype" or "do this
+  as a {archetype}" workflow.
+- You're routing from `triage` to a real archetype after classifying the
+  work.
+
+Do **not** use this skill for:
+- Continuation tokens ("yes", "ok", "do it"). Those carry no new shape;
+  keep going on the current archetype.
+- Simple-edit work (typos, single-line fixes, cosmetic changes). The v11
+  hook already suppresses archetype tags on `simple-edit` intent.
+
+## The 9 archetypes
+
+| Archetype | Phases                                                    | Produces                        | HITL                  |
+|-----------|-----------------------------------------------------------|---------------------------------|-----------------------|
+| triage    | classify                                                  | routing decision                | none                  |
+| explore   | frame → diverge → converge                                | option set / hypothesis         | continuous            |
+| specify   | elicit → structure → validate                             | SMART acceptance criteria       | discrete:validate     |
+| decide    | brief → options → score → record                          | ADR / decision artifact         | discrete:select       |
+| ship      | canary → ramp → full → soak                               | rollout verdict / SLO snapshot  | discrete:ramp         |
+| review    | scope → assess → findings → remediate-or-accept           | verdict / remediation list      | hard:final-verdict    |
+| incident  | triage → investigate → mitigate → resolve → followup      | mitigation / RCA / followup     | hard:mitigate         |
+| build     | plan → implement → test → review                          | shipped code / test report      | discrete:review       |
+| migrate   | plan → expand → backfill → cutover → contract             | shape change / rollback proof   | hard:cutover          |
+
+## Procedure
+
+1. **Identify the archetype.** Read the `<wg archetype>` tag in the system
+   reminder OR ask the user which archetype they want when ambiguous.
+2. **Load the playbook.** Read `refs/{archetype}.md` for the phase-by-phase
+   playbook, the produces contract, and the HITL discipline.
+3. **Execute the phases.** Run each phase in order. At each phase boundary
+   ask: "do I have what this phase produces?" Don't move on until yes.
+4. **Honor HITL.** When the playbook marks a gate as `hard:*`, **stop and
+   ask the user** before proceeding. `discrete:*` gates may auto-pass when
+   the produces contract is met. `none` and `continuous` carry no gate.
+5. **Multi-archetype prompts.** When the hook emitted `<wg archetypes>`
+   with two co-firing matches (e.g. `build + migrate` for a schema-change
+   feature), run them in dependency order: `migrate` shape work first, then
+   `build` integration work. The dependency graph lives in each archetype's
+   `next_archetypes` field in the catalog.
+
+## Catalog source of truth
+
+`.claude-plugin/archetypes.json` is canonical. The detector lives at
+`scripts/crew/archetypes_v11.py`. The CLI shim:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/crew/archetypes_v11.py" \
+  detect --prompt "<text>" --signals '{"production_impact": true}' --steering
+```
+
+## Refs
+
+- `refs/triage.md` — entry classification
+- `refs/explore.md` — diverge/converge for open problems
+- `refs/specify.md` — elicit + structure + validate ACs
+- `refs/decide.md` — ADR-shaped option scoring
+- `refs/ship.md` — canary/ramp rollout
+- `refs/review.md` — independent assessment with verdict
+- `refs/incident.md` — live-fire response
+- `refs/build.md` — plan/implement/test/review (the common case)
+- `refs/migrate.md` — expand/backfill/cutover/contract
+
+## What v11 archetypes are NOT
+
+- They are **not** the v6.3 target-kind archetypes (`code-repo`, `docs-only`,
+  `config-infra`, etc.). Those classify *what is being changed*; v11
+  classifies *what shape of work is happening*. Both stay; they answer
+  different questions.
+- They are **not** rigor tiers (`minimal | standard | full`). v11 obsoletes
+  the rigor-tier dial: each archetype owns its own cost band and HITL.
+- They are **not** phase slots in a universal pipeline. Each archetype's
+  phases live only inside that archetype.

--- a/skills/archetype/refs/build.md
+++ b/skills/archetype/refs/build.md
@@ -1,0 +1,90 @@
+# build — plan / implement / test / review
+
+The most common archetype. Implement and ship a feature or fix. **Test
+rigor scales with complexity, blast_radius, and novelty** — a one-line
+typo fix and a new auth path are both `build` archetype, but the test
+phase looks different.
+
+## Phase shape
+
+| Phase     | Goal                                                |
+|-----------|-----------------------------------------------------|
+| plan      | Name the diff in 2–3 sentences. Pick the test rigor. |
+| implement | Write the change. Stay in the diff; resist drift.   |
+| test      | Verify the diff does what plan said. Rigor scales.  |
+| review    | Hand off to the `review` archetype if needed.       |
+
+## Produces
+
+- **Shipped code**: a commit (or PR) with the diff.
+- **Test report**: at minimum, evidence that the change was exercised.
+  At higher rigor: unit tests, integration tests, acceptance evidence.
+
+## HITL
+
+`discrete:review-gate` — review is the discrete gate. Approve happens
+through PR review, council, or the `review` archetype if rigor warrants.
+
+## How to run
+
+### plan
+
+1. Name the diff in 2–3 sentences. What changes? What stays the same?
+   What's the smallest possible scope?
+2. Pick the test rigor based on signals (factor scoring from the
+   propose-process rubric is a fine input):
+
+   | Signal pattern                                  | Test rigor             |
+   |-------------------------------------------------|------------------------|
+   | reversibility HIGH + blast_radius LOW + novelty LOW | one targeted test  |
+   | medium on any of the above                      | unit tests + 1–2 integration |
+   | high on any of the above                        | unit + integration + acceptance |
+   | compliance scope OR auth changes                | full + security audit  |
+
+3. If the diff is simple-edit-class (typo, comment, format), build
+   shouldn't have been the archetype — drop back to `triage` and
+   suppress.
+
+### implement
+
+1. Write the change. Stay tight to the plan.
+2. Use `wicked-garden:engineering:apply` for patch-style edits when the
+   change is well-scoped.
+3. **Don't refactor adjacent code unless plan said so.** Drift is the
+   #1 source of inflated build cycles.
+
+### test
+
+1. The rigor picked in plan governs which tests get written.
+2. Use `wicked-testing:authoring` to generate tests when the rigor is
+   medium or high.
+3. **Tests must actually fail when the code is wrong.** The
+   test-code-quality-auditor exists for a reason — assertion-free
+   tests are worse than no tests.
+
+### review
+
+1. Open the PR. Use the appropriate review skill:
+   - Low rigor: `pr-review-toolkit:code-reviewer` only.
+   - Medium: code-reviewer + relevant specialist (security / data /
+     etc.).
+   - High: full `review` archetype (this skill family).
+2. Address findings. Keep the response narrow — review feedback is for
+   THIS diff, not for opening adjacent issues.
+
+## When to stop
+
+Build is done when the PR is merged AND the test report is committed.
+If the change is high-blast-radius, hand off to `ship`.
+
+## Anti-patterns
+
+- **Don't refactor in build.** A bug fix doesn't need surrounding
+  cleanup. The CLAUDE.md "no premature abstraction" rule applies.
+- **Don't write tests before the code compiles.** TDD is fine; testing
+  uncompilable code is not.
+- **Don't merge with red CI.** The "I'll fix it in a follow-up"
+  mentality is how main goes red and stays red.
+- **Don't test-stamp with rigor that doesn't match the change.**
+  Adding 200 LOC of integration scaffolding for a typo fix is its own
+  anti-pattern.

--- a/skills/archetype/refs/decide.md
+++ b/skills/archetype/refs/decide.md
@@ -1,0 +1,80 @@
+# decide — pick between options with an ADR
+
+When 2+ paths are viable AND the choice is load-bearing (changing it later
+is expensive). Produces an ADR-shaped artifact that records the chosen
+path and the reasons.
+
+## Phase shape
+
+| Phase   | Goal                                                       |
+|---------|------------------------------------------------------------|
+| brief   | One-paragraph framing: the problem, the stakes, the constraints. |
+| options | 2–4 named alternatives, each with a one-paragraph description. |
+| score   | Qualitative scoring on the dimensions that matter for this decision. |
+| record  | Write the ADR. Pick a path. Note the trade-offs you accepted. |
+
+## Produces
+
+- An **ADR** (Architecture Decision Record) at `docs/decisions/{N}-{slug}.md`
+  or `docs/adr/{N}-{slug}.md`, following whatever ADR convention the repo
+  uses. New repos: use the standard ADR template.
+- A **decision artifact**: which option was picked, and the explicit
+  trade-offs accepted by picking it.
+
+## HITL
+
+`discrete:select-gate` — the user (or a council) picks. Don't auto-select.
+
+## How to run
+
+### brief
+
+1. Restate the problem in one paragraph. What changes if we pick wrong?
+2. Name the constraints: budget, time, team capability, blast radius,
+   reversibility.
+3. If reversibility is HIGH and blast radius is LOW, **stop and ask**
+   whether this even needs an ADR. Cheap-to-reverse decisions don't
+   benefit from this archetype's overhead.
+
+### options
+
+1. Generate 2–4 distinct options. Don't pad — false alternatives weaken
+   the decision.
+2. For each option:
+   - One-paragraph description.
+   - Cost: time + complexity + ongoing maintenance.
+   - Reversibility: how hard is undoing this in 6 months?
+   - Failure mode: what's the worst plausible outcome?
+
+### score
+
+1. Pick 3–5 dimensions that actually matter for this decision (not a
+   generic checklist). Examples: latency, operational complexity,
+   contract stability, team familiarity, vendor lock-in.
+2. Score each option qualitatively (LOW/MEDIUM/HIGH) on each dimension.
+3. The score is a *thinking aid*, not a winner-picker. The user picks.
+
+### record
+
+1. Use `wicked-garden:jam:council` for a multi-model second opinion when
+   the stakes warrant it.
+2. Write the ADR. Sections: context, options considered, decision,
+   consequences, trade-offs accepted.
+3. Commit the ADR with the implementing change, not separately. The ADR
+   is the explanation for the diff.
+
+## When to stop
+
+Decide is done when an ADR is committed and the chosen option is named.
+Hand off to `build` (implement the chosen path), `migrate` (when the
+choice is a shape change), or `ship` (when the choice is a rollout
+strategy).
+
+## Anti-patterns
+
+- **Don't run decide for cheap-reversible choices.** A feature flag that
+  defaults to off does not need an ADR. The overhead exceeds the benefit.
+- **Don't pad to 4 options.** Three honest options beats four with one
+  filler.
+- **Don't quantify when you don't have data.** Qualitative scoring is
+  fine; spurious numbers are worse than honest LOW/MEDIUM/HIGH.

--- a/skills/archetype/refs/explore.md
+++ b/skills/archetype/refs/explore.md
@@ -1,0 +1,66 @@
+# explore — diverge then converge on open problems
+
+When the problem space is genuinely open and a single answer would be
+premature. Produces an option set or hypothesis, **not a decision** — that's
+the `decide` archetype's job.
+
+## Phase shape
+
+| Phase    | Goal                                                     |
+|----------|----------------------------------------------------------|
+| frame    | Name the problem in one sentence. Surface assumptions.   |
+| diverge  | Generate 4–8 distinct options. Aim for variety, not quality. |
+| converge | Cluster, score qualitatively, and pick a top-3 to take forward. |
+
+## Produces
+
+- **Option set**: 3–8 named alternatives with one-line rationales.
+- **Hypothesis** (when the prompt is research-shaped): testable statement
+  with a falsification condition.
+
+## HITL
+
+`continuous` — the user is a participant. Don't run explore as a closed
+loop; check in after frame, after diverge, before convergence.
+
+## How to run
+
+### frame
+
+1. Restate the problem in one sentence in your own words. Confirm with the user.
+2. List 2–4 assumptions you're making. Get the user to mark them
+   "true / unknown / false".
+3. If a critical assumption is "unknown", branch to `specify` to elicit
+   facts before continuing.
+
+### diverge
+
+1. Generate 4–8 options. **Variety beats quality.** Include at least one
+   "lazy" option (do nothing) and one "expensive" option (the over-built
+   answer).
+2. Use `wicked-garden:jam:quick` or `wicked-garden:jam:brainstorm` for
+   structured ideation when the surface is unfamiliar.
+3. Don't score yet. Just name them.
+
+### converge
+
+1. Cluster the options into 2–3 thematic groups.
+2. Pick the top-3 to take forward. Each one needs:
+   - A one-line description.
+   - A risk note.
+   - A reversibility note.
+3. Hand off to `decide` if the user wants a verdict, or to `specify` /
+   `build` if the path forward is now clear.
+
+## When to stop
+
+Explore is done when the user has a top-3 option set OR a falsifiable
+hypothesis they can take forward. Don't keep diverging.
+
+## Anti-patterns
+
+- **Don't pick a winner inside explore.** That's the decide archetype.
+- **Don't skip frame.** A bad problem statement makes diverge produce
+  noise.
+- **Don't rank prematurely.** Convergence is qualitative clustering,
+  not quantitative scoring.

--- a/skills/archetype/refs/incident.md
+++ b/skills/archetype/refs/incident.md
@@ -1,0 +1,90 @@
+# incident — live-fire response to production failure
+
+Mitigate first, RCA second, follow-up third. The cost band is variable —
+a quick rollback may take 5 minutes; a complex multi-service incident
+may consume a day. The phase order is **non-negotiable**: do not
+investigate before mitigating unless investigation IS the mitigation.
+
+## Phase shape
+
+| Phase        | Goal                                                |
+|--------------|-----------------------------------------------------|
+| triage       | Classify severity + scope. Page who needs paging.   |
+| investigate  | Find proximate cause. Just enough to mitigate.      |
+| mitigate     | Stop the bleeding. Rollback / feature flag / scaling / circuit break. |
+| resolve      | Permanent fix. May be the same as mitigate, may not. |
+| followup     | RCA writeup, action items, tests/alerting that would have caught this. |
+
+## Produces
+
+- **Mitigation**: the action that stopped the impact (rollback hash,
+  feature flag toggle, scaling change, etc.).
+- **RCA**: root cause analysis writeup at `docs/postmortems/INC-{N}.md`.
+- **Followup list**: action items with owners. Each gets a github issue
+  or tracked task.
+
+## HITL
+
+`hard:mitigate` — mitigate is a hard gate. Don't move past it without
+confirming the bleeding stopped. Don't skip to followup before resolve.
+
+## How to run
+
+### triage
+
+1. Classify severity: SEV-1 (revenue/data impact), SEV-2 (degraded
+   primary path), SEV-3 (degraded secondary path).
+2. Page the right people. SEV-1 is a phone call, not a slack message.
+3. Open an incident channel + tracking ticket. The ticket is the
+   single source of truth for the timeline.
+
+### investigate
+
+1. Look at dashboards FIRST — `wicked-garden:platform:health` /
+   `:traces` / `:incident`. Hypothesize from data, not memory.
+2. Run `wicked-garden:platform:incident` for triage workflows.
+3. **Time-box investigation to 15 minutes during SEV-1.** If you don't
+   have a mitigation hypothesis in 15 min, escalate; don't keep
+   investigating.
+
+### mitigate
+
+1. Pick the cheapest reversible action that stops the impact:
+   - Rollback to last-known-good (cheapest).
+   - Feature flag off (cheap if instrumented).
+   - Scale up (when capacity is the issue).
+   - Circuit break a downstream (when a dependency is the issue).
+2. **Confirm the bleeding stopped.** Watch the same dashboards that
+   surfaced the incident. Don't declare mitigated based on logs alone.
+3. Update the incident channel: "MITIGATED via {action} at {time}".
+
+### resolve
+
+1. The permanent fix may be the same as the mitigation (rollback that
+   stays rolled back) or different (rollback unblocks impact, then
+   forward-fix the bug).
+2. Test the fix in staging when possible. Cowboying a fix into prod
+   during an incident is how you get a second incident.
+3. Land the fix; close the incident channel.
+
+### followup
+
+1. Write the RCA within 48h. Use the standard postmortem template.
+2. Use `wicked-garden:incident-to-scenario-synthesizer` to convert the
+   incident into a regression scenario that would catch the same break.
+3. Track action items in github. Don't bury them in a Slack thread.
+
+## When to stop
+
+Incident is done when the followup list is owned and tracked. Hand off
+to `build` (forward-fix work), `migrate` (when the fix is a shape
+change), or `review` (when the followup includes auditing prevention).
+
+## Anti-patterns
+
+- **Don't investigate before you mitigate.** SEV-1 with users impacted
+  is not the time for root-cause analysis.
+- **Don't skip the RCA.** "We know what happened" is what every team
+  says before the same incident recurs.
+- **Don't blame.** Blameless postmortems aren't soft — they produce
+  better followups.

--- a/skills/archetype/refs/migrate.md
+++ b/skills/archetype/refs/migrate.md
@@ -1,0 +1,97 @@
+# migrate — expand / backfill / cutover / contract
+
+For shape changes that require both forward and rollback proof. Schema
+migrations, data backfills, breaking API rollouts. Uses the standard
+**expand-contract** pattern: add the new shape, make both work, switch
+readers, switch writers, remove the old shape.
+
+## Phase shape
+
+| Phase    | Goal                                                  |
+|----------|-------------------------------------------------------|
+| plan     | Document the shape change. Define rollback contract.  |
+| expand   | Add the new shape. **Do not remove the old shape.**   |
+| backfill | Populate the new shape from the old. Idempotent.      |
+| cutover  | Switch readers/writers. **Hard gate** — staged.       |
+| contract | Remove the old shape. Only after cutover has soaked.  |
+
+## Produces
+
+- **Shape change**: the new schema / API / data layout.
+- **Rollback proof**: an executable rollback path. Tested in staging
+  before cutover.
+
+## HITL
+
+`hard:cutover-gate` — cutover is a hard gate. Don't cutover without
+explicit user approval AND a green pre-cutover checklist (rollback
+tested, backfill complete, dual-read working).
+
+## How to run
+
+### plan
+
+1. Document the shape change at `docs/migrations/{N}-{slug}.md`. The
+   doc names:
+   - The OLD shape, the NEW shape.
+   - The rollback contract: how to undo, who pulls the trigger, how
+     long the rollback window is.
+   - The expand-contract phase boundaries: when each step happens.
+2. Use `wicked-garden:engineering:migration-engineer` for the canonical
+   playbook.
+3. **If the shape change is reversible HIGH (e.g. a column add), this
+   archetype is overkill.** Drop back to `build`.
+
+### expand
+
+1. Add the new shape alongside the old. **Both must work.**
+2. New writes go to BOTH shapes (dual-write). New reads still come from
+   the old shape.
+3. Land + deploy expand. Don't combine with backfill.
+
+### backfill
+
+1. Populate the new shape from the old. The backfill must be
+   **idempotent** — a half-completed backfill that gets restarted
+   should converge to the same end state as a clean run.
+2. Run in batches; rate-limit against the production DB.
+3. Verify completeness: the row count + checksum + spot-check sample
+   match the old shape.
+
+### cutover
+
+1. **Pre-cutover checklist**:
+   - Rollback path executed in staging. (`✓` or block.)
+   - Backfill complete + verified.
+   - Dual-write running cleanly for at least 24h.
+   - Monitoring + alerts updated to surface new shape's anomalies.
+2. **Cutover staged**: switch readers first, watch for 1h, then switch
+   writers. Don't switch both at once.
+3. The cutover gate is HARD — explicit user "go" before each switch.
+4. If anything looks off post-cutover: **rollback first, debug second.**
+
+### contract
+
+1. Wait for cutover to soak (24–72h, longer for data shape).
+2. Stop the dual-write. Only the new shape is being written.
+3. After another soak, drop the old shape.
+4. Land the contract change with a docs update — the migration is now
+   complete.
+
+## When to stop
+
+Migrate is done when the old shape is removed AND the contract phase
+has soaked. Hand off to `review` for a post-migration audit when the
+change touched compliance or revenue surface.
+
+## Anti-patterns
+
+- **Don't combine expand with backfill.** Each phase is a separate
+  ship. Combining them removes the ability to roll back to a clean
+  intermediate state.
+- **Don't switch readers and writers simultaneously.** Stage them.
+- **Don't contract before soaking.** "We've cutover; let's clean up
+  the old shape" is how you discover at 3am that one consumer never
+  switched.
+- **Don't skip rollback testing.** A rollback path you haven't
+  exercised is not a rollback path.

--- a/skills/archetype/refs/review.md
+++ b/skills/archetype/refs/review.md
@@ -1,0 +1,81 @@
+# review — independent assessment with hard verdict
+
+When an artifact (code, design, spec, incident response) needs an
+external quality check. Produces a verdict: APPROVE / CONDITIONAL /
+REJECT, with a remediation list when not APPROVE.
+
+## Phase shape
+
+| Phase                  | Goal                                       |
+|------------------------|--------------------------------------------|
+| scope                  | Name what's being reviewed and what isn't. |
+| assess                 | Apply the relevant rubric / quality bar.   |
+| findings               | List what's wrong, what's missing, what's good (in that order). |
+| remediate-or-accept    | Pick: fix the findings, accept them with a CONDITIONAL, or reject. |
+
+## Produces
+
+- **Verdict**: `APPROVE` / `CONDITIONAL` / `REJECT`.
+- **Remediation list**: each item has an id, severity, and a concrete
+  action. Empty when APPROVE.
+
+## HITL
+
+`hard:final-verdict` — the verdict is a hard gate. Auto-approve is
+banned (banned-reviewer enforcement applies — `auto-approve-*`,
+`fast-pass`, `just-finish-auto` are rejected at the gate).
+
+## How to run
+
+### scope
+
+1. Name what's in scope: this PR, this commit, this design doc.
+2. Name what's out of scope: don't drift into adjacent code that wasn't
+   changed.
+3. Pick the rubric: code review uses R1–R6; design review uses
+   testability + boundary clarity; spec review uses SMART+T.
+
+### assess
+
+1. Apply the rubric. Take notes; don't write the findings yet.
+2. Use the right specialist subagent — `pr-review-toolkit:code-reviewer`,
+   `wicked-garden:engineering:senior-engineer`, `qe:semantic-reviewer`,
+   etc. Match the artifact to the specialist.
+3. For high-stakes reviews, run a council via
+   `wicked-garden:jam:council` — independent multi-model verdicts
+   catch what a single reviewer misses.
+
+### findings
+
+1. Write the findings list. Each finding:
+   - `id`: F-1, F-2, ...
+   - `severity`: blocker / major / minor / nit
+   - `claim`: what's wrong, in one sentence.
+   - `fix`: a concrete action.
+2. Order: blockers first, then major, then minor. Nits last (or
+   collapsed into a "nit-pile" comment).
+
+### remediate-or-accept
+
+1. Decide the verdict:
+   - **APPROVE**: no blockers, no majors, the code is shippable as-is.
+   - **CONDITIONAL**: blockers/majors that have a clear fix path. Each
+     condition gets a `mark-condition` entry (Issue #848) so build can
+     pin it to the resolution artifact.
+   - **REJECT**: fundamental issues. Don't bandaid; send back to the
+     author.
+2. Write the verdict. Don't soften — REJECT means REJECT.
+
+## When to stop
+
+Review is done when the verdict is recorded. Hand off to `build` (when
+fixes are needed before ship) or `ship` (when APPROVE).
+
+## Anti-patterns
+
+- **Don't sandbag with nits.** If the only findings are nits, APPROVE.
+  Don't gate on cosmetic preferences.
+- **Don't write a fix during review.** The reviewer's job is the
+  verdict; the fix is the author's.
+- **Don't auto-approve for speed.** Banned-reviewer enforcement exists
+  for a reason. Time pressure is not a CONDITIONAL.

--- a/skills/archetype/refs/ship.md
+++ b/skills/archetype/refs/ship.md
@@ -1,0 +1,74 @@
+# ship — progressive rollout with widening blast radius
+
+For changes that are already built and tested but need controlled exposure
+to production. Each phase widens blast radius; gates are explicit ramps.
+
+## Phase shape
+
+| Phase  | Goal                                                       |
+|--------|------------------------------------------------------------|
+| canary | Expose to a small slice (1–5% traffic, internal only, single region). |
+| ramp   | Widen progressively (10% → 25% → 50%) with monitoring at each step. |
+| full   | 100% exposure. Production traffic on the new path.         |
+| soak   | Keep the new path running unchanged for 24–72h. Watch the long tail. |
+
+## Produces
+
+- **Rollout verdict**: APPROVE / ROLLBACK / HOLD at each gate.
+- **SLO snapshot**: error rate, latency, saturation at each phase
+  boundary, compared to the pre-rollout baseline.
+
+## HITL
+
+`discrete:ramp-gates` — each phase boundary is a discrete gate. Auto-pass
+is allowed when SLO criteria are clean and prior phases passed; auto-fail
+(rollback) is allowed when SLO criteria breach. **Manual override is
+always available.** Don't bypass the gate; widen the criteria.
+
+## How to run
+
+### canary
+
+1. Define the slice: which traffic, what %, what region.
+2. Define the SLO criteria: error rate threshold, latency p95/p99
+   threshold, saturation threshold. Pull baseline from the last 7d.
+3. Deploy. Watch for at least 1 hour OR 1000 requests, whichever is
+   longer.
+4. Compare to baseline. If clean: pass to ramp. If degraded:
+   **rollback immediately**. Don't tune in production.
+
+### ramp
+
+1. Step the ramp at 10% → 25% → 50%. Don't skip steps.
+2. At each step, the SLO criteria from canary still apply. New metrics
+   may surface as load scales (saturation, queue depth, lock contention).
+3. Each step gets at least 30 minutes of soak before stepping up.
+4. Use `wicked-garden:delivery:rollout` for the canonical playbook.
+
+### full
+
+1. Step from 50% → 100%. The same SLO criteria apply.
+2. Tag the release. Publish a one-line "shipped X" note for visibility.
+
+### soak
+
+1. Watch for 24–72h depending on the change's criticality.
+2. The long tail surfaces issues canary missed: data drift, slow leaks,
+   off-hours load patterns, third-party rate limits.
+3. Soak ends when there's no anomaly outside the baseline noise band.
+
+## When to stop
+
+Ship is done when soak is clean. Hand off to `review` for a post-rollout
+audit when the change was high-blast-radius, or close out otherwise.
+
+## Anti-patterns
+
+- **Don't skip ramp.** 0% → 100% is not a rollout; it's a deploy.
+- **Don't auto-pass under degraded SLOs.** "It's only slightly worse"
+  has rolled out exactly the kind of regression rollouts are meant to
+  catch.
+- **Don't ship and walk.** Soak is part of ship. A rollout that ends at
+  full is incomplete.
+- **Don't treat ramp as a build phase.** No code changes during ramp.
+  Tuning happens in a follow-up build → ship cycle.

--- a/skills/archetype/refs/specify.md
+++ b/skills/archetype/refs/specify.md
@@ -1,0 +1,69 @@
+# specify — turn an ask into testable acceptance criteria
+
+When the implementation path is clear-ish but the success criteria are
+fuzzy. Produces SMART acceptance criteria — Specific, Measurable,
+Achievable, Relevant, Time-bound — that downstream `build` can verify.
+
+## Phase shape
+
+| Phase    | Goal                                                       |
+|----------|------------------------------------------------------------|
+| elicit   | Surface the user's intent through targeted questions.      |
+| structure | Convert intent into REQ-/AC- numbered acceptance criteria.|
+| validate | Confirm with the user that the ACs match their intent.    |
+
+## Produces
+
+- **SMART acceptance criteria** in the form `AC-N: when X, then Y`.
+- One-line invariants: "A response time over 500ms is a regression".
+- Optional: a `requirements.md` artifact in the project dir.
+
+## HITL
+
+`discrete:validate-gate` — the validate phase is a hard checkpoint. Don't
+proceed past validate without explicit user agreement on the AC set.
+
+## How to run
+
+### elicit
+
+1. Use `/wicked-garden:product:elicit` if requirements analysis is needed,
+   or jump in directly when the surface is small.
+2. Ask 3–5 questions. Each should be answerable in one line and target a
+   specific dimension: scope, success metric, failure mode, edge case,
+   non-goal.
+3. **Don't ask open-ended "tell me more about X".** Force the user to pick
+   between concrete options.
+
+### structure
+
+1. Convert each elicited fact into one acceptance criterion: `AC-N: when
+   <trigger>, then <observable>`.
+2. Add invariants for things that should NOT change: `INV-N: <thing> must
+   stay under <threshold>`.
+3. Keep ACs minimal — 3–7 is the sweet spot. More than 10 means you're
+   treating ACs as design.
+
+### validate
+
+1. Show the user the AC list.
+2. Ask: "is anything missing? is anything wrong? is anything overspecified?"
+3. **Hard gate**: do not exit specify until the user explicitly approves the
+   AC set. "Looks good" is enough; silence is not.
+4. If they want changes, loop back to elicit or structure as appropriate.
+
+## When to stop
+
+Specify is done when the user has signed off on the AC list. Hand off to
+`build` (when the next step is implementation), `decide` (when you've
+uncovered competing options), or `explore` (when the act of writing ACs
+revealed the problem isn't well understood).
+
+## Anti-patterns
+
+- **Don't write design inside ACs.** "AC-1: implementation uses Redis"
+  is a design choice, not an acceptance criterion. Use `decide` for that.
+- **Don't merge multiple criteria into one.** Split them so each is
+  individually testable.
+- **Don't auto-pass the validate gate.** The whole point is the user
+  agrees this is what they wanted.

--- a/skills/archetype/refs/triage.md
+++ b/skills/archetype/refs/triage.md
@@ -1,0 +1,62 @@
+# triage — classify and route
+
+The entry archetype. Every prompt that doesn't already carry an archetype tag
+starts here. Triage is not a workflow on its own — it's a routing decision.
+
+## Phase shape
+
+| Phase    | Goal                                          |
+|----------|-----------------------------------------------|
+| classify | Pick the right archetype (or set of archetypes) and hand off. |
+
+## Produces
+
+- A routing decision: which archetype(s) this prompt belongs in.
+
+## HITL
+
+`none` — fully automated. The detector runs, the directive emits, the
+agent picks up the playbook from there.
+
+## How to run
+
+1. **Read the prompt.** What is the user actually asking for?
+2. **Run the detector.** Call `scripts/crew/archetypes_v11.py detect` with
+   the prompt and any known signals.
+3. **Inspect the matches.**
+   - Single high-confidence match (≥ 0.7): hand off to that archetype's
+     playbook.
+   - Multiple medium matches (0.5–0.7): pick the one with the strongest
+     evidence; if you can't, ask the user which shape they want.
+   - Only triage matched: ask a clarifying question naming what's
+     missing — usually the work isn't ambiguous, the prompt is.
+
+## When to stop in triage
+
+Triage exits as soon as you've named the next archetype. Do **not**
+do work inside triage — every minute spent here is a minute the
+real work isn't moving.
+
+## Examples
+
+| Prompt                                            | Routes to            |
+|---------------------------------------------------|----------------------|
+| "implement caching for the dashboard"             | build                |
+| "drop legacy_id column"                           | build + migrate      |
+| "checkout is down — 5xx spiking"                  | incident             |
+| "redis or memcached for sessions?"                | decide               |
+| "review the new auth middleware"                  | review               |
+| "what should we do about rate limiting?"          | explore              |
+| "write acceptance criteria for the export"        | specify              |
+| "kick off canary for the pricing change"          | ship                 |
+| "fix typo in README"                              | (suppressed — simple-edit, no archetype) |
+
+## Anti-patterns
+
+- **Don't classify into a tier.** "standard rigor" is not an archetype.
+  Triage picks a *shape*, not a depth dial.
+- **Don't stack triage onto an active archetype.** If the user is already
+  inside `build`, a follow-up "and also run the migration" doesn't restart
+  triage — it adds `migrate` as a co-archetype.
+- **Don't write code in triage.** If your hands are at the keyboard,
+  you've already left triage.


### PR DESCRIPTION
Builds on #861 + #862. Agent-facing entry point: `skills/archetype/` with a slim SKILL.md (101 lines) and 9 ref playbooks (62-97 lines each).

Each playbook documents that archetype's phase shape, produces contract, HITL discipline, run procedure, exit condition, and anti-patterns.

Loop is now closed:
```
prompt → hook detects archetype → emits <wg archetype> tag
       → agent invokes wicked-garden:archetype skill
       → skill loads refs/{archetype}.md
       → agent runs the per-archetype phase shape
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)