### PR TITLE
release: v11.1.2 — marketplace.json version sync + drift detector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "8.8.1"
+      "version": "11.1.2"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "11.1.1",
+  "version": "11.1.2",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ dial) that was replaced wholesale.
 
 ---
 
+## [11.1.2] — 2026-05-08
+
+**marketplace.json plugin version sync.**
+
+The marketplace registration's `plugins[0].version` field had drifted —
+stuck at `8.8.1` across the three v11 releases (`v11.0.0`, `v11.1.0`,
+`v11.1.1`) because nobody bumped it. The plugin manifest reported
+`11.1.1`; the marketplace listing reported `8.8.1`. Anyone consulting
+the marketplace registration saw a stale number.
+
+### Fixed
+
+- `.claude-plugin/marketplace.json` `plugins[0].version` bumped to
+  `11.1.2` to match `.claude-plugin/plugin.json`.
+
+### Added
+
+- `scripts/ci/validate.py` now enforces the version-parity invariant.
+  When `plugin.json` and `marketplace.json` disagree on the plugin's
+  version, validation fails with a named error: *"marketplace.json
+  plugins[name=X].version = '8.8.1' does not match plugin.json version
+  = '11.1.1'. Bump both together."* This catches the same drift class
+  on the next release attempt rather than the release after.
+
+No behavior change beyond the version bump and the validator addition.
+Tests still 390/390 passing.
+
+---
+
 ## [11.1.1] — 2026-05-08
 
 **Closes the wicked-brain + wicked-bus persistence verification gap.**

--- a/scripts/ci/validate.py
+++ b/scripts/ci/validate.py
@@ -31,6 +31,7 @@ def main():
 
     # --- 1. plugin.json validity ---
     plugin_json = root / ".claude-plugin" / "plugin.json"
+    plugin_version = None
     if not plugin_json.exists():
         errors.append("Missing .claude-plugin/plugin.json")
     else:
@@ -39,13 +40,36 @@ def main():
             for field in ("name", "version", "description"):
                 if field not in plugin:
                     errors.append(f"plugin.json missing required field: {field}")
-            version = plugin.get("version", "")
+            plugin_version = plugin.get("version", "")
             # Allow semver core X.Y.Z plus optional pre-release (-alpha.N, -beta.N, -rc.N)
             # per semver.org; v6 ships as 6.0.0-beta.1.
-            if not re.match(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$", version):
-                errors.append(f"plugin.json version is not semver: {version}")
+            if not re.match(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$", plugin_version):
+                errors.append(f"plugin.json version is not semver: {plugin_version}")
         except json.JSONDecodeError as e:
             errors.append(f"plugin.json is invalid JSON: {e}")
+
+    # --- 1b. marketplace.json must agree with plugin.json on plugin version ---
+    # Drift caught at v11.1.1: plugins[0].version was stuck at 8.8.1 across
+    # 3 v11 releases because nobody bumped it. The marketplace registration
+    # is the public-facing version; the plugin manifest is the runtime-
+    # facing version; if they diverge, marketplace consumers see a stale
+    # number.
+    marketplace_json = root / ".claude-plugin" / "marketplace.json"
+    if marketplace_json.exists() and plugin_version:
+        try:
+            mkt = json.loads(marketplace_json.read_text())
+            for entry in mkt.get("plugins") or []:
+                if entry.get("name") == plugin.get("name"):
+                    mkt_version = entry.get("version")
+                    if mkt_version != plugin_version:
+                        errors.append(
+                            f"marketplace.json plugins[name={entry['name']}].version "
+                            f"= {mkt_version!r} does not match plugin.json version "
+                            f"= {plugin_version!r}. Bump both together."
+                        )
+                    break
+        except json.JSONDecodeError as e:
+            errors.append(f"marketplace.json is invalid JSON: {e}")
 
     # --- 2. SKILL.md line counts ---
     for skill_md in sorted(root.glob("skills/**/SKILL.md")):


### PR DESCRIPTION
**Caught**: marketplace.json plugins[0].version was stuck at 8.8.1 across all three v11 releases. plugin.json said 11.1.1, marketplace said 8.8.1.

**Fixed**: both bumped to 11.1.2; validator now enforces parity so this drift class can't recur silently.

390/390 tests still pass. No runtime behavior change.

🤖