### PR TITLE
feat(v11): 9 archetype slash commands — direct invocation entry points

### DIFF
--- a/commands/archetype/build.md
+++ b/commands/archetype/build.md
@@ -1,0 +1,12 @@
+---
+description: Implement and ship a feature or fix — test rigor scales with signals
+argument-hint: "[work description]"
+phase_relevance: ["*"]
+archetype_relevance: ["build"]
+---
+
+# /wicked-garden:archetype:build
+
+Run the build archetype: plan → implement → test → review. Produces shipped code + test report.
+
+Invoke `wicked-garden:archetype` skill with archetype=build. Loads `refs/build.md`. Test rigor scales with complexity / blast_radius / novelty — pick the matching tier in the plan phase.

--- a/commands/archetype/decide.md
+++ b/commands/archetype/decide.md
@@ -1,0 +1,12 @@
+---
+description: Pick between options with an ADR-shaped decision artifact
+argument-hint: "[decision context]"
+phase_relevance: ["*"]
+archetype_relevance: ["decide"]
+---
+
+# /wicked-garden:archetype:decide
+
+Run the decide archetype: brief → options → score → record. Produces an ADR with the chosen path + accepted trade-offs.
+
+Invoke `wicked-garden:archetype` skill with archetype=decide. Loads `refs/decide.md`. Stop and ask before generating an ADR for cheap-reversible choices.

--- a/commands/archetype/explore.md
+++ b/commands/archetype/explore.md
@@ -1,0 +1,12 @@
+---
+description: Explore an open problem space — diverge then converge on options
+argument-hint: "[problem statement]"
+phase_relevance: ["*"]
+archetype_relevance: ["explore"]
+---
+
+# /wicked-garden:archetype:explore
+
+Run the explore archetype: frame → diverge → converge. Produces an option set or hypothesis, NOT a decision.
+
+Invoke `wicked-garden:archetype` skill with archetype=explore. Loads `refs/explore.md` and runs the three phases. HITL is continuous — keep the user in the loop.

--- a/commands/archetype/incident.md
+++ b/commands/archetype/incident.md
@@ -1,0 +1,12 @@
+---
+description: Live-fire production incident response — mitigate first, RCA second
+argument-hint: "[INC-id or symptom]"
+phase_relevance: ["*"]
+archetype_relevance: ["incident"]
+---
+
+# /wicked-garden:archetype:incident
+
+Run the incident archetype: triage → investigate → mitigate → resolve → followup. Produces mitigation + RCA + followup list.
+
+Invoke `wicked-garden:archetype` skill with archetype=incident. Loads `refs/incident.md`. Mitigate gate is HARD — do not skip past it. Time-box investigate to 15 min during SEV-1.

--- a/commands/archetype/migrate.md
+++ b/commands/archetype/migrate.md
@@ -1,0 +1,12 @@
+---
+description: Schema/API/data shape change with expand-contract pattern
+argument-hint: "[migration description]"
+phase_relevance: ["*"]
+archetype_relevance: ["migrate"]
+---
+
+# /wicked-garden:archetype:migrate
+
+Run the migrate archetype: plan → expand → backfill → cutover → contract. Produces shape change + tested rollback proof.
+
+Invoke `wicked-garden:archetype` skill with archetype=migrate. Loads `refs/migrate.md`. Cutover gate is HARD — pre-cutover checklist (rollback tested, backfill verified, dual-write soaked) before each switch.

--- a/commands/archetype/review.md
+++ b/commands/archetype/review.md
@@ -1,0 +1,12 @@
+---
+description: Independent assessment with hard verdict (APPROVE/CONDITIONAL/REJECT)
+argument-hint: "[artifact / PR / commit]"
+phase_relevance: ["*"]
+archetype_relevance: ["review"]
+---
+
+# /wicked-garden:archetype:review
+
+Run the review archetype: scope → assess → findings → remediate-or-accept. Produces a verdict + remediation list.
+
+Invoke `wicked-garden:archetype` skill with archetype=review. Loads `refs/review.md`. Final verdict is a HARD gate — banned-reviewer enforcement applies (no auto-approve identities).

--- a/commands/archetype/ship.md
+++ b/commands/archetype/ship.md
@@ -1,0 +1,12 @@
+---
+description: Roll out an already-built change with widening blast radius
+argument-hint: "[release / change ref]"
+phase_relevance: ["*"]
+archetype_relevance: ["ship"]
+---
+
+# /wicked-garden:archetype:ship
+
+Run the ship archetype: canary → ramp → full → soak. Produces a rollout verdict + SLO snapshot.
+
+Invoke `wicked-garden:archetype` skill with archetype=ship. Loads `refs/ship.md`. Each phase boundary is a discrete ramp gate. Auto-pass under clean SLOs; auto-rollback under degraded SLOs.

--- a/commands/archetype/specify.md
+++ b/commands/archetype/specify.md
@@ -1,0 +1,12 @@
+---
+description: Turn an ask into SMART acceptance criteria
+argument-hint: "[ask]"
+phase_relevance: ["*"]
+archetype_relevance: ["specify"]
+---
+
+# /wicked-garden:archetype:specify
+
+Run the specify archetype: elicit → structure → validate. Produces SMART acceptance criteria.
+
+Invoke `wicked-garden:archetype` skill with archetype=specify. Loads `refs/specify.md`. Validate gate is HARD — do not exit without explicit user signoff on the AC list.

--- a/commands/archetype/triage.md
+++ b/commands/archetype/triage.md
@@ -1,0 +1,12 @@
+---
+description: Classify a prompt into a work-shape archetype and route to its playbook
+argument-hint: "[prompt]"
+phase_relevance: ["*"]
+archetype_relevance: ["triage"]
+---
+
+# /wicked-garden:archetype:triage
+
+Run the triage archetype: classify and route. Detect the work shape, then hand off.
+
+Invoke the `wicked-garden:archetype` skill with archetype=triage. The skill loads `refs/triage.md` and runs the classify phase. When the prompt is empty, run the detector against the conversation context.


### PR DESCRIPTION
Builds on #861 + #862 + #863. One slash command per archetype:

- `/wicked-garden:archetype:triage`
- `/wicked-garden:archetype:explore`
- `/wicked-garden:archetype:specify`
- `/wicked-garden:archetype:decide`
- `/wicked-garden:archetype:ship`
- `/wicked-garden:archetype:review`
- `/wicked-garden:archetype:incident`
- `/wicked-garden:archetype:build`
- `/wicked-garden:archetype:migrate`

Each is 12 lines (Pattern A — slim body, just dispatches to the `wicked-garden:archetype` skill with the named archetype). Loop closed end-to-end: hook auto-tags OR user explicitly invokes a command, both routes converge on the same skill family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)