### PR TITLE
release: v12.0.0 — vault-backed gates + the compiler

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "11.1.3"
+      "version": "12.0.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "11.1.3",
+  "version": "12.0.0",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ dial) that was replaced wholesale.
 
 ---
 
+## [12.0.0] — 2026-05-25
+
+**"Done" is re-derived, not asserted — and the garden can compile that guarantee onto any repo.**
+
+Every gating archetype's produces-gate stops trusting a self-asserted "done"
+and re-derives it through [wicked-vault](https://www.npmjs.com/package/wicked-vault),
+a new **required** peer. A new compiler emits that same re-derivation as a
+self-contained harness into any repo.
+
+### Breaking changes
+
+- **wicked-vault is now a required peer** (`^0.3.0`; sibling to wicked-bus /
+  wicked-brain / wicked-testing). `/wicked-garden:setup` verifies it and blocks
+  without it, and the SessionStart hook warns. Install with
+  `npx wicked-vault-install`. Offline/dev kill-switch: `WICKED_VAULT_BIN=""`
+  (see CONTRIBUTING.md).
+
+### Features
+
+- **Vault-backed gates for all gating archetypes** (`scripts/qe/vault_gate.py`).
+  The gate runs `wicked-vault cross-check` — re-hashing the recorded evidence
+  and re-running its verifier — instead of `evidence_tracker`'s
+  satisfied-when-claimed model. A claimed-but-false "tests pass" is REJECTED; a
+  missing vault **fails closed** rather than passing on a self-assertion. Hard
+  gates (review / incident / migrate) require an *independent* attestation —
+  the evaluator is not the agent that did the work.
+- **The compiler emit stage + `/wicked-garden:compile`** (`scripts/compiler/`).
+  Detects a repo's test/lint/build commands and emits a self-contained,
+  vault-backed gate into `<repo>/.wicked/` (contract + a stdlib-only `gate.py`
+  + a claims-vs-evidence lint + README) that runs with **no wicked-garden
+  runtime present** (resolves the vault via `npx`). Optionally installs the
+  triggers that fire it — a git pre-push hook and a GitHub Actions workflow
+  whose toolchain setup is derived from the detected ecosystem. Multi-claim
+  contracts (test/lint/build), each pinned to its own verifier.
+
+### Notes
+
+- 422 tests; proven on an unseen repo (memos) and self-hosted on wicked-garden
+  (which surfaced and fixed a detector scoping bug).
+- Follow-up: #879 — two rotted test files CI never collected, found while
+  self-hosting the compiler.
+
+---
+
 ## [11.1.3] — 2026-05-08
 
 **Council command + 4 sibling commands had broken refs the validator missed.**

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -58,7 +58,7 @@ npx wicked-testing --version 2>/dev/null || echo "MISSING"
 ```
 
 - `MISSING` → blocking. Show "wicked-testing is not installed. wicked-garden v7.0+ requires wicked-testing >= 0.1 as a peer plugin. Upgrading from v6.x? See `docs/MIGRATION-v7.md`." **INTERACTIVE mode**: AskUserQuestion header "wicked-testing Required", options "Install now (Required)" = "Run: npx wicked-testing install" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npx wicked-testing install`, re-probe with `npx wicked-testing --version`, confirm the version. On failure, show stderr and exit with manual instructions. If exit: "Run `npx wicked-testing install` then restart with `/wicked-garden:setup`."
-- Version string (e.g. `0.2.1`) → check it satisfies `^0.2.0` (the pin from `plugin.json`). In range: show "wicked-testing {version} — ready." Out of range: warn "wicked-testing {version} is outside the supported range (^0.2.0). Update with: `npx wicked-testing install`" and ask whether to update now (same INTERACTIVE / PLAIN_TEXT pattern). Updating is strongly recommended but not a hard block — the SessionStart hook will warn each session.
+- Version string (e.g. `0.3.0`) → check it satisfies `^0.3.0` (the pin from `plugin.json`). In range: show "wicked-testing {version} — ready." Out of range: warn "wicked-testing {version} is outside the supported range (^0.3.0). Update with: `npx wicked-testing install`" and ask whether to update now (same INTERACTIVE / PLAIN_TEXT pattern). Updating is strongly recommended but not a hard block — the SessionStart hook will warn each session.
 
 ### 2.6 Verify wicked-vault (Required)
 


### PR DESCRIPTION
Release PR for **v12.0.0** (major — wicked-vault becomes a required peer).

- plugin.json + marketplace.json → 12.0.0 (in sync; validator PASS)
- curated CHANGELOG [12.0.0] entry
- setup.md: stale wicked-testing pin prose `^0.2.0` → `^0.3.0`

Ships the work merged in #880 (vault-backed gates for all gating archetypes + the compiler emit stage). Tag `wicked-garden-v12.0.0` + GitHub release created after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)