### PR TITLE
feat: vault-backed gates for all archetypes + the compiler emit stage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "name": "wicked-garden",
   "version": "11.1.3",
-  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
+  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
   "wicked_testing_version": "^0.3.0",
+  "wicked_vault_version": "^0.3.0",
   "author": {
     "name": "Mike Parcewski"
   },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -108,6 +108,10 @@ wicked-garden/
 
 Each archetype's playbook documents what *should* happen, not what gets blocked. HITL discipline ranges from `none` (triage) through `continuous` (explore) and `discrete:*` gates to `hard:*` gates (mitigate, cutover, final-verdict). Hard gates require explicit user approval; discrete gates may auto-pass when the produces contract is met. Nothing else gates.
 
+### Evidence is re-derived, not asserted
+
+A produces-gate does not pass because an agent claimed "done". It re-derives through **wicked-vault** (a required peer; on npm, `>= 0.3`): the gate runs `scripts/qe/vault_gate.py` → `wicked-vault cross-check`, which re-hashes the recorded evidence and **re-runs its verifier**, never trusting a cached status. A claimed-but-false "tests pass" is REJECTED; a missing vault **fails closed** (`gate: "unavailable"`), never a vacuous pass. Hard gates (review/incident/migrate) additionally require an *independent* attestation — the evaluator is not the agent that did the work (`--with-attestations`). So when building/migrating/etc., **record verifiable evidence** (`wicked-vault record … --run`); don't self-assert completion. The vault is resolved at runtime (`WICKED_VAULT_BIN` → config → PATH → `node_modules/.bin` → `npx`); `WICKED_VAULT_BIN=""` is the kill-switch.
+
 ### Per-archetype, not per-phase
 
 There is no universal pipeline. A `migrate` doesn't have a `clarify` phase; a `build` doesn't have a `cutover` phase. Phase names mean different things inside different archetypes. Don't try to factor common phases — that's how the v6 universal pipeline emerged, and it forced every kind of work into the same shape.
@@ -149,6 +153,12 @@ Skills use **progressive disclosure**:
 Valid events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `TaskCompleted`, `SubagentStart`, `SubagentStop`, `Stop`, `PreCompact`, `Notification`, `PermissionRequest`, `TeammateIdle`, `SessionEnd`.
 
 Prefer `command` hooks over `prompt`/`agent` (deterministic, testable, no token cost). Use `"async": true` for Stop hooks. Return `{"ok": true}` on success, `{"ok": false, "reason": "..."}` to block. Stdlib-only for Python hook scripts.
+
+## Evidence backend + compiler
+
+**The gate (`scripts/qe/vault_gate.py`)** — resolves the wicked-vault CLI and runs `cross-check` for an archetype's produces. `gate_satisfied()` is the front door (`require=True` default → fail-closed when the vault is absent; `--no-require` opts back to the doctrine-light `evidence_tracker` claim-only path). This *replaced* `evidence_tracker.py`'s satisfied-when-claimed model as the gate; the tracker remains the fallback/bookkeeping.
+
+**The compiler (`scripts/compiler/`)** — emits a self-contained, vault-backed gate into *any* repo. `compile.py` builds on `phase0/detect.py` (binding detector: test/lint/build commands, ecosystem, claims docs, risk surfaces) → derives a multi-claim contract → writes `<repo>/.wicked/{contract.json, gate.py, claims_lint.py, README, bindings.json}` and can install triggers (git pre-push hook + GitHub Actions). The emitted `gate.py` is **stdlib-only, imports nothing from the garden** (AST-enforced in tests), and resolves the vault via `npx` — it runs with no wicked-garden present. Surface: `/wicked-garden:compile <repo> [--trigger hook,ci]` (`commands/compile.md`). The on-switch rule: **compile the trigger + enforcement; never the tool** — the vault is a runtime-resolved utility. Tests: `tests/compiler/test_compile.py`.
 
 ## Storage
 

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ _meta/
 # Gate 1 facilitator measurement artifact (narrow exception to *.log rule)
 !scripts/ci/facilitator_outputs/_measurement.log
 .hypothesis/
+
+# wicked-garden compiler: transient probe transcripts (regenerable)
+scripts/compiler/phase0/evidence/
+scripts/compiler/**/__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 - Get the current date and time from the system — your internal notion is unreliable.
 - Always use subagents. You are an orchestrator, even for synthesizing subagent results, reading files, etc. — this stops context bloat.
 
+## Evidence & gates
+
+- Never self-assert "done". Gating archetypes re-derive their produces through wicked-vault (`scripts/qe/vault_gate.py` → `wicked-vault cross-check`) and REJECT unbacked claims — fail-closed if the vault is absent.
+- Record verifiable evidence as you work (`wicked-vault record ... --run`), not after. The gate re-hashes and re-runs the verifier; a claim with no recorded evidence does not pass.
+- Hard gates (review / incident / migrate) also require an INDEPENDENT attestation — the evaluator must not be the worker.
+- To carry this gate into any repo, run `/wicked-garden:compile <repo> [--trigger hook,ci]` — it emits a self-contained, vault-backed build gate into that repo's `.wicked/` that runs with no wicked-garden runtime present.
+
 ## Specialist Routing (v6)
 
 wicked-garden ships 63 specialist agents across 13 domains. The facilitator skill (`skills/propose-process/`) discovers them at runtime by reading `agents/**/*.md` frontmatter — every agent declares `subagent_type: wicked-garden:{domain}:{name}` for Task-tool dispatch. There is no static `enhances` map. To add a specialist, drop a markdown file with the right frontmatter and it becomes routable next session.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,45 @@ will still fail if the package is absent).
 This escape hatch is a developer override. It does NOT appear in user-facing help,
 setup wizard output, or the README. It is not a supported production configuration.
 
+### WICKED_VAULT_BIN
+
+**For offline CI and dev environments without the wicked-vault peer only.**
+
+wicked-vault (npm, ≥0.3, install `npx wicked-vault-install`) is a required peer
+alongside wicked-bus/brain/testing. The garden's produces-gates re-derive evidence
+through it (`scripts/qe/vault_gate.py` → `wicked-vault cross-check`). The CLI is
+resolved in order:
+
+1. `WICKED_VAULT_BIN` env var
+2. a config preference
+3. a global `wicked-vault` on `PATH`
+4. a local `node_modules/.bin/wicked-vault`
+5. `npx --yes wicked-vault`
+
+Setting `WICKED_VAULT_BIN=""` (set-but-empty) is the vault analogue of
+`WG_SKIP_WICKED_TESTING_CHECK`:
+
+```bash
+export WICKED_VAULT_BIN=""
+```
+
+Effect:
+- Vault resolution is disabled entirely — none of the fallbacks above are tried.
+- The produces-gate fails closed (or, with `--no-require`, falls back to the
+  doctrine-light claim-only path).
+- A SessionStart bootstrap check warns (non-blocking) when the vault isn't
+  resolvable.
+
+**When to use**: CI pipelines or local sessions where the wicked-vault peer is
+unavailable and you accept gates failing closed (or running claim-only).
+
+**When NOT to use**: Production environments, or any session where produces-gates
+must actually re-derive evidence — disabling resolution means there is no vault to
+cross-check against.
+
+This escape hatch is a developer override. It does NOT appear in user-facing help,
+setup wizard output, or the README. It is not a supported production configuration.
+
 ### Fail-open boundary
 
 The wicked-testing probe (`_wicked_testing_probe.probe()`) is called by

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Each archetype's playbook documents its phases, what it produces, where the huma
 
 ## Why it works
 
-**Steering, not blocking.** Each archetype's playbook tells you what *should* happen. Hard gates exist where they matter (mitigate during an incident, cutover during a migration, final-verdict during review). Everything else is a discrete or continuous gate that auto-passes when the produces contract is met.
+**Steering, not blocking.** Each archetype's playbook tells you what *should* happen. Hard gates exist where they matter (mitigate during an incident, cutover during a migration, final-verdict during review). Everything else is a discrete or continuous gate that auto-passes when the produces contract is met — and "met" is *re-derived*, never self-asserted (see below).
 
 **Per-archetype, not per-phase.** A `migrate` doesn't have a `clarify` phase; a `build` doesn't have a `cutover` phase. Phase names mean different things inside different archetypes. We don't try to factor common phases — that's how the v6 universal pipeline emerged, and it forced every kind of work into the same shape.
 
@@ -77,11 +77,15 @@ Each archetype's playbook documents its phases, what it produces, where the huma
 
 **The bus carries the audit trail.** Every meaningful event flows through [wicked-bus](https://github.com/mikeparcewski/wicked-bus). The v6–v10 "bus-as-truth" enforcement (signed dispatches, projection resolvers per event type) is gone; the bus is now an audit substrate, not a gate enforcement mechanism. Archetypes own their own discipline.
 
+**Evidence is re-derived, not asserted.** A produces-gate doesn't go green because an agent said "done." It re-derives through [wicked-vault](https://www.npmjs.com/package/wicked-vault) — the evidence is re-hashed and its verifier re-run, never trusting a cached status. A claimed-but-false "tests pass" is **REJECTED**; a missing vault **fails closed** rather than passing on a self-assertion. Hard gates (review, incident, migrate) additionally require an *independent* judgment — the evaluator is not the agent that did the work. This is what makes "auto-passes when the produces contract is met" trustworthy: *met* means re-derived.
+
 ---
 
 ## What's in the box
 
 - **9 work-shape archetypes** with playbooks, slash commands, and a detector.
+- **Vault-backed gates** — every gating archetype re-derives its produces through [wicked-vault](https://www.npmjs.com/package/wicked-vault) (required), fail-closed. "Done" can't be asserted into truth.
+- **The compiler** (`/wicked-garden:compile`) — detect a repo's test/lint/build commands and emit a self-contained, vault-backed build gate into `<repo>/.wicked/`. It runs with **no wicked-garden runtime present** (resolves the vault via `npx`), and can install the triggers that fire it (pre-push hook / GitHub Actions).
 - **Hooks** for prompt classification, tool tracking, session lifecycle.
 - **Domain skills + agents** across engineering, platform, product, data, jam, search, agentic, persona, and delivery — invoked by archetypes when their work needs domain expertise.
 - **wicked-brain integration** for persistent memory across sessions.
@@ -95,8 +99,14 @@ Each archetype's playbook documents its phases, what it produces, where the huma
 # In Claude Code
 /plugin install wicked-garden
 
-# First time setup
+# First time setup (verifies the required peers below)
 /wicked-garden:setup
+```
+
+Required peers (`/wicked-garden:setup` checks these and blocks without them):
+```bash
+npx wicked-testing install     # evidence-gated acceptance testing (≥ 0.3)
+npx wicked-vault-install       # the honest-evidence backend gates re-derive against (≥ 0.3)
 ```
 
 Recommended companions:
@@ -123,6 +133,12 @@ Recommended companions:
 
 Each command loads `skills/archetype/refs/{archetype}.md` and runs the per-archetype phase shape.
 
+```bash
+# Compile a self-contained, vault-backed gate into ANY repo
+# (the emitted gate runs with no wicked-garden runtime present)
+/wicked-garden:compile ~/path/to/repo --trigger ci
+```
+
 ---
 
 ## Principles
@@ -147,7 +163,9 @@ Each command loads `skills/archetype/refs/{archetype}.md` and runs the per-arche
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) ≥ 1.0
 - Python 3.9+ (stdlib only for hook scripts)
-- Optional: `wicked-brain`, `wicked-bus`, `wicked-testing` plugins
+- Node.js + `npx` — required by `wicked-vault` (the evidence backend) and `wicked-testing`
+- **Required peers:** `wicked-testing` (≥ 0.3) and `wicked-vault` (≥ 0.3, the backend gates re-derive against). `/wicked-garden:setup` verifies both and blocks without them.
+- Optional: `wicked-brain` (session memory + search), `wicked-bus` (audit trail)
 
 ---
 

--- a/commands/compile.md
+++ b/commands/compile.md
@@ -1,0 +1,33 @@
+---
+allowed-tools: ["Bash", "Read"]
+description: "Compile a repo-native build gate — detect bindings, emit a vault-backed harness"
+argument-hint: "[repo-path] [--trigger hook,ci]"
+phase_relevance: ["bootstrap", "build"]
+archetype_relevance: ["build", "migrate"]
+---
+
+# /wicked-garden:compile
+
+Emit a **self-contained, vault-backed build gate** into a target repo. Detects
+the repo's test/lint/build commands and writes `<repo>/.wicked/` (contract +
+`gate.py` + README). The gate re-derives each claim through wicked-vault and
+runs with **no wicked-garden runtime present**. Optionally installs the
+triggers that fire it (pre-push hook / GitHub Actions). The vault is resolved
+at runtime via `npx` — it is the one thing the compiler never compiles.
+
+## Run
+
+Parse `$ARGUMENTS`: first non-flag token is the repo path (default `.`); pass
+`--trigger <value>` through verbatim when present. Then:
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/compiler/compile.py" "<repo-path>" <flags>
+```
+
+Parse the JSON manifest and report, concisely:
+- the emitted **claims** (`tests-pass` / `lint-clean` / `build-clean`) and their commands;
+- if `needs_review: true` — **warn** which bindings were inferred at low confidence and tell the user to confirm/fix `<repo>/.wicked/contract.json`;
+- any installed **triggers** and their status (created / appended / skipped);
+- next step: run `python3 <repo>/.wicked/gate.py` (exit 0 = PASS); note wicked-vault must be resolvable (`npx wicked-vault` or a global install).
+
+Never hand-edit the emitted bindings block — re-run this command after the repo changes shape.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -60,7 +60,16 @@ npx wicked-testing --version 2>/dev/null || echo "MISSING"
 - `MISSING` → blocking. Show "wicked-testing is not installed. wicked-garden v7.0+ requires wicked-testing >= 0.1 as a peer plugin. Upgrading from v6.x? See `docs/MIGRATION-v7.md`." **INTERACTIVE mode**: AskUserQuestion header "wicked-testing Required", options "Install now (Required)" = "Run: npx wicked-testing install" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npx wicked-testing install`, re-probe with `npx wicked-testing --version`, confirm the version. On failure, show stderr and exit with manual instructions. If exit: "Run `npx wicked-testing install` then restart with `/wicked-garden:setup`."
 - Version string (e.g. `0.2.1`) → check it satisfies `^0.2.0` (the pin from `plugin.json`). In range: show "wicked-testing {version} — ready." Out of range: warn "wicked-testing {version} is outside the supported range (^0.2.0). Update with: `npx wicked-testing install`" and ask whether to update now (same INTERACTIVE / PLAIN_TEXT pattern). Updating is strongly recommended but not a hard block — the SessionStart hook will warn each session.
 
-### 2.6 v6→v11 Project State Migration (optional)
+### 2.6 Verify wicked-vault (Required)
+
+```bash
+npx wicked-vault --version 2>/dev/null || echo "MISSING"
+```
+
+- `MISSING` → blocking. wicked-vault is the evidence backend every archetype gate re-derives against — without it, "done" can only be self-asserted. Show "wicked-vault is not installed. wicked-garden requires it as a peer (sibling to wicked-bus / wicked-brain / wicked-testing)." **INTERACTIVE mode**: AskUserQuestion header "wicked-vault Required", options "Install now (Required)" = "Run: npx wicked-vault-install" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npx wicked-vault-install` (installs the cross-CLI skills) and confirm the CLI resolves with `npx wicked-vault --version`. On failure, show stderr and exit with manual instructions (`npm i -g wicked-vault`). If exit: "Run `npx wicked-vault-install` then restart with `/wicked-garden:setup`."
+- Version string (e.g. `0.3.0`) → show "wicked-vault {version} — ready." Then verify the garden can resolve it for gating: `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/qe/vault_gate.py" resolve` should report `resolvable: true`. If `installed: false` (resolving only via npx), suggest `npm i -g wicked-vault` for faster gate latency — recommended, not a hard block.
+
+### 2.7 v6→v11 Project State Migration (optional)
 
 If the user has v6-v10 crew projects on disk, advise them to run the v11 migration script:
 
@@ -203,6 +212,7 @@ wicked-garden is ready!
 
 Storage:         Local (DomainStore)
 wicked-testing:  {version e.g. "0.1.2 — ready" or "MISSING — install required"}
+wicked-vault:    {version e.g. "0.3.0 — ready" or "MISSING — install required"}
 Onboarding:      {Full | Quick scout | Skipped}
 Directories:     {paths onboarded}
 Project type:    {DETECTED_LANGS} / {DETECTED_FWS} (or "Not detected")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,11 +6,24 @@
 claude plugins add mikeparcewski/wicked-garden
 ```
 
-That's it. No configuration, no API keys, no external services required. Everything works locally out of the box.
+No API keys, no external services, no cloud — everything runs locally. Two companion plugins are required (below); like wicked-garden itself, both install locally via npm.
+
+### Required peer plugins
+
+Two companion plugins are **required** — `/wicked-garden:setup` verifies both and blocks until they are present:
+
+```bash
+npx wicked-vault-install      # wicked-vault (≥0.3) — vault-backed evidence
+npx wicked-testing install    # wicked-testing (≥0.3) — evidence-gated testing
+```
+
+### Optional companions
+
+[wicked-brain](https://github.com/mikeparcewski/wicked-brain) (cross-session memory) and [wicked-bus](https://github.com/mikeparcewski/wicked-bus) (event bridge) are optional but recommended — install them when you want those capabilities.
 
 ## Your First Session
 
-After installing, you can use any command immediately. Here are five ways to start:
+After installing, you can use any command immediately. Here are six ways to start:
 
 ### 1. Run a Full Workflow
 
@@ -53,6 +66,14 @@ Not grep — structural code intelligence across 73 languages. Find functions, c
 ```
 
 Plain English to SQL results via DuckDB. Works on CSV, Excel, Parquet — files up to 10GB+. Zero setup.
+
+### 6. Compile a Standalone Build Gate
+
+```bash
+/wicked-garden:compile ./my-service --trigger hook,ci  # emit a vault-backed gate into ./my-service/.wicked/
+```
+
+Detects the repo's test/lint/build commands and emits a self-contained `gate.py` that re-derives the build's claims through wicked-vault — runs with no wicked-garden runtime present (resolves the vault via npx). The `--trigger` flag installs a git pre-push hook and/or GitHub Actions workflow.
 
 ## Common Workflows
 

--- a/docs/v11/archetypes.md
+++ b/docs/v11/archetypes.md
@@ -122,6 +122,27 @@ There is no global `gate-policy.json`. There is no universal banned-
 reviewer list. There is no rigor-tier × gate matrix. Each archetype's
 playbook is the policy.
 
+## What "produces contract met" means now
+
+The gating archetypes (`build`, `specify`, `decide`, `ship`, `review`,
+`incident`, `migrate`) no longer self-assert "done". A produces gate is
+not the agent declaring its own contract satisfied — it is the contract
+**re-derived**. The gate runs `scripts/qe/vault_gate.py`, which calls
+`wicked-vault cross-check`: it re-hashes the recorded evidence and
+**re-runs its verifier** rather than trusting a cached status. A
+claimed-but-false "tests pass" is rejected at the gate; a missing vault
+**fails closed** — there is no vacuous pass. "Met" means re-derived,
+not asserted.
+
+The `hard:*` gates (`review`/final-verdict, `incident`/mitigate,
+`migrate`/cutover) additionally require an **independent judgment** —
+the evaluator is not the agent that did the work, recorded as a
+tamper-evident attestation (`--with-attestations`). Self-graded "done"
+cannot clear a hard gate.
+
+This makes **wicked-vault** a required peer alongside wicked-bus,
+wicked-brain, and wicked-testing — on npm, `>= 0.3`.
+
 ## What replaces propose-process
 
 Nothing, structurally. The `triage` archetype handles classification.

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -634,6 +634,58 @@ def _check_brain_dependency():
 
 
 # ---------------------------------------------------------------------------
+# wicked-vault dependency check (required evidence backend)
+# ---------------------------------------------------------------------------
+
+def _check_vault_dependency():
+    """Return a briefing note if wicked-vault is not resolvable, else None.
+
+    wicked-vault is a required peer (sibling to wicked-bus / wicked-brain /
+    wicked-testing): every archetype produces-gate re-derives against it via
+    ``scripts/qe/vault_gate.py``. When it is absent those gates fail closed,
+    so we surface a one-line install pointer at SessionStart.
+
+    Fast + stdlib-only (no subprocess to npx): checks PATH and loose skill
+    installs only. Always fails open — never blocks the session.
+    """
+    try:
+        import shutil
+
+        # WICKED_VAULT_BIN explicitly set (even empty kill-switch) → operator
+        # is driving resolution deliberately; don't nag.
+        if "WICKED_VAULT_BIN" in os.environ:
+            return None
+
+        if shutil.which("wicked-vault"):
+            return None
+
+        # Loose skill installs land as skills/wicked-vault-*/ under each CLI
+        # config root (npx wicked-vault-install). PATH miss + skills present
+        # still means the CLI runs via npx, so treat skills as "installed".
+        skill_roots = [Path.home() / ".claude" / "skills"]
+        cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+        if cfg:
+            skill_roots.append(Path(cfg) / "skills")
+        for root in skill_roots:
+            try:
+                if root.exists():
+                    for entry in root.iterdir():
+                        if entry.is_dir() and entry.name.startswith("wicked-vault"):
+                            return None
+            except OSError:
+                continue  # fail open
+
+        return (
+            "[wicked-vault] REQUIRED but not installed.\n"
+            "Install now: npx wicked-vault-install  (or: npm i -g wicked-vault)\n"
+            "wicked-vault is the evidence backend every archetype gate "
+            "re-derives against — without it, produces-gates fail closed."
+        )
+    except Exception:
+        return None  # Fail open — never block session start
+
+
+# ---------------------------------------------------------------------------
 # Discovery: contextual command suggestions based on project type (Issue #322)
 # ---------------------------------------------------------------------------
 
@@ -1295,6 +1347,10 @@ def main():
         # CH-02: inject legacy reeval-log migration notice when legacy entries are found.
         if _legacy_reeval_notice:
             mode_notes.append(_legacy_reeval_notice)
+        # Required-peer check: wicked-vault (the evidence backend for gates).
+        _vault_note = _check_vault_dependency()
+        if _vault_note:
+            mode_notes.append(_vault_note)
         if onedrive_path:
             mode_notes.append(
                 f"[Path] OneDrive directory detected. Resolved base: {onedrive_path}. "

--- a/scripts/compiler/compile.py
+++ b/scripts/compiler/compile.py
@@ -44,6 +44,7 @@ from pathlib import Path
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE / "phase0"))
 import detect as _detect  # noqa: E402  (phase0/detect.py — the proven binding detector)
+import emit as _emit      # noqa: E402  (phase0/emit.py — the claims-vs-evidence lint renderer)
 
 # A detected test command below this confidence is emitted but flagged: the
 # harness still works, but a human should confirm the command is right.
@@ -76,6 +77,17 @@ def claim_specs(bindings: dict) -> list[dict]:
                 "claim_id": claim_id, "kind": kind, "command": cmd,
                 "source": b.get("source"), "confidence": b.get("confidence"),
             })
+    # claims_surface: when the repo carries structured `claims:` docs (the
+    # command_iq shape), emit a claims-lint and gate on it too — every
+    # success-claim in the docs must point to backing evidence. The lint is
+    # just another verifiable command; the vault re-derives it like the rest.
+    cs = bindings.get("claims_surface") or {}
+    if cs.get("value") == "frontmatter":
+        specs.append({
+            "claim_id": "claims-backed", "kind": "claims-lint",
+            "command": "python3 .wicked/claims_lint.py",
+            "source": cs.get("source"), "confidence": cs.get("confidence"),
+        })
     return specs
 
 
@@ -251,7 +263,7 @@ claim re-derives.
 ### Claims this gate re-derives
 
 {claims_md}
-{flag_block}
+{flag_block}{risk_block}
 ## Run it
 
 ```bash
@@ -290,6 +302,20 @@ def _claims_md(specs: list[dict]) -> str:
         rows.append(f"- `{s['claim_id']}` → {cmd}  "
                     f"_({s.get('source')}, confidence {s.get('confidence')})_")
     return "\n".join(rows)
+
+
+def _risk_block(bindings: dict) -> str:
+    """Advisory: list detected risk surfaces. Fuzzy binding — informational,
+    not enforced. Changes touching these surfaces warrant a claim."""
+    rs = bindings.get("risk_surfaces") or {}
+    surfaces = rs.get("value") or []
+    if not surfaces:
+        return ""
+    src = rs.get("from", "module structure")
+    listed = ", ".join(f"`{s}`" for s in surfaces[:12])
+    return (f"\n### Risk surfaces (advisory)\n\n"
+            f"Detected from {src}: {listed}. Changes here warrant their own "
+            f"claim + evidence — not yet enforced by this gate.\n")
 
 
 def _flag_block(bindings: dict, specs: list[dict]) -> str:
@@ -337,15 +363,24 @@ def compile_repo(repo_root: str, out_subdir: str = ".wicked") -> dict:
     (out / "bindings.json").write_text(json.dumps(bindings, indent=2))
     (out / "contract.json").write_text(json.dumps(contract, indent=2))
 
+    emitted = ["bindings.json", "contract.json", "gate.py", "README.md"]
+
     gate_claims = [{"claim": s["claim_id"], "kind": s["kind"], "command": s["command"]}
                    for s in specs]
     (out / "gate.py").write_text(_GATE_TEMPLATE.format(
         repo=bindings["repo"], scope=scope, claims=gate_claims,
     ))
 
+    # claims_surface consumer: emit the claims-vs-evidence lint when the repo
+    # has structured claims docs (its `claims-backed` claim runs it).
+    if (bindings.get("claims_surface") or {}).get("value") == "frontmatter":
+        (out / "claims_lint.py").write_text(_emit.render_lint(bindings))
+        emitted.append("claims_lint.py")
+
     (out / "README.md").write_text(_README_TEMPLATE.format(
         repo=bindings["repo"], scope=scope,
         claims_md=_claims_md(specs), flag_block=_flag_block(bindings, specs),
+        risk_block=_risk_block(bindings),
     ))
 
     tc = bindings["test_command"]
@@ -361,7 +396,7 @@ def compile_repo(repo_root: str, out_subdir: str = ".wicked") -> dict:
         "root": str(root),
         "scope": scope,
         "out_dir": str(out),
-        "emitted": ["bindings.json", "contract.json", "gate.py", "README.md"],
+        "emitted": emitted,
         "claims": {s["claim_id"]: s["command"] for s in specs},
         "needs_review": needs_review,
         "bindings": bindings,

--- a/scripts/compiler/compile.py
+++ b/scripts/compiler/compile.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""compile.py — the wicked-garden compiler emit stage.
+
+Phase 0 proved a single repo-agnostic detector can infer a repo's bindings
+(``detect.py``) and that detect→declare-contract→record→cross-check works
+end-to-end (``wire_vault.py``). But ``wire_vault`` is a *probe*: it cleans up
+after itself, leaving the target repo untouched. This is the *emitter*: it
+writes a **persistent, self-contained harness** into the target repo.
+
+The thesis, made concrete:
+
+    wicked-garden = a compiler that emits a small repo-native harness
+                  = compiled bindings + compiled enforcement + a trigger
+                    over a *utility* (wicked-vault) it never compiles.
+
+What gets emitted into ``<repo>/.wicked/``:
+
+  - ``bindings.json``  — the detected bindings (provenance; what we saw).
+  - ``contract.json``  — the vault contract: the repo's real test command,
+                         pinned, as a ``tests-pass`` claim → ``exit_code_eq:0``.
+                         This is the **compiled binding**.
+  - ``gate.py``        — a stdlib-only, dependency-free harness that resolves
+                         the vault via ``npx`` (or ``WICKED_VAULT_BIN``), then
+                         init → declare-contract → record --run → cross-check.
+                         Exit 0 == the build's claims re-derive. This is the
+                         **compiled enforcement** + the **trigger** a CI step or
+                         pre-commit hook invokes. It imports NOTHING from
+                         wicked-garden — the garden compiled it and left.
+  - ``README.md``      — what this is and how to wire it into CI / pre-commit.
+
+The on-switch rule holds: the vault (the *tool*) is resolved at runtime via
+npx and is fully skippable by the operator; its *trigger* (gate.py in CI) is
+what the compiler bakes in and what is not skippable once wired.
+
+Stdlib-only. The emitted gate is stdlib-only too, so it runs in any repo's
+CI with zero deps beyond node+npx (which the vault needs anyway).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "phase0"))
+import detect as _detect  # noqa: E402  (phase0/detect.py — the proven binding detector)
+
+# A detected test command below this confidence is emitted but flagged: the
+# harness still works, but a human should confirm the command is right.
+_LOW_CONFIDENCE = 0.6
+
+
+# ---------------------------------------------------------------------------
+# Binding → contract
+# ---------------------------------------------------------------------------
+
+# Each detected command becomes one required claim. `tests-pass` is the core
+# claim and is always present (flagged unconfigured if no test command was
+# found); lint/build claims are added only when actually detected — pinning a
+# command the repo doesn't have would make the gate fail forever.
+_CLAIM_MAP = [
+    ("tests-pass", "test-run", "test_command", True),
+    ("lint-clean", "lint-run", "lint_command", False),
+    ("build-clean", "build-run", "build_command", False),
+]
+
+
+def claim_specs(bindings: dict) -> list[dict]:
+    """Detected commands → claim specs {claim_id, kind, command, source, confidence}."""
+    specs = []
+    for claim_id, kind, key, always in _CLAIM_MAP:
+        b = bindings.get(key) or {}
+        cmd = b.get("value")
+        if always or cmd:
+            specs.append({
+                "claim_id": claim_id, "kind": kind, "command": cmd,
+                "source": b.get("source"), "confidence": b.get("confidence"),
+            })
+    return specs
+
+
+def derive_contract(bindings: dict) -> dict:
+    """Turn detected bindings into a multi-claim wicked-vault contract spec.
+
+    Each detected command (test / lint / build) becomes a required claim
+    pinned (G8) to an ``exit_code_eq:0`` verifier. The gate then means "this
+    build is actually clean" — re-derived at gate time — not merely "tests ran".
+    """
+    specs = claim_specs(bindings)
+    required = [
+        {
+            "claim_id": s["claim_id"],
+            "kind": s["kind"],
+            "source_pin": s["command"],
+            "verifier": {"kind": "exit_code_eq", "params": {"code": 0}},
+            "required": True,
+        }
+        for s in specs
+    ]
+    return {
+        "required_evidence": required,
+        "origin": "wicked-garden:compiler:emit",
+        "_provenance": {
+            "ecosystem": bindings["test_command"].get("ecosystem"),
+            "claims": {s["claim_id"]: {"command": s["command"],
+                                       "source": s["source"],
+                                       "confidence": s["confidence"]} for s in specs},
+            "test_command_ambiguity": bindings["test_command"].get("ambiguity"),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# The emitted harness (self-contained; imports nothing from wicked-garden)
+# ---------------------------------------------------------------------------
+
+_GATE_TEMPLATE = '''#!/usr/bin/env python3
+"""gate.py — EMITTED by the wicked-garden compiler. DO NOT hand-edit bindings.
+
+A repo-native build gate. It re-derives this build's claims against frozen
+acceptance criteria using wicked-vault — it never trusts a cached or
+self-asserted "done". This script depends on NOTHING but the Python stdlib
+and a resolvable wicked-vault CLI (via npx, or the WICKED_VAULT_BIN env).
+wicked-garden is not required to run it.
+
+Flow: init (idempotent) -> declare-contract (.wicked/contract.json)
+   -> record --run each claim's command (capture fresh exit codes NOW)
+   -> cross-check (re-run the pure verifiers; exit 0 == all PASS).
+
+Usage:
+  python3 .wicked/gate.py            # record a fresh run, then gate
+  python3 .wicked/gate.py --check    # gate on existing evidence (no new run)
+  python3 .wicked/gate.py --dry-run  # print compiled bindings, do nothing
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # noqa: S404 — argv lists, shell=False
+import sys
+import tempfile
+from pathlib import Path
+
+# ---- COMPILED BINDINGS (repo-specific; emitted, not hand-written) ----
+REPO = {repo!r}
+SCOPE = {scope!r}
+PHASE = "build"
+# Each claim: re-derived by running `command` and checking it exits 0.
+CLAIMS = {claims!r}
+# ----------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parent.parent  # repo root (.wicked/ is one down)
+_CONTRACT = Path(__file__).resolve().parent / "contract.json"
+
+
+def _vault_prefix():
+    """Resolve the wicked-vault CLI argv prefix. npx is the portable default
+    so this harness works on a fresh checkout with no global install."""
+    env = os.environ.get("WICKED_VAULT_BIN", "").strip()
+    if env:
+        return ["node", env] if env.endswith((".mjs", ".js")) else [env]
+    found = shutil.which("wicked-vault")
+    if found:
+        return [found]
+    if shutil.which("npx"):
+        return ["npx", "--yes", "wicked-vault"]
+    return None
+
+
+def _vault(prefix, args, timeout=600):
+    proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+        prefix + args, cwd=str(_ROOT), capture_output=True, text=True, timeout=timeout,
+    )
+    out = proc.stdout.strip()
+    try:
+        parsed = json.loads(out) if out else {{}}
+    except json.JSONDecodeError:
+        parsed = {{"_raw": out, "_stderr": proc.stderr.strip()[:400]}}
+    return proc.returncode, parsed
+
+
+def main(argv) -> int:
+    dry = "--dry-run" in argv
+    check_only = "--check" in argv
+
+    if dry:
+        print(json.dumps({{
+            "repo": REPO, "scope": SCOPE, "phase": PHASE, "claims": CLAIMS,
+            "contract": json.loads(_CONTRACT.read_text()) if _CONTRACT.exists() else None,
+        }}, indent=2))
+        return 0
+
+    prefix = _vault_prefix()
+    if prefix is None:
+        print(json.dumps({{"gate": "unavailable",
+            "error": "wicked-vault not resolvable (need npx or WICKED_VAULT_BIN); "
+                     "install: npm i -g wicked-vault"}}))
+        return 1  # fail closed — never self-assert a PASS
+
+    _vault(prefix, ["init"])  # idempotent
+    if _CONTRACT.exists():
+        _vault(prefix, ["declare-contract", "--scope", SCOPE, "--phase", PHASE,
+                        "--spec", str(_CONTRACT)])
+
+    if not check_only:
+        runnable = [c for c in CLAIMS if c.get("command")]
+        if not runnable:
+            print(json.dumps({{"gate": "unconfigured",
+                "error": "no runnable command was detected for any claim; "
+                         "edit .wicked/gate.py + contract.json"}}))
+            return 1
+        for c in runnable:
+            _vault(prefix, ["record", "--scope", SCOPE, "--phase", PHASE,
+                            "--claim", c["claim"], "--kind", c["kind"],
+                            "--source", c["command"],
+                            "--criteria", c["claim"] + ": `" + c["command"] + "` exits 0",
+                            "--verifier", "exit_code_eq:0", "--run"])
+
+    rc, cc = _vault(prefix, ["cross-check", "--scope", SCOPE, "--phase", PHASE])
+    overall = cc.get("overall") if isinstance(cc, dict) else None
+    print(json.dumps({{"gate": "vault-cross-check", "overall": overall,
+                       "scope": SCOPE, "phase": PHASE,
+                       "claims": cc.get("claims") if isinstance(cc, dict) else None}},
+                      indent=2))
+    return 0 if overall == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+'''
+
+
+_README_TEMPLATE = '''# .wicked/ — emitted build gate (wicked-garden compiler)
+
+This directory was **emitted** by the wicked-garden compiler from this repo's
+detected bindings. It is self-contained: the gate depends only on the Python
+stdlib and a resolvable [wicked-vault](https://www.npmjs.com/package/wicked-vault)
+CLI (`npx wicked-vault`). wicked-garden itself is **not** required to run it.
+
+## What it does
+
+`gate.py` re-derives this build's claims instead of trusting a self-asserted
+"done": it runs each detected command (test / lint / build), captures the real
+exit code, and re-runs a pure verifier through the vault. Exit 0 means every
+claim re-derives.
+
+- **Repo:** `{repo}`
+- **Vault scope:** `{scope}` · phase `build`
+
+### Claims this gate re-derives
+
+{claims_md}
+{flag_block}
+## Run it
+
+```bash
+python3 .wicked/gate.py            # record a fresh run, then gate (exit 0 = PASS)
+python3 .wicked/gate.py --check    # gate on existing evidence, no new run
+python3 .wicked/gate.py --dry-run  # show the compiled bindings
+```
+
+## Wire it into CI
+
+```yaml
+# .github/workflows — minimal
+- run: python3 .wicked/gate.py
+```
+
+Or as a pre-push hook (`.git/hooks/pre-push`): `python3 .wicked/gate.py`.
+
+## Files
+
+- `bindings.json` — what the detector saw (provenance).
+- `contract.json` — the vault contract: one required claim per detected
+  command (test / lint / build), each pinned to its command + `exit_code_eq:0`.
+  Edit this to add claims/verifiers.
+- `gate.py` — the harness (compiled enforcement + trigger). Re-emit rather
+  than hand-editing the bindings block.
+
+Regenerate after the repo changes shape:
+`python3 <wicked-garden>/scripts/compiler/compile.py <repo-root>`.
+'''
+
+
+def _claims_md(specs: list[dict]) -> str:
+    rows = []
+    for s in specs:
+        cmd = f"`{s['command']}`" if s.get("command") else "_(none detected)_"
+        rows.append(f"- `{s['claim_id']}` → {cmd}  "
+                    f"_({s.get('source')}, confidence {s.get('confidence')})_")
+    return "\n".join(rows)
+
+
+def _flag_block(bindings: dict, specs: list[dict]) -> str:
+    notes = []
+    for s in specs:
+        if s.get("command") and (s.get("confidence") or 0) < _LOW_CONFIDENCE:
+            notes.append(
+                f"- ⚠️ **Low confidence** for `{s['claim_id']}` "
+                f"(`{s['command']}`, {s.get('confidence')}). Inferred, not declared "
+                "— confirm before relying on the gate; fix in `contract.json` + `gate.py`."
+            )
+        if not s.get("command") and s["claim_id"] == "tests-pass":
+            notes.append(
+                "- ⚠️ **No test command detected** — `tests-pass` will fail closed "
+                "(MISSING) until you set a command in `contract.json` + `gate.py`."
+            )
+    tc = bindings["test_command"]
+    if tc.get("ambiguity"):
+        notes.append(f"- ⚠️ **Ambiguity:** {tc['ambiguity']} (alt: `{tc.get('alt')}`).")
+    return ("\n".join(notes) + "\n") if notes else ""
+
+
+# ---------------------------------------------------------------------------
+# Emit
+# ---------------------------------------------------------------------------
+
+def compile_repo(repo_root: str, out_subdir: str = ".wicked") -> dict:
+    """Detect bindings and emit the harness into ``<repo>/<out_subdir>/``.
+
+    Returns a manifest: the emitted files, the derived scope, and
+    ``needs_review`` (True when a binding was inferred at low confidence).
+    """
+    root = Path(repo_root).resolve()
+    if not root.is_dir():
+        raise NotADirectoryError(f"not a directory: {root}")
+
+    bindings = _detect.detect(str(root))
+    contract = derive_contract(bindings)
+    specs = claim_specs(bindings)
+    scope = root.name
+
+    out = root / out_subdir
+    out.mkdir(parents=True, exist_ok=True)
+
+    (out / "bindings.json").write_text(json.dumps(bindings, indent=2))
+    (out / "contract.json").write_text(json.dumps(contract, indent=2))
+
+    gate_claims = [{"claim": s["claim_id"], "kind": s["kind"], "command": s["command"]}
+                   for s in specs]
+    (out / "gate.py").write_text(_GATE_TEMPLATE.format(
+        repo=bindings["repo"], scope=scope, claims=gate_claims,
+    ))
+
+    (out / "README.md").write_text(_README_TEMPLATE.format(
+        repo=bindings["repo"], scope=scope,
+        claims_md=_claims_md(specs), flag_block=_flag_block(bindings, specs),
+    ))
+
+    tc = bindings["test_command"]
+    needs_review = (
+        not tc.get("value")  # no test command at all
+        or any(s.get("command") and (s.get("confidence") or 0) < _LOW_CONFIDENCE
+               for s in specs)
+        or bool(tc.get("ambiguity"))
+    )
+
+    return {
+        "repo": bindings["repo"],
+        "root": str(root),
+        "scope": scope,
+        "out_dir": str(out),
+        "emitted": ["bindings.json", "contract.json", "gate.py", "README.md"],
+        "claims": {s["claim_id"]: s["command"] for s in specs},
+        "needs_review": needs_review,
+        "bindings": bindings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Triggers — what FIRES the gate. The gate is the compiled enforcement; a
+# trigger is what makes it non-skippable once wired. We compile the trigger;
+# we never compile the tool (the vault is resolved at runtime via npx).
+# ---------------------------------------------------------------------------
+
+_HOOK_START = "# >>> wicked-gate (managed by wicked-garden) >>>"
+_HOOK_END = "# <<< wicked-gate <<<"
+_HOOK_BLOCK = f'''{_HOOK_START}
+# Re-derives this build's claims via .wicked/gate.py before allowing a push.
+# Delete this block (or the file) to disable; edit .wicked/gate.py to retune.
+_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -n "$_root" ] && [ -f "$_root/.wicked/gate.py" ]; then
+  python3 "$_root/.wicked/gate.py" || {{
+    echo "wicked-gate: build claims do not re-derive — push blocked." >&2
+    exit 1
+  }}
+fi
+{_HOOK_END}'''
+
+_CI_MARKER = "generated-by: wicked-garden:compiler:emit"
+
+# The vault needs node/npx everywhere; the repo's own toolchain is added per
+# detected ecosystem so `gate.py` can actually run the test command in CI.
+_CI_SETUP = {
+    "node": "      - uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n",
+    "go": ("      - uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n"
+           "      - uses: actions/setup-go@v5\n        with:\n          go-version: 'stable'\n"),
+    "python": ("      - uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n"
+               "      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.x'\n"),
+    "rust": ("      - uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n"
+             "      - uses: dtolnay/rust-toolchain@stable\n"),
+}
+_CI_SETUP_DEFAULT = ("      - uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n"
+                     "      # TODO: add your toolchain setup so .wicked/gate.py can run the tests\n")
+
+
+def _ci_workflow(ecosystem: str | None) -> str:
+    setup = _CI_SETUP.get(ecosystem or "", _CI_SETUP_DEFAULT)
+    return (
+        f"# {_CI_MARKER}  (safe to re-emit; edit .wicked/gate.py or contract.json instead)\n"
+        "name: wicked-gate\n"
+        "on: [push, pull_request]\n"
+        "jobs:\n"
+        "  gate:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v4\n"
+        f"{setup}"
+        "      - name: re-derive build claims (wicked-vault)\n"
+        "        run: python3 .wicked/gate.py\n"
+    )
+
+
+def _install_pre_push_hook(root: Path) -> dict:
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        return {"trigger": "pre-push-hook", "status": "skipped", "reason": "not a git repo"}
+    hooks = git_dir / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    hook = hooks / "pre-push"
+    existing = hook.read_text(encoding="utf-8") if hook.exists() else ""
+
+    if _HOOK_START in existing:
+        # Replace our managed region in place (idempotent re-emit).
+        pre = existing.split(_HOOK_START)[0]
+        post = existing.split(_HOOK_END, 1)[1] if _HOOK_END in existing else ""
+        text, status = pre + _HOOK_BLOCK + post, "updated"
+    elif existing.strip():
+        # Foreign hook present — preserve it, append our block. Never clobber.
+        text, status = existing.rstrip() + "\n\n" + _HOOK_BLOCK + "\n", "appended"
+    else:
+        text, status = "#!/bin/sh\n" + _HOOK_BLOCK + "\n", "created"
+
+    hook.write_text(text, encoding="utf-8")
+    hook.chmod(0o755)
+    return {"trigger": "pre-push-hook", "status": status, "path": str(hook)}
+
+
+def _install_ci_workflow(root: Path, ecosystem: str | None) -> dict:
+    wf_dir = root / ".github" / "workflows"
+    wf = wf_dir / "wicked-gate.yml"
+    if wf.exists() and _CI_MARKER not in wf.read_text(encoding="utf-8"):
+        # A foreign file owns this name — do not overwrite hand-authored CI.
+        return {"trigger": "ci-workflow", "status": "skipped",
+                "reason": "wicked-gate.yml exists but is not wicked-generated", "path": str(wf)}
+    status = "updated" if wf.exists() else "created"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    wf.write_text(_ci_workflow(ecosystem), encoding="utf-8")
+    return {"trigger": "ci-workflow", "status": status, "path": str(wf)}
+
+
+def install_triggers(repo_root: str, kinds: list[str], ecosystem: str | None = None) -> list[dict]:
+    """Install the requested trigger surfaces. ``kinds`` ⊆ {"hook", "ci"}.
+
+    Idempotent and non-destructive: the pre-push hook appends to (never
+    clobbers) a foreign hook and replaces only its own managed block; the CI
+    workflow refuses to overwrite a same-named file it did not generate.
+    """
+    root = Path(repo_root).resolve()
+    results = []
+    if "hook" in kinds:
+        results.append(_install_pre_push_hook(root))
+    if "ci" in kinds:
+        results.append(_install_ci_workflow(root, ecosystem))
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="wicked-garden compiler — emit a repo-native gate.")
+    p.add_argument("repo_root")
+    p.add_argument("--out", default=".wicked", help="harness subdir (default .wicked)")
+    p.add_argument("--trigger", default="",
+                   help="comma list of triggers to install: hook,ci (or 'all'). "
+                        "Default: emit harness only (no triggers).")
+    a = p.parse_args()
+
+    manifest = compile_repo(a.repo_root, a.out)
+
+    kinds_raw = [k.strip() for k in a.trigger.split(",") if k.strip()]
+    kinds = ["hook", "ci"] if "all" in kinds_raw else kinds_raw
+    if kinds:
+        manifest["triggers"] = install_triggers(
+            a.repo_root, kinds, ecosystem=manifest["bindings"]["test_command"].get("ecosystem"))
+
+    print(json.dumps({k: v for k, v in manifest.items() if k != "bindings"}, indent=2))

--- a/scripts/compiler/compile.py
+++ b/scripts/compiler/compile.py
@@ -151,7 +151,6 @@ import os
 import shutil
 import subprocess  # noqa: S404 — argv lists, shell=False
 import sys
-import tempfile
 from pathlib import Path
 
 # ---- COMPILED BINDINGS (repo-specific; emitted, not hand-written) ----
@@ -167,10 +166,13 @@ _CONTRACT = Path(__file__).resolve().parent / "contract.json"
 
 
 def _vault_prefix():
-    """Resolve the wicked-vault CLI argv prefix. npx is the portable default
-    so this harness works on a fresh checkout with no global install."""
-    env = os.environ.get("WICKED_VAULT_BIN", "").strip()
-    if env:
+    """Resolve the wicked-vault CLI argv prefix. npx is the portable fallback,
+    so this harness works on a fresh checkout. WICKED_VAULT_BIN set-but-empty
+    is a kill-switch: disables resolution (the gate then fails closed)."""
+    if "WICKED_VAULT_BIN" in os.environ:
+        env = os.environ["WICKED_VAULT_BIN"].strip()
+        if not env:
+            return None  # kill-switch
         return ["node", env] if env.endswith((".mjs", ".js")) else [env]
     found = shutil.which("wicked-vault")
     if found:
@@ -181,9 +183,13 @@ def _vault_prefix():
 
 
 def _vault(prefix, args, timeout=600):
-    proc = subprocess.run(  # noqa: S603 — argv list, shell=False
-        prefix + args, cwd=str(_ROOT), capture_output=True, text=True, timeout=timeout,
-    )
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            prefix + args, cwd=str(_ROOT), capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError:
+        # node/npx/wicked-vault not on PATH — fail closed, don't crash.
+        return 127, {{"error": "wicked-vault executable not found"}}
     out = proc.stdout.strip()
     try:
         parsed = json.loads(out) if out else {{}}
@@ -461,6 +467,19 @@ def _install_pre_push_hook(root: Path) -> dict:
     git_dir = root / ".git"
     if not git_dir.exists():
         return {"trigger": "pre-push-hook", "status": "skipped", "reason": "not a git repo"}
+    # In submodules / worktrees, `.git` is a FILE holding a `gitdir:` pointer
+    # to the real git directory — not a directory we can mkdir hooks/ under.
+    if git_dir.is_file():
+        try:
+            content = git_dir.read_text(encoding="utf-8").strip()
+        except OSError:
+            return {"trigger": "pre-push-hook", "status": "skipped",
+                    "reason": "could not read .git file"}
+        if content.startswith("gitdir:"):
+            git_dir = (root / content.split(":", 1)[1].strip()).resolve()
+        if not git_dir.is_dir():
+            return {"trigger": "pre-push-hook", "status": "skipped",
+                    "reason": "resolved gitdir is not a directory"}
     hooks = git_dir / "hooks"
     hooks.mkdir(parents=True, exist_ok=True)
     hook = hooks / "pre-push"

--- a/scripts/compiler/phase0/VERDICT.md
+++ b/scripts/compiler/phase0/VERDICT.md
@@ -1,0 +1,58 @@
+# Phase-0 Verdict — compiler falsification probe
+
+**Result: PASS (4/4).** The compiler thesis cleared its Phase-0 bar.
+Throwaway prototype under `scripts/compiler/phase0/` (uncommitted).
+
+## What was tested
+
+Can ONE repo-agnostic detector infer a repo's `test_command` + evidence
+conventions, and can ONE emitter produce a working repo-native
+claim→evidence lint, **without per-repo hand-correction**, across
+structurally different repos? Falsifier: if it needs hand-correction per
+repo, the "compiler" is really templating-with-manual-wiring.
+
+## Targets (real repos)
+
+| Repo | Ecosystem | Detected `test_command` | Conf | Notes |
+|---|---|---|---|---|
+| command_iq | node pnpm **monorepo** | `pnpm test` (→ turbo wrapper) | 0.9 | real `claims:` frontmatter + real evidence dir both detected |
+| wicked-bus | node single-package | `npm test` (→ `vitest run`) | 0.9 | `coverage/` evidence dir detected |
+| Enterprise-AISDLC | python | `python3 -m pytest` | 0.55 | **ambiguity flagged**: Makefile `test:` AND pytest both present |
+| memos | **go** (foreign, no package.json) | `go test ./...` | 0.9 | clean foreign-ecosystem detection |
+
+## Findings
+
+1. **Detection generalized, unaided** — all 4 ecosystems, including the
+   foreign no-`package.json` Go path. The ambiguous python case was
+   *flagged* (conf 0.55), not silently guessed. This was the risky core.
+2. **The emitter is genuinely generic** — the first emit had a UNIFORM
+   bug (mixed `N passed | M failed` evidence slipped through a
+   "tests pass" claim — the §7 "5848 pass / 4 fail → build green"
+   failure mode). ONE central fix in `emit.py` flipped all 4 repos.
+   A per-repo-rigged emitter could not be fixed by a single central edit.
+3. **The emitted lint runs with zero wicked-garden runtime** — plain
+   stdlib python; catches missing-evidence AND contradictory-evidence
+   claims; embeds the repo's own re-verification command.
+
+## Honest caveats (what Phase-0 did NOT prove)
+
+- **Claims surface is the real next problem.** Only command_iq had a
+  structured `claims:` convention to detect. The other 3 fell back to
+  `commit-msg` (a stub). The lint LOGIC was proven via staged fixtures,
+  but in practice 3/4 repos have no claims doc to check. → Phase-2 emit
+  must *install* the claim+evidence convention where absent, not just
+  detect it. The compiler establishes conventions in greenfield repos.
+- **Honest-control real-runs were mostly synthetic** (vitest invocation
+  issues; go toolchain timed out). Only python got a REAL run. The
+  fabrication-catch gate held regardless, but "detected command actually
+  executes & passes" is only truly proven for 1/4.
+- **risk_surfaces detection was not exercised** by the lint (that's the
+  validator-pair trigger — Phase 3).
+- n=4, narrow sample.
+
+## Decision
+
+Plan gate (`>=2/3 → compiler is real → proceed`) is met decisively.
+**Proceed to Phase 2 (compiler emit stage) + Phase 1 (verb re-index +
+re-runner) in parallel.** The sharpened Phase-2 scope: the emit stage
+must scaffold the claims+evidence convention, since most repos lack one.

--- a/scripts/compiler/phase0/VERDICT.md
+++ b/scripts/compiler/phase0/VERDICT.md
@@ -1,7 +1,9 @@
 # Phase-0 Verdict — compiler falsification probe
 
 **Result: PASS (4/4).** The compiler thesis cleared its Phase-0 bar.
-Throwaway prototype under `scripts/compiler/phase0/` (uncommitted).
+Prototype under `scripts/compiler/phase0/` — committed as provenance, not
+production code. The production emit stage is `scripts/compiler/compile.py`,
+which reuses this prototype's `detect.py` and `emit.py`.
 
 ## What was tested
 

--- a/scripts/compiler/phase0/detect.py
+++ b/scripts/compiler/phase0/detect.py
@@ -21,13 +21,6 @@ DETECTED = "detected"          # inferred from a real repo signal
 DEFAULT = "proposed-default"   # emitted convention; repo had none
 
 
-def _exists(root: Path, *names: str) -> str | None:
-    for n in names:
-        if (root / n).exists():
-            return n
-    return None
-
-
 def _read_json(p: Path) -> dict:
     try:
         return json.loads(p.read_text())
@@ -74,7 +67,6 @@ def _detect_test_command(root: Path) -> dict:
                 "ecosystem": "go"}
 
     # python — the ambiguous case: Makefile test target vs pytest vs pyproject
-    py_signals = []
     has_pyproject = (root / "pyproject.toml").exists()
     has_setup = (root / "setup.py").exists() or (root / "setup.cfg").exists()
     tests_dir = ("tests" if (root / "tests").is_dir()

--- a/scripts/compiler/phase0/detect.py
+++ b/scripts/compiler/phase0/detect.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Phase-0 detection probe — repo root -> bindings.json.
+
+Falsification question: can ONE repo-agnostic detector infer a repo's
+test-invocation, evidence sink, claims surface, and risk surfaces well
+enough to drive an emitted enforcement lint, WITHOUT hand-correction,
+across structurally different repos?
+
+Every binding records {value, source, confidence} so the verdict can
+distinguish "detected unaided" from "fell back to a proposed default".
+Stdlib-only.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DETECTED = "detected"          # inferred from a real repo signal
+DEFAULT = "proposed-default"   # emitted convention; repo had none
+
+
+def _exists(root: Path, *names: str) -> str | None:
+    for n in names:
+        if (root / n).exists():
+            return n
+    return None
+
+
+def _read_json(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def _pkg_manager(root: Path) -> str:
+    if (root / "pnpm-lock.yaml").exists():
+        return "pnpm"
+    if (root / "yarn.lock").exists():
+        return "yarn"
+    return "npm"
+
+
+def _detect_test_command(root: Path) -> dict:
+    # node
+    pkg = root / "package.json"
+    if pkg.exists():
+        data = _read_json(pkg)
+        scripts = data.get("scripts", {}) or {}
+        pm = _pkg_manager(root)
+        monorepo = bool(data.get("workspaces")) or (root / "pnpm-workspace.yaml").exists()
+        if scripts.get("test"):
+            run = "test" if pm == "npm" else "test"
+            cmd = f"{pm} {('run ' if pm=='npm' else '')}{run}".strip()
+            # npm needs `npm test`; pnpm/yarn `pnpm test`
+            cmd = f"{pm} test"
+            return {"value": cmd, "source": DETECTED, "confidence": 0.9,
+                    "ecosystem": "node", "monorepo": monorepo,
+                    "declared_script": scripts["test"]}
+        return {"value": f"{pm} test", "source": DEFAULT, "confidence": 0.3,
+                "ecosystem": "node", "monorepo": monorepo,
+                "note": "package.json has no scripts.test"}
+
+    # rust
+    if (root / "Cargo.toml").exists():
+        return {"value": "cargo test", "source": DETECTED, "confidence": 0.9,
+                "ecosystem": "rust"}
+
+    # go
+    if (root / "go.mod").exists():
+        return {"value": "go test ./...", "source": DETECTED, "confidence": 0.9,
+                "ecosystem": "go"}
+
+    # python — the ambiguous case: Makefile test target vs pytest vs pyproject
+    py_signals = []
+    has_pyproject = (root / "pyproject.toml").exists()
+    has_setup = (root / "setup.py").exists() or (root / "setup.cfg").exists()
+    tests_dir = ("tests" if (root / "tests").is_dir()
+                 else "test" if (root / "test").is_dir() else None)
+    has_tests_dir = tests_dir is not None
+    # Scope pytest to the tests dir when one exists. Bare `pytest` collects
+    # from the repo root and trips over stray test-like files elsewhere in the
+    # tree (a real failure mode found dogfooding the garden: scripts/**/test_*.py
+    # with broken imports → exit 2). Scoped collection matches how repos
+    # actually run their suite (`pytest tests/`).
+    _pytest = "python3 -m pytest" + (f" {tests_dir}" if tests_dir else "")
+    make = root / "Makefile"
+    make_test = False
+    if make.exists():
+        try:
+            make_test = bool(re.search(r"(?m)^test:", make.read_text()))
+        except Exception:
+            make_test = False
+    pytest_cfg = False
+    if has_pyproject:
+        try:
+            txt = (root / "pyproject.toml").read_text()
+            pytest_cfg = "[tool.pytest" in txt
+        except Exception:
+            pass
+    if (root / "pytest.ini").exists():
+        pytest_cfg = True
+
+    if has_pyproject or has_setup or has_tests_dir:
+        # Priority: declared Makefile target (explicit author intent) >
+        # ecosystem default pytest. Confidence drops when both exist
+        # (genuine ambiguity the detector must flag, not silently pick).
+        if make_test and (pytest_cfg or has_tests_dir):
+            return {"value": _pytest, "source": DETECTED,
+                    "confidence": 0.55, "ecosystem": "python",
+                    "ambiguity": "Makefile `test:` target AND pytest config both present",
+                    "alt": "make test"}
+        if make_test:
+            return {"value": "make test", "source": DETECTED, "confidence": 0.8,
+                    "ecosystem": "python"}
+        return {"value": _pytest, "source": DETECTED,
+                "confidence": 0.8 if (pytest_cfg or has_tests_dir) else 0.5,
+                "ecosystem": "python"}
+
+    return {"value": None, "source": DEFAULT, "confidence": 0.0,
+            "ecosystem": "unknown", "note": "no recognized test ecosystem"}
+
+
+def _detect_evidence_sink(root: Path) -> dict:
+    # existing convention?
+    candidates = []
+    for p in root.rglob("evidence"):
+        if p.is_dir() and ".git" not in p.parts and "node_modules" not in p.parts:
+            candidates.append(p.relative_to(root).as_posix())
+            if len(candidates) >= 5:
+                break
+    if candidates:
+        # pick the shallowest existing evidence dir
+        candidates.sort(key=lambda s: s.count("/"))
+        return {"value": candidates[0], "source": DETECTED, "confidence": 0.8,
+                "others": candidates[1:]}
+    for d in ("test-results", "coverage", "reports"):
+        if (root / d).is_dir():
+            return {"value": d, "source": DETECTED, "confidence": 0.5}
+    return {"value": ".wg/evidence", "source": DEFAULT, "confidence": 0.3,
+            "note": "no existing evidence convention; proposing default"}
+
+
+def _detect_claims_surface(root: Path) -> dict:
+    # structured claims doc? (frontmatter `claims:` block, command_iq build.md shape)
+    search_roots = [root / ".projects", root / "docs", root]
+    hits = []
+    for sr in search_roots:
+        if not sr.exists():
+            continue
+        for md in sr.rglob("*.md"):
+            if "node_modules" in md.parts or ".git" in md.parts:
+                continue
+            try:
+                head = md.read_text(errors="ignore")[:2000]
+            except Exception:
+                continue
+            if re.search(r"(?m)^claims:\s*$", head):
+                hits.append(md.relative_to(root).as_posix())
+            if len(hits) >= 5:
+                break
+        if hits:
+            break
+    if hits:
+        return {"value": "frontmatter", "glob": hits, "source": DETECTED,
+                "confidence": 0.85}
+    return {"value": "commit-msg", "source": DEFAULT, "confidence": 0.4,
+            "note": "no structured claims doc; default to commit-message scanning"}
+
+
+def _detect_risk_surfaces(root: Path) -> dict:
+    # explicit surface table? (a markdown with a Surface|Skill dispatch table)
+    for md in (root / "CLAUDE.md", root / "AGENTS.md"):
+        if md.exists():
+            try:
+                txt = md.read_text(errors="ignore")
+            except Exception:
+                txt = ""
+            if re.search(r"Surface\b.*\bSkill", txt) or "surface-skill" in txt:
+                rows = re.findall(r"(?m)^\|\s*`?([a-z][\w/.-]+)`?\s*\|", txt)
+                return {"value": sorted(set(rows))[:20], "source": DETECTED,
+                        "confidence": 0.7, "from": md.name}
+    # else: derive candidate surfaces from code module dirs
+    surfaces = []
+    for base in ("src", "packages", "lib"):
+        b = root / base
+        if b.is_dir():
+            for sub in sorted(b.iterdir()):
+                if sub.is_dir() and not sub.name.startswith("."):
+                    surfaces.append(f"{base}/{sub.name}")
+            if surfaces:
+                break
+    if surfaces:
+        return {"value": surfaces[:20], "source": DETECTED, "confidence": 0.4,
+                "note": "derived from top-level module dirs; no explicit surface map"}
+    return {"value": [], "source": DEFAULT, "confidence": 0.0,
+            "note": "no module structure detected"}
+
+
+def _node_script_cmd(root: Path, script: str) -> str | None:
+    """Return the run-command for a package.json script, or None if absent."""
+    pkg = root / "package.json"
+    if not pkg.exists():
+        return None
+    scripts = (_read_json(pkg).get("scripts") or {})
+    if script not in scripts:
+        return None
+    pm = _pkg_manager(root)
+    return f"npm run {script}" if pm == "npm" else f"{pm} {script}"
+
+
+def _detect_lint_command(root: Path) -> dict:
+    """Detect a lint/static-check command. Omitted (value=None) when none —
+    pinning a non-existent linter would make the gate fail forever."""
+    # node — only if the repo declares a lint script (don't assume eslint).
+    cmd = _node_script_cmd(root, "lint")
+    if cmd:
+        return {"value": cmd, "source": DETECTED, "confidence": 0.9, "ecosystem": "node"}
+    if (root / "package.json").exists():
+        return {"value": None, "source": DEFAULT, "confidence": 0.0, "ecosystem": "node"}
+
+    # go — `go vet` is standard and always runnable for a module, no config.
+    if (root / "go.mod").exists():
+        return {"value": "go vet ./...", "source": DETECTED, "confidence": 0.85, "ecosystem": "go"}
+
+    # rust — clippy ships with the toolchain.
+    if (root / "Cargo.toml").exists():
+        return {"value": "cargo clippy", "source": DETECTED, "confidence": 0.7, "ecosystem": "rust"}
+
+    # python — ruff > flake8 > Makefile lint target. Only if configured.
+    if (root / "pyproject.toml").exists():
+        try:
+            txt = (root / "pyproject.toml").read_text()
+        except Exception:
+            txt = ""
+        if "[tool.ruff" in txt:
+            return {"value": "ruff check .", "source": DETECTED, "confidence": 0.85, "ecosystem": "python"}
+    if (root / "ruff.toml").exists() or (root / ".ruff.toml").exists():
+        return {"value": "ruff check .", "source": DETECTED, "confidence": 0.85, "ecosystem": "python"}
+    if (root / ".flake8").exists():
+        return {"value": "flake8", "source": DETECTED, "confidence": 0.8, "ecosystem": "python"}
+    make = root / "Makefile"
+    if make.exists():
+        try:
+            if re.search(r"(?m)^lint:", make.read_text()):
+                return {"value": "make lint", "source": DETECTED, "confidence": 0.75, "ecosystem": "python"}
+        except Exception:
+            pass
+
+    return {"value": None, "source": DEFAULT, "confidence": 0.0,
+            "note": "no lint command detected"}
+
+
+def _detect_build_command(root: Path) -> dict:
+    """Detect a build/compile command. Omitted when none (e.g. most pure-Python
+    libs don't have a build step)."""
+    cmd = _node_script_cmd(root, "build")
+    if cmd:
+        return {"value": cmd, "source": DETECTED, "confidence": 0.9, "ecosystem": "node"}
+    if (root / "package.json").exists():
+        return {"value": None, "source": DEFAULT, "confidence": 0.0, "ecosystem": "node"}
+
+    if (root / "go.mod").exists():
+        return {"value": "go build ./...", "source": DETECTED, "confidence": 0.85, "ecosystem": "go"}
+    if (root / "Cargo.toml").exists():
+        return {"value": "cargo build", "source": DETECTED, "confidence": 0.85, "ecosystem": "rust"}
+
+    make = root / "Makefile"
+    if make.exists():
+        try:
+            if re.search(r"(?m)^build:", make.read_text()):
+                return {"value": "make build", "source": DETECTED, "confidence": 0.7, "ecosystem": "make"}
+        except Exception:
+            pass
+
+    return {"value": None, "source": DEFAULT, "confidence": 0.0,
+            "note": "no build command detected"}
+
+
+def detect(repo_root: str) -> dict:
+    root = Path(repo_root).resolve()
+    return {
+        "repo": root.name,
+        "root": str(root),
+        "test_command": _detect_test_command(root),
+        "lint_command": _detect_lint_command(root),
+        "build_command": _detect_build_command(root),
+        "evidence_sink": _detect_evidence_sink(root),
+        "claims_surface": _detect_claims_surface(root),
+        "risk_surfaces": _detect_risk_surfaces(root),
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: detect.py <repo_root>", file=sys.stderr)
+        sys.exit(2)
+    print(json.dumps(detect(sys.argv[1]), indent=2))

--- a/scripts/compiler/phase0/emit.py
+++ b/scripts/compiler/phase0/emit.py
@@ -193,21 +193,30 @@ if __name__ == "__main__":
 '''
 
 
-def emit(bindings: dict, out_dir: str) -> str:
+def render_lint(bindings: dict) -> str:
+    """Render the claims-vs-evidence lint source for a repo's bindings.
+
+    Single source of the lint logic — both the phase-0 ``emit()`` and the
+    ``compile`` emit stage (which writes it as ``.wicked/claims_lint.py``)
+    render through here. Stdlib-only output.
+    """
     tc = bindings["test_command"]
     es = bindings["evidence_sink"]
     cs = bindings["claims_surface"]
-    rendered = TEMPLATE.format(
+    return TEMPLATE.format(
         repo=bindings["repo"],
         test_command=tc.get("value") or "(none-detected)",
         evidence_sink=es.get("value") or ".wg/evidence",
         claims_mode=cs.get("value"),
         claims_glob=cs.get("glob", []),
     )
+
+
+def emit(bindings: dict, out_dir: str) -> str:
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
     target = out / "wg_check_claims.py"
-    target.write_text(rendered)
+    target.write_text(render_lint(bindings))
     return str(target)
 
 

--- a/scripts/compiler/phase0/emit.py
+++ b/scripts/compiler/phase0/emit.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Phase-0 emitter — bindings.json -> a repo-native `wg_check_claims.py` lint.
+
+This is the "compile" step under test: the SAME emitter, parameterized
+only by detected bindings, must produce a lint that works in each repo
+with no hand edits. The bindings are baked in as constants at the top of
+the emitted file — that is the repo-specific "compiled" surface; the
+checking logic below it is generic.
+
+Stdlib-only. The emitted file is also stdlib-only so it can live in any
+repo's pre-commit/CI with zero deps.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+TEMPLATE = '''#!/usr/bin/env python3
+"""wg_check_claims.py — EMITTED by wicked-garden phase-0 compiler.
+
+Repo-native claim->evidence enforcement. Compiled bindings for THIS repo
+are the constants directly below; everything under them is generic.
+
+A claim that asserts success ("tests pass", "N/N pass", "done", "clean")
+must point to an evidence artifact that exists, is non-empty, carries a
+success signal, and is not dominated by a failure signal. A claim whose
+evidence is missing / empty / contradictory is a fabricated claim and
+fails the lint.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---- COMPILED BINDINGS (repo-specific; emitted, not hand-written) ----
+REPO = {repo!r}
+TEST_COMMAND = {test_command!r}
+EVIDENCE_SINK = {evidence_sink!r}
+CLAIMS_MODE = {claims_mode!r}        # "frontmatter" | "commit-msg"
+CLAIMS_GLOB = {claims_glob!r}        # list of frontmatter docs (if mode=frontmatter)
+# ----------------------------------------------------------------------
+
+PASS_LANG = re.compile(
+    r"\\b(tests?\\s+pass|passing|all\\s+green|\\d+\\s*/\\s*\\d+\\s+(?:tests?\\s+)?pass"
+    r"|exit\\s*0|typecheck[- ]?clean|build[- ]?clean|\\bclean\\b|\\bdone\\b"
+    r"|complete|fixed|merged)",
+    re.IGNORECASE,
+)
+SUCCESS_SIG = re.compile(
+    r"(\\bpass(?:ed|ing)?\\b|\\bok\\b|\\u2713|\\bexit\\s*(?:code\\s*)?0\\b"
+    r"|\\b\\d+\\s+passed\\b|test files\\s+\\d+\\s+passed|no\\s+violations)",
+    re.IGNORECASE,
+)
+# A nonzero-failure token DOMINATES a success claim even when partial
+# "passed" counts are also present. "0 failed" must NOT trigger; bare
+# lowercase "fail" in prose must NOT trigger (only uppercase FAIL token).
+HARD_FAIL = re.compile(
+    r"([1-9]\\d*\\s+(?:failed|errors?|failures?)"
+    r"|(?-i:\\bFAIL\\b|\\u2717)"
+    r"|exit\\s*(?:code\\s*)?[1-9]"
+    r"|no test files found"
+    r"|\\btraceback\\b"
+    r"|failures?\\s*=\\s*[1-9])",
+    re.IGNORECASE,
+)
+
+
+def _resolve_evidence(repo_root: Path, slug: str) -> Path | None:
+    sink = repo_root / EVIDENCE_SINK
+    cands = [sink / slug, sink / (slug + ".txt"), sink / (slug + ".md"),
+             repo_root / slug]
+    # also: evidence dir co-located next to the claims doc (common shape)
+    for c in cands:
+        if c.exists() and c.is_file():
+            return c
+    # last resort: glob the sink for the slug
+    if sink.is_dir():
+        for p in sink.rglob(slug + "*"):
+            if p.is_file():
+                return p
+    return None
+
+
+def _parse_frontmatter_claims(text: str):
+    """Return list of {{id,text,evidence}} from a `claims:` frontmatter block."""
+    if not text.startswith("---"):
+        return []
+    end = text.find("\\n---", 3)
+    fm = text[3:end] if end != -1 else text
+    lines = fm.splitlines()
+    claims, cur, in_block = [], None, False
+    for ln in lines:
+        if re.match(r"^claims:\\s*$", ln):
+            in_block = True
+            continue
+        if in_block:
+            if re.match(r"^\\S", ln):  # next top-level key ends the block
+                break
+            m_id = re.match(r"^\\s*-\\s*id:\\s*(.+)$", ln)
+            if m_id:
+                if cur:
+                    claims.append(cur)
+                cur = {{"id": m_id.group(1).strip(), "text": "", "evidence": ""}}
+                continue
+            m_ev = re.match(r"^\\s*evidence:\\s*(.+)$", ln)
+            if m_ev and cur is not None:
+                cur["evidence"] = m_ev.group(1).strip().strip('"\\'')
+                continue
+            m_tx = re.match(r"^\\s*text:\\s*(.+)$", ln)
+            if m_tx and cur is not None:
+                cur["text"] = m_tx.group(1).strip().strip('"\\'')
+                continue
+    if cur:
+        claims.append(cur)
+    return claims
+
+
+def _evaluate(repo_root: Path, claims, source_label: str):
+    violations = []
+    checked = 0
+    for c in claims:
+        text = c.get("text", "")
+        if not PASS_LANG.search(text):
+            continue  # not a success-claim; nothing to back
+        checked += 1
+        slug = c.get("evidence", "").strip()
+        if not slug:
+            violations.append((c.get("id", "?"), "success claim has NO evidence pointer", text))
+            continue
+        ev = _resolve_evidence(repo_root, slug)
+        if ev is None:
+            violations.append((c.get("id", "?"), f"evidence '{{slug}}' not found under {{EVIDENCE_SINK}}/", text))
+            continue
+        body = ev.read_text(errors="ignore")
+        if not body.strip():
+            violations.append((c.get("id", "?"), f"evidence '{{slug}}' is empty", text))
+            continue
+        has_pass = bool(SUCCESS_SIG.search(body))
+        has_fail = bool(HARD_FAIL.search(body))
+        if has_fail:
+            violations.append((c.get("id", "?"), f"evidence '{{slug}}' shows FAILURE, claim asserts success", text))
+        elif not has_pass:
+            violations.append((c.get("id", "?"), f"evidence '{{slug}}' has no success signal", text))
+    return checked, violations
+
+
+def main(argv):
+    repo_root = Path(".").resolve()
+    docs = []
+    args = list(argv)
+    while args:
+        a = args.pop(0)
+        if a == "--repo-root":
+            repo_root = Path(args.pop(0)).resolve()
+        elif a == "--claims-file":
+            docs.append(Path(args.pop(0)))
+        else:
+            docs.append(Path(a))
+
+    if not docs:
+        if CLAIMS_MODE == "frontmatter" and CLAIMS_GLOB:
+            docs = [repo_root / g for g in CLAIMS_GLOB]
+        else:
+            print("wg_check_claims: commit-msg mode requires a claims source; "
+                  "pass --claims-file <doc>", file=sys.stderr)
+            return 0
+
+    total_checked, all_v = 0, []
+    for d in docs:
+        if not d.exists():
+            continue
+        text = d.read_text(errors="ignore")
+        claims = _parse_frontmatter_claims(text)
+        checked, v = _evaluate(repo_root, claims, d.name)
+        total_checked += checked
+        all_v.extend((d.name, *row) for row in v)
+
+    if all_v:
+        print(f"wg_check_claims: FAIL ({{len(all_v)}} unbacked claim(s)) in {{REPO}}")
+        for doc, cid, why, text in all_v:
+            print(f"  [{{doc}}] claim {{cid}}: {{why}}")
+            print(f"      claim text: {{text[:100]}}")
+        print(f"  test_command for re-verification: {{TEST_COMMAND}}")
+        return 1
+    print(f"wg_check_claims: PASS ({{total_checked}} success-claim(s) all evidence-backed) in {{REPO}}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+'''
+
+
+def emit(bindings: dict, out_dir: str) -> str:
+    tc = bindings["test_command"]
+    es = bindings["evidence_sink"]
+    cs = bindings["claims_surface"]
+    rendered = TEMPLATE.format(
+        repo=bindings["repo"],
+        test_command=tc.get("value") or "(none-detected)",
+        evidence_sink=es.get("value") or ".wg/evidence",
+        claims_mode=cs.get("value"),
+        claims_glob=cs.get("glob", []),
+    )
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    target = out / "wg_check_claims.py"
+    target.write_text(rendered)
+    return str(target)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: emit.py <bindings.json> <out_dir>", file=sys.stderr)
+        sys.exit(2)
+    b = json.loads(Path(sys.argv[1]).read_text())
+    print(emit(b, sys.argv[2]))

--- a/scripts/compiler/phase0/run_probe.py
+++ b/scripts/compiler/phase0/run_probe.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Phase-0 falsification harness.
+
+For each target repo: detect -> emit -> stage honest+fabricated claim
+fixtures -> run the EMITTED lint -> record a per-repo verdict. Writes
+evidence + a verdict summary. Zero wicked-garden runtime touches the
+target repo: only the emitted stdlib lint runs there.
+
+Gate: >= 2/3 real repos PASS, where PASS =
+  (a) test_command detected unaided (source=detected, conf>=0.5), AND
+  (b) emitted lint passes an honest claim, AND
+  (c) emitted lint catches a missing-evidence fabricated claim, AND
+  (d) emitted lint catches a failure-evidence fabricated claim.
+
+usage: run_probe.py <repo1> [<repo2> ...]
+Stdlib-only.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import detect as detect_mod  # noqa: E402
+import emit as emit_mod      # noqa: E402
+
+EVID = HERE / "evidence"
+EVID.mkdir(exist_ok=True)
+
+
+def _run(cmd, cwd=None, timeout=120):
+    try:
+        p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                           timeout=timeout)
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except subprocess.TimeoutExpired:
+        return 124, f"<timeout after {timeout}s>"
+    except FileNotFoundError as e:
+        return 127, f"<not found: {e}>"
+    except Exception as e:  # noqa: BLE001
+        return 1, f"<error: {e}>"
+
+
+def _real_pass_evidence(ecosystem: str, repo_root: Path):
+    """Produce REAL evidence by running a minimal passing test in the repo's
+    runner family. Returns (text, is_real, note). Falls back to a clearly
+    labelled synthetic pass when the toolchain/runner is unavailable —
+    the lint can't tell provenance; it only reads content."""
+    tmp = Path(tempfile.mkdtemp(prefix="wgprobe-"))
+    try:
+        if ecosystem == "node":
+            spec = tmp / "wgprobe.test.mjs"
+            spec.write_text(
+                "import { test, expect } from 'vitest'\n"
+                "test('wgprobe', () => { expect(1+1).toBe(2) })\n"
+            )
+            rc, out = _run(["npx", "vitest", "run", str(spec)],
+                           cwd=str(repo_root), timeout=120)
+            if rc == 0 and ("pass" in out.lower()):
+                return out[-1500:], True, "real vitest run"
+            return ("Test Files  1 passed (1)\n Tests  1 passed (1)\n"
+                    "(synthetic: real vitest run unavailable rc=%s)" % rc), False, \
+                   f"synthetic; vitest rc={rc}"
+        if ecosystem == "python":
+            t = tmp / "test_wgprobe.py"
+            t.write_text("def test_wgprobe():\n    assert 1 + 1 == 2\n")
+            rc, out = _run([sys.executable, "-m", "pytest", "-q", str(t)],
+                           cwd=str(repo_root), timeout=90)
+            if rc == 0 and ("passed" in out.lower()):
+                return out[-1500:], True, "real pytest run"
+            # fall back to a real plain-python assertion run (always available)
+            rc2, out2 = _run([sys.executable, "-c",
+                              "assert 1+1==2; print('1 passed (plain python assert OK)')"],
+                             timeout=30)
+            if rc2 == 0:
+                return out2 + f"\n(pytest unavailable rc={rc}; real python assert used)", \
+                       True, "real python assert (pytest unavailable)"
+            return "1 passed\n(synthetic)", False, "synthetic"
+        if ecosystem == "go":
+            rc, out = _run(["go", "test", "./..."], cwd=str(repo_root), timeout=120)
+            if rc == 0:
+                return out[-1500:] or "ok\tPASS\n", True, "real go test"
+            return "ok  PASS\n(synthetic: go rc=%s)" % rc, False, f"synthetic; go rc={rc}"
+        if ecosystem == "rust":
+            rc, out = _run(["cargo", "test"], cwd=str(repo_root), timeout=180)
+            if rc == 0:
+                return out[-1500:] or "test result: ok. 1 passed\n", True, "real cargo test"
+            return "test result: ok. 1 passed\n(synthetic rc=%s)" % rc, False, f"synthetic; cargo rc={rc}"
+        return "1 passed\n(synthetic; unknown ecosystem)", False, "synthetic"
+    finally:
+        pass  # leave tmp; harmless
+
+
+def probe_repo(repo_path: str) -> dict:
+    root = Path(repo_path).resolve()
+    name = root.name
+    bindings = detect_mod.detect(str(root))
+    (EVID / f"{name}.bindings.json").write_text(json.dumps(bindings, indent=2))
+
+    eco = bindings["test_command"].get("ecosystem")
+    tc = bindings["test_command"]
+    detected = tc.get("source") == detect_mod.DETECTED and tc.get("value") and tc.get("confidence", 0) >= 0.5
+
+    # emit the lint into an isolated staging dir (NOT the repo tree)
+    stage = EVID / f"{name}.stage"
+    if stage.exists():
+        for p in stage.rglob("*"):
+            if p.is_file():
+                p.unlink()
+    stage.mkdir(parents=True, exist_ok=True)
+    lint_path = emit_mod.emit(bindings, str(stage))
+
+    # build fixtures: a fake "repo root" = stage, with an evidence sink
+    sink = stage / bindings["evidence_sink"]["value"]
+    sink.mkdir(parents=True, exist_ok=True)
+
+    # honest evidence (real where possible)
+    ev_text, ev_real, ev_note = _real_pass_evidence(eco, root)
+    (sink / "honest-tests.txt").write_text(ev_text)
+    # failure evidence for the contradiction case
+    (sink / "failing-tests.txt").write_text(
+        "FAIL src/foo.test\n 2 failed | 1 passed\nError: expected 2 received 3\nexit code 1\n"
+    )
+
+    honest_doc = stage / "honest.build.md"
+    honest_doc.write_text(
+        "---\nphase: build\nclaims:\n"
+        "  - id: c-honest\n    evidence: honest-tests\n"
+        '    text: "tests pass: 1/1 passing, exit 0"\n'
+        "---\n# honest\n"
+    )
+    fab_missing_doc = stage / "fab-missing.build.md"
+    fab_missing_doc.write_text(
+        "---\nphase: build\nclaims:\n"
+        "  - id: c-fab-missing\n    evidence: tests-that-were-never-run\n"
+        '    text: "all tests pass, build clean, ready to merge"\n'
+        "---\n# fabricated: evidence file does not exist\n"
+    )
+    fab_fail_doc = stage / "fab-fail.build.md"
+    fab_fail_doc.write_text(
+        "---\nphase: build\nclaims:\n"
+        "  - id: c-fab-fail\n    evidence: failing-tests\n"
+        '    text: "tests pass — all green"\n'
+        "---\n# fabricated: evidence actually shows failure\n"
+    )
+
+    def run_lint(doc):
+        return _run([sys.executable, lint_path, "--repo-root", str(stage),
+                     "--claims-file", str(doc)], timeout=30)
+
+    h_rc, h_out = run_lint(honest_doc)
+    fm_rc, fm_out = run_lint(fab_missing_doc)
+    ff_rc, ff_out = run_lint(fab_fail_doc)
+
+    (EVID / f"{name}.lint-output.txt").write_text(
+        f"$ emitted lint (test_command={tc.get('value')})\n\n"
+        f"--- honest (expect exit 0) -> rc={h_rc} ---\n{h_out}\n"
+        f"--- fabricated/missing (expect exit 1) -> rc={fm_rc} ---\n{fm_out}\n"
+        f"--- fabricated/failure (expect exit 1) -> rc={ff_rc} ---\n{ff_out}\n"
+    )
+
+    lint_ok = (h_rc == 0) and (fm_rc == 1) and (ff_rc == 1)
+    verdict = "PASS" if (detected and lint_ok) else ("FAIL" if not detected else "FAIL")
+
+    return {
+        "repo": name,
+        "ecosystem": eco,
+        "detection": {
+            "test_command": tc.get("value"),
+            "declared_script": tc.get("declared_script"),
+            "source": tc.get("source"),
+            "confidence": tc.get("confidence"),
+            "ambiguity": tc.get("ambiguity"),
+            "hand_correction_needed": not detected,
+        },
+        "evidence_sink": bindings["evidence_sink"]["value"]
+                         + f" ({bindings['evidence_sink']['source']})",
+        "claims_surface": bindings["claims_surface"]["value"]
+                          + f" ({bindings['claims_surface']['source']})",
+        "lint": {
+            "honest_exit": h_rc, "expect": 0,
+            "fab_missing_exit": fm_rc, "fab_failure_exit": ff_rc,
+            "honest_evidence_real": ev_real, "honest_evidence_note": ev_note,
+            "behaviour_ok": lint_ok,
+        },
+        "verdict": verdict,
+    }
+
+
+def main(argv):
+    targets = argv or []
+    if not targets:
+        print("usage: run_probe.py <repo1> [<repo2> ...]", file=sys.stderr)
+        return 2
+    results = [probe_repo(t) for t in targets]
+    passes = sum(1 for r in results if r["verdict"] == "PASS")
+    summary = {
+        "targets": len(results),
+        "passes": passes,
+        "gate": "PASS" if passes >= max(2, (len(results) + 1) // 2) else "FAIL",
+        "gate_rule": ">=2/3 real repos detect test_command unaided AND emitted lint catches both fabrication shapes",
+        "results": results,
+    }
+    (EVID / "verdict.json").write_text(json.dumps(summary, indent=2))
+
+    print("=" * 70)
+    print(f"PHASE-0 VERDICT: {summary['gate']}  ({passes}/{len(results)} repos PASS)")
+    print("=" * 70)
+    for r in results:
+        d = r["detection"]
+        l = r["lint"]
+        print(f"\n[{r['verdict']}] {r['repo']} ({r['ecosystem']})")
+        print(f"   test_command : {d['test_command']}  "
+              f"[{d['source']} conf={d['confidence']}]"
+              + (f"  AMBIGUITY: {d['ambiguity']}" if d.get('ambiguity') else ""))
+        if d.get("declared_script"):
+            print(f"   declared     : {d['declared_script']}")
+        print(f"   evidence_sink: {r['evidence_sink']}")
+        print(f"   claims       : {r['claims_surface']}")
+        print(f"   lint exits   : honest={l['honest_exit']}(want 0) "
+              f"fab-missing={l['fab_missing_exit']}(want 1) "
+              f"fab-failure={l['fab_failure_exit']}(want 1)  ok={l['behaviour_ok']}")
+        print(f"   honest-ev    : {'REAL' if l['honest_evidence_real'] else 'synthetic'} "
+              f"({l['honest_evidence_note']})")
+    print(f"\nevidence dir: {EVID}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/compiler/phase0/wire_vault.py
+++ b/scripts/compiler/phase0/wire_vault.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Phase-0 consumer-contract wiring: wicked-garden -> wicked-vault.
+
+Demonstrates CONTRACTS.md §10-A (compile time) and §10-B (runtime gate) END
+TO END against a real repo. The OLD Phase-0 model emitted a `wg_check_claims.py`
+lint that grepped files; this REPLACES that file-grep gate with a real
+`wicked-vault cross-check` call — the harness gate is now a vault verdict.
+
+Flow per repo:
+  1. detect.py  -> bindings (test_command especially).
+  2. declare-contract  scope=<repo>-demo phase=build, one required claim
+     `tests-pass`, kind `test-run`, verifier `exit_code_eq:0`, source_pin set
+     to the DETECTED test_command (§10-A.2: source pinned to the repo's real
+     command).
+  3a. REAL run: record --run the detected test_command. Honest data — if the
+      toolchain is absent / slow it will FAIL or time out, and the gate REJECTs.
+  3b. GATE-TRANSITION demo (separate scope <repo>-demo-gate): a single contract
+      whose source is a marker-driven command (`sh -c 'exit $(cat MARKER)'`).
+      We record a genuinely-FAILING capture (marker=1) then a genuinely-PASSING
+      capture (marker=0). Same pinned source string both times (honors G8), but
+      the captured exit code differs — so the latest-active artifact flips the
+      verdict. This explicitly shows BOTH outcomes the task asks for: `true`
+      (pass) and `false` (fail), both verified with `exit_code_eq:0`.
+  4. cross-check --scope <...> --phase build (§10-B): REJECT when the failing
+     capture is latest, PASS when a passing capture is latest. Exit code of the
+     CLI IS the gate signal (0 == PASS).
+
+Cleanup: the vault writes `.wicked-vault/` into the target repo; this script
+removes it afterward so the target repos stay clean.
+
+Stdlib-only. Cross-platform note: uses `sh -c` for the marker command, which is
+available on macOS/Linux and Git Bash/WSL on Windows; native PowerShell would
+need a different marker command but the §10 interaction is identical.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VAULT_CLI = Path.home() / "Projects" / "wicked-vault" / "bin" / "wicked-vault.mjs"
+EVIDENCE = HERE / "evidence" / "wire-vault-transcript.txt"
+
+# Per-repo wall-clock budget for the REAL detected test_command. If it exceeds
+# this we kill it; the captured run then counts as a fail (honest REJECT).
+REAL_RUN_TIMEOUT_S = 90
+
+
+class Tee:
+    """Mirror everything we print to both stdout and the transcript file."""
+
+    def __init__(self, path: Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(path, "w", encoding="utf-8")
+
+    def __call__(self, *parts: object) -> None:
+        line = " ".join(str(p) for p in parts)
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+        self._fh.write(line + "\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        self._fh.close()
+
+
+def run_vault(args: list[str], cwd_repo: Path, timeout: int | None = None) -> tuple[int, dict | str]:
+    """Invoke the vault CLI. Returns (exit_code, parsed_json_or_raw_text)."""
+    cmd = ["node", str(VAULT_CLI), *args, "--cwd", str(cwd_repo)]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, {"error": f"vault CLI timed out after {timeout}s", "args": args}
+    out = proc.stdout.strip()
+    try:
+        parsed: dict | str = json.loads(out) if out else {"error": "empty stdout", "stderr": proc.stderr.strip()}
+    except json.JSONDecodeError:
+        parsed = out or proc.stderr.strip()
+    return proc.returncode, parsed
+
+
+def detect(repo: Path, tee: Tee) -> dict:
+    out = subprocess.run(
+        [sys.executable, str(HERE / "detect.py"), str(repo)],
+        capture_output=True, text=True,
+    )
+    bindings = json.loads(out.stdout)
+    tc = bindings["test_command"]
+    tee(f"  detect.py: test_command = {tc.get('value')!r}  "
+        f"(source={tc.get('source')}, confidence={tc.get('confidence')}, "
+        f"ecosystem={tc.get('ecosystem')})")
+    if tc.get("ambiguity"):
+        tee(f"            ambiguity flagged: {tc['ambiguity']}")
+    return bindings
+
+
+def write_spec(source_pin: str) -> str:
+    """Write a contract spec JSON to a temp file; return its path."""
+    spec = {
+        "required_evidence": [{
+            "claim_id": "tests-pass",
+            "kind": "test-run",
+            "source_pin": source_pin,
+            "verifier": {"kind": "exit_code_eq", "params": {"code": 0}},
+            "required": True,
+        }],
+        "origin": "wicked-garden:compiler:phase0:wire_vault",
+    }
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="wg-vault-spec-")
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(spec, fh)
+    return path
+
+
+def real_run_section(repo: Path, reponame: str, test_cmd: str | None, tee: Tee) -> dict:
+    """§10-A/B against the DETECTED test_command. Honest: may FAIL/timeout."""
+    scope = f"{reponame}-demo"
+    result: dict = {"scope": scope, "runnable": None}
+    tee(f"\n  [REAL] scope={scope} phase=build  source_pin={test_cmd!r}")
+
+    if not test_cmd:
+        tee("  [REAL] no test_command detected — skipping real run.")
+        result["runnable"] = False
+        result["note"] = "detect.py returned no test_command"
+        return result
+
+    spec = write_spec(test_cmd)
+    rc, out = run_vault(
+        ["declare-contract", "--scope", scope, "--phase", "build", "--spec", spec],
+        repo)
+    os.unlink(spec)
+    tee(f"  [REAL] declare-contract exit={rc} contract_version="
+        f"{out.get('contract_version') if isinstance(out, dict) else out}")
+
+    tee(f"  [REAL] record --run  (timeout {REAL_RUN_TIMEOUT_S}s) ...")
+    rc, out = run_vault(
+        ["record", "--scope", scope, "--phase", "build", "--claim", "tests-pass",
+         "--kind", "test-run", "--source", test_cmd, "--verifier", "exit_code_eq:0",
+         "--run"],
+        repo, timeout=REAL_RUN_TIMEOUT_S)
+    if rc == 124:
+        # Our wrapper killed the vault process. The detected command did not
+        # complete in budget => not runnable here. Fall back to gate demo only.
+        tee(f"  [REAL] record TIMED OUT after {REAL_RUN_TIMEOUT_S}s — "
+            "detected command is NOT runnable in budget on this machine.")
+        result["runnable"] = False
+        result["note"] = f"detected command timed out > {REAL_RUN_TIMEOUT_S}s"
+        return result
+    if isinstance(out, dict) and out.get("error"):
+        tee(f"  [REAL] record ERROR: {out['error']}")
+        result["runnable"] = False
+        result["note"] = f"record error: {out['error']}"
+        return result
+
+    status = out.get("status_at_record") if isinstance(out, dict) else None
+    detail = out.get("status_detail") if isinstance(out, dict) else None
+    tee(f"  [REAL] record exit={rc} status_at_record={status} detail={detail!r}")
+    result["runnable"] = True
+    result["status_at_record"] = status
+
+    rc, out = run_vault(["cross-check", "--scope", scope, "--phase", "build"], repo)
+    overall = out.get("overall") if isinstance(out, dict) else out
+    tee(f"  [REAL] cross-check exit={rc} overall={overall}  "
+        "(this exit code IS the harness gate signal)")
+    result["crosscheck_overall"] = overall
+    result["crosscheck_exit"] = rc
+    return result
+
+
+def gate_transition_section(repo: Path, reponame: str, tee: Tee) -> dict:
+    """Explicit REJECT->PASS demo on ONE contract, both outcomes genuine.
+
+    Records a genuinely-FAILING capture (`false`-equivalent, marker=1) then a
+    genuinely-PASSING capture (`true`-equivalent, marker=0), both via the SAME
+    pinned source (honors G8). Latest-active artifact flips the verdict.
+    """
+    scope = f"{reponame}-demo-gate"
+    result: dict = {"scope": scope}
+    marker = Path(tempfile.gettempdir()) / f"wg-vault-gate-{reponame}-marker"
+    # Same source string for both records => G8 source_pin satisfied; exit code
+    # comes from the marker file the vault reads at run time.
+    source = f"sh -c 'exit $(cat {marker})'"
+    tee(f"\n  [GATE] scope={scope} phase=build  source_pin={source!r}")
+
+    spec = write_spec(source)
+    rc, out = run_vault(
+        ["declare-contract", "--scope", scope, "--phase", "build", "--spec", spec],
+        repo)
+    os.unlink(spec)
+    tee(f"  [GATE] declare-contract exit={rc} contract_version="
+        f"{out.get('contract_version') if isinstance(out, dict) else out}")
+
+    # 1) genuinely FAILING capture (false): marker=1
+    marker.write_text("1")
+    rc, out = run_vault(
+        ["record", "--scope", scope, "--phase", "build", "--claim", "tests-pass",
+         "--kind", "test-run", "--source", source, "--verifier", "exit_code_eq:0",
+         "--run"],
+        repo)
+    tee(f"  [GATE] record FAILING (false/exit 1) exit={rc} "
+        f"status_at_record={out.get('status_at_record') if isinstance(out, dict) else out}")
+
+    rc_fail, out = run_vault(["cross-check", "--scope", scope, "--phase", "build"], repo)
+    overall_fail = out.get("overall") if isinstance(out, dict) else out
+    tee(f"  [GATE] cross-check (failing latest) exit={rc_fail} overall={overall_fail}  "
+        "<- expect REJECT / exit 1")
+    result["fail_overall"] = overall_fail
+    result["fail_exit"] = rc_fail
+
+    # 2) genuinely PASSING capture (true): marker=0  -> becomes latest active
+    marker.write_text("0")
+    rc, out = run_vault(
+        ["record", "--scope", scope, "--phase", "build", "--claim", "tests-pass",
+         "--kind", "test-run", "--source", source, "--verifier", "exit_code_eq:0",
+         "--run"],
+        repo)
+    tee(f"  [GATE] record PASSING (true/exit 0) exit={rc} "
+        f"status_at_record={out.get('status_at_record') if isinstance(out, dict) else out}")
+
+    rc_pass, out = run_vault(["cross-check", "--scope", scope, "--phase", "build"], repo)
+    overall_pass = out.get("overall") if isinstance(out, dict) else out
+    tee(f"  [GATE] cross-check (passing latest) exit={rc_pass} overall={overall_pass}  "
+        "<- expect PASS / exit 0")
+    result["pass_overall"] = overall_pass
+    result["pass_exit"] = rc_pass
+
+    marker.unlink(missing_ok=True)
+    return result
+
+
+def cleanup(repo: Path, tee: Tee) -> None:
+    vdir = repo / ".wicked-vault"
+    if vdir.exists():
+        shutil.rmtree(vdir)
+        tee(f"  cleanup: removed {vdir}")
+    else:
+        tee(f"  cleanup: nothing to remove at {vdir}")
+
+
+def wire(repo: Path, tee: Tee) -> dict:
+    reponame = repo.name
+    tee("\n" + "=" * 72)
+    tee(f"REPO: {repo}")
+    tee("=" * 72)
+    # Clean slate: the cross-check is re-run from a fresh vault every time.
+    cleanup(repo, tee)
+    bindings = detect(repo, tee)
+    test_cmd = bindings["test_command"].get("value")
+    real = real_run_section(repo, reponame, test_cmd, tee)
+    gate = gate_transition_section(repo, reponame, tee)
+    cleanup(repo, tee)
+    return {"repo": reponame, "real": real, "gate": gate}
+
+
+def main() -> int:
+    if not VAULT_CLI.exists():
+        sys.stderr.write(f"wicked-vault CLI not found at {VAULT_CLI}\n")
+        return 2
+    repos = [Path(a).resolve() for a in sys.argv[1:]] or [
+        Path.home() / "Projects" / "memos",
+        Path.home() / "Projects" / "Enterprise-AISDLC",
+    ]
+    tee = Tee(EVIDENCE)
+    tee("wicked-garden -> wicked-vault consumer-contract wiring (Phase-0)")
+    tee(f"vault CLI: {VAULT_CLI}")
+    tee(f"transcript: {EVIDENCE}")
+    summary = []
+    try:
+        for repo in repos:
+            if not repo.exists():
+                tee(f"\nSKIP (missing): {repo}")
+                continue
+            summary.append(wire(repo, tee))
+    finally:
+        tee("\n" + "=" * 72)
+        tee("SUMMARY")
+        tee("=" * 72)
+        for s in summary:
+            tee(f"\n{s['repo']}:")
+            r = s["real"]
+            tee(f"  REAL detected command runnable: {r.get('runnable')}"
+                + (f"  ({r['note']})" if r.get("note") else ""))
+            if r.get("runnable"):
+                tee(f"    real cross-check: overall={r.get('crosscheck_overall')} "
+                    f"exit={r.get('crosscheck_exit')}")
+            g = s["gate"]
+            tee(f"  GATE failing-latest: overall={g.get('fail_overall')} exit={g.get('fail_exit')} (expect REJECT/1)")
+            tee(f"  GATE passing-latest: overall={g.get('pass_overall')} exit={g.get('pass_exit')} (expect PASS/0)")
+        tee.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compiler/phase0/wire_vault.py
+++ b/scripts/compiler/phase0/wire_vault.py
@@ -43,7 +43,12 @@ import tempfile
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-VAULT_CLI = Path.home() / "Projects" / "wicked-vault" / "bin" / "wicked-vault.mjs"
+# Resolve the vault CLI portably: WICKED_VAULT_BIN env first, else a sibling
+# checkout (dev default). A .mjs/.js path runs via node; anything else direct.
+_VAULT_BIN = os.environ.get("WICKED_VAULT_BIN", "").strip() or str(
+    Path.home() / "Projects" / "wicked-vault" / "bin" / "wicked-vault.mjs")
+VAULT_PREFIX = (["node", _VAULT_BIN] if _VAULT_BIN.endswith((".mjs", ".js"))
+                else [_VAULT_BIN])
 EVIDENCE = HERE / "evidence" / "wire-vault-transcript.txt"
 
 # Per-repo wall-clock budget for the REAL detected test_command. If it exceeds
@@ -71,7 +76,7 @@ class Tee:
 
 def run_vault(args: list[str], cwd_repo: Path, timeout: int | None = None) -> tuple[int, dict | str]:
     """Invoke the vault CLI. Returns (exit_code, parsed_json_or_raw_text)."""
-    cmd = ["node", str(VAULT_CLI), *args, "--cwd", str(cwd_repo)]
+    cmd = [*VAULT_PREFIX, *args, "--cwd", str(cwd_repo)]
     try:
         proc = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout,
@@ -260,8 +265,12 @@ def wire(repo: Path, tee: Tee) -> dict:
 
 
 def main() -> int:
-    if not VAULT_CLI.exists():
-        sys.stderr.write(f"wicked-vault CLI not found at {VAULT_CLI}\n")
+    # When invoked via `node <path>`, that path must exist. A bare command
+    # (global install / PATH) is left to the subprocess to resolve.
+    if VAULT_PREFIX[0] == "node" and not Path(_VAULT_BIN).exists():
+        sys.stderr.write(
+            f"wicked-vault CLI not found at {_VAULT_BIN} "
+            "(set WICKED_VAULT_BIN to override)\n")
         return 2
     repos = [Path(a).resolve() for a in sys.argv[1:]] or [
         Path.home() / "Projects" / "memos",
@@ -269,7 +278,7 @@ def main() -> int:
     ]
     tee = Tee(EVIDENCE)
     tee("wicked-garden -> wicked-vault consumer-contract wiring (Phase-0)")
-    tee(f"vault CLI: {VAULT_CLI}")
+    tee(f"vault CLI: {' '.join(VAULT_PREFIX)}")
     tee(f"transcript: {EVIDENCE}")
     summary = []
     try:

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -12,22 +12,27 @@ pure verifier every time, never trusting a cached status — and answers
 So the gate becomes: *is the claim actually backed by evidence that
 clears its declared contract?* — not *did someone say it was done?*
 
-**Optional sibling, never a hard dependency.** wicked-vault is resolved
-the same way the vault resolves wicked-bus: if it isn't installed, the
-gate degrades gracefully to the doctrine-light ``evidence_tracker``
-fallback and says so loudly (``re_derived: false``). A missing vault
-never crashes a playbook; it only downgrades the gate's *trust*.
+**Required peer, fail-closed by default.** wicked-vault is a required
+sibling (like wicked-bus / wicked-brain / wicked-testing). When it is
+genuinely unresolvable, ``gate_satisfied`` (``require=True`` default)
+**fails closed** — it never self-asserts a PASS. ``require=False`` is an
+explicit opt-out to the doctrine-light ``evidence_tracker`` claim-only
+path for throwaway/low-rigor work.
 
-Resolution order for the vault CLI:
+Resolution order for the vault CLI (see ``resolve_vault``):
     1. ``WICKED_VAULT_BIN`` env var (explicit override; a ``.mjs``/``.js``
        path is invoked via ``node``, anything else is run directly).
+       **Set-but-empty is a kill-switch** → unresolvable (forces
+       fail-closed / opt-out; used for offline dev, see CONTRIBUTING.md).
     2. ``tool_preferences.wicked-vault`` in
        ``~/.something-wicked/wicked-garden/config.json``.
-    3. A ``wicked-vault`` executable on ``PATH`` (``shutil.which``).
-    4. None → fall back to claim-only.
-
-We never silently shell out to ``npx`` (it would hit the network); the
-caller opts in by setting the env var or installing the CLI.
+    3. A ``wicked-vault`` executable on ``PATH``.
+    4. A project-local ``node_modules/.bin/wicked-vault``.
+    5. ``npx --yes wicked-vault`` — the portable fallback. The vault is
+       commonly run via npx (``npx wicked-vault-install`` does not place a
+       global binary), so this tier is what lets the required peer resolve
+       out of the box; it is *not* counted as a concrete install
+       (``vault_available`` excludes it). ``--yes`` fetches once, then caches.
 
 Stdlib-only. Cross-platform (argv lists, ``shutil.which``, no shell).
 """
@@ -61,20 +66,20 @@ def _argv_for(target: str) -> List[str]:
     return [target]
 
 
-def resolve_vault(*, allow_npx: bool = True) -> Optional[List[str]]:
+def resolve_vault(*, allow_npx: bool = True,
+                  project_dir: Optional[Path] = None) -> Optional[List[str]]:
     """Return the argv prefix that invokes wicked-vault, or None.
 
     Resolution tiers (first hit wins):
       1. ``WICKED_VAULT_BIN`` env. Set-but-empty is a deliberate
-         **kill-switch** → return None (forces the fail-closed / opt-out
-         path; never silently reaches for npx).
+         **kill-switch** → return None (forces fail-closed / opt-out).
       2. ``tool_preferences.wicked-vault`` in config.json.
-      3. ``wicked-vault`` on PATH (a global ``npm i -g`` — what setup does).
-      4. a project-local ``node_modules/.bin/wicked-vault``.
-      5. ``npx --yes wicked-vault`` — last resort, only when ``allow_npx``.
-         npx exists almost everywhere, so this tier is what makes the
-         required-but-not-globally-installed case still work; it is *not*
-         counted as a concrete install (see ``vault_available``).
+      3. ``wicked-vault`` on PATH (a global ``npm i -g``).
+      4. a project-local ``node_modules/.bin/wicked-vault`` — resolved
+         under ``project_dir`` when given, else the cwd (so a gate run from
+         a different cwd still finds the target repo's local install).
+      5. ``npx --yes wicked-vault`` — the portable fallback, only when
+         ``allow_npx``; not counted as a concrete install (``vault_available``).
 
     None means no vault is resolvable at all.
     """
@@ -90,7 +95,8 @@ def resolve_vault(*, allow_npx: bool = True) -> Optional[List[str]]:
     if found:
         return [found]
 
-    local = Path.cwd() / "node_modules" / ".bin" / "wicked-vault"
+    base = Path(project_dir) if project_dir else Path.cwd()
+    local = base / "node_modules" / ".bin" / "wicked-vault"
     if local.exists():
         return [str(local)]
 
@@ -100,12 +106,12 @@ def resolve_vault(*, allow_npx: bool = True) -> Optional[List[str]]:
     return None
 
 
-def vault_available() -> bool:
+def vault_available(project_dir: Optional[Path] = None) -> bool:
     """True iff a **concrete** vault install is resolvable (env, config,
     PATH, or node_modules) — not the npx last-resort. This is the signal
     setup and the SessionStart bootstrap use to decide whether the
     required peer is actually installed."""
-    return resolve_vault(allow_npx=False) is not None
+    return resolve_vault(allow_npx=False, project_dir=project_dir) is not None
 
 
 def _read_config_preference(key: str) -> Optional[str]:
@@ -139,7 +145,7 @@ def _run(
     ``error`` is populated (and exit_code left None) only when the CLI
     could not be executed at all — not found, or timed out.
     """
-    prefix = resolve_vault()
+    prefix = resolve_vault(project_dir=project_dir)
     if prefix is None:
         return {"exit_code": None, "stdout": "", "stderr": "",
                 "error": "wicked-vault not resolvable"}
@@ -234,7 +240,7 @@ def gate_satisfied(
     - vault unresolvable, ``require=False`` → legacy claim-only path
       (opt-out for throwaway/low-rigor work; treat "done" with suspicion).
     """
-    if resolve_vault() is not None:
+    if resolve_vault(project_dir=Path(project_dir)) is not None:
         cc = cross_check(scope, phase, project_dir=Path(project_dir),
                          with_attestations=with_attestations)
         if cc.get("available"):

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""vault_gate.py — the garden's produces-gate, backed by wicked-vault.
+
+This is the load-bearing replacement for ``evidence_tracker``'s
+*satisfied-when-claimed* model. The tracker records what an archetype
+*claims* to have produced and never re-derives it; that lets a build's
+review gate pass on a self-asserted "tests pass". ``wicked-vault``
+instead re-derives — it recomputes the envelope hash and re-runs the
+pure verifier every time, never trusting a cached status — and answers
+``cross-check`` with a mechanical PASS / REJECT / ERROR.
+
+So the gate becomes: *is the claim actually backed by evidence that
+clears its declared contract?* — not *did someone say it was done?*
+
+**Optional sibling, never a hard dependency.** wicked-vault is resolved
+the same way the vault resolves wicked-bus: if it isn't installed, the
+gate degrades gracefully to the doctrine-light ``evidence_tracker``
+fallback and says so loudly (``re_derived: false``). A missing vault
+never crashes a playbook; it only downgrades the gate's *trust*.
+
+Resolution order for the vault CLI:
+    1. ``WICKED_VAULT_BIN`` env var (explicit override; a ``.mjs``/``.js``
+       path is invoked via ``node``, anything else is run directly).
+    2. ``tool_preferences.wicked-vault`` in
+       ``~/.something-wicked/wicked-garden/config.json``.
+    3. A ``wicked-vault`` executable on ``PATH`` (``shutil.which``).
+    4. None → fall back to claim-only.
+
+We never silently shell out to ``npx`` (it would hit the network); the
+caller opts in by setting the env var or installing the CLI.
+
+Stdlib-only. Cross-platform (argv lists, ``shutil.which``, no shell).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # noqa: S404 — argv lists only, shell=False
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
+_DEFAULT_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def _argv_for(target: str) -> List[str]:
+    """Turn a resolved vault location into an argv prefix.
+
+    A ``.mjs``/``.js`` file is a script → invoke via ``node``. Anything
+    else (an executable name or a shim) is run directly.
+    """
+    if target.endswith((".mjs", ".js")):
+        return ["node", target]
+    return [target]
+
+
+def resolve_vault(*, allow_npx: bool = True) -> Optional[List[str]]:
+    """Return the argv prefix that invokes wicked-vault, or None.
+
+    Resolution tiers (first hit wins):
+      1. ``WICKED_VAULT_BIN`` env. Set-but-empty is a deliberate
+         **kill-switch** → return None (forces the fail-closed / opt-out
+         path; never silently reaches for npx).
+      2. ``tool_preferences.wicked-vault`` in config.json.
+      3. ``wicked-vault`` on PATH (a global ``npm i -g`` — what setup does).
+      4. a project-local ``node_modules/.bin/wicked-vault``.
+      5. ``npx --yes wicked-vault`` — last resort, only when ``allow_npx``.
+         npx exists almost everywhere, so this tier is what makes the
+         required-but-not-globally-installed case still work; it is *not*
+         counted as a concrete install (see ``vault_available``).
+
+    None means no vault is resolvable at all.
+    """
+    if "WICKED_VAULT_BIN" in os.environ:
+        env = os.environ["WICKED_VAULT_BIN"].strip()
+        return _argv_for(env) if env else None  # empty == kill-switch
+
+    pref = _read_config_preference("wicked-vault")
+    if pref:
+        return _argv_for(pref)
+
+    found = shutil.which("wicked-vault")
+    if found:
+        return [found]
+
+    local = Path.cwd() / "node_modules" / ".bin" / "wicked-vault"
+    if local.exists():
+        return [str(local)]
+
+    if allow_npx and shutil.which("npx"):
+        return ["npx", "--yes", "wicked-vault"]
+
+    return None
+
+
+def vault_available() -> bool:
+    """True iff a **concrete** vault install is resolvable (env, config,
+    PATH, or node_modules) — not the npx last-resort. This is the signal
+    setup and the SessionStart bootstrap use to decide whether the
+    required peer is actually installed."""
+    return resolve_vault(allow_npx=False) is not None
+
+
+def _read_config_preference(key: str) -> Optional[str]:
+    """Read ``tool_preferences.{key}`` from config.json; None on any error."""
+    try:
+        if not _CONFIG_PATH.exists():
+            return None
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = data.get("tool_preferences")
+        if isinstance(prefs, dict):
+            value = prefs.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Invocation
+# ---------------------------------------------------------------------------
+
+def _run(
+    args: List[str],
+    *,
+    project_dir: Optional[Path],
+    timeout: int,
+) -> Dict[str, Any]:
+    """Run the vault CLI; return ``{exit_code, stdout, stderr, error}``.
+
+    ``error`` is populated (and exit_code left None) only when the CLI
+    could not be executed at all — not found, or timed out.
+    """
+    prefix = resolve_vault()
+    if prefix is None:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": "wicked-vault not resolvable"}
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            prefix + args,
+            cwd=str(project_dir) if project_dir else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {"exit_code": proc.returncode, "stdout": proc.stdout,
+                "stderr": proc.stderr, "error": None}
+    except FileNotFoundError:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": "vault executable not found on PATH"}
+    except subprocess.TimeoutExpired:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": f"vault cross-check exceeded {timeout}s"}
+
+
+def cross_check(
+    scope: str,
+    phase: str,
+    *,
+    project_dir: Optional[Path] = None,
+    with_attestations: bool = False,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    """Run ``wicked-vault cross-check`` and return its mechanical verdict.
+
+    Returns a dict with ``available`` (False when no vault is resolvable
+    or it could not be run) and, when available, the parsed ``overall``
+    (PASS / REJECT / ERROR), ``exit_code``, ``claims``, ``mode``, and
+    ``contract_version``.
+
+    Per G5 the vault is fail-closed: no contract declared → ERROR. We
+    surface that verbatim; we never invent a PASS.
+    """
+    args = ["cross-check", "--scope", scope, "--phase", phase]
+    if with_attestations:
+        args.append("--with-attestations")
+
+    run = _run(args, project_dir=project_dir, timeout=timeout)
+    if run["error"] is not None:
+        return {"available": False, "overall": "ERROR",
+                "error": run["error"], "exit_code": None}
+
+    try:
+        parsed = json.loads(run["stdout"]) if run["stdout"].strip() else {}
+    except json.JSONDecodeError:
+        return {"available": True, "overall": "ERROR", "exit_code": run["exit_code"],
+                "error": "vault returned non-JSON output",
+                "stderr": run["stderr"][:500]}
+
+    return {
+        "available": True,
+        "overall": parsed.get("overall", "ERROR"),
+        "exit_code": run["exit_code"],
+        "claims": parsed.get("claims", []),
+        "mode": parsed.get("mode"),
+        "contract_version": parsed.get("contract_version"),
+        "detail": parsed.get("detail"),
+        "raw": parsed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+def gate_satisfied(
+    project_dir: Path,
+    scope: str,
+    phase: str,
+    *,
+    with_attestations: bool = False,
+    require: bool = True,
+) -> Dict[str, Any]:
+    """The produces-gate. The vault is a **required** evidence backend
+    (installed by ``/wicked-garden:setup``), so the default is to re-derive
+    or **fail closed** — never to self-assert a PASS.
+
+    Returns ``{satisfied, re_derived, gate, ...}``. ``re_derived`` is the
+    honesty flag: True means the verdict was recomputed from frozen
+    evidence; False means either a fail-closed "unavailable" verdict or the
+    explicitly opted-out claim-only path.
+
+    - vault resolvable → run cross-check, ``re_derived: true``.
+    - vault unresolvable, ``require=True`` (default) → fail closed:
+      ``satisfied: false``, ``gate: "unavailable"`` with remediation.
+    - vault unresolvable, ``require=False`` → legacy claim-only path
+      (opt-out for throwaway/low-rigor work; treat "done" with suspicion).
+    """
+    if resolve_vault() is not None:
+        cc = cross_check(scope, phase, project_dir=Path(project_dir),
+                         with_attestations=with_attestations)
+        if cc.get("available"):
+            return {
+                "satisfied": cc.get("overall") == "PASS",
+                "re_derived": True,
+                "gate": "vault-cross-check",
+                "overall": cc.get("overall"),
+                "claims": cc.get("claims", []),
+                "contract_version": cc.get("contract_version"),
+                "detail": cc.get("detail"),
+                "error": cc.get("error"),
+            }
+        # Resolver pointed at a vault but it could not be run (offline npx,
+        # missing executable). Fail closed — do not invent a PASS.
+        if require:
+            return {
+                "satisfied": False, "re_derived": False, "gate": "unavailable",
+                "error": cc.get("error", "vault resolvable but not runnable"),
+                "reason": "wicked-vault could not be executed; gate fails closed.",
+            }
+
+    if require:
+        return {
+            "satisfied": False,
+            "re_derived": False,
+            "gate": "unavailable",
+            "reason": (
+                "wicked-vault is a required evidence backend but is not "
+                "resolvable. Install it (`npm i -g wicked-vault` or "
+                "`npx wicked-vault-install`) and re-run /wicked-garden:setup. "
+                "Gate fails closed — 'done' cannot be self-asserted."
+            ),
+        }
+
+    # Explicit opt-out (require=False): the doctrine-light tracker.
+    _here = str(Path(__file__).resolve().parent)
+    if _here not in sys.path:
+        sys.path.insert(0, _here)
+    import evidence_tracker as et  # noqa: E402
+
+    return {
+        "satisfied": et.produces_satisfied(Path(project_dir)),
+        "re_derived": False,
+        "gate": "claim-only",
+        "reason": (
+            "vault opt-out (require=False) — gate is doctrine-light "
+            "(satisfied-when-claimed, not re-derived)."
+        ),
+    }
+
+
+__all__ = ["resolve_vault", "vault_available", "cross_check", "gate_satisfied"]
+
+
+# ---------------------------------------------------------------------------
+# CLI — so markdown playbooks can call the gate from Bash.
+#   exit 0 == satisfied (gate / cross-check both gate on exit code)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="wicked-vault-backed produces gate.")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    res = sub.add_parser("resolve", help="show how the vault CLI resolves")
+
+    cc = sub.add_parser("cross-check", help="run vault cross-check for a phase")
+    cc.add_argument("project_dir")
+    cc.add_argument("--scope", required=True)
+    cc.add_argument("--phase", required=True)
+    cc.add_argument("--with-attestations", action="store_true")
+
+    g = sub.add_parser("gate", help="gate verdict (vault required; fail-closed)")
+    g.add_argument("project_dir")
+    g.add_argument("--scope", required=True)
+    g.add_argument("--phase", required=True)
+    g.add_argument("--with-attestations", action="store_true")
+    g.add_argument("--no-require", action="store_true",
+                   help="opt out of the requirement (low-rigor claim-only fallback)")
+
+    a = parser.parse_args()
+
+    if a.action == "resolve":
+        prefix = resolve_vault()
+        print(json.dumps({
+            "resolvable": prefix is not None,
+            "installed": vault_available(),  # concrete install (not npx)
+            "argv_prefix": prefix,
+        }))
+        sys.exit(0)
+
+    if a.action == "cross-check":
+        out = cross_check(a.scope, a.phase, project_dir=Path(a.project_dir),
+                         with_attestations=a.with_attestations)
+        print(json.dumps(out, indent=2))
+        sys.exit(0 if out.get("overall") == "PASS" else 1)
+
+    if a.action == "gate":
+        out = gate_satisfied(Path(a.project_dir), a.scope, a.phase,
+                            with_attestations=a.with_attestations,
+                            require=not a.no_require)
+        print(json.dumps(out, indent=2))
+        sys.exit(0 if out.get("satisfied") else 1)

--- a/skills/archetype/refs/build.md
+++ b/skills/archetype/refs/build.md
@@ -20,6 +20,14 @@ phase looks different.
 - **Test report**: at minimum, evidence that the change was exercised.
   At higher rigor: unit tests, integration tests, acceptance evidence.
 
+The review gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the evidence is re-hashed and its verifier
+re-run, never trusting a cached "done". wicked-vault is a **required**
+peer (installed by `/wicked-garden:setup`); if it is genuinely absent the
+gate **fails closed** (`gate: "unavailable"`, `satisfied: false`) rather
+than self-asserting a PASS. `--no-require` opts a throwaway/low-rigor run
+back to the doctrine-light claim-only path.
+
 ## HITL
 
 `discrete:review-gate` — review is the discrete gate. Approve happens
@@ -32,6 +40,14 @@ through PR review, council, or the `review` archetype if rigor warrants.
 1. Initialise the evidence tracker for this archetype run:
    `scripts/qe/evidence_tracker.py init <project_dir> --archetype build`.
    Pre-populates `shipped-code` and `test-report` as pending.
+   Then, if a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`), declare the
+   re-derivable contract for this phase so the review gate has a bar to
+   check against:
+   `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase build --spec contract.json`
+   — `required_evidence` should pin `tests-pass` to a deterministic
+   verifier (e.g. `exit_code_eq:0`). Skip silently if no vault.
 2. If picking up open conditions from a prior `review` archetype, read
    `scripts/qe/conditions_manifest.py status <project_dir>` and pin
    each one to a build task so they don't get lost.
@@ -67,6 +83,13 @@ through PR review, council, or the `review` archetype if rigor warrants.
 3. **Tests must actually fail when the code is wrong.** The
    test-code-quality-auditor exists for a reason — assertion-free
    tests are worse than no tests.
+4. Record the test run as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase build --claim tests-pass
+   --kind test-run --source "<the test command>" --criteria "<the bar>"
+   --verifier exit_code_eq:0 --run`. The `--run` captures the command's
+   real exit code now and the gate re-runs it later — a claim you can't
+   re-derive is not evidence. No vault → fall back to
+   `evidence_tracker.py claim`.
 
 ### review
 
@@ -80,8 +103,14 @@ through PR review, council, or the `review` archetype if rigor warrants.
 
 ## When to stop
 
-Build is done when the PR is merged AND the test report is committed.
-If the change is high-blast-radius, hand off to `ship`.
+Build is done when the produces-gate is satisfied AND the PR is merged.
+Check the gate — don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase build`
+(exit 0 = satisfied). This is a re-derived PASS over the declared
+contract. A REJECT means the recorded evidence does not clear its
+contract — fix the work, not the claim. An `unavailable` verdict means
+the required vault isn't installed — run `/wicked-garden:setup`. If the
+change is high-blast-radius, hand off to `ship`.
 
 ## Anti-patterns
 

--- a/skills/archetype/refs/decide.md
+++ b/skills/archetype/refs/decide.md
@@ -21,6 +21,19 @@ path and the reasons.
 - A **decision artifact**: which option was picked, and the explicit
   trade-offs accepted by picking it.
 
+The select gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the ADR's bytes are re-hashed and its
+structure verifier re-run, never trusting a cached "ADR written". The
+check is **deterministic document-structure** — it proves the ADR
+contains the required sections, not that the call was wise. wicked-vault
+is a **required** peer (installed by `/wicked-garden:setup`); if it is
+genuinely absent the gate **fails closed** (`gate: "unavailable"`,
+`satisfied: false`) rather than self-asserting a PASS. `--no-require`
+opts a throwaway/low-rigor decision back to the doctrine-light
+claim-only path. (A judgment tier — `wicked-vault analyze-evidence` —
+exists for "was this the right call" sign-off; it's optional here and
+not part of this discrete gate.)
+
 ## HITL
 
 `discrete:select-gate` — the user (or a council) picks. Don't auto-select.
@@ -35,6 +48,16 @@ path and the reasons.
 3. If reversibility is HIGH and blast radius is LOW, **stop and ask**
    whether this even needs an ADR. Cheap-to-reverse decisions don't
    benefit from this archetype's overhead.
+4. If a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`), declare the
+   re-derivable contract so the select gate has a bar to check against:
+   `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase decide --spec contract.json`.
+   `required_evidence` pins `adr` (kind `adr-doc`) to a `regex_match`
+   verifier proving the ADR carries every required section — Status,
+   Context, Decision, Consequences — and pins `decision-artifact` to a
+   presence/structure check (`regex_match`, or `commit_exists` once the
+   ADR is committed). Skip silently if no vault.
 
 ### options
 
@@ -62,13 +85,30 @@ path and the reasons.
    consequences, trade-offs accepted.
 3. Commit the ADR with the implementing change, not separately. The ADR
    is the explanation for the diff.
+4. Record the ADR as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase decide --claim adr
+   --kind adr-doc --source "<path to the ADR>"
+   --criteria "ADR has Status / Context / Decision / Consequences"
+   --verifier 'regex_match:(?ims)^#+\s*(status|context|decision|consequences)\b'
+   --run`, then record `decision-artifact` against the committed ADR
+   (`--verifier commit_exists:<sha>` once committed, else a `regex_match`
+   on the decision line). The `--run` hashes the file's bytes now and the
+   gate re-derives the structure later — a claim you can't re-derive is
+   not evidence. No vault → fall back to `evidence_tracker.py claim`.
 
 ## When to stop
 
-Decide is done when an ADR is committed and the chosen option is named.
-Hand off to `build` (implement the chosen path), `migrate` (when the
-choice is a shape change), or `ship` (when the choice is a rollout
-strategy).
+Decide is done when the produces-gate is satisfied AND the chosen option
+is named. Check the gate — don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase decide`
+(exit 0 = satisfied). This is a re-derived PASS over the declared
+contract — the ADR was re-hashed and its structure verifier re-run. A
+REJECT means the recorded ADR doesn't clear its contract (a missing
+section, an uncommitted artifact) — fix the document, not the claim. An
+`unavailable` verdict means the required vault isn't installed — run
+`/wicked-garden:setup`. Then hand off to `build` (implement the chosen
+path), `migrate` (when the choice is a shape change), or `ship` (when the
+choice is a rollout strategy).
 
 ## Anti-patterns
 

--- a/skills/archetype/refs/incident.md
+++ b/skills/archetype/refs/incident.md
@@ -23,6 +23,16 @@ investigate before mitigating unless investigation IS the mitigation.
 - **Followup list**: action items with owners. Each gets a github issue
   or tracked task.
 
+The mitigate gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the evidence is re-hashed and its verifier
+re-run, never trusting a cached "mitigated". The honesty move here is the
+mitigation pin — a claimed mitigation that doesn't actually make the
+symptom check pass must REJECT. wicked-vault is a **required** peer
+(installed by `/wicked-garden:setup`); if it is genuinely absent the gate
+**fails closed** (`gate: "unavailable"`, `satisfied: false`) rather than
+self-asserting a PASS. `--no-require` opts a throwaway/low-rigor run back
+to the doctrine-light claim-only path.
+
 ## HITL
 
 `hard:mitigate` — mitigate is a hard gate. Don't move past it without
@@ -37,6 +47,15 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
 2. Page the right people. SEV-1 is a phone call, not a slack message.
 3. Open an incident channel + tracking ticket. The ticket is the
    single source of truth for the timeline.
+4. If a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`), declare the
+   re-derivable contract so the mitigate gate has a bar to check against:
+   `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase incident --spec contract.json`.
+   `required_evidence` pins `mitigation` to a deterministic re-run of the
+   symptom check (`exit_code_eq:0`), and `rca` / `followup-list` to
+   presence/structure `regex_match` (required RCA sections present;
+   followup list non-empty). Skip silently if no vault.
 
 ### investigate
 
@@ -46,6 +65,9 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
 3. **Time-box investigation to 15 minutes during SEV-1.** If you don't
    have a mitigation hypothesis in 15 min, escalate; don't keep
    investigating.
+4. Capture the **symptom check** — the command that reproduces the break
+   (it fails now). This becomes the deterministic verifier the mitigate
+   gate re-runs: a real mitigation makes this same command pass.
 
 ### mitigate
 
@@ -56,7 +78,15 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
    - Circuit break a downstream (when a dependency is the issue).
 2. **Confirm the bleeding stopped.** Watch the same dashboards that
    surfaced the incident. Don't declare mitigated based on logs alone.
-3. Update the incident channel: "MITIGATED via {action} at {time}".
+3. Record the mitigation as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase incident --claim mitigation
+   --kind mitigation-check --source "<the symptom-check command>"
+   --criteria "symptom check passes post-mitigation"
+   --verifier exit_code_eq:0 --run`. The `--run` captures the symptom
+   check's real exit code now and the gate re-runs it later — a mitigation
+   you can't re-derive is not evidence. No vault → fall back to
+   `evidence_tracker.py claim`.
+4. Update the incident channel: "MITIGATED via {action} at {time}".
 
 ### resolve
 
@@ -73,12 +103,35 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
 2. Use `wicked-garden:incident-to-scenario-synthesizer` to convert the
    incident into a regression scenario that would catch the same break.
 3. Track action items in github. Don't bury them in a Slack thread.
+4. Record the docs evidence (vault present):
+   `wicked-vault record --scope <scope> --phase incident --claim rca
+   --kind doc --artifact docs/postmortems/INC-{N}.md
+   --criteria "required RCA sections present"
+   --verifier "regex_match:## Root Cause"` and
+   `wicked-vault record --scope <scope> --phase incident
+   --claim followup-list --kind doc --artifact <followup-list>
+   --criteria "followup list non-empty"
+   --verifier "regex_match:- \["`. No vault → `evidence_tracker.py claim`.
 
 ## When to stop
 
-Incident is done when the followup list is owned and tracked. Hand off
-to `build` (forward-fix work), `migrate` (when the fix is a shape
-change), or `review` (when the followup includes auditing prevention).
+`mitigate` is a **hard gate** — confirm the bleeding stopped before
+moving past it, and don't self-grade the mitigation. Check the gate WITH
+judgment:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase incident --with-attestations`
+(exit 0 = satisfied). This re-runs the symptom check (the mitigation pin)
+and requires an **independent attestation** — an evaluator who is *not*
+the responder confirms the mitigation holds and the RCA is adequate,
+recorded via `wicked-vault:analyze-evidence`. It fails closed on a
+self-grade. A REJECT means the symptom check still fails or the
+attestation is missing/negative — fix the work, not the claim. An
+`unavailable` verdict means the required vault isn't installed — run
+`/wicked-garden:setup`.
+
+Incident is done when the gate is satisfied and the followup list is
+owned and tracked. Hand off to `build` (forward-fix work), `migrate`
+(when the fix is a shape change), or `review` (when the followup includes
+auditing prevention).
 
 ## Anti-patterns
 

--- a/skills/archetype/refs/migrate.md
+++ b/skills/archetype/refs/migrate.md
@@ -21,6 +21,20 @@ readers, switch writers, remove the old shape.
 - **Rollback proof**: an executable rollback path. Tested in staging
   before cutover.
 
+The cutover gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the rollback drill is re-run and the
+shape-change post-condition re-checked, never trusting a self-asserted
+"rolled back fine". This is the original evidence-vault use case — for a
+migration the load-bearing honesty move is **no cutover without a
+re-derivable rollback proof**. wicked-vault is a **required** peer
+(installed by `/wicked-garden:setup`); if it is genuinely absent the gate
+**fails closed** (`gate: "unavailable"`, `satisfied: false`) rather than
+self-asserting a PASS. Because `cutover` is a HARD gate, the gate also
+demands an **independent attestation**: an evaluator who is **not** the
+migrator confirms the rollback proof and shape change are adequate
+(recorded via `wicked-vault:analyze-evidence`), and the gate fails closed
+on a self-grade.
+
 ## HITL
 
 `hard:cutover-gate` — cutover is a hard gate. Don't cutover without
@@ -39,7 +53,19 @@ tested, backfill complete, dual-read working).
    - The expand-contract phase boundaries: when each step happens.
 2. Use `wicked-garden:engineering:migration-engineer` for the canonical
    playbook.
-3. **If the shape change is reversible HIGH (e.g. a column add), this
+3. Declare the re-derivable contract early so the cutover gate has a bar
+   to check against. If a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`):
+   `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase migrate --spec contract.json`.
+   `required_evidence` must pin both claim_ids:
+   - `rollback-proof` → `exit_code_eq:0` on the rollback-drill command —
+     the rollback was actually exercised and succeeded, not asserted.
+   - `shape-change` → a deterministic post-condition: `exit_code_eq:0`
+     on a migration-applied verification, or `jq_pred` over a captured
+     schema-state JSON.
+   Skip silently if no vault.
+4. **If the shape change is reversible HIGH (e.g. a column add), this
    archetype is overkill.** Drop back to `build`.
 
 ### expand
@@ -48,6 +74,12 @@ tested, backfill complete, dual-read working).
 2. New writes go to BOTH shapes (dual-write). New reads still come from
    the old shape.
 3. Land + deploy expand. Don't combine with backfill.
+4. Record the **shape-change** as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase migrate --claim shape-change
+   --kind schema-state --source "<migration-applied verification>"
+   --criteria "<the post-condition>" --verifier exit_code_eq:0 --run`. The
+   `--run` captures the real exit code now and the gate re-runs it later —
+   a claim you can't re-derive is not evidence.
 
 ### backfill
 
@@ -57,6 +89,14 @@ tested, backfill complete, dual-read working).
 2. Run in batches; rate-limit against the production DB.
 3. Verify completeness: the row count + checksum + spot-check sample
    match the old shape.
+4. **Exercise the rollback drill and record it as re-derivable evidence —
+   this must exist and re-derive BEFORE cutover** (vault present):
+   `wicked-vault record --scope <scope> --phase migrate --claim rollback-proof
+   --kind rollback-drill --source "<the rollback-drill command>"
+   --criteria "rollback exercised and succeeded" --verifier exit_code_eq:0 --run`.
+   The `--run` captures the drill's real exit code now; the gate re-runs
+   it at cutover. A rollback path you can't re-derive is not a rollback
+   path. No vault → fall back to `evidence_tracker.py claim`.
 
 ### cutover
 
@@ -65,10 +105,20 @@ tested, backfill complete, dual-read working).
    - Backfill complete + verified.
    - Dual-write running cleanly for at least 24h.
    - Monitoring + alerts updated to surface new shape's anomalies.
-2. **Cutover staged**: switch readers first, watch for 1h, then switch
+2. **Gate before any switch** — don't self-assert the checklist. Run the
+   produces-gate WITH judgment:
+   `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+   (exit 0 = satisfied). This re-derives the rollback drill and the
+   shape-change post-condition over the declared contract, and requires
+   the independent attestation (evaluator ≠ migrator, via
+   `wicked-vault:analyze-evidence`). A REJECT means the rollback proof or
+   shape change doesn't clear its contract — fix the work, not the claim.
+   An `unavailable` verdict means the required vault isn't installed — run
+   `/wicked-garden:setup`. **No cutover on a fail-closed verdict.**
+3. **Cutover staged**: switch readers first, watch for 1h, then switch
    writers. Don't switch both at once.
-3. The cutover gate is HARD — explicit user "go" before each switch.
-4. If anything looks off post-cutover: **rollback first, debug second.**
+4. The cutover gate is HARD — explicit user "go" before each switch.
+5. If anything looks off post-cutover: **rollback first, debug second.**
 
 ### contract
 
@@ -79,6 +129,13 @@ tested, backfill complete, dual-read working).
    complete.
 
 ## When to stop
+
+Cutover may only proceed when the produces-gate is satisfied — check it,
+don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+(exit 0 = satisfied). This is a re-derived PASS over the declared contract
+plus the independent attestation; a missing vault is `gate: "unavailable"`
+/ `satisfied: false`, never a claim-only pass.
 
 Migrate is done when the old shape is removed AND the contract phase
 has soaked. Hand off to `review` for a post-migration audit when the

--- a/skills/archetype/refs/review.md
+++ b/skills/archetype/refs/review.md
@@ -19,6 +19,18 @@ REJECT, with a remediation list when not APPROVE.
 - **Remediation list**: each item has an id, severity, and a concrete
   action. Empty when APPROVE.
 
+The final-verdict gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the verdict JSON is re-validated and the
+remediation-list structure re-checked, never trusting a self-asserted
+"done". wicked-vault is a **required** peer (installed by
+`/wicked-garden:setup`); if it is genuinely absent the gate **fails
+closed** (`gate: "unavailable"`, `satisfied: false`) rather than passing
+on a claim alone. Because final-verdict is a **hard** gate, the contract
+also demands an **independent attestation** — the verdict must be signed
+off by an evaluator that is NOT the worker who did the reviewed work
+(anti-self-grade, G10). `--no-require` opts a throwaway/low-rigor run
+back to the doctrine-light claim-only path.
+
 ## HITL
 
 `hard:final-verdict` — the verdict is a hard gate. Auto-approve is
@@ -34,6 +46,17 @@ banned (banned-reviewer enforcement applies — `auto-approve-*`,
    changed.
 3. Pick the rubric: code review uses R1–R6; design review uses
    testability + boundary clarity; spec review uses SMART+T.
+4. If a vault is resolvable (`scripts/qe/vault_gate.py resolve` →
+   `available: true`), declare the re-derivable contract for this phase
+   so the final-verdict gate has a bar to check against:
+   `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase review --spec contract.json`.
+   `required_evidence` should pin `verdict` to `exit_code_eq:0` on a
+   verdict-schema validation (`scripts/qe/verdict_schema.py`) and
+   `remediation-list` to a presence/structure `regex_match`. Because
+   this is a **hard** gate, the contract also requires a passing
+   independent `opinion_attestation` (the judgment tier). Skip silently
+   if no vault.
 
 ### assess
 
@@ -73,6 +96,21 @@ banned (banned-reviewer enforcement applies — `auto-approve-*`,
    condition descriptions before persisting.
 4. Append to the audit log with `scripts/qe/verdict_audit.py append`
    so the verdict is replayable.
+   Then record both produces as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase review --claim verdict
+   --kind verdict --source "<verdict.json>" --criteria "<the bar>"
+   --verifier exit_code_eq:0 --run` where the run is
+   `scripts/qe/verdict_schema.py <verdict.json>`, and a second `record`
+   for `--claim remediation-list ... --verifier regex_match:<pattern>`.
+   The `--run` captures the validator's real exit code now and the gate
+   re-runs it later — a claim you can't re-derive is not evidence. No
+   vault → fall back to `evidence_tracker.py claim`.
+   Then have an **independent** evaluator sign off via the
+   `wicked-vault:analyze-evidence` skill, which records an
+   `opinion_attestation` over the frozen criteria. The evaluator must
+   NOT be the agent that did the reviewed work — the gate fails closed
+   on a self-grade. This is the "never let work self-grade its own done"
+   guarantee.
 5. On CONDITIONAL: initialise the conditions manifest with
    `scripts/qe/conditions_manifest.py init --from-verdict <path>`.
    The downstream archetype calls `mark` as it satisfies each one.
@@ -80,7 +118,17 @@ banned (banned-reviewer enforcement applies — `auto-approve-*`,
 
 ## When to stop
 
-Review is done when the verdict is recorded. Hand off to `build` (when
+Review is done when the produces-gate is satisfied. Check the gate —
+don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase review --with-attestations`
+(exit 0 = satisfied). This is a re-derived PASS over the declared
+contract. `--with-attestations` makes the gate require a passing
+independent `opinion_attestation` recorded via the
+`wicked-vault:analyze-evidence` skill, where the evaluator ≠ the agent
+that did the reviewed work — it fails closed on a self-grade. A REJECT
+means the recorded evidence does not clear its contract — fix the work,
+not the claim. An `unavailable` verdict means the required vault isn't
+installed — run `/wicked-garden:setup`. Then hand off to `build` (when
 fixes are needed before ship) or `ship` (when APPROVE).
 
 ## Anti-patterns

--- a/skills/archetype/refs/ship.md
+++ b/skills/archetype/refs/ship.md
@@ -18,6 +18,19 @@ to production. Each phase widens blast radius; gates are explicit ramps.
 - **SLO snapshot**: error rate, latency, saturation at each phase
   boundary, compared to the pre-rollout baseline.
 
+The ramp gate **re-derives** these via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the SLO snapshot's verifier is re-run and
+the rollout-verdict command's exit code re-checked, never trusting a
+cached "looked clean". Because live observation verifiers
+(`http_status_eq`, `pr_check_status`) aren't implemented yet, **capture
+the SLO metrics to a snapshot file** and verify with `jq_pred` over that
+captured JSON — deterministic and re-derivable, not a one-shot live
+probe. wicked-vault is a **required** peer (installed by
+`/wicked-garden:setup`); if it is genuinely absent the gate **fails
+closed** (`gate: "unavailable"`, `satisfied: false`) rather than
+self-asserting an APPROVE. `--no-require` opts a throwaway/low-rigor
+rollout back to the doctrine-light claim-only path.
+
 ## HITL
 
 `discrete:ramp-gates` — each phase boundary is a discrete gate. Auto-pass
@@ -32,9 +45,19 @@ always available.** Don't bypass the gate; widen the criteria.
 1. Define the slice: which traffic, what %, what region.
 2. Define the SLO criteria: error rate threshold, latency p95/p99
    threshold, saturation threshold. Pull baseline from the last 7d.
-3. Deploy. Watch for at least 1 hour OR 1000 requests, whichever is
+3. If a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`), declare the
+   re-derivable contract for this rollout so every ramp gate has a bar to
+   check against: `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase ship --spec
+   contract.json`. `required_evidence` pins `slo-snapshot` (kind
+   `metrics-snapshot`) to a `jq_pred` verifier over a captured metrics
+   JSON file (e.g. `.error_rate <= 0.01 and .p95_ms < 250`) and
+   `rollout-verdict` to `exit_code_eq:0` on the canary/ramp check command.
+   Skip silently if no vault.
+4. Deploy. Watch for at least 1 hour OR 1000 requests, whichever is
    longer.
-4. Compare to baseline. If clean: pass to ramp. If degraded:
+5. Compare to baseline. If clean: pass to ramp. If degraded:
    **rollback immediately**. Don't tune in production.
 
 ### ramp
@@ -43,7 +66,21 @@ always available.** Don't bypass the gate; widen the criteria.
 2. At each step, the SLO criteria from canary still apply. New metrics
    may surface as load scales (saturation, queue depth, lock contention).
 3. Each step gets at least 30 minutes of soak before stepping up.
-4. Use `wicked-garden:delivery:rollout` for the canonical playbook.
+4. At each step, **capture fresh SLO metrics to a snapshot file** (don't
+   probe live), then record both produces as re-derivable evidence
+   (vault present):
+   `wicked-vault record --scope <scope> --phase ship --claim slo-snapshot
+   --kind metrics-snapshot --artifact <metrics.json> --criteria "<the
+   SLO bar>" --verifier 'jq_pred:.error_rate <= 0.01 and .p95_ms < 250'`
+   and `wicked-vault record --scope <scope> --phase ship --claim
+   rollout-verdict --kind check --source "<the canary/ramp check
+   command>" --criteria "verdict is APPROVE" --verifier exit_code_eq:0
+   --run`. The `jq_pred` re-runs against the captured snapshot and
+   `--run` re-checks the verdict command's real exit code — a claim you
+   can't re-derive is not evidence. Each ramp step supersedes the prior
+   snapshot, so the cross-check runs against fresh captured evidence at
+   every step. No vault → fall back to `evidence_tracker.py claim`.
+5. Use `wicked-garden:delivery:rollout` for the canonical playbook.
 
 ### full
 
@@ -58,6 +95,15 @@ always available.** Don't bypass the gate; widen the criteria.
 3. Soak ends when there's no anomaly outside the baseline noise band.
 
 ## When to stop
+
+Each ramp step advances only when the produces-gate is satisfied — check
+it, don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase ship`
+(exit 0 = satisfied). This is a re-derived APPROVE over the declared
+contract, re-run at **every** ramp step against the fresh captured
+snapshot. A REJECT means the recorded SLO snapshot doesn't clear its
+budget — **rollback**, don't widen. An `unavailable` verdict means the
+required vault isn't installed — run `/wicked-garden:setup`.
 
 Ship is done when soak is clean. Hand off to `review` for a post-rollout
 audit when the change was high-blast-radius, or close out otherwise.

--- a/skills/archetype/refs/specify.md
+++ b/skills/archetype/refs/specify.md
@@ -18,6 +18,18 @@ Achievable, Relevant, Time-bound — that downstream `build` can verify.
 - One-line invariants: "A response time over 500ms is a regression".
 - Optional: a `requirements.md` artifact in the project dir.
 
+The validate gate **re-derives** this via `wicked-vault`
+(`scripts/qe/vault_gate.py`): the recorded `smart-acceptance-criteria`
+artifact is re-hashed and its structural verifier re-run, never trusting
+a self-asserted "the ACs are testable". wicked-vault is a **required**
+peer (installed by `/wicked-garden:setup`); if it is genuinely absent the
+gate **fails closed** (`gate: "unavailable"`, `satisfied: false`) rather
+than claiming a PASS. `--no-require` opts a throwaway/low-rigor run back
+to the doctrine-light claim-only path. This is a discrete (light) gate —
+the deterministic check proves *shape* (each AC is measurable); if the
+AC *quality* needs an independent sign-off, the judgment tier
+(`wicked-vault analyze-evidence` / `--with-attestations`) is available.
+
 ## HITL
 
 `discrete:validate-gate` — the validate phase is a hard checkpoint. Don't
@@ -37,12 +49,29 @@ proceed past validate without explicit user agreement on the AC set.
 
 ### structure
 
-1. Convert each elicited fact into one acceptance criterion: `AC-N: when
+1. If a vault is resolvable
+   (`scripts/qe/vault_gate.py resolve` → `available: true`), declare the
+   re-derivable contract for this phase so the validate gate has a bar to
+   check against: `wicked-vault init` (once per repo) then
+   `wicked-vault declare-contract --scope <scope> --phase specify --spec contract.json`
+   — `required_evidence` should pin `smart-acceptance-criteria`
+   (kind `spec-doc`) to a `regex_match` verifier proving the criteria are
+   testable/measurable (e.g. each AC carries a measurable assertion or a
+   Given/When/Then shape). Skip silently if no vault.
+2. Convert each elicited fact into one acceptance criterion: `AC-N: when
    <trigger>, then <observable>`.
-2. Add invariants for things that should NOT change: `INV-N: <thing> must
+3. Add invariants for things that should NOT change: `INV-N: <thing> must
    stay under <threshold>`.
-3. Keep ACs minimal — 3–7 is the sweet spot. More than 10 means you're
+4. Keep ACs minimal — 3–7 is the sweet spot. More than 10 means you're
    treating ACs as design.
+5. Record the AC artifact as re-derivable evidence (vault present):
+   `wicked-vault record --scope <scope> --phase specify
+   --claim smart-acceptance-criteria --kind spec-doc
+   --artifact <path/to/requirements.md>
+   --criteria "<the testability bar>"
+   --verifier regex_match:'(?im)^(AC|INV)-\d+:' --run`. The verifier
+   re-runs against the artifact later — a claim you can't re-derive is
+   not evidence. No vault → fall back to the claim-only path.
 
 ### validate
 
@@ -54,8 +83,15 @@ proceed past validate without explicit user agreement on the AC set.
 
 ## When to stop
 
-Specify is done when the user has signed off on the AC list. Hand off to
-`build` (when the next step is implementation), `decide` (when you've
+Specify is done when the user has signed off on the AC list AND the
+produces-gate is satisfied. Check the gate — don't self-assert it:
+`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase specify`
+(exit 0 = satisfied). This is a re-derived PASS over the declared
+contract: the AC artifact is re-hashed and its structural verifier
+re-run. A REJECT means the recorded ACs don't clear the testability bar —
+fix the criteria, not the claim. An `unavailable` verdict means the
+required vault isn't installed — run `/wicked-garden:setup`. Then hand off
+to `build` (when the next step is implementation), `decide` (when you've
 uncovered competing options), or `explore` (when the act of writing ACs
 revealed the problem isn't well understood).
 

--- a/tests/compiler/test_compile.py
+++ b/tests/compiler/test_compile.py
@@ -95,6 +95,57 @@ class EmitterOutputTests(unittest.TestCase):
             self.assertNotIn("sys.path", gate_src)
             self.assertIn("'command': 'npm test'", gate_src)
 
+    def test_claims_surface_adds_claims_backed_and_emits_lint(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+            docs = repo / "docs"
+            docs.mkdir()
+            (docs / "build.md").write_text(
+                "---\nclaims:\n  - id: c1\n    text: tests pass\n    evidence: c1\n---\n# build\n")
+            m = wgc.compile_repo(str(repo))
+            self.assertIn("claims-backed", m["claims"])
+            self.assertEqual(m["claims"]["claims-backed"], "python3 .wicked/claims_lint.py")
+            self.assertIn("claims_lint.py", m["emitted"])
+            self.assertTrue((repo / ".wicked" / "claims_lint.py").exists())
+
+    def test_no_claims_docs_means_no_claims_backed(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+            m = wgc.compile_repo(str(repo))
+            self.assertNotIn("claims-backed", m["claims"])
+            self.assertNotIn("claims_lint.py", m["emitted"])
+
+    def test_emitted_claims_lint_flags_unbacked_claim(self):
+        # The lint itself is stdlib + dependency-free — run it directly.
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+            docs = repo / "docs"
+            docs.mkdir()
+            claim_doc = docs / "build.md"
+            claim_doc.write_text(
+                "---\nclaims:\n  - id: c1\n    text: tests pass\n    evidence: c1\n---\n")
+            wgc.compile_repo(str(repo))
+            lint = repo / ".wicked" / "claims_lint.py"
+            # No evidence file yet -> the success-claim is unbacked -> exit 1.
+            r = subprocess.run([sys.executable, str(lint), "--repo-root", str(repo),
+                                "--claims-file", str(claim_doc)],
+                               capture_output=True, text=True)
+            self.assertEqual(r.returncode, 1, r.stdout)
+
+    def test_risk_surfaces_listed_advisorily_in_readme(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+            for mod in ("alpha", "beta"):
+                (repo / "src" / mod).mkdir(parents=True)
+            wgc.compile_repo(str(repo))
+            readme = (repo / ".wicked" / "README.md").read_text()
+            self.assertIn("Risk surfaces (advisory)", readme)
+            self.assertIn("src/alpha", readme)
+
     def test_unknown_ecosystem_flags_needs_review(self):
         with tempfile.TemporaryDirectory() as d:
             repo = Path(d)  # no package.json / go.mod / pyproject → unknown

--- a/tests/compiler/test_compile.py
+++ b/tests/compiler/test_compile.py
@@ -23,7 +23,11 @@ import unittest
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_REPO_ROOT / "scripts" / "compiler"))
+# Append (not insert(0)) so scripts/ stays at sys.path[0] for the rest of the
+# suite (tests/conftest.py convention); we only need compile importable here.
+_COMPILER_DIR = str(_REPO_ROOT / "scripts" / "compiler")
+if _COMPILER_DIR not in sys.path:
+    sys.path.append(_COMPILER_DIR)
 import compile as wgc  # noqa: E402
 
 
@@ -152,6 +156,20 @@ class EmitterOutputTests(unittest.TestCase):
             m = wgc.compile_repo(str(repo))
             self.assertTrue(m["needs_review"])
 
+    def test_emitted_gate_honors_killswitch_fails_closed(self):
+        # WICKED_VAULT_BIN="" (set-but-empty) disables resolution -> the
+        # emitted gate must fail closed, not fall through to npx.
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+            wgc.compile_repo(str(repo))
+            env = {"PATH": os.environ.get("PATH", ""), "WICKED_VAULT_BIN": ""}
+            proc = subprocess.run(
+                [sys.executable, str(repo / ".wicked" / "gate.py")],
+                cwd=str(repo), capture_output=True, text=True, env=env, timeout=60)
+            self.assertEqual(proc.returncode, 1)
+            self.assertEqual(json.loads(proc.stdout).get("gate"), "unavailable")
+
     def test_go_repo_pins_test_lint_build(self):
         with tempfile.TemporaryDirectory() as d:
             repo = Path(d)
@@ -245,6 +263,18 @@ class TriggerInstallTests(unittest.TestCase):
         repo = self._repo(git=False)
         res = wgc.install_triggers(str(repo), ["hook"])[0]
         self.assertEqual(res["status"], "skipped")
+
+    def test_hook_resolves_gitdir_pointer_for_worktree(self):
+        # In worktrees/submodules `.git` is a FILE with a `gitdir:` pointer.
+        repo = self._repo(git=False)
+        realgit = repo / "realgit"
+        realgit.mkdir()
+        (repo / ".git").write_text("gitdir: ./realgit\n")
+        res = wgc.install_triggers(str(repo), ["hook"])[0]
+        self.assertEqual(res["status"], "created")
+        hook = realgit / "hooks" / "pre-push"
+        self.assertTrue(hook.exists())
+        self.assertIn(".wicked/gate.py", hook.read_text())
 
     def test_ci_workflow_uses_detected_ecosystem_setup(self):
         repo = self._repo()

--- a/tests/compiler/test_compile.py
+++ b/tests/compiler/test_compile.py
@@ -1,0 +1,275 @@
+"""Tests for the wicked-garden compiler emit stage (scripts/compiler/compile.py).
+
+Two layers:
+  - EmitterOutputTests — pure, fast, no vault. The emitter writes the 4
+    harness files, the contract pins the detected command, the emitted
+    gate bakes in the command, and (critically) the emitted gate imports
+    NOTHING from wicked-garden — it must run with the garden absent.
+  - EmittedGateIntegrationTests — the falsification. Emit onto a passing
+    repo and a failing repo, run the emitted gate.py AS A SUBPROCESS with
+    a clean PYTHONPATH (no garden on the path), and assert PASS / exit 0
+    vs REJECT / exit 1. Skipped when node or the vault CLI is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "compiler"))
+import compile as wgc  # noqa: E402
+
+
+def _git_init(d: Path) -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q"], cwd=str(d), check=True)
+    subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"],
+                   cwd=str(d), env=env, check=True)
+
+
+def _node_pkg(d: Path, test_script: str, lint: str | None = None,
+              build: str | None = None) -> None:
+    scripts = {"test": test_script}
+    if lint is not None:
+        scripts["lint"] = lint
+    if build is not None:
+        scripts["build"] = build
+    (d / "package.json").write_text(json.dumps({
+        "name": d.name, "version": "1.0.0", "scripts": scripts,
+    }))
+
+
+def _locate_vault() -> str | None:
+    if shutil.which("node") is None:
+        return None
+    env = os.environ.get("WICKED_VAULT_BIN")
+    if env and Path(env).exists():
+        return env
+    sibling = _REPO_ROOT.parent / "wicked-vault" / "bin" / "wicked-vault.mjs"
+    return str(sibling) if sibling.exists() else None
+
+
+class EmitterOutputTests(unittest.TestCase):
+    def test_emits_four_files_and_pins_detected_command(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            _node_pkg(repo, "exit 0")
+            m = wgc.compile_repo(str(repo))
+            self.assertEqual(sorted(m["emitted"]),
+                             ["README.md", "bindings.json", "contract.json", "gate.py"])
+            contract = json.loads((repo / ".wicked" / "contract.json").read_text())
+            req = contract["required_evidence"][0]
+            self.assertEqual(req["claim_id"], "tests-pass")
+            self.assertEqual(req["source_pin"], "npm test")
+            self.assertEqual(req["verifier"], {"kind": "exit_code_eq", "params": {"code": 0}})
+
+    def test_emitted_gate_is_self_contained_no_garden_imports(self):
+        import ast
+        _STDLIB = {"json", "os", "shutil", "subprocess", "sys", "tempfile", "pathlib"}
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            _node_pkg(repo, "exit 0")
+            wgc.compile_repo(str(repo))
+            gate_src = (repo / ".wicked" / "gate.py").read_text()
+            tree = ast.parse(gate_src)
+            # The whole point: the emitted harness cannot reach back into the
+            # garden. Every import must be stdlib — no vault_gate, no scripts.qe.
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for n in node.names:
+                        self.assertIn(n.name.split(".")[0], _STDLIB,
+                                      f"non-stdlib import leaked: {n.name}")
+                elif isinstance(node, ast.ImportFrom):
+                    root = (node.module or "").split(".")[0]
+                    self.assertIn(root, _STDLIB | {"__future__"},
+                                  f"non-stdlib import leaked: {node.module}")
+            # And it must not reach back out via sys.path manipulation.
+            self.assertNotIn("sys.path", gate_src)
+            self.assertIn("'command': 'npm test'", gate_src)
+
+    def test_unknown_ecosystem_flags_needs_review(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)  # no package.json / go.mod / pyproject → unknown
+            m = wgc.compile_repo(str(repo))
+            self.assertTrue(m["needs_review"])
+
+    def test_go_repo_pins_test_lint_build(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "go.mod").write_text("module example.com/x\n\ngo 1.21\n")
+            m = wgc.compile_repo(str(repo))
+            # go gives all three for free (go test/vet/build are standard).
+            self.assertEqual(m["claims"], {
+                "tests-pass": "go test ./...",
+                "lint-clean": "go vet ./...",
+                "build-clean": "go build ./...",
+            })
+            self.assertFalse(m["needs_review"])
+            contract = json.loads((repo / ".wicked" / "contract.json").read_text())
+            self.assertEqual(len(contract["required_evidence"]), 3)
+
+    def test_python_pytest_is_scoped_to_tests_dir(self):
+        # Regression (found dogfooding the garden): bare `python3 -m pytest`
+        # collects stray test-like files across the repo and can exit 2 on a
+        # broken import. Scope it to the tests dir, matching how CI runs it.
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / "pyproject.toml").write_text("[tool.pytest.ini_options]\n")
+            (repo / "tests").mkdir()
+            m = wgc.compile_repo(str(repo))
+            self.assertEqual(m["claims"]["tests-pass"], "python3 -m pytest tests")
+
+    def test_node_lint_build_only_when_declared(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            _node_pkg(repo, "exit 0")  # test only, no lint/build scripts
+            m = wgc.compile_repo(str(repo))
+            # tests-pass present; lint/build omitted (pinning a missing linter
+            # would make the gate fail forever).
+            self.assertEqual(list(m["claims"]), ["tests-pass"])
+
+    def test_node_multi_claim_when_all_declared(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d)
+            _node_pkg(repo, "exit 0", lint="exit 0", build="exit 0")
+            m = wgc.compile_repo(str(repo))
+            self.assertEqual(m["claims"], {
+                "tests-pass": "npm test",
+                "lint-clean": "npm run lint",
+                "build-clean": "npm run build",
+            })
+            gate_src = (repo / ".wicked" / "gate.py").read_text()
+            self.assertIn("lint-clean", gate_src)
+            self.assertIn("build-clean", gate_src)
+
+
+class TriggerInstallTests(unittest.TestCase):
+    """The compiler installs the trigger; it never clobbers foreign content."""
+
+    def _repo(self, git: bool = True) -> Path:
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        repo = Path(tmp)
+        if git:
+            _git_init(repo)
+        wgc.compile_repo(str(repo))
+        return repo
+
+    def test_hook_created_executable_and_calls_gate(self):
+        repo = self._repo()
+        res = wgc.install_triggers(str(repo), ["hook"])[0]
+        self.assertEqual(res["status"], "created")
+        hook = repo / ".git" / "hooks" / "pre-push"
+        self.assertTrue(hook.exists())
+        self.assertTrue(os.access(hook, os.X_OK), "hook must be executable")
+        self.assertIn(".wicked/gate.py", hook.read_text())
+
+    def test_hook_reemit_is_idempotent(self):
+        repo = self._repo()
+        wgc.install_triggers(str(repo), ["hook"])
+        res2 = wgc.install_triggers(str(repo), ["hook"])[0]
+        self.assertEqual(res2["status"], "updated")
+        body = (repo / ".git" / "hooks" / "pre-push").read_text()
+        self.assertEqual(body.count(wgc._HOOK_START), 1, "managed block must not duplicate")
+
+    def test_hook_preserves_foreign_hook(self):
+        repo = self._repo()
+        hook = repo / ".git" / "hooks" / "pre-push"
+        hook.write_text("#!/bin/sh\necho my-existing-hook\n")
+        res = wgc.install_triggers(str(repo), ["hook"])[0]
+        self.assertEqual(res["status"], "appended")
+        body = hook.read_text()
+        self.assertIn("my-existing-hook", body)   # foreign content preserved
+        self.assertIn(".wicked/gate.py", body)     # ours added
+
+    def test_hook_skipped_without_git(self):
+        repo = self._repo(git=False)
+        res = wgc.install_triggers(str(repo), ["hook"])[0]
+        self.assertEqual(res["status"], "skipped")
+
+    def test_ci_workflow_uses_detected_ecosystem_setup(self):
+        repo = self._repo()
+        wgc.install_triggers(str(repo), ["ci"], ecosystem="go")
+        wf = (repo / ".github" / "workflows" / "wicked-gate.yml").read_text()
+        self.assertIn("actions/setup-go@", wf)
+        self.assertIn("python3 .wicked/gate.py", wf)
+
+    def test_ci_refuses_to_overwrite_foreign_workflow(self):
+        repo = self._repo()
+        wf = repo / ".github" / "workflows" / "wicked-gate.yml"
+        wf.parent.mkdir(parents=True, exist_ok=True)
+        wf.write_text("name: someone-elses-workflow\n")
+        res = wgc.install_triggers(str(repo), ["ci"], ecosystem="go")[0]
+        self.assertEqual(res["status"], "skipped")
+        self.assertIn("someone-elses-workflow", wf.read_text())  # untouched
+
+
+@unittest.skipIf(_locate_vault() is None,
+                 "no runnable wicked-vault (set WICKED_VAULT_BIN or sibling checkout)")
+class EmittedGateIntegrationTests(unittest.TestCase):
+    """Run the EMITTED gate.py with the garden off its path — PASS vs REJECT."""
+
+    def setUp(self):
+        self._bin = _locate_vault()
+
+    def _emit_and_gate(self, test_script: str, lint: str | None = None,
+                       build: str | None = None):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        repo = Path(tmp)
+        _git_init(repo)
+        _node_pkg(repo, test_script, lint=lint, build=build)
+        wgc.compile_repo(str(repo))
+        # Subprocess with a CLEAN environment path: the emitted gate must NOT
+        # rely on anything from wicked-garden. We hand it only the vault bin.
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+            "WICKED_VAULT_BIN": self._bin,
+            # Deliberately NO PYTHONPATH — garden is unreachable.
+        }
+        proc = subprocess.run(
+            [sys.executable, str(repo / ".wicked" / "gate.py")],
+            cwd=str(repo), capture_output=True, text=True, timeout=180, env=env,
+        )
+        out = json.loads(proc.stdout) if proc.stdout.strip() else {}
+        return proc.returncode, out
+
+    def test_passing_repo_gate_passes(self):
+        rc, out = self._emit_and_gate("exit 0")
+        self.assertEqual(out.get("overall"), "PASS")
+        self.assertEqual(rc, 0)
+
+    def test_failing_repo_gate_rejects(self):
+        # The falsification: a build whose tests do NOT pass cannot gate green,
+        # even with the garden entirely absent. Re-derived, not self-asserted.
+        rc, out = self._emit_and_gate("exit 1")
+        self.assertEqual(out.get("overall"), "REJECT")
+        self.assertEqual(rc, 1)
+
+    def test_lint_failure_rejects_even_when_tests_pass(self):
+        # The multi-claim money case: tests pass but lint fails -> the gate
+        # must REJECT. A tests-only gate would have passed this build.
+        rc, out = self._emit_and_gate("exit 0", lint="exit 1", build="exit 0")
+        self.assertEqual(out.get("overall"), "REJECT")
+        self.assertEqual(rc, 1)
+        claims = {c["claim_id"]: c.get("result") for c in (out.get("claims") or [])}
+        self.assertEqual(claims.get("tests-pass"), "PASS")
+        self.assertEqual(claims.get("lint-clean"), "FAIL")
+
+    def test_all_clean_passes(self):
+        rc, out = self._emit_and_gate("exit 0", lint="exit 0", build="exit 0")
+        self.assertEqual(out.get("overall"), "PASS")
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/qe/test_vault_gate.py
+++ b/tests/qe/test_vault_gate.py
@@ -1,0 +1,196 @@
+"""Tests for vault_gate — the garden's produces-gate backed by wicked-vault.
+
+The load-bearing test is ``test_gate_rejects_claimed_but_false``: it
+proves the gate REJECTS a claim that ``evidence_tracker`` would have
+passed (satisfied-when-claimed). That delta is the whole reason the gate
+moved onto the vault.
+
+Tests that need a real vault resolve it from ``WICKED_VAULT_BIN`` or a
+sibling ``../wicked-vault`` checkout, and ``skipTest`` when neither node
+nor the vault is available — so CI stays honest rather than green-by-skip
+masquerading as green-by-pass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.append(str(_p))
+
+import vault_gate as vg  # noqa: E402
+import evidence_tracker as et  # noqa: E402
+
+_CONTRACT = {
+    "required_evidence": [
+        {
+            "claim_id": "tests-pass",
+            "kind": "test-run",
+            "verifier": {"kind": "exit_code_eq", "params": {"code": 0}},
+            "required": True,
+        }
+    ]
+}
+
+
+def _locate_vault() -> str | None:
+    """Resolve a runnable vault .mjs path, or None to skip vault-backed tests."""
+    if shutil.which("node") is None:
+        return None
+    env = os.environ.get("WICKED_VAULT_BIN")
+    if env and Path(env).exists():
+        return env
+    sibling = _REPO_ROOT.parent / "wicked-vault" / "bin" / "wicked-vault.mjs"
+    if sibling.exists():
+        return str(sibling)
+    return None
+
+
+def _vault(bin_path: str, work: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["node", bin_path, *args],
+        cwd=str(work), capture_output=True, text=True, timeout=120,
+    )
+
+
+class ResolutionTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_VAULT_BIN")
+        os.environ.pop("WICKED_VAULT_BIN", None)
+
+    def tearDown(self):
+        os.environ.pop("WICKED_VAULT_BIN", None)
+        if self._saved is not None:
+            os.environ["WICKED_VAULT_BIN"] = self._saved
+
+    def test_env_mjs_path_resolves_via_node(self):
+        os.environ["WICKED_VAULT_BIN"] = "/some/where/wicked-vault.mjs"
+        self.assertEqual(vg.resolve_vault(), ["node", "/some/where/wicked-vault.mjs"])
+
+    def test_env_executable_resolves_directly(self):
+        os.environ["WICKED_VAULT_BIN"] = "/usr/local/bin/wicked-vault"
+        self.assertEqual(vg.resolve_vault(), ["/usr/local/bin/wicked-vault"])
+
+    def test_empty_env_is_killswitch(self):
+        # Set-but-empty disables resolution entirely (no silent npx reach).
+        os.environ["WICKED_VAULT_BIN"] = ""
+        self.assertIsNone(vg.resolve_vault())
+        self.assertFalse(vg.vault_available())
+
+
+class RequiredFailClosedTests(unittest.TestCase):
+    """vault is required: no vault + default require → fail closed, never a
+    self-asserted PASS."""
+
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_VAULT_BIN")
+        os.environ["WICKED_VAULT_BIN"] = ""  # kill-switch: force unresolvable
+
+    def tearDown(self):
+        os.environ.pop("WICKED_VAULT_BIN", None)
+        if self._saved is not None:
+            os.environ["WICKED_VAULT_BIN"] = self._saved
+
+    def test_required_missing_vault_fails_closed(self):
+        with tempfile.TemporaryDirectory() as d:
+            project = Path(d)
+            et.initialize_for_archetype(project, "build")
+            # Even a fully-claimed tracker must NOT pass when the required
+            # vault is absent — this is the anti-vacuous-PASS guarantee.
+            et.claim_produces(project, "shipped-code", artifact_path="x", claimed_by="t")
+            et.claim_produces(project, "test-report", artifact_path="y", claimed_by="t")
+            out = vg.gate_satisfied(project, "demo", "build")
+            self.assertFalse(out["satisfied"])
+            self.assertEqual(out["gate"], "unavailable")
+            self.assertFalse(out["re_derived"])
+
+    def test_opt_out_restores_claim_only(self):
+        with tempfile.TemporaryDirectory() as d:
+            project = Path(d)
+            et.initialize_for_archetype(project, "build")
+            self.assertFalse(
+                vg.gate_satisfied(project, "demo", "build", require=False)["satisfied"])
+            et.claim_produces(project, "shipped-code", artifact_path="x", claimed_by="t")
+            et.claim_produces(project, "test-report", artifact_path="y", claimed_by="t")
+            out = vg.gate_satisfied(project, "demo", "build", require=False)
+            self.assertTrue(out["satisfied"])
+            self.assertEqual(out["gate"], "claim-only")
+            self.assertFalse(out["re_derived"])
+
+
+@unittest.skipIf(_locate_vault() is None,
+                 "no runnable wicked-vault (set WICKED_VAULT_BIN or sibling checkout)")
+class VaultBackedGateTests(unittest.TestCase):
+    """The real point: a re-derived gate that rejects a self-asserted 'done'."""
+
+    def setUp(self):
+        self._bin = _locate_vault()
+        self._saved = os.environ.get("WICKED_VAULT_BIN")
+        os.environ["WICKED_VAULT_BIN"] = self._bin
+        self._tmp = tempfile.TemporaryDirectory()
+        self.work = Path(self._tmp.name)
+        subprocess.run(["git", "init", "-q"], cwd=str(self.work), check=True)
+        subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"],
+                       cwd=str(self.work),
+                       env={**os.environ, "GIT_AUTHOR_NAME": "t",
+                            "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t",
+                            "GIT_COMMITTER_EMAIL": "t@t"}, check=True)
+        _vault(self._bin, self.work, "init")
+        contract = self.work / "contract.json"
+        contract.write_text(json.dumps(_CONTRACT), encoding="utf-8")
+        _vault(self._bin, self.work, "declare-contract",
+               "--scope", "demo", "--phase", "build", "--spec", str(contract))
+
+    def tearDown(self):
+        os.environ.pop("WICKED_VAULT_BIN", None)
+        if self._saved is not None:
+            os.environ["WICKED_VAULT_BIN"] = self._saved
+        self._tmp.cleanup()
+
+    def _record(self, source: str):
+        _vault(self._bin, self.work, "record", "--scope", "demo", "--phase", "build",
+               "--claim", "tests-pass", "--kind", "test-run", "--source", source,
+               "--criteria", "tests pass (exit 0)", "--verifier", "exit_code_eq:0",
+               "--run")
+
+    def test_gate_fails_closed_with_no_evidence(self):
+        # Contract declared, but nothing recorded → fail-closed (G5).
+        out = vg.gate_satisfied(self.work, "demo", "build")
+        self.assertTrue(out["re_derived"])
+        self.assertFalse(out["satisfied"])
+
+    def test_gate_rejects_claimed_but_false(self):
+        # The falsifier: claim 'tests-pass' but the command exits 1.
+        # evidence_tracker would have passed this; the vault must REJECT.
+        self._record("false")
+        out = vg.gate_satisfied(self.work, "demo", "build")
+        self.assertTrue(out["re_derived"])
+        self.assertFalse(out["satisfied"])
+        self.assertEqual(out["overall"], "REJECT")
+
+    def test_gate_passes_genuinely_passing(self):
+        self._record("true")
+        out = vg.gate_satisfied(self.work, "demo", "build")
+        self.assertTrue(out["re_derived"])
+        self.assertTrue(out["satisfied"])
+        self.assertEqual(out["overall"], "PASS")
+
+    def test_cross_check_returns_structured_verdict(self):
+        self._record("true")
+        cc = vg.cross_check("demo", "build", project_dir=self.work)
+        self.assertTrue(cc["available"])
+        self.assertEqual(cc["overall"], "PASS")
+        self.assertEqual(len(cc["claims"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

Reinvents how wicked-garden verifies "done": it stops trusting self-asserted completion and **re-derives evidence** through [wicked-vault](https://www.npmjs.com/package/wicked-vault), and adds a **compiler** that emits that same re-derivation onto any repo.

Four logical commits:

1. **`be5967d` — wicked-vault as the required, fail-closed evidence backend for all gating archetypes.** Replaces `evidence_tracker`'s satisfied-when-claimed model with a re-derived `wicked-vault cross-check` (`scripts/qe/vault_gate.py`). A claimed-but-false "tests pass" → REJECT; a missing vault → fail closed (never a vacuous PASS). Wired into build + specify/decide/ship (discrete) and review/incident/migrate (hard gates, independent `--with-attestations` sign-off). Vault becomes a required peer (setup + bootstrap checks).
2. **`37de81e` — the compiler emit stage + `/wicked-garden:compile`.** Detects a repo's bindings → emits a self-contained, vault-backed gate into `<repo>/.wicked/` that runs with **no wicked-garden runtime present** (resolves the vault via npx). Installs triggers (git pre-push hook + GitHub Actions). On-switch rule: compile the trigger + enforcement, never the tool.
3. **`1ca97ec` — consume `claims_surface` + `risk_surfaces`.** Emits the claims-vs-evidence lint as a `claims-backed` claim when a repo has structured claims docs; risk surfaces listed advisorily.
4. **`69cc154` — docs.** README/getting-started/v11/CONTRIBUTING/CLAUDE/AGENTS + `plugin.json` declare the required peer and the re-derivation model.

## Proof

- **420 tests** green (`pytest tests/`); compiler suite includes the falsification (emitted gate, garden off its PATH: passing repo PASS, failing repo REJECT, lint-fail-while-tests-pass REJECT) and trigger idempotency.
- Proven on an **unseen repo** (memos) and **self-hosted** on wicked-garden (gate PASS after a scoping fix the dogfood surfaced).

## Breaking change

`wicked-vault` is now a **required peer** — `/wicked-garden:setup` blocks without it. Offline/dev kill-switch: `WICKED_VAULT_BIN=""` (documented in CONTRIBUTING.md).

## Follow-up

Self-hosting surfaced #879 (two rotted test files CI never collects) — tracked separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)