### PR TITLE
feat(v11): LLM-based archetype classifier via wicked-garden:classify skill

### DIFF
--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -180,24 +180,52 @@ def _has_ambiguity_signals(prompt: str) -> bool:
     return any(sig in lower for sig in _JAM_AMBIGUITY_SIGNALS)
 
 
-def _build_archetype_directive(prompt: str, intent: str) -> str | None:
+def _build_archetype_directive(prompt: str, intent: str, state=None) -> str | None:
     """v11 — emit a slim work-shape archetype steering directive.
 
-    Skips emission when intent is 'simple-edit' (silence is the signal,
-    matching the v10 directive convention). For other intents, runs the
-    archetype detector and emits a one-line steering hint when a single
-    archetype scores at HIGH confidence, or a two-line shape-card when
-    two archetypes co-fire (e.g. build + migrate on schema-change).
+    Two-tier classification:
 
-    Fail-open: any import / detection error returns None so the hook
-    never blocks on archetype routing.
+    1. **Persisted (LLM)**: when SessionState carries a recent
+       `classified_at` + `archetypes_v11`, prefer that — the model
+       already classified through the wicked-garden:classify skill.
+    2. **Fallback (regex)**: when no persisted classification exists,
+       run archetypes_v11.detect_archetypes() against the prompt
+       directly. If the prompt is non-trivial (intent != simple-edit)
+       AND the regex result is weak (only triage matched), emit a
+       directive asking the model to invoke the classify skill —
+       LLM reasoning beats regex on ambiguous prompts.
+
+    Skips emission when intent is 'simple-edit' (silence is the signal).
+    Fail-open on any error.
     """
     if not prompt or not prompt.strip():
         return None
     if intent == "simple-edit":
         return None
+
+    # Tier 1: persisted classification from the classify skill
+    persisted = (getattr(state, "archetypes_v11", None) or []) if state else []
+    if persisted:
+        # Filter triage out unless sole match; emit shape-card from persisted.
+        real = [a for a in persisted if a.get("name") != "triage"]
+        if not real:
+            return None
+        if len(real) == 1 and float(real[0].get("score", 0)) >= 0.7:
+            n = real[0]["name"]
+            s = float(real[0]["score"])
+            return f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"llm\" />"
+        shape_lines = [
+            f"  - {a['name']} ({float(a.get('score', 0)):.2f})"
+            for a in real[:3]
+        ]
+        return (
+            "<wg archetypes classified=\"llm\">\n"
+            + "\n".join(shape_lines)
+            + "\n</wg>"
+        )
+
+    # Tier 2: regex fallback
     try:
-        # Lazy import — keeps HOT path cost low when intent gates skip us.
         from pathlib import Path as _Path
         import sys as _sys
         _scripts = _Path(__file__).resolve().parents[1].parent / "scripts"
@@ -214,28 +242,28 @@ def _build_archetype_directive(prompt: str, intent: str) -> str | None:
     except Exception:
         return None
 
-    # Filter triage out unless it's the only match
     real = [(n, s, e) for (n, s, e) in matches if n != "triage"]
-    if not real:
-        # Nothing scored above threshold — let the user clarify naturally.
-        # No directive needed; intent classification already routed this.
-        return None
 
-    # Single high-confidence archetype: emit a slim recommend-tier hint.
+    if not real:
+        # Regex couldn't classify cleanly — ask the model to do it instead.
+        # This is the LLM-classifier opt-in path: the model invokes the
+        # wicked-garden:classify skill, persists the result, and on the
+        # next turn the persisted-tier branch above takes over.
+        return (
+            "<wg classify-due />\n"
+            "Regex classifier could not route this prompt to a v11 archetype. "
+            "Invoke the `wicked-garden:classify` skill to classify with model "
+            "reasoning, then run the chosen archetype's playbook."
+        )
+
     high = [(n, s, e) for (n, s, e) in real if s >= HIGH_CONFIDENCE]
     if len(high) == 1 and len(real) == 1:
         n, s, _ = high[0]
-        return (
-            f"<wg archetype=\"{n}\" score=\"{s:.2f}\" />"
-        )
+        return f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"regex\" />"
 
-    # Multi-archetype or medium-confidence: name the shape so the model
-    # picks an appropriate phase order.
-    shape_lines = []
-    for (n, s, _) in real[:3]:  # cap at top-3
-        shape_lines.append(f"  - {n} ({s:.2f})")
+    shape_lines = [f"  - {n} ({s:.2f})" for (n, s, _) in real[:3]]
     return (
-        "<wg archetypes>\n"
+        "<wg archetypes classified=\"regex\">\n"
         + "\n".join(shape_lines)
         + "\n</wg>"
     )
@@ -1042,7 +1070,7 @@ def main():
         # specific archetype (build / migrate / incident / specify / ...),
         # emits a slim tag so the agent knows the work shape it's in.
         archetype_directive = _build_archetype_directive(
-            prompt, _intent or "simple-edit"
+            prompt, _intent or "simple-edit", state=state,
         )
         if archetype_directive:
             all_parts.append(archetype_directive)

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -243,6 +243,16 @@ class SessionState:
     intent: str | None = None
     intent_explicit: bool = False
 
+    # v11: LLM-classified work-shape archetype + signals.
+    # Populated by the wicked-garden:classify skill. When set, the
+    # prompt_submit hook prefers this over the regex detector.
+    # archetypes_v11: list of {name, score, evidence} dicts (top-3).
+    # signals_v11: dict of boolean signal flags (blast_radius_high, etc.).
+    # classified_at: ISO timestamp; None means not classified yet.
+    archetypes_v11: list | None = None
+    signals_v11: dict | None = None
+    classified_at: str | None = None
+
     # PostToolUse hook latency profiling (Issue #312).
     # Cumulative milliseconds spent in the post_tool.py main() function.
     post_tool_total_ms: int = 0

--- a/scripts/classify/persist.py
+++ b/scripts/classify/persist.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""persist.py — Write LLM classification result to SessionState.
+
+The wicked-garden:classify skill asks the model to reason through the
+prompt and emit a JSON classification. The model invokes this script
+with the JSON on stdin (or as --data), and we persist to SessionState
+so prompt_submit.py reads it on subsequent turns.
+
+Schema accepted (any subset OK; we coerce defaults):
+
+    {
+      "intent": "simple-edit | feature | rigor | research",
+      "archetypes": [
+        {"name": "build", "score": 0.85, "evidence": ["..."]},
+        ...
+      ],
+      "signals": {
+        "blast_radius_high": false,
+        "novelty_high": true,
+        "state_complexity_high": false,
+        "reversibility_low": false,
+        "production_impact": false,
+        "compliance_scope": false
+      }
+    }
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_SCRIPTS))
+
+
+VALID_INTENTS = {"simple-edit", "feature", "rigor", "research"}
+VALID_ARCHETYPES = {"triage", "explore", "specify", "decide", "ship",
+                    "review", "incident", "build", "migrate"}
+VALID_SIGNAL_KEYS = {
+    "blast_radius_high", "novelty_high", "state_complexity_high",
+    "reversibility_low", "reversibility_medium_or_low",
+    "production_impact", "compliance_scope",
+    "ambiguity_high", "spec_ambiguity_high", "scope_unclear",
+    "multiple_viable_options", "post_build", "code_change",
+    "independent_assessment_needed",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _normalize(payload: dict) -> dict:
+    """Coerce user-supplied JSON to the canonical shape. Drop unknowns."""
+    out = {}
+
+    intent = payload.get("intent")
+    if isinstance(intent, str) and intent in VALID_INTENTS:
+        out["intent"] = intent
+
+    archetypes_raw = payload.get("archetypes") or []
+    archetypes = []
+    if isinstance(archetypes_raw, list):
+        for a in archetypes_raw[:5]:  # cap top-5
+            if not isinstance(a, dict):
+                continue
+            name = a.get("name")
+            if name not in VALID_ARCHETYPES:
+                continue
+            try:
+                score = float(a.get("score", 0))
+            except (TypeError, ValueError):
+                score = 0.0
+            score = max(0.0, min(1.0, score))
+            evidence = a.get("evidence") or []
+            if not isinstance(evidence, list):
+                evidence = [str(evidence)]
+            evidence = [str(e)[:200] for e in evidence[:5]]
+            archetypes.append({
+                "name": name, "score": round(score, 3), "evidence": evidence,
+            })
+    out["archetypes"] = archetypes
+
+    signals_raw = payload.get("signals") or {}
+    signals = {}
+    if isinstance(signals_raw, dict):
+        for k, v in signals_raw.items():
+            if k in VALID_SIGNAL_KEYS and isinstance(v, bool):
+                signals[k] = v
+    out["signals"] = signals
+
+    return out
+
+
+def persist(payload: dict) -> dict:
+    """Write the classification to SessionState. Returns the normalised
+    payload for confirmation."""
+    normalized = _normalize(payload)
+    try:
+        from _session import SessionState  # type: ignore
+    except ImportError:
+        print(json.dumps({"ok": False, "error": "SessionState unavailable"}),
+              file=sys.stderr)
+        sys.exit(1)
+
+    state = SessionState.load()
+    if normalized.get("intent"):
+        state.update(intent=normalized["intent"], intent_explicit=False)
+    state.update(
+        archetypes_v11=normalized.get("archetypes") or [],
+        signals_v11=normalized.get("signals") or {},
+        classified_at=_utc_now(),
+    )
+    return normalized
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(
+        description="Persist a classify-skill JSON result to SessionState."
+    )
+    parser.add_argument(
+        "--data", default=None,
+        help="JSON string. If omitted, reads from stdin.",
+    )
+    args = parser.parse_args()
+    raw = args.data if args.data else sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw and raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"ok": False, "error": f"invalid JSON: {exc}"}),
+              file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(payload, dict):
+        print(json.dumps({"ok": False, "error": "expected JSON object"}),
+              file=sys.stderr)
+        sys.exit(1)
+    normalized = persist(payload)
+    print(json.dumps({"ok": True, "persisted": normalized}, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/skills/classify/SKILL.md
+++ b/skills/classify/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: wicked-garden:classify
+description: |
+  v11 LLM-based work-shape classifier. Replaces the regex archetype detector
+  with the model's own reasoning. Reads the user's prompt, picks the right
+  archetype(s) from the catalog, identifies signals (blast_radius, novelty,
+  reversibility, etc.), and persists to SessionState so subsequent turns
+  steer correctly.
+
+  Use when: the prompt_submit hook emitted a `<wg classify-due />` directive,
+  OR explicitly invoked at session start, OR when re-classifying after the
+  user changes scope mid-session.
+allowed-tools: ["*"]
+---
+
+# /wicked-garden:classify
+
+You are classifying a prompt into a v11 work-shape archetype. Your output
+drives downstream archetype routing for the rest of the session (until
+the user changes scope or invokes this skill again).
+
+## Why this exists
+
+The v11 hook auto-classifier is a regex + boolean-signal heuristic. It
+works for prompts whose vocabulary matches the catalog phrase lists, but
+it misses paraphrases and underuses signals. **You are a better classifier
+than regex.** This skill is the path to use the model's full reasoning
+on the classification step, then persist the result so the rest of the
+session benefits without re-running classification on every turn.
+
+## What the catalog declares
+
+`.claude-plugin/archetypes.json` defines 9 archetypes. Read it once at the
+start of this skill. Summary table:
+
+| Archetype | Phases                                        | Use when                                          |
+|-----------|-----------------------------------------------|---------------------------------------------------|
+| triage    | classify                                      | prompt is genuinely ambiguous; ask for clarification |
+| explore   | frame → diverge → converge                    | open problem space, multiple paths, brainstorm    |
+| specify   | elicit → structure → validate                 | requirements / acceptance criteria need writing   |
+| decide    | brief → options → score → record              | 2+ viable options, need an ADR                    |
+| ship      | canary → ramp → full → soak                   | already-built change being rolled out             |
+| review    | scope → assess → findings → remediate-or-accept | independent assessment of an artifact            |
+| incident  | triage → investigate → mitigate → resolve → followup | live production failure                      |
+| build     | plan → implement → test → review              | implement a feature or fix (most common)          |
+| migrate   | plan → expand → backfill → cutover → contract | shape change with rollback proof                  |
+
+## Procedure
+
+### 1. Read the prompt
+
+What is the user actually asking for? Restate in one sentence in your own
+words. If you can't, the prompt is genuinely ambiguous → triage.
+
+### 2. Pick archetype(s)
+
+Archetypes are NOT mutually exclusive. Pick a SET. Common combinations:
+
+- "implement schema change with backfill" → `build + migrate`
+- "review the auth PR before deploy" → `review + ship`
+- "should we use redis or memcached for sessions?" → `decide` (and
+  possibly `build` if they want you to also implement it)
+
+Score each match between 0.0 and 1.0. Use these calibration anchors:
+
+- **0.9+**: keyword + signal both clear, no ambiguity (e.g. "checkout is
+  down 5xx spiking" → incident 1.0).
+- **0.7–0.9**: clear shape with one or two minor uncertainties.
+- **0.5–0.7**: archetype matches but the prompt is partial — agent should
+  read the playbook and gracefully ask if anything was missed.
+- **<0.5**: too weak; don't return this archetype.
+
+If nothing scores ≥ 0.5, return `triage` only — that's the signal to ask
+for clarification before doing work.
+
+### 3. Identify signals
+
+Boolean flags that downstream archetypes use to scale rigor. Mark TRUE
+only when the prompt clearly implies it:
+
+- `blast_radius_high` — change affects production traffic / many users / many systems.
+- `novelty_high` — pattern not yet in this codebase.
+- `state_complexity_high` — touches data shape, migrations, persistent state.
+- `reversibility_low` — undoing is expensive (data migrations, destructive ops).
+- `reversibility_medium_or_low` — undoing is non-trivial (config changes, breaking APIs).
+- `production_impact` — production users / systems affected right now.
+- `compliance_scope` — GDPR / SOC2 / HIPAA / PCI surface.
+- `ambiguity_high` — multiple plausible reads.
+- `spec_ambiguity_high` — success criteria are fuzzy.
+- `scope_unclear` — boundary of work is undefined.
+- `multiple_viable_options` — 2+ paths with no obvious winner.
+- `post_build` — change is already implemented; this is about deployment.
+- `code_change` — implementation work involved.
+- `independent_assessment_needed` — someone else's work needs review.
+
+Default any flag you didn't explicitly mark to FALSE. Do not over-tag.
+
+### 4. Pick intent
+
+Intent is coarser than archetype — used by the hook to gate directive
+emission. One of:
+
+- `simple-edit` — typo, comment, formatting, single-line fix. Hook stays silent.
+- `feature` — most non-trivial work (default for build/migrate/ship).
+- `rigor` — high stakes (compliance, security, blast_radius_high).
+- `research` — exploratory (explore, decide).
+
+### 5. Persist
+
+Emit a JSON object with the four keys above and pipe to the persist
+script. Use this exact shape — extras get dropped:
+
+```bash
+echo '{
+  "intent": "feature",
+  "archetypes": [
+    {"name": "build", "score": 0.85, "evidence": ["implement keyword + code_change signal"]},
+    {"name": "migrate", "score": 0.65, "evidence": ["schema change + state_complexity signal"]}
+  ],
+  "signals": {
+    "code_change": true,
+    "state_complexity_high": true,
+    "reversibility_low": true
+  }
+}' | sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/classify/persist.py"
+```
+
+The script normalises and writes to SessionState. Confirm the response
+shows `"ok": true`, then return control.
+
+### 6. Hand off
+
+After persisting, look at the top archetype's playbook
+(`skills/archetype/refs/{name}.md`) and start running it. Do not re-run
+classification mid-session unless the user explicitly changes scope.
+
+## When to skip this skill
+
+- The prompt is a continuation token ("yes", "do it", "lgtm"). The hook
+  already short-circuits these.
+- The user typed `/wicked-garden:archetype:<name>` directly — they
+  already classified.
+- SessionState already has `classified_at` set for this session and the
+  prompt fits the existing classification. Re-classifying on every turn
+  is exactly the cost we're trying to avoid.
+
+## Failure modes
+
+- Persist script fails: return the JSON to the user as text and ask
+  them how to proceed. Do not invent a workflow.
+- Catalog file unreadable: return triage with an explanation. The
+  archetype machinery will surface the read error separately.
+- Model can't decide between 3+ archetypes: return triage with a note.
+  triage's job is to ask. Don't pick at random.

--- a/tests/qe/test_classify_persist.py
+++ b/tests/qe/test_classify_persist.py
@@ -1,0 +1,128 @@
+"""Tests for scripts/classify/persist.py — v11 LLM-classifier persist path."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "classify"):
+    if str(_p) not in sys.path:
+        sys.path.append(str(_p))
+
+import persist as p  # noqa: E402
+
+
+class _FakeState:
+    """Minimal stand-in for SessionState. Records updates."""
+    def __init__(self):
+        self.intent = None
+        self.intent_explicit = False
+        self.archetypes_v11 = None
+        self.signals_v11 = None
+        self.classified_at = None
+        self.updates = []
+
+    def update(self, **kw):
+        self.updates.append(kw)
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+    def save(self):
+        pass
+
+
+class TestNormalize(unittest.TestCase):
+    def test_drops_unknown_intent(self):
+        out = p._normalize({"intent": "xxx"})
+        self.assertNotIn("intent", out)
+
+    def test_keeps_valid_intent(self):
+        for intent in p.VALID_INTENTS:
+            out = p._normalize({"intent": intent})
+            self.assertEqual(out["intent"], intent)
+
+    def test_drops_unknown_archetype(self):
+        out = p._normalize({
+            "archetypes": [{"name": "not-a-thing", "score": 0.9}],
+        })
+        self.assertEqual(out["archetypes"], [])
+
+    def test_clamps_score_range(self):
+        out = p._normalize({
+            "archetypes": [{"name": "build", "score": 1.5}],
+        })
+        self.assertEqual(out["archetypes"][0]["score"], 1.0)
+        out2 = p._normalize({
+            "archetypes": [{"name": "build", "score": -0.3}],
+        })
+        self.assertEqual(out2["archetypes"][0]["score"], 0.0)
+
+    def test_caps_top_archetypes(self):
+        out = p._normalize({
+            "archetypes": [
+                {"name": n, "score": 0.5} for n in
+                ("build", "migrate", "ship", "review", "incident", "decide")
+            ],
+        })
+        self.assertEqual(len(out["archetypes"]), 5)
+
+    def test_drops_unknown_signals(self):
+        out = p._normalize({
+            "signals": {"blast_radius_high": True, "fake_signal": True},
+        })
+        self.assertEqual(out["signals"],
+                         {"blast_radius_high": True})
+
+    def test_drops_non_bool_signals(self):
+        out = p._normalize({
+            "signals": {"blast_radius_high": "yes"},
+        })
+        self.assertEqual(out["signals"], {})
+
+    def test_caps_evidence_per_archetype(self):
+        out = p._normalize({
+            "archetypes": [{
+                "name": "build", "score": 0.5,
+                "evidence": [f"reason-{i}" for i in range(20)],
+            }],
+        })
+        self.assertEqual(len(out["archetypes"][0]["evidence"]), 5)
+
+
+class TestPersist(unittest.TestCase):
+    def test_persist_writes_to_session_state(self):
+        fake = _FakeState()
+        # The persist() function does a local `from _session import
+        # SessionState`. We patch that import path so the real load is
+        # intercepted.
+        import _session  # type: ignore
+        with patch.object(_session.SessionState, "load",
+                          classmethod(lambda cls: fake)):
+            normalized = p.persist({
+                "intent": "feature",
+                "archetypes": [{"name": "build", "score": 0.85}],
+                "signals": {"code_change": True},
+            })
+        self.assertEqual(fake.intent, "feature")
+        self.assertFalse(fake.intent_explicit)
+        self.assertEqual(fake.archetypes_v11,
+                         [{"name": "build", "score": 0.85, "evidence": []}])
+        self.assertEqual(fake.signals_v11, {"code_change": True})
+        self.assertIsNotNone(fake.classified_at)
+        self.assertEqual(normalized["intent"], "feature")
+
+    def test_persist_skips_intent_when_invalid(self):
+        fake = _FakeState()
+        import _session  # type: ignore
+        with patch.object(_session.SessionState, "load",
+                          classmethod(lambda cls: fake)):
+            p.persist({"archetypes": [{"name": "build", "score": 0.5}]})
+        self.assertIsNone(fake.intent)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an LLM-classifier path as Tier 1 routing, keeping regex as Tier 2 fallback. Model reasons through the prompt, picks archetypes, identifies signals, persists to SessionState. Subsequent turns reuse the persisted classification.

Tier 1 (preferred): `wicked-garden:classify` skill
Tier 2 (fallback): `archetypes_v11.detect_archetypes` regex
Triage path: regex returns only triage → hook emits `<wg classify-due />` → model invokes Tier 1 → next turn uses persisted

Tags now carry `classified="llm"` or `classified="regex"` so the agent knows which classifier produced the routing.

356/356 tests pass.

🤖