### PR TITLE
feat(v11.1.1): wire v11 archetype events to wicked-bus

### DIFF
--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -45,6 +45,37 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.project",
         "description": "Crew project completed (final phase approved)",
     },
+    # v11.1.1 archetype lifecycle events. The v11.0.0/v11.1.0 phase_manager
+    # rewrote the project state but didn't register any v11 event types,
+    # so emit_event(...) was returning early on Unknown event type.
+    # These four events let v11 archetype-mode projects flow through the
+    # bus exactly the way v6 universal-pipeline projects did, without
+    # the v6 gate ceremony.
+    "wicked.archetype.created": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.archetype",
+        "description": "v11 archetype-mode project created (carries v11_archetype + initial phase_plan)",
+    },
+    "wicked.archetype.advanced": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.archetype",
+        "description": "v11 archetype phase approved + (when present) next phase named",
+    },
+    "wicked.archetype.completed": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.archetype",
+        "description": "v11 archetype final phase approved (project is_complete)",
+    },
+    "wicked.archetype.hard_gate_passed": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.archetype",
+        "description": "v11 archetype hard gate (cutover/mitigate/etc.) passed with confirmed_by + evidence",
+    },
+    "wicked.archetype.classified": {
+        "domain": "wicked-garden",
+        "subdomain": "crew.classify",
+        "description": "v11 prompt classified into work-shape archetype set (LLM or regex tier)",
+    },
     "wicked.project.complexity_scored": {
         "domain": "wicked-garden",
         "subdomain": "crew.scoring",

--- a/scripts/classify/persist.py
+++ b/scripts/classify/persist.py
@@ -118,6 +118,26 @@ def persist(payload: dict) -> dict:
         signals_v11=normalized.get("signals") or {},
         classified_at=_utc_now(),
     )
+
+    # v11.1.1: emit a bus event so the classification is in the audit log.
+    # Fail-open: bus unavailable must not break the persist call.
+    try:
+        from _bus import emit_event  # type: ignore
+        archetypes = normalized.get("archetypes") or []
+        primary = archetypes[0]["name"] if archetypes else "triage"
+        emit_event(
+            "wicked.archetype.classified",
+            {
+                "intent": normalized.get("intent"),
+                "primary_archetype": primary,
+                "archetypes": [a.get("name") for a in archetypes],
+                "tier": "llm",
+            },
+            chain_id=f"classify.{primary}.{state.session_id or 'no-session'}",
+        )
+    except Exception:
+        pass
+
     return normalized
 
 

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -43,6 +43,23 @@ _sm = DomainStore("projects")
 logger = __import__("logging").getLogger("wicked-garden.phase-manager")
 
 
+def _bus_emit_safe(event_type: str, payload: dict, *,
+                   chain_id: Optional[str] = None) -> None:
+    """Fire-and-forget bus emit. Fail-open on every error.
+
+    The phase_manager is the v11 source-of-truth surface for project
+    state transitions. Each transition emits an event for downstream
+    consumers (audit, dashboards, future replay). Bus unavailable
+    must never block the disk write — bus failure is recorded only
+    in emit_stats.
+    """
+    try:
+        from _bus import emit_event  # type: ignore
+        emit_event(event_type, payload, chain_id=chain_id)
+    except Exception:
+        pass  # Bus is optional infrastructure.
+
+
 # ---------------------------------------------------------------------------
 # Naming & resolution
 # ---------------------------------------------------------------------------
@@ -215,6 +232,28 @@ def create_project(
 
     project_dir = get_project_dir(name)
     save_project_state(state)
+
+    # v11.1.1: bus emit for archetype-mode creation. Legacy (no archetype)
+    # projects also emit project.created via the v6 path; archetype-mode
+    # gets its own event so dashboards can distinguish.
+    if archetype_mode:
+        _bus_emit_safe(
+            "wicked.archetype.created",
+            {
+                "project_id": name,
+                "archetype": archetype_mode,
+                "phase_plan": state.phase_plan,
+                "produces": list(state.extras.get("archetype_produces") or []),
+                "hitl": state.extras.get("archetype_hitl"),
+            },
+            chain_id=f"{name}.{archetype_mode}.root",
+        )
+    else:
+        _bus_emit_safe(
+            "wicked.project.created",
+            {"project_id": name},
+            chain_id=f"{name}.root",
+        )
     return state, project_dir
 
 
@@ -339,6 +378,47 @@ def approve_phase(
     if next_phase:
         state.current_phase = next_phase
     save_project_state(state)
+
+    # v11.1.1: emit hard_gate_passed when a hard gate advanced
+    archetype = (state.extras or {}).get("v11_archetype")
+    if archetype and confirmed_by:
+        _bus_emit_safe(
+            "wicked.archetype.hard_gate_passed",
+            {
+                "project_id": state.name,
+                "archetype": archetype,
+                "phase": phase,
+                "confirmed_by": confirmed_by,
+                "confirmation_evidence": confirmation_evidence,
+            },
+            chain_id=f"{state.name}.{archetype}.{phase}.hard-gate",
+        )
+
+    # v11.1.1: emit advance event for any archetype-mode approval
+    if archetype:
+        _bus_emit_safe(
+            "wicked.archetype.advanced",
+            {
+                "project_id": state.name,
+                "archetype": archetype,
+                "phase": phase,
+                "next_phase": next_phase,
+            },
+            chain_id=f"{state.name}.{archetype}.{phase}",
+        )
+
+    # v11.1.1: emit completed event when project is_complete after this approval
+    if archetype and is_complete(state):
+        _bus_emit_safe(
+            "wicked.archetype.completed",
+            {
+                "project_id": state.name,
+                "archetype": archetype,
+                "final_phase": phase,
+            },
+            chain_id=f"{state.name}.{archetype}.completed",
+        )
+
     return state, next_phase
 
 

--- a/tests/crew/test_phase_manager.py
+++ b/tests/crew/test_phase_manager.py
@@ -330,6 +330,114 @@ class TestHardGateEnforcement(unittest.TestCase):
         self.assertNotIn("confirmed_by", approvals[0])
 
 
+class TestBusEmits(unittest.TestCase):
+    """v11.1.1 — phase_manager state transitions emit bus events.
+
+    Each emit goes through _bus_emit_safe which is fail-open. We patch
+    the underlying emit_event to assert the right event types fire with
+    the right payloads, without hitting the actual subprocess.
+    """
+
+    def _state(self, archetype=None):
+        s = pm.ProjectState(
+            name="emit-proj", current_phase="plan",
+            created_at="2026-05-08T00:00:00Z",
+            phase_plan=["plan", "implement", "test", "review"],
+            extras={"v11_archetype": archetype} if archetype else {},
+        )
+        return s
+
+    def test_create_archetype_emits_archetype_created(self):
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.create_project("emit-proj", archetype_mode="build")
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        self.assertIn("wicked.archetype.created", events)
+
+    def test_create_legacy_emits_project_created(self):
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.create_project("emit-proj-legacy")
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        self.assertIn("wicked.project.created", events)
+        self.assertNotIn("wicked.archetype.created", events)
+
+    def test_approve_emits_archetype_advanced(self):
+        state = self._state(archetype="build")
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.approve_phase(state, "plan")
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        self.assertIn("wicked.archetype.advanced", events)
+        # Payload contains archetype + phase + next_phase
+        advance_call = next(
+            c for c in mock_emit.call_args_list
+            if c.args[0] == "wicked.archetype.advanced"
+        )
+        self.assertEqual(advance_call.args[1]["archetype"], "build")
+        self.assertEqual(advance_call.args[1]["phase"], "plan")
+        self.assertEqual(advance_call.args[1]["next_phase"], "implement")
+
+    def test_approve_legacy_does_not_emit_archetype_events(self):
+        # No v11_archetype on the state → no archetype.* events
+        state = self._state(archetype=None)
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.approve_phase(state, "plan")
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        for ev in events:
+            self.assertFalse(
+                ev.startswith("wicked.archetype."),
+                f"legacy approve emitted archetype event: {ev}",
+            )
+
+    def test_hard_gate_pass_emits_dedicated_event(self):
+        state = pm.ProjectState(
+            name="emit-mig", current_phase="cutover",
+            created_at="2026-05-08T00:00:00Z",
+            phase_plan=["plan", "expand", "backfill", "cutover", "contract"],
+            extras={"v11_archetype": "migrate"},
+        )
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.approve_phase(
+                state, "cutover",
+                confirmed_by="oncall-mike",
+                confirmation_evidence="rollback-drill:staging",
+            )
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        self.assertIn("wicked.archetype.hard_gate_passed", events)
+        self.assertIn("wicked.archetype.advanced", events)
+        # hard_gate_passed payload carries confirmed_by + evidence
+        hg_call = next(
+            c for c in mock_emit.call_args_list
+            if c.args[0] == "wicked.archetype.hard_gate_passed"
+        )
+        self.assertEqual(hg_call.args[1]["confirmed_by"], "oncall-mike")
+        self.assertEqual(hg_call.args[1]["confirmation_evidence"],
+                         "rollback-drill:staging")
+
+    def test_completion_emits_archetype_completed(self):
+        # Build state: pre-mark plan/implement/test approved so review
+        # is the last remaining phase.
+        state = pm.ProjectState(
+            name="emit-final", current_phase="review",
+            created_at="2026-05-08T00:00:00Z",
+            phase_plan=["plan", "implement", "test", "review"],
+            phases={
+                "plan": pm.PhaseState(status="approved"),
+                "implement": pm.PhaseState(status="approved"),
+                "test": pm.PhaseState(status="approved"),
+            },
+            extras={"v11_archetype": "build"},
+        )
+        with patch.object(pm, "save_project_state"), \
+             patch.object(pm, "_bus_emit_safe") as mock_emit:
+            pm.approve_phase(state, "review")
+        events = [c.args[0] for c in mock_emit.call_args_list]
+        self.assertIn("wicked.archetype.completed", events)
+
+
 class TestEndToEndArchetypeFlow(unittest.TestCase):
     """Integration test: full archetype flow from creation through final
     approval, exercising:


### PR DESCRIPTION
**Found and fixed**: v11.0.0/v11.1.0 `phase_manager` rewrote project state without registering any v11 event types in `BUS_EVENT_MAP`. `emit_event()` was returning early on "Unknown event type" for every v11 operation. The plugin was structurally healthy but invisible to the bus.

5 new event types: `wicked.archetype.{created,advanced,completed,hard_gate_passed,classified}`. Emit sites in `phase_manager.create_project`, `phase_manager.approve_phase` (3 conditional emits), and `scripts/classify/persist.py`.

Real bus round-trip verified: creating + approving advances `newest_event_id` by 3 (1 created + 2 advanced) with per-type counters incrementing.

390/390 tests pass.

🤖