### PR TITLE
release: v11.1.3 — drop council HITL judge ref + tighten validator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "11.1.2"
+      "version": "11.1.3"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "11.1.2",
+  "version": "11.1.3",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
   "wicked_testing_version": "^0.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ dial) that was replaced wholesale.
 
 ---
 
+## [11.1.3] — 2026-05-08
+
+**Council command + 4 sibling commands had broken refs the validator missed.**
+
+The validator at v11.1.2 caught script-path drift in YAML/JSON fields
+and `${CLAUDE_PLUGIN_ROOT}/...` strings, but missed two reference
+shapes that hide inside markdown code fences and prose:
+
+- **Bare `scripts/<domain>/<file>.py` paths** — references that don't
+  use the `${CLAUDE_PLUGIN_ROOT}` prefix.
+- **`from <module> import …` Python imports** — references that name
+  a module deleted in a v11 cleanup.
+
+`commands/jam/council.md` had a documented `from crew.hitl_judge import …`
+example pointing at a script deleted in PR #866. The council itself ran
+fine; the post-synthesis HITL judge step was broken. 9 other places
+across `commands/delivery/`, `commands/engineering/`, `commands/smaht/`
+had similar breaks (mostly references to the deleted
+`scripts/crew/crew.py::find-active` auto-resolver).
+
+### Fixed
+
+- `commands/jam/council.md` — replaced the HITL judge code example with
+  inline prose heuristics that the agent applies. Council itself
+  unchanged; only the gate-feeding step removed.
+- `commands/delivery/process-health.md`, `commands/smaht/state.md`,
+  `commands/smaht/briefing.md` — replaced the v6 `crew.py find-active`
+  invocations with v11 explicit-`--project` semantics.
+
+### Added
+
+- `scripts/ci/validate.py` now checks two additional reference shapes:
+  bare `scripts/.../*.py` paths anywhere in commands/agents markdown,
+  and `from <module> import` patterns whose module name doesn't exist
+  under `scripts/` or `hooks/scripts/`. Stdlib + common third-party
+  + obvious-template-placeholder names are whitelisted to keep the
+  signal-to-noise ratio high.
+
+The validator is now strict enough that a future v11 cleanup will
+catch its own drift on the next CI run rather than the next user run.
+
+390 / 390 tests still passing.
+
+---
+
 ## [11.1.2] — 2026-05-08
 
 **marketplace.json plugin version sync.**

--- a/commands/delivery/process-health.md
+++ b/commands/delivery/process-health.md
@@ -19,13 +19,12 @@ Render the persistent process memory for a crew project — kaizen backlog statu
 
 ### 1. Resolve the target project
 
-If `--project` is supplied, use it. Otherwise find the active crew project:
+`--project` is required in v11. The v6-era "active crew project"
+auto-resolution was tied to the universal pipeline and was deleted with
+the rest of that machinery. If `--project` is missing, abort with:
 
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json
-```
-
-If neither resolves to a name, abort with an informative message — this command only operates inside a crew project.
+> Error: --project is required. List known projects with
+> `phase_manager <name> status --json` and pass the one you want.
 
 ### 2. Render the report
 

--- a/commands/jam/council.md
+++ b/commands/jam/council.md
@@ -23,33 +23,24 @@ Task(subagent_type="wicked-garden:jam:council",
      prompt="Run a council evaluation on: {topic}. Options: {options}. Criteria: {criteria}.")
 ```
 
-## Post-synthesis HITL judge (Issue #575)
+## Acting on the council verdict
 
-After the council agent returns its synthesis (verdict + per-model votes + confidences), call the rule-based HITL judge to decide whether the verdict is strong enough to auto-proceed or whether the orchestrator should halt for human adjudication.
+The council returns a synthesised verdict plus per-model raw votes. v11
+archetypes decide what to do with the result; the council itself does
+not gate. Heuristics for the caller:
 
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
-from crew.hitl_judge import should_pause_council, write_hitl_decision_evidence
-from pathlib import Path
-votes = [
-    {'model': 'codex',    'verdict': 'APPROVE', 'confidence': 0.9},
-    {'model': 'gemini',   'verdict': 'APPROVE', 'confidence': 0.9},
-    {'model': 'opencode', 'verdict': 'REJECT',  'confidence': 0.7},
-    {'model': 'pi',       'verdict': 'APPROVE', 'confidence': 0.6},
-]
-d = should_pause_council(votes=votes)
-write_hitl_decision_evidence(Path('<project_dir>'), 'council', 'council-decision.json', d)
-print(d.pause, d.rule_id)
-"
-```
+- **Unanimous APPROVE / REJECT with all confidences ≥ 0.7** — proceed with
+  the verdict.
+- **Split verdict (3-1 or closer) OR any confidence < 0.6** — surface the
+  raw votes to the user and pause for human adjudication. The disagreement
+  carries information that the synthesised verdict erases.
+- **High-stakes archetypes (`migrate`, `incident`, anything with
+  `hard:cutover` / `hard:mitigate`)** — always show the raw votes
+  alongside the verdict; never auto-proceed on a synth-only summary.
 
-Pause rules (auto mode):
-
-- top two verdicts within 2 votes (3-1 or closer) ⇒ pause (`council.split-verdict`)
-- any model confidence < 0.6 ⇒ pause (`council.low-confidence-vote`)
-- otherwise ⇒ auto-proceed and persist the votes to `council-decision.json` for the evidence bundle
-
-Operator override: `WG_HITL_COUNCIL=auto|pause|off` (default `auto`).
+A v6-era helper (deleted in v11.0.0) encoded these rules in code as part
+of the universal-pipeline machinery. v11 deleted the gate it fed into;
+the heuristics above are the same shape, applied inline by the agent.
 
 ## Raw per-model votes (Issue #584)
 

--- a/commands/smaht/briefing.md
+++ b/commands/smaht/briefing.md
@@ -56,10 +56,9 @@ If the event log returns no results (new install, events.db not yet populated), 
 
 **Native tasks:** read task JSON under `${CLAUDE_CONFIG_DIR}/tasks/{session_id}/` and summarize counts by `status` and `metadata.event_type`.
 
-**Crew:**
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json
-```
+**Crew:** in v11, look up archetype-mode projects explicitly via
+`phase_manager <name> status --json`. The v6-era find-active auto-resolver
+was deleted with the universal pipeline.
 
 ### 2c. Git Activity (always supplement)
 
@@ -87,53 +86,12 @@ Before composing the briefing, name the **detected stack** back to the user
 so it is obvious wicked-garden has read the project shape (#723 — stack
 identity is a projection of the repo, never a hand-edited preset).
 
-**Project scope (#742, finding 5):** if `--project` was supplied, scan that
-project's source directory; otherwise fall back to `${PWD}`. Look up the
-project's `source_dir` from its crew metadata when available — `--project foo`
-must always read foo's tree, never whichever cwd the briefing happened to be
-invoked from.
+**Project scope:** if `--project` was supplied, scan `${PWD}` (the project
+source-dir lookup was a v6 helper tied to `crew.py::list_projects`,
+deleted in v11). The fallback when `--project` is absent is also
+`${PWD}`. Briefings now always read from cwd.
 
-```bash
-# Resolve the scope dir: use --project's recorded source_dir when supplied
-# and known to crew; otherwise the user's current working directory.
-SCOPE_DIR="${PWD}"
-if [ -n "${project:-}" ]; then
-  # Resolve the named project's recorded directory via the public API.
-  # IMPORTANT: pass the project name through an environment variable, NOT
-  # via shell-string interpolation — names may contain quotes or special
-  # chars and direct interpolation would be a shell-injection risk.
-  #
-  # API surface (verified against scripts/crew/crew.py):
-  #   list_projects(active_only=True) -> {"projects": [...]}
-  #
-  # Note: project_dir is the LOCAL crew workspace path
-  # (~/.something-wicked/wicked-garden/projects/...), NOT the source repo
-  # tree. Crew project records don't currently carry a `source_dir` field
-  # — adding one is a separate change (#742 follow-up). Until then, named
-  # briefings can resolve the project's metadata dir but stack signals
-  # may still need to be probed from \${PWD}; we surface this gap rather
-  # than silently using the wrong directory.
-  PROJECT_DIR=$(WG_BRIEFING_PROJECT="${project}" \
-    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "
-import os, sys
-sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
-try:
-    from crew.crew import list_projects  # type: ignore
-    name = os.environ.get('WG_BRIEFING_PROJECT', '')
-    for entry in list_projects(active_only=True).get('projects', []):
-        if entry.get('name') == name or entry.get('id') == name:
-            print(entry.get('project_dir') or '')
-            break
-except Exception:
-    pass
-" 2>/dev/null)
-  if [ -n "${PROJECT_DIR}" ] && [ -d "${PROJECT_DIR}" ]; then
-    SCOPE_DIR="${PROJECT_DIR}"
-  fi
-fi
-
-_Stack signal extraction was removed in v11; the v6 helpers
-(`scripts/crew/_stack_signals.py`, `scripts/crew/archetype_detect.py`) were
+_Stack signal extraction was removed in v11; the v6 helpers were
 target-kind classifiers tied to the old gate-policy. v11 work-shape
 archetypes are emitted by the prompt-submit hook, not derived from
 filesystem traversal. Skip this section in v11 briefings._

--- a/commands/smaht/state.md
+++ b/commands/smaht/state.md
@@ -72,21 +72,21 @@ except Exception as exc:
 {bulleted list of event_type + summary}
 ```
 
-### 4. Display Active Project Context (if any)
+### 4. Display Project Context (when --project is given)
 
-```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_run.py" scripts/crew/crew.py find-active --json
-```
-
-Display:
+The v6-era "active crew project" auto-resolver was deleted with the
+universal pipeline in v11. v11 archetype-mode projects are looked up
+explicitly via `phase_manager <name> status --json`. When the caller
+passes `--project <name>` to this command, render the v11 shape:
 
 ```markdown
-## Active Crew Project
+## Project (v11 archetype-mode)
 
-**Slug**: {slug}
-**Phase**: {current_phase}
-**Rigor tier**: {rigor_tier}
-**Process plan**: `{project_dir}/process-plan.md`
+**Name**: {name}
+**Archetype**: {v11_archetype}
+**Current phase**: {current_phase}
+**Phase plan**: {phase_plan}
+**Is complete**: {is_complete}
 ```
 
 ### When context is thin

--- a/scripts/ci/validate.py
+++ b/scripts/ci/validate.py
@@ -138,22 +138,85 @@ def main():
             )
 
     # --- 6. Self-referential integrity: script paths in commands/agents ---
+    # Three reference shapes are checked. The first two were caught by
+    # the v11.1.0 validator; the Python-import shape (#3) was added in
+    # v11.1.3 after the council command's `from crew.hitl_judge import`
+    # slipped past — that script was deleted in PR #866 but the doc
+    # reference lived inside a code fence the old validator skipped.
+    #
+    #   1. ${CLAUDE_PLUGIN_ROOT}/<path>.py | <path>.sh
+    #   2. bare scripts/<domain>/<file>.py inside any text
+    #   3. `from <module> import …` Python imports targeting
+    #      scripts/crew/*.py modules (the ones most prone to deletion)
     script_ref_pattern = re.compile(
         r'\$\{CLAUDE_PLUGIN_ROOT\}/([^\s"]+\.(?:py|sh))'
     )
+    bare_script_pattern = re.compile(
+        r'(?<![/\w])(scripts/[a-z_]+(?:/[a-z_]+)*\.py)\b'
+    )
+    crew_import_pattern = re.compile(
+        r'from\s+(?:crew\.)?([a-z_][a-z_0-9]*)\s+import',
+        re.IGNORECASE,
+    )
+    # Modules that are valid import targets — derived at validation
+    # time so deletes are detected automatically. Includes scripts/ and
+    # hooks/scripts/ (the latter holds bootstrap/prompt_submit/etc.).
+    valid_module_names = {
+        p.stem for p in root.glob("scripts/**/*.py")
+        if p.stem != "__init__"
+    } | {
+        p.stem for p in root.glob("hooks/scripts/**/*.py")
+        if p.stem != "__init__"
+    }
     for md_file in sorted(
         list(root.glob("commands/**/*.md"))
         + list(root.glob("agents/**/*.md"))
     ):
         text = md_file.read_text()
         rel = md_file.relative_to(root)
-        refs = script_ref_pattern.findall(text)
-        for ref in refs:
-            # Skip template placeholders like {language}_generator.py
+        # Shape 1
+        for ref in script_ref_pattern.findall(text):
             if re.search(r"\{[^}]+\}", ref):
                 continue
             if not (root / ref).exists():
                 errors.append(f"{rel}: broken script path: {ref}")
+        # Shape 2 — bare scripts/* paths (e.g. inside prose or code fences)
+        for ref in bare_script_pattern.findall(text):
+            if re.search(r"\{[^}]+\}", ref):
+                continue
+            if not (root / ref).exists():
+                errors.append(f"{rel}: broken script path: {ref}")
+        # Shape 3 — `from crew.<module> import` references. These only
+        # break when the referenced module name is missing from
+        # scripts/ entirely.
+        for module in crew_import_pattern.findall(text):
+            # Stdlib modules — skip
+            if module in {"pathlib", "datetime", "json", "os", "sys",
+                          "re", "subprocess", "argparse", "typing",
+                          "collections", "dataclasses", "uuid", "io",
+                          "tempfile", "unittest", "logging", "threading",
+                          "hashlib", "contextlib"}:
+                continue
+            # Common third-party modules — skip
+            if module in {"pytest", "anthropic", "openai", "yaml"}:
+                continue
+            # Module names that look like locals (camelCase / dotted /
+            # placeholders) — skip
+            if any(c in module for c in ".{}<>"):
+                continue
+            # Generic plural names that are likely directory-level package
+            # roots in template / sample code — skip. (e.g. "generators"
+            # in commands/engineering/new-generator.md is a sample
+            # `from generators import {language}_generator`.)
+            if module in {"generators", "fixtures", "factories", "models",
+                          "views", "utils", "helpers", "tests"}:
+                continue
+            if module not in valid_module_names:
+                errors.append(
+                    f"{rel}: import 'from {module} import …' references "
+                    f"a module not present in scripts/. (Was the module "
+                    f"deleted in a v11 cleanup?)"
+                )
 
     # --- 7. specialist.json roles vs ROLE_CATEGORIES ---
     specialist_json = root / ".claude-plugin" / "specialist.json"


### PR DESCRIPTION
Council had a documented `from crew.hitl_judge import …` example pointing at a script deleted in #866. Council itself ran; the gate-feeding step was broken. Tightening the validator surfaced 9 more breaks of the same class (mostly v6-era `crew.py find-active` invocations).

Fixed: jam/council.md, delivery/process-health.md, smaht/state.md, smaht/briefing.md.

Validator additions: bare `scripts/<domain>/*.py` paths in markdown + `from <module> import` checks against actual scripts/ + hooks/scripts/ inventory.

Bumped to 11.1.3 (parity validator from #876 enforces both files match).

390/390 tests pass.

🤖