### PR TITLE
feat(v11): runtime hard-gate enforcement + end-to-end integration test

### DIFF
--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -245,24 +245,86 @@ def complete_phase(state: ProjectState, phase: str) -> ProjectState:
     return state
 
 
+_HARD_GATE_PHASES: Dict[str, Tuple[str, ...]] = {
+    # Issue: doctrinal hard gates were not enforced in code.
+    # This map names the (archetype, phase) pairs that genuinely need
+    # the user in the loop AT RUNTIME, not just in playbook prose.
+    "migrate": ("cutover",),
+    "incident": ("mitigate",),
+    "review": ("remediate-or-accept",),
+    "specify": ("validate",),
+    "decide": ("record",),
+}
+
+
+def _is_hard_gate(state: ProjectState, phase: str) -> bool:
+    """True iff (archetype, phase) is a hard gate per _HARD_GATE_PHASES."""
+    archetype = (state.extras or {}).get("v11_archetype")
+    if not archetype:
+        return False
+    return resolve_phase(phase) in _HARD_GATE_PHASES.get(archetype, ())
+
+
 def approve_phase(
-    state: ProjectState, phase: str, approver: str = "user"
+    state: ProjectState,
+    phase: str,
+    approver: str = "user",
+    *,
+    confirmed_by: Optional[str] = None,
+    confirmation_evidence: Optional[str] = None,
 ) -> Tuple[ProjectState, Optional[str]]:
     """Approve a phase. Returns (state, next_phase_name_or_None).
 
-    v11: no gate machinery. The archetype's playbook is responsible for
-    enforcing produces and HITL discipline; phase_manager just records
-    the state transition. Legacy projects with phase_plan_mode != "archetype"
-    behave the same way — the v6 gate gauntlet is gone for everyone.
+    Hard-gate enforcement (v11): when (archetype, phase) is in
+    ``_HARD_GATE_PHASES`` (e.g. migrate.cutover, incident.mitigate),
+    advancing past the phase REQUIRES non-empty ``confirmed_by`` AND
+    ``confirmation_evidence``. The audit log records both. ``approver``
+    alone is not enough — the doctrine of "user in the loop" becomes
+    runtime: the caller must explicitly attest that confirmation
+    happened, and name the artifact (commit / dashboard URL / ticket /
+    Slack thread) that proves it.
+
+    Non-hard phases retain the v11 default: lightweight state transition,
+    no gate machinery, archetype's playbook owns discipline.
     """
     phase = resolve_phase(phase)
+
+    # Hard-gate guard: enforce explicit confirmation at runtime.
+    if _is_hard_gate(state, phase):
+        if not confirmed_by or not confirmed_by.strip():
+            archetype = (state.extras or {}).get("v11_archetype")
+            raise ValueError(
+                f"Hard gate at archetype={archetype!r} phase={phase!r} "
+                f"requires --confirmed-by (user / oncall / approver name). "
+                f"This is a v11 enforced HITL gate, not a doctrinal "
+                f"hint — the playbook documents this as hard:* and the "
+                f"runtime mirrors that. Pass --confirmed-by AND "
+                f"--confirmation-evidence (path / URL / ticket id)."
+            )
+        if not confirmation_evidence or not confirmation_evidence.strip():
+            archetype = (state.extras or {}).get("v11_archetype")
+            raise ValueError(
+                f"Hard gate at archetype={archetype!r} phase={phase!r} "
+                f"requires --confirmation-evidence (path to artifact "
+                f"proving the gate-specific check passed: rollback "
+                f"drill log, dashboard screenshot, mitigation commit, "
+                f"approval ticket, etc.)."
+            )
+
     ps = state.phases.get(phase) or PhaseState()
     ps.status = "approved"
     ps.approved_at = get_utc_timestamp()
     state.phases[phase] = ps
-    state.extras.setdefault("approvals", []).append({
+
+    approval_record = {
         "phase": phase, "approver": approver, "at": ps.approved_at,
-    })
+    }
+    if confirmed_by:
+        approval_record["confirmed_by"] = confirmed_by
+        approval_record["confirmation_evidence"] = confirmation_evidence
+        approval_record["hard_gate"] = True
+
+    state.extras.setdefault("approvals", []).append(approval_record)
 
     # Resolve next phase from phase_plan
     next_phase: Optional[str] = None
@@ -327,6 +389,19 @@ def main() -> None:
     parser.add_argument("--description", default="")
     parser.add_argument("--reason", default="")
     parser.add_argument("--approver", default="user")
+    parser.add_argument(
+        "--confirmed-by", default=None,
+        help="v11 hard-gate confirmation: name of the user/oncall/approver "
+             "who confirmed the gate-specific check (required for "
+             "migrate:cutover, incident:mitigate, review:remediate-or-accept, "
+             "specify:validate, decide:record).",
+    )
+    parser.add_argument(
+        "--confirmation-evidence", default=None,
+        help="v11 hard-gate confirmation evidence: path / URL / ticket id "
+             "proving the check passed (e.g. rollback drill log, "
+             "dashboard screenshot, mitigation commit).",
+    )
     parser.add_argument(
         "--archetype-mode",
         default=None,
@@ -399,10 +474,20 @@ def main() -> None:
         return
 
     if args.action == "approve":
-        state, next_phase = approve_phase(state, phase, approver=args.approver)
+        try:
+            state, next_phase = approve_phase(
+                state, phase, approver=args.approver,
+                confirmed_by=args.confirmed_by,
+                confirmation_evidence=args.confirmation_evidence,
+            )
+        except ValueError as exc:
+            _emit({"ok": False, "error": str(exc)}, args.json,
+                  f"Error: {exc}")
+            sys.exit(1)
         _emit(
             {"ok": True, "phase": phase, "status": "approved",
-             "next_phase": next_phase, "is_complete": is_complete(state)},
+             "next_phase": next_phase, "is_complete": is_complete(state),
+             "hard_gate_confirmed": bool(args.confirmed_by)},
             args.json,
             f"Approved phase '{phase}'. "
             f"{'Next: ' + next_phase if next_phase else 'Project complete.'}",
@@ -417,7 +502,16 @@ def main() -> None:
         return
 
     if args.action == "advance":
-        state, next_phase = approve_phase(state, phase, approver=args.approver)
+        try:
+            state, next_phase = approve_phase(
+                state, phase, approver=args.approver,
+                confirmed_by=args.confirmed_by,
+                confirmation_evidence=args.confirmation_evidence,
+            )
+        except ValueError as exc:
+            _emit({"ok": False, "error": str(exc)}, args.json,
+                  f"Error: {exc}")
+            sys.exit(1)
         if next_phase:
             state = start_phase(state, next_phase)
         _emit(

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -209,7 +209,6 @@ class TestCLI(unittest.TestCase):
         return result
 
     def test_cli_help_runs(self):
-        # --help exits 0; ensures argparse setup is intact
         result = subprocess.run(
             [sys.executable,
              str(_REPO_ROOT / "scripts" / "crew" / "phase_manager.py"),
@@ -218,6 +217,193 @@ class TestCLI(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0)
         self.assertIn("--archetype-mode", result.stdout)
+        self.assertIn("--confirmed-by", result.stdout)
+
+
+class TestHardGateEnforcement(unittest.TestCase):
+    """v11 hard-gate enforcement at the runtime layer.
+
+    The doctrine of `hard:cutover`, `hard:mitigate`, etc. used to live
+    only in playbook prose. v11 mirrors it in code: approve_phase
+    refuses to advance past a hard gate without explicit
+    `--confirmed-by` AND `--confirmation-evidence`. The audit trail
+    records both.
+    """
+
+    def _migrate_state_at_cutover(self):
+        s = pm.ProjectState(
+            name="mig-proj", current_phase="cutover",
+            created_at="2026-05-08T00:00:00Z",
+            phase_plan=["plan", "expand", "backfill", "cutover", "contract"],
+            extras={
+                "phase_plan_mode": "archetype",
+                "v11_archetype": "migrate",
+            },
+        )
+        return s
+
+    def _build_state_at_test(self):
+        s = pm.ProjectState(
+            name="build-proj", current_phase="test",
+            created_at="2026-05-08T00:00:00Z",
+            phase_plan=["plan", "implement", "test", "review"],
+            extras={
+                "phase_plan_mode": "archetype",
+                "v11_archetype": "build",
+            },
+        )
+        return s
+
+    def test_is_hard_gate_for_migrate_cutover(self):
+        s = self._migrate_state_at_cutover()
+        self.assertTrue(pm._is_hard_gate(s, "cutover"))
+        self.assertFalse(pm._is_hard_gate(s, "plan"))
+
+    def test_is_hard_gate_for_incident_mitigate(self):
+        s = pm.ProjectState(
+            name="inc", current_phase="mitigate",
+            created_at="2026-05-08T00:00:00Z",
+            extras={"v11_archetype": "incident"},
+        )
+        self.assertTrue(pm._is_hard_gate(s, "mitigate"))
+        self.assertFalse(pm._is_hard_gate(s, "investigate"))
+
+    def test_is_hard_gate_false_for_legacy_no_archetype(self):
+        s = pm.ProjectState(name="x", current_phase="cutover",
+                            created_at="2026-05-08T00:00:00Z")
+        self.assertFalse(pm._is_hard_gate(s, "cutover"))
+
+    def test_cutover_refuses_without_confirmed_by(self):
+        with patch.object(pm, "save_project_state"):
+            with self.assertRaises(ValueError) as cm:
+                pm.approve_phase(self._migrate_state_at_cutover(), "cutover")
+        msg = str(cm.exception)
+        self.assertIn("requires --confirmed-by", msg)
+        self.assertIn("v11 enforced HITL gate", msg)
+
+    def test_cutover_refuses_without_evidence(self):
+        with patch.object(pm, "save_project_state"):
+            with self.assertRaises(ValueError) as cm:
+                pm.approve_phase(
+                    self._migrate_state_at_cutover(), "cutover",
+                    confirmed_by="oncall-mike",
+                )
+        self.assertIn("requires --confirmation-evidence", str(cm.exception))
+
+    def test_cutover_refuses_blank_confirmed_by(self):
+        with patch.object(pm, "save_project_state"):
+            with self.assertRaises(ValueError):
+                pm.approve_phase(
+                    self._migrate_state_at_cutover(), "cutover",
+                    confirmed_by="   ",
+                    confirmation_evidence="x",
+                )
+
+    def test_cutover_advances_when_both_provided(self):
+        with patch.object(pm, "save_project_state"):
+            state, next_phase = pm.approve_phase(
+                self._migrate_state_at_cutover(), "cutover",
+                confirmed_by="oncall-mike",
+                confirmation_evidence="dashboard:reads-switched-clean",
+            )
+        self.assertEqual(state.phases["cutover"].status, "approved")
+        self.assertEqual(next_phase, "contract")
+        approvals = state.extras["approvals"]
+        self.assertEqual(len(approvals), 1)
+        self.assertEqual(approvals[0]["confirmed_by"], "oncall-mike")
+        self.assertEqual(approvals[0]["confirmation_evidence"],
+                         "dashboard:reads-switched-clean")
+        self.assertTrue(approvals[0]["hard_gate"])
+
+    def test_non_hard_phase_does_not_require_confirmation(self):
+        # build:test is NOT a hard gate; approve without --confirmed-by
+        # must succeed and not include hard_gate=True in the audit row.
+        with patch.object(pm, "save_project_state"):
+            state, next_phase = pm.approve_phase(
+                self._build_state_at_test(), "test",
+            )
+        self.assertEqual(state.phases["test"].status, "approved")
+        self.assertEqual(next_phase, "review")
+        approvals = state.extras["approvals"]
+        self.assertEqual(len(approvals), 1)
+        self.assertNotIn("hard_gate", approvals[0])
+        self.assertNotIn("confirmed_by", approvals[0])
+
+
+class TestEndToEndArchetypeFlow(unittest.TestCase):
+    """Integration test: full archetype flow from creation through final
+    approval, exercising:
+      - archetype-mode project creation
+      - phase_plan hydrated from catalog
+      - state transitions per phase
+      - hard-gate enforcement at cutover
+      - is_complete predicate
+      - audit trail captured in extras
+    """
+
+    def test_full_migrate_lifecycle(self):
+        """A migrate project: plan -> expand -> backfill -> cutover -> contract.
+
+        The cutover phase requires hard-gate confirmation; everything else
+        is a discrete-gate auto-pass."""
+        with patch.object(pm, "save_project_state"):
+            state, _ = pm.create_project(
+                "migrate-int-test",
+                description="drop legacy_id with backfill",
+                archetype_mode="migrate",
+            )
+            self.assertEqual(
+                state.phase_plan,
+                ["plan", "expand", "backfill", "cutover", "contract"],
+            )
+            self.assertEqual(state.current_phase, "plan")
+
+            # plan -> expand
+            state = pm.start_phase(state, "plan")
+            state = pm.complete_phase(state, "plan")
+            state, nxt = pm.approve_phase(state, "plan")
+            self.assertEqual(nxt, "expand")
+
+            # expand -> backfill
+            state = pm.start_phase(state, "expand")
+            state = pm.complete_phase(state, "expand")
+            state, nxt = pm.approve_phase(state, "expand")
+            self.assertEqual(nxt, "backfill")
+
+            # backfill -> cutover
+            state = pm.start_phase(state, "backfill")
+            state = pm.complete_phase(state, "backfill")
+            state, nxt = pm.approve_phase(state, "backfill")
+            self.assertEqual(nxt, "cutover")
+
+            # cutover REFUSES without confirmation
+            state = pm.start_phase(state, "cutover")
+            state = pm.complete_phase(state, "cutover")
+            with self.assertRaises(ValueError):
+                pm.approve_phase(state, "cutover")
+
+            # cutover advances WITH confirmation
+            state, nxt = pm.approve_phase(
+                state, "cutover",
+                confirmed_by="release-eng-lead",
+                confirmation_evidence="rollback-drill-log:staging-2026-05-08",
+            )
+            self.assertEqual(nxt, "contract")
+
+            # contract -> done
+            state = pm.start_phase(state, "contract")
+            state = pm.complete_phase(state, "contract")
+            state, nxt = pm.approve_phase(state, "contract")
+            self.assertIsNone(nxt)
+            self.assertTrue(pm.is_complete(state))
+
+            # Audit trail: 5 approvals, exactly one with hard_gate=True
+            approvals = state.extras["approvals"]
+            self.assertEqual(len(approvals), 5)
+            hard_gate_approvals = [a for a in approvals
+                                    if a.get("hard_gate")]
+            self.assertEqual(len(hard_gate_approvals), 1)
+            self.assertEqual(hard_gate_approvals[0]["phase"], "cutover")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the doctrinal-vs-enforced critique. The v11 playbooks documented hard gates but the runtime didn't enforce them. This PR mirrors the doctrine in code.

5 hard gates enforced: migrate:cutover, incident:mitigate, review:remediate-or-accept, specify:validate, decide:record. `approve_phase` requires `--confirmed-by` and `--confirmation-evidence` when one is hit; audit row carries `hard_gate=True` plus both fields.

End-to-end integration test (TestEndToEndArchetypeFlow): full migrate lifecycle from create through is_complete, including hard-gate refusal AND advancement.

365/365 tests pass.

🤖