### PR TITLE
docs: v12 refresh + all four sibling peers required

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,11 @@
 {
   "name": "wicked-garden",
   "version": "12.0.0",
-  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery), wicked-brain for persistent memory, and wicked-bus for the event audit substrate.",
+  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires four sibling peers verified at setup — wicked-testing, wicked-vault, wicked-brain, wicked-bus — required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",
+  "wicked_brain_version": "^0.14.0",
+  "wicked_bus_version": "^2.0.0",
   "author": {
     "name": "Mike Parcewski"
   },

--- a/ETHOS.md
+++ b/ETHOS.md
@@ -1,12 +1,16 @@
 # ETHOS
 
-> **What this is.** A single-page identity for wicked-garden — what we believe, what we refuse, what we optimize for. `CLAUDE.md` tells you *how* the system works. This tells you *why*.
+> **What this is.** A single-page identity for wicked-garden — what we believe, what we refuse, what we optimize for.
+>
+> wicked-garden is an evidence-driven SDLC for Claude Code: it detects the shape of work, applies the rigor that shape needs, verifies "done" through independent, re-derived evidence, and preserves decisions, evidence, and learning across sessions. **Done is not claimed; done is re-derived.**
+>
+> `CLAUDE.md` tells you *how* the system works. This tells you *why*.
 
 ---
 
 ## What we believe
 
-**Project shape determines ceremony.** A typo fix and a multi-repo schema migration are not the same project. Each prompt classifies into one or more of nine **work-shape archetypes**; each owns its own phase shape, produces contract, and HITL discipline. A typo and a migration get appropriately-scaled rigor — not the same rigor, and not the same shape.
+**Project shape determines ceremony.** A typo fix and a multi-repo schema migration are not the same project. Each prompt classifies into one or more of nine **work-shape archetypes** — `triage`, `explore`, `specify`, `decide`, `build`, `review`, `ship`, `incident`, `migrate` — and each owns its own phase shape, produces contract, and human-in-the-loop (HITL) discipline. A typo and a migration get appropriately-scaled rigor — not the same rigor, and not the same shape.
 
 **"Done" is re-derived, not asserted.** A gate does not go green because someone said so. Evidence is re-hashed and its verifier re-run through wicked-vault every time — a claimed-but-false "tests pass" is REJECTED, and a missing backend fails closed rather than passing on a self-assertion. The cheapest lie in software is a green checkmark with nothing behind it; we refuse to accept it.
 
@@ -16,7 +20,7 @@
 
 **Native primitives over bespoke abstractions.** Claude Code's `TaskCreate`, `Skill`, `Agent`, hooks, and slash commands are the surface. We extend them — we don't replace them. A task with metadata is more durable than a custom kanban; an agent with a frontmatter description is more discoverable than a registry call.
 
-**Required infrastructure, resilient at runtime.** wicked-garden stands on four siblings: **wicked-testing** (proves behavior), **wicked-vault** (makes "done" re-derivable), **wicked-brain** (carries knowledge across sessions), **wicked-bus** (carries the audit trail). These are *required infrastructure*, not optional add-ons — the honest-evidence model does not work if any of them is merely nice-to-have, so `/wicked-garden:setup` verifies all four and blocks without them. But required-at-install is not brittle-at-runtime: a transient outage — brain server down, bus momentarily unavailable — degrades gracefully and never bricks a session. We depend on our infrastructure; we don't crash with it.
+**Required infrastructure, resilient at runtime.** wicked-garden stands on four siblings: **wicked-testing** (proves behavior), **wicked-vault** (makes "done" re-derivable), **wicked-brain** (carries knowledge across sessions), **wicked-bus** (carries the audit trail). These are *required infrastructure*, not optional add-ons — the honest-evidence model does not work if any of them is merely nice-to-have, so `/wicked-garden:setup` verifies all four and blocks without them. But required-at-install is not brittle-at-runtime: a transient outage — brain server down, bus momentarily unavailable — degrades gracefully and never bricks a session. Graceful degradation means a session continues where it's *safe* to; it never means a gate pretends missing evidence is a pass — that path **fails closed**. We depend on our infrastructure; we don't crash with it.
 
 **Cross-platform is non-negotiable.** macOS, Linux, Windows (Git Bash, WSL, native). Bare `python3` doesn't exist on Windows; bare `/tmp` doesn't exist on Windows; the shim and `${TMPDIR:-/tmp}` exist for a reason. If a contributor adds shell that breaks on Windows, the contribution is incomplete.
 
@@ -58,7 +62,7 @@
 
 **Not a fixed-sequence pipeline.** No two prompts run the same phase chain. Work shape is detected per prompt, not configured once per repo.
 
-**Not a starter for learning Claude Code.** This is a working SDLC, not a tutorial. Bring some Claude Code fluency or expect a steep first hour.
+**Not a starter for learning Claude Code.** This is a working SDLC, not a beginner tutorial. Basic Claude Code fluency makes the first hour productive rather than steep.
 
 **Not a single-language toolkit.** Cross-platform stdlib-only Python for the plumbing. wicked-patch's generators support Python, TypeScript, Java, Go, SQL, Rust, Kotlin, C#, PHP, Ruby out of the box; new languages plug in via the generator interface.
 

--- a/ETHOS.md
+++ b/ETHOS.md
@@ -6,31 +6,33 @@
 
 ## What we believe
 
-**Project shape determines ceremony.** A typo fix and a multi-repo schema migration are not the same project. Forcing one fixed sequence on both wastes the small one and under-protects the large one. Adaptive rigor is the point, not an optional setting.
+**Project shape determines ceremony.** A typo fix and a multi-repo schema migration are not the same project. Each prompt classifies into one or more of nine **work-shape archetypes**; each owns its own phase shape, produces contract, and HITL discipline. A typo and a migration get appropriately-scaled rigor — not the same rigor, and not the same shape.
 
-**Quality pressure must be structural, not delegated to willpower.** Reviews skipped under deadline pressure are gates that didn't exist. Hard enforcement, signed dispatch logs, and append-only audit trails are not bureaucracy — they're how good intentions survive a Friday afternoon.
+**"Done" is re-derived, not asserted.** A gate does not go green because someone said so. Evidence is re-hashed and its verifier re-run through wicked-vault every time — a claimed-but-false "tests pass" is REJECTED, and a missing backend fails closed rather than passing on a self-assertion. The cheapest lie in software is a green checkmark with nothing behind it; we refuse to accept it.
 
-**Knowledge compounds across sessions or it isn't knowledge.** If a decision, gotcha, or pattern lives only in the current chat, it dies with the chat. Every memorable thing belongs in a tier-appropriate memory store with confidence and decay rules. The brain is the difference between learning once and learning every time.
+**Quality pressure must be structural, not delegated to willpower.** Reviews skipped under deadline pressure are gates that didn't exist. So enforcement lives in code, not prose: hard gates refuse to advance at runtime, produces re-derive through the vault, and the audit trail is append-only. Good intentions don't have to survive a Friday afternoon — the gates do.
+
+**Knowledge compounds across sessions or it isn't knowledge.** If a decision, gotcha, or pattern lives only in the current chat, it dies with the chat. Every memorable thing belongs in a tier-appropriate memory store with confidence and decay rules. wicked-brain is the difference between learning once and learning every time.
 
 **Native primitives over bespoke abstractions.** Claude Code's `TaskCreate`, `Skill`, `Agent`, hooks, and slash commands are the surface. We extend them — we don't replace them. A task with metadata is more durable than a custom kanban; an agent with a frontmatter description is more discoverable than a registry call.
 
-**Local-first, graceful degradation, always works standalone.** Optional integrations enhance, they never gate. wicked-brain offline? The plugin still ships verdicts. wicked-bus down? The hooks still fire. If a feature requires an external dependency to function at all, it isn't a feature — it's a coupling bug.
+**Required infrastructure, resilient at runtime.** wicked-garden stands on four siblings: **wicked-testing** (proves behavior), **wicked-vault** (makes "done" re-derivable), **wicked-brain** (carries knowledge across sessions), **wicked-bus** (carries the audit trail). These are *required infrastructure*, not optional add-ons — the honest-evidence model does not work if any of them is merely nice-to-have, so `/wicked-garden:setup` verifies all four and blocks without them. But required-at-install is not brittle-at-runtime: a transient outage — brain server down, bus momentarily unavailable — degrades gracefully and never bricks a session. We depend on our infrastructure; we don't crash with it.
 
 **Cross-platform is non-negotiable.** macOS, Linux, Windows (Git Bash, WSL, native). Bare `python3` doesn't exist on Windows; bare `/tmp` doesn't exist on Windows; the shim and `${TMPDIR:-/tmp}` exist for a reason. If a contributor adds shell that breaks on Windows, the contribution is incomplete.
 
-**Honest verdicts beat green dashboards.** A FAIL that surfaces a real bug is worth more than a PASS that masked it. Bot reviews catch what self-review can't. Independent reviewers exist because authors cannot review their own work credibly.
+**Honest verdicts beat green dashboards.** A FAIL that surfaces a real bug is worth more than a PASS that masked it. Hard gates demand an *independent* judgment — the evaluator is not the agent that did the work — because authors cannot review their own work credibly.
 
 ---
 
 ## What we refuse
 
-**We do not require one fixed sequence of phases.** Other plugins ship a single rigid pipeline. The facilitator scores nine factors, detects one of seven archetypes, and picks phases per project. A typo and a migration get appropriately-scaled rigor — not the same rigor.
+**We do not require one fixed sequence of phases.** No universal pipeline. A prompt routes to a *set* of work-shape archetypes, and each runs its own phases. We deliberately do not factor "common phases" — that's how the old universal pipeline emerged, and it forced every kind of work into the same shape.
 
-**We do not gate via heuristics that ignore project shape.** A 0.85 score threshold means nothing if the rubric reading the project is the same one used for a docs-only PR and a database refactor. Per-archetype score bands replace one-size-fits-all thresholds.
+**We do not let work grade its own "done".** Self-assessment is not evidence. A produces-gate re-derives the claim; a hard gate's verdict comes from an evaluator who is not the worker, recorded as a tamper-evident attestation. A "done" with no re-derivable backing is a fabrication, not a verdict.
 
-**We do not require a custom toolchain to install.** Stdlib Python, sh-shim, JSON state files, SQLite for FTS — all present on the platforms we target. No npm-only paths, no compiled extensions, no proprietary registries.
+**We do not silently degrade quality signals.** When the evidence backend isn't resolvable, the gate **fails closed** and says so — it never invents a pass. When a signal is missing, we surface it as a finding; we don't paper over it to keep a dashboard green.
 
-**We do not silently degrade quality signals.** When the semantic reviewer is unavailable we say so as an `info` finding — we don't pretend it ran clean. When a panel reviewer fails to respond, the gate stays `pending` — never silently approved.
+**We do not hide our dependencies.** The four required peers are named, pinned, and checked at setup — not silent transitive surprises. If wicked-garden needs something to function, it says so up front and verifies it, rather than failing mysteriously three commands in.
 
 **We do not let vendors land regressions in the name of cleanup.** Five legitimate skill rewrites bundled with three frontmatter regressions and a vendor-CI hook is not a contribution worth merging. Reject the bundle, salvage the wins in-house.
 
@@ -38,37 +40,38 @@
 
 ## What we optimize for
 
-**Time to first useful gate verdict — minutes, not hours.** A reviewer who waits an hour for a verdict has lost flow before they read it. Targets: under 5 min for minimal rigor, under 30 min for full rigor, with parallel dispatch where the panel allows.
+**A verdict you can trust on the first read.** A reviewer who can't trust the gate re-reads everything by hand, and flow is gone. We optimize for verdicts that are *re-derived* (recomputed, not cached) and *independent* (not self-graded) — trustworthy enough that the green means green.
 
-**Cross-platform install with zero compiled toolchain.** Anyone with `python3` (or `python`, or `py -3` on Windows) and `git` should have a working plugin in under 5 minutes. No build step, no vendor account, no API key required.
+**Archetype-shaped rigor.** The detector classifies *work shape*, and rigor follows the shape — not a global dial that defaults to maximum. A `triage` is negligible; a `migrate` cutover is a hard gate with a rollback proof. The output is rigor that fits the work, applied where it matters.
 
-**Adaptive rigor: archetype-detected, factor-scored, project-shaped.** Every project starts with a 9-factor scoring pass and a 1-of-7 archetype detection. Both feed phase selection, specialist routing, gate evidence demands, and review depth. The output is rigor that fits, not rigor that defaults to maximum.
+**Enforcement that travels.** `/wicked-garden:compile` emits a self-contained, vault-backed gate into any repo — one that re-derives the build's claims with **no wicked-garden runtime present**. We compile the *trigger* and the *enforcement*; we never compile the *tool*. The guarantee outlives the session that created it.
 
-**Append-only audit trails that survive context resets.** Decisions, gate verdicts, dispatch records, and reeval addenda all land on disk in JSONL form. A new session can resume work without losing the chain of reasoning. State that lives only in chat history is state that doesn't exist.
+**Append-only audit trails that survive context resets.** Decisions, gate verdicts, and evidence all land on disk in append-only form. A new session resumes work without losing the chain of reasoning. State that lives only in chat history is state that doesn't exist.
 
-**Honest measurement over vanity metrics.** PASS counts inflated by SKIPped scenarios are not coverage. MANUAL-ONLY is a distinct verdict from SKIP. A 70% real PASS rate beats a 95% inflated one because the second hides regressions.
+**Honest measurement over vanity metrics.** PASS counts inflated by SKIPped scenarios are not coverage. MANUAL-ONLY is a distinct verdict from SKIP. A 70% real PASS rate beats a 95% inflated one, because the second hides regressions.
 
 ---
 
 ## What this is not
 
-**Not a prompt library.** Skills, agents, and commands are executable surfaces with frontmatter contracts and hard enforcement — not text snippets to copy.
+**Not a prompt library.** Skills, agents, and commands are executable surfaces with frontmatter contracts and runtime enforcement — not text snippets to copy.
 
-**Not a fixed-sequence pipeline.** No two projects run the same phase chain. Phase selection is rubric-driven per project, not configured once per repo.
+**Not a fixed-sequence pipeline.** No two prompts run the same phase chain. Work shape is detected per prompt, not configured once per repo.
 
 **Not a starter for learning Claude Code.** This is a working SDLC, not a tutorial. Bring some Claude Code fluency or expect a steep first hour.
 
-**Not a single-language toolkit.** Cross-platform stdlib-only Python for the plumbing. Generators support Python, TypeScript, Java, Go, SQL out of the box; new languages plug in via wicked-patch's generator interface.
+**Not a single-language toolkit.** Cross-platform stdlib-only Python for the plumbing. wicked-patch's generators support Python, TypeScript, Java, Go, SQL, Rust, Kotlin, C#, PHP, Ruby out of the box; new languages plug in via the generator interface.
 
-**Not closed.** Third-party plugins integrate via the [v9 drop-in contract](docs/v9/drop-in-plugin-contract.md). wicked-testing is the canonical example of a sibling plugin slotting into the unified workflow without forking.
+**Not closed.** The four siblings (testing, vault, brain, bus) are required peers, not forks — and the compiler emits a vault-backed harness any repo can adopt **without installing wicked-garden at all**. The plugin's relationship to other tools is "stand on, and hand off," not "absorb."
 
 ---
 
 ## How to read the rest
 
-- **`CLAUDE.md`** — operational guidance. How the surfaces compose, what the hooks enforce, where state lives.
+- **`CLAUDE.md`** — operational guidance. How the surfaces compose, what the gates enforce, where state lives.
 - **`README.md`** — what to install, how to start, where to go next.
-- **`docs/v9/`** — the contract surface for sibling plugins.
+- **`docs/v11/archetypes.md`** — the design note: why the universal pipeline went away and what replaced it.
+- **`docs/required-peers.md`** · **`docs/compiler.md`** — the four required siblings, and the compiler.
 - **`scenarios/`** — acceptance tests; each scenario is an executable assertion of intended behavior.
 
 If you can quote one sentence from this page after reading it once, the document worked. If you can quote three, we won.

--- a/README.md
+++ b/README.md
@@ -103,17 +103,15 @@ Each archetype's playbook documents its phases, what it produces, where the huma
 /wicked-garden:setup
 ```
 
-Required peers (`/wicked-garden:setup` checks these and blocks without them):
+Required peers — `/wicked-garden:setup` verifies all four and blocks without them (required at install, resilient to a transient runtime outage):
 ```bash
 npx wicked-testing install     # evidence-gated acceptance testing (≥ 0.3)
 npx wicked-vault-install       # the honest-evidence backend gates re-derive against (≥ 0.3)
-```
-
-Recommended companions:
-```bash
-/plugin install wicked-brain   # session memory + cited search
+/plugin install wicked-brain   # cross-session memory + cited search
 /plugin install wicked-bus     # event audit substrate
 ```
+
+See [`docs/required-peers.md`](docs/required-peers.md) for why each is load-bearing.
 
 ---
 
@@ -164,8 +162,7 @@ Each command loads `skills/archetype/refs/{archetype}.md` and runs the per-arche
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) ≥ 1.0
 - Python 3.9+ (stdlib only for hook scripts)
 - Node.js + `npx` — required by `wicked-vault` (the evidence backend) and `wicked-testing`
-- **Required peers:** `wicked-testing` (≥ 0.3) and `wicked-vault` (≥ 0.3, the backend gates re-derive against). `/wicked-garden:setup` verifies both and blocks without them.
-- Optional: `wicked-brain` (session memory + search), `wicked-bus` (audit trail)
+- **Required peers (all four):** `wicked-testing` (≥ 0.3), `wicked-vault` (≥ 0.3, the backend gates re-derive against), `wicked-brain` (cross-session memory + search), `wicked-bus` (audit substrate). `/wicked-garden:setup` verifies all four and blocks without them — required at install, resilient at runtime. See [`docs/required-peers.md`](docs/required-peers.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 # Wicked Garden
 
+**An evidence-driven SDLC for Claude Code: it detects the shape of work, applies the rigor that shape needs, verifies "done" through independent re-derived evidence, and preserves decisions, evidence, and learning across sessions. Done is not claimed; done is re-derived.**
+
 > **Identity at a glance:** see [`ETHOS.md`](ETHOS.md) — what we believe, what we refuse, what we optimize for.
 >
-> **Vision (v11):** work-shape archetypes, not a fixed pipeline. Each prompt routes to one or more archetypes; each archetype owns its phase shape, produces, and HITL discipline. Steering, not blocking.
+> **Vision (v11):** work-shape archetypes, not a fixed pipeline. Each prompt routes to one or more archetypes; each archetype owns its phase shape, produces, and human-in-the-loop (HITL) discipline. Steering, not blocking.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,69 +17,37 @@
 
 ---
 
-## The problem
+## Why you'd want it
 
-Every Claude Code session starts from scratch. Session 47 has no idea what session 1 decided. The auth token format, the migration that caused the outage, the architectural call you spent two hours debating — all gone. So Claude fills the gap the only way it can: it guesses, skips review steps, and ships things that feel right but aren't grounded in your actual history.
+AI coding assistants confidently announce "tests pass" and "done" — sometimes when neither is true — and the reasoning behind last week's decisions is gone by next session. Wicked Garden doesn't take "done" on faith. Every gate **re-derives** the evidence (re-runs the test command, re-checks the artifact) instead of trusting the claim, and the gates that matter are signed off by an **independent** reviewer — not the agent that did the work. Decisions, evidence, and audit persist across sessions, so session 47 knows what session 1 decided.
 
-The second problem is shape. Software work is not one shape. A typo fix is not a schema migration. A spec elicitation is not a code review. A production incident is not a roadmap brainstorm. Most workflows force every kind of work through one fixed pipeline (`clarify → design → build → test → review`) and modulate "rigor" with a dial. The dial saves you from the worst ceremony but doesn't change the shape — a typo fix still goes through the same phases as a feature.
-
-The third problem is context. The right specialist for a security decision is different from the right specialist for a data architecture call. Claude doesn't route. It answers from whatever context happens to be in the window.
+You get verdicts you can trust, not green checkmarks you can't. *Done is not claimed; done is re-derived.*
 
 ---
 
-## The fix
+## How it works (four beats)
 
-Wicked Garden is an AI-native SDLC plugin for Claude Code. v11 reframed the workflow primitive: instead of a fixed pipeline, every prompt classifies into one or more **work-shape archetypes**. Each archetype is a complete unit with its own phase shape, produces, HITL discipline, and cost band.
+**1 · Detect the shape.** A `UserPromptSubmit` hook classifies your prompt into one or more of nine **work-shape archetypes** — a typo is `triage`, a feature is `build`, a schema change is `build + migrate`. There's no universal pipeline; each shape runs its own phases. (Why archetypes and not one pipeline? → [`docs/v11/archetypes.md`](docs/v11/archetypes.md).)
 
-| Archetype | Phases                                                  | Produces                       | HITL                  | Cost      |
-|-----------|---------------------------------------------------------|--------------------------------|-----------------------|-----------|
-| triage    | classify                                                | routing decision               | none                  | negligible|
-| explore   | frame → diverge → converge                              | option set / hypothesis        | continuous            | low       |
-| specify   | elicit → structure → validate                           | SMART acceptance criteria      | discrete:validate     | low       |
-| decide    | brief → options → score → record                        | ADR / decision artifact        | discrete:select       | medium    |
-| ship      | canary → ramp → full → soak                             | rollout verdict / SLO snapshot | discrete:ramp         | medium    |
-| review    | scope → assess → findings → remediate-or-accept         | verdict / remediation list     | hard:final-verdict    | medium    |
-| incident  | triage → investigate → mitigate → resolve → followup    | mitigation / RCA / followup    | hard:mitigate         | variable  |
-| build     | plan → implement → test → review                        | shipped code / test report     | discrete:review       | high      |
-| migrate   | plan → expand → backfill → cutover → contract           | shape change / rollback proof  | hard:cutover          | high      |
+| Archetype | Phases | Produces | HITL |
+|---|---|---|---|
+| triage | classify | routing decision | none |
+| explore | frame → diverge → converge | option set / hypothesis | continuous |
+| specify | elicit → structure → validate | SMART acceptance criteria | discrete:validate |
+| decide | brief → options → score → record | ADR / decision artifact | discrete:select |
+| ship | canary → ramp → full → soak | rollout verdict / SLO snapshot | discrete:ramp |
+| review | scope → assess → findings → remediate-or-accept | verdict / remediation list | hard:final-verdict |
+| incident | triage → investigate → mitigate → resolve → followup | mitigation / RCA / followup | hard:mitigate |
+| build | plan → implement → test → review | shipped code / test report | discrete:review |
+| migrate | plan → expand → backfill → cutover → contract | shape change / rollback proof | hard:cutover |
 
-Archetypes are NOT mutually exclusive. A schema-changing feature is `build + migrate`. A risky deploy is `ship + review`.
+**2 · Run the archetype.** Each has its own phases, produces contract, and human-in-the-loop (HITL) gates — light for a fix, hard for a migration cutover. Archetypes compose: a schema-changing feature is `build + migrate`; a risky deploy is `ship + review`.
 
----
+**3 · Gate on re-derived evidence.** At each gate, [wicked-vault](https://www.npmjs.com/package/wicked-vault) re-hashes the evidence and re-runs its verifier — a false "tests pass" is **REJECTED**, a missing backend **fails closed** (never a vacuous pass). Hard gates also require an *independent* attestation: the evaluator is not the agent that did the work.
 
-## How it works
+**4 · Carry it forward.** Decisions, evidence, and audit persist on disk via the four required peers — testing · vault · brain · bus — so the next session resumes with the chain intact.
 
-```
-prompt
-  ↓
-UserPromptSubmit hook → archetypes_v11.detect_archetypes()
-  ↓
-emits <wg archetype="incident" score="0.90" /> system reminder
-  ↓
-agent invokes /wicked-garden:archetype:incident OR auto-routes
-  ↓
-skills/archetype/SKILL.md → loads refs/incident.md (the playbook)
-  ↓
-agent runs: triage → investigate → mitigate → resolve → followup
-  ↓
-HITL discipline enforced per the archetype (mitigate is hard:*)
-```
-
-Each archetype's playbook documents its phases, what it produces, where the human gates are, and what NOT to do. No universal pipeline. No rigor-tier dial. Each shape is self-contained.
-
----
-
-## Why it works
-
-**Steering, not blocking.** Each archetype's playbook tells you what *should* happen. Hard gates exist where they matter (mitigate during an incident, cutover during a migration, final-verdict during review). Everything else is a discrete or continuous gate that auto-passes when the produces contract is met — and "met" is *re-derived*, never self-asserted (see below).
-
-**Per-archetype, not per-phase.** A `migrate` doesn't have a `clarify` phase; a `build` doesn't have a `cutover` phase. Phase names mean different things inside different archetypes. We don't try to factor common phases — that's how the v6 universal pipeline emerged, and it forced every kind of work into the same shape.
-
-**The brain carries knowledge across sessions.** Decisions, gotchas, and patterns persist via [wicked-brain](https://github.com/mikeparcewski/wicked-brain) and surface when relevant. Wicked Garden's archetype detector + steering directives don't replace context — they sit on top of it.
-
-**The bus carries the audit trail.** Every meaningful event flows through [wicked-bus](https://github.com/mikeparcewski/wicked-bus). The v6–v10 "bus-as-truth" enforcement (signed dispatches, projection resolvers per event type) is gone; the bus is now an audit substrate, not a gate enforcement mechanism. Archetypes own their own discipline.
-
-**Evidence is re-derived, not asserted.** A produces-gate doesn't go green because an agent said "done." It re-derives through [wicked-vault](https://www.npmjs.com/package/wicked-vault) — the evidence is re-hashed and its verifier re-run, never trusting a cached status. A claimed-but-false "tests pass" is **REJECTED**; a missing vault **fails closed** rather than passing on a self-assertion. Hard gates (review, incident, migrate) additionally require an *independent* judgment — the evaluator is not the agent that did the work. This is what makes "auto-passes when the produces contract is met" trustworthy: *met* means re-derived.
+`/wicked-garden:compile` can stamp that same evidence gate into *any* repo; the emitted gate runs with **no wicked-garden installed**.
 
 ---
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -60,6 +60,40 @@ npx wicked-testing --version 2>/dev/null || echo "MISSING"
 - `MISSING` → blocking. Show "wicked-testing is not installed. wicked-garden v7.0+ requires wicked-testing >= 0.1 as a peer plugin. Upgrading from v6.x? See `docs/MIGRATION-v7.md`." **INTERACTIVE mode**: AskUserQuestion header "wicked-testing Required", options "Install now (Required)" = "Run: npx wicked-testing install" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npx wicked-testing install`, re-probe with `npx wicked-testing --version`, confirm the version. On failure, show stderr and exit with manual instructions. If exit: "Run `npx wicked-testing install` then restart with `/wicked-garden:setup`."
 - Version string (e.g. `0.3.0`) → check it satisfies `^0.3.0` (the pin from `plugin.json`). In range: show "wicked-testing {version} — ready." Out of range: warn "wicked-testing {version} is outside the supported range (^0.3.0). Update with: `npx wicked-testing install`" and ask whether to update now (same INTERACTIVE / PLAIN_TEXT pattern). Updating is strongly recommended but not a hard block — the SessionStart hook will warn each session.
 
+### 2.5b Verify wicked-brain (Required)
+
+wicked-brain installs as a **Claude Code plugin** (not an npx CLI), so verify by presence rather than a version probe.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PY' 2>/dev/null || python - <<'PY'
+import json, os
+from pathlib import Path
+installed = False
+candidates = [Path.home()/".claude"/"settings.json", Path(".claude")/"settings.json"]
+cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+if cfg: candidates.append(Path(cfg)/"settings.json")
+for p in candidates:
+    try:
+        if not p.exists(): continue
+        enabled = json.loads(p.read_text(encoding="utf-8")).get("enabledPlugins", {})
+        if "wicked-brain" in (enabled if isinstance(enabled, (dict, list)) else {}):
+            installed = True; break
+    except Exception: continue
+if not installed:
+    roots = [Path.home()/".claude"/"skills"]
+    if cfg: roots.append(Path(cfg)/"skills")
+    for r in roots:
+        try:
+            if r.exists() and any(e.is_dir() and e.name.startswith("wicked-brain") for e in r.iterdir()):
+                installed = True; break
+        except OSError: continue
+print("READY" if installed else "MISSING")
+PY
+```
+
+- `MISSING` → blocking. wicked-brain is the memory, search, and context-assembly layer wicked-garden depends on — it cannot function without it. Show "wicked-brain is not installed. wicked-garden requires it as a peer (sibling to wicked-bus / wicked-vault / wicked-testing)." **INTERACTIVE mode**: AskUserQuestion header "wicked-brain Required", options "Install now (Required)" = "Run: /plugin install wicked-brain" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: instruct the user to run `/plugin install wicked-brain` (a Claude Code slash command, not a shell command), then re-run the presence check above and confirm `READY`. On failure, exit with manual instructions (`/plugin install wicked-brain`). If exit: "Run `/plugin install wicked-brain` then restart with `/wicked-garden:setup`."
+- `READY` → show "wicked-brain — ready (plugin installed)."
+
 ### 2.6 Verify wicked-vault (Required)
 
 ```bash
@@ -69,7 +103,41 @@ npx wicked-vault --version 2>/dev/null || echo "MISSING"
 - `MISSING` → blocking. wicked-vault is the evidence backend every archetype gate re-derives against — without it, "done" can only be self-asserted. Show "wicked-vault is not installed. wicked-garden requires it as a peer (sibling to wicked-bus / wicked-brain / wicked-testing)." **INTERACTIVE mode**: AskUserQuestion header "wicked-vault Required", options "Install now (Required)" = "Run: npx wicked-vault-install" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npx wicked-vault-install` (installs the cross-CLI skills) and confirm the CLI resolves with `npx wicked-vault --version`. On failure, show stderr and exit with manual instructions (`npm i -g wicked-vault`). If exit: "Run `npx wicked-vault-install` then restart with `/wicked-garden:setup`."
 - Version string (e.g. `0.3.0`) → show "wicked-vault {version} — ready." Then verify the garden can resolve it for gating: `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/qe/vault_gate.py" resolve` should report `resolvable: true`. If `installed: false` (resolving only via npx), suggest `npm i -g wicked-vault` for faster gate latency — recommended, not a hard block.
 
-### 2.7 v6→v11 Project State Migration (optional)
+### 2.7 Verify wicked-bus (Required)
+
+wicked-bus installs as a **Claude Code plugin** (not an npx CLI), so verify by presence rather than a version probe.
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" - <<'PY' 2>/dev/null || python - <<'PY'
+import json, os
+from pathlib import Path
+installed = False
+candidates = [Path.home()/".claude"/"settings.json", Path(".claude")/"settings.json"]
+cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+if cfg: candidates.append(Path(cfg)/"settings.json")
+for p in candidates:
+    try:
+        if not p.exists(): continue
+        enabled = json.loads(p.read_text(encoding="utf-8")).get("enabledPlugins", {})
+        if "wicked-bus" in (enabled if isinstance(enabled, (dict, list)) else {}):
+            installed = True; break
+    except Exception: continue
+if not installed:
+    roots = [Path.home()/".claude"/"skills"]
+    if cfg: roots.append(Path(cfg)/"skills")
+    for r in roots:
+        try:
+            if r.exists() and any(e.is_dir() and e.name.startswith("wicked-bus") for e in r.iterdir()):
+                installed = True; break
+        except OSError: continue
+print("READY" if installed else "MISSING")
+PY
+```
+
+- `MISSING` → blocking. wicked-bus is the event backbone the garden's archetype events flow through — without it, cross-plugin event wiring is silently dropped. Show "wicked-bus is not installed. wicked-garden requires it as a peer (sibling to wicked-brain / wicked-vault / wicked-testing)." **INTERACTIVE mode**: AskUserQuestion header "wicked-bus Required", options "Install now (Required)" = "Run: /plugin install wicked-bus" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: instruct the user to run `/plugin install wicked-bus` (a Claude Code slash command, not a shell command), then re-run the presence check above and confirm `READY`. On failure, exit with manual instructions (`/plugin install wicked-bus`). If exit: "Run `/plugin install wicked-bus` then restart with `/wicked-garden:setup`."
+- `READY` → show "wicked-bus — ready (plugin installed)."
+
+### 2.8 v6→v11 Project State Migration (optional)
 
 If the user has v6-v10 crew projects on disk, advise them to run the v11 migration script:
 
@@ -211,6 +279,8 @@ Show:
 wicked-garden is ready!
 
 Storage:         Local (DomainStore)
+wicked-brain:    {"ready (plugin installed)" or "MISSING — install required"}
+wicked-bus:      {"ready (plugin installed)" or "MISSING — install required"}
 wicked-testing:  {version e.g. "0.1.2 — ready" or "MISSING — install required"}
 wicked-vault:    {version e.g. "0.3.0 — ready" or "MISSING — install required"}
 Onboarding:      {Full | Quick scout | Skipped}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,30 +1,32 @@
 # Wicked Garden Documentation
 
-Detailed guides for getting the most out of wicked-garden (v6).
+Detailed guides for getting the most out of wicked-garden.
+
+Work in wicked-garden is organized around **9 work-shape archetypes** — not a fixed pipeline. Each prompt classifies into one or more archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate); each owns its own phase shape, produces contract, and HITL discipline.
 
 ## Guides
 
 | Guide | Description |
 |-------|-------------|
-| [Getting Started](getting-started.md) | Installation, first session, common workflows |
-| [Domains](domains.md) | All 13 domains with commands, agents, and use cases |
-| [Crew Workflow](crew-workflow.md) | Facilitator rubric, archetype detection, gates, convergence |
-| [Architecture](architecture.md) | Storage, native task metadata, gate policy, context assembly |
-| [Advanced Usage](advanced.md) | Multi-model reviews, yolo mode, customization, dev commands |
-| [Cross-Phase Intelligence](cross-phase-intelligence.md) | Traceability, verification, convergence, knowledge graph |
+| [Getting Started](getting-started.md) | Installation, required peers, first session, common workflows |
+| [Archetypes](v11/archetypes.md) | The 9 work-shape archetypes — why the universal pipeline went away |
+| [Domains](domains.md) | The 10 domain skill/agent families archetypes invoke for expertise |
+| [Required Peers](required-peers.md) | The four required peer plugins and the install/runtime stance |
+| [The Compiler](compiler.md) | `/wicked-garden:compile` — emit a self-contained vault-backed gate into any repo |
+| [Brain Chunk Format](brain-chunk-format.md) | How wicked-garden content is chunked for the brain index |
 
 ## Quick Links
 
-- **New to wicked-garden?** Start with [Getting Started](getting-started.md)
-- **Want to understand the workflow engine?** Read [Crew Workflow](crew-workflow.md)
-- **Looking for a specific command?** Browse [Domains](domains.md)
-- **Building on top of wicked-garden?** See [Architecture](architecture.md)
-- **Curious what v6 changed?** The [README changelog](../README.md#changelog) summarizes v6.0 → v6.3.
+- **New to wicked-garden?** Start with [Getting Started](getting-started.md).
+- **Want to understand how work is shaped?** Read [Archetypes](v11/archetypes.md).
+- **Setting up?** The [Required Peers](required-peers.md) — wicked-testing, wicked-vault, wicked-brain, wicked-bus — are verified by `/wicked-garden:setup`.
+- **Looking for domain expertise or a specific command?** Browse [Domains](domains.md).
+- **Want a build gate that runs without wicked-garden present?** See [The Compiler](compiler.md).
 
 ## Need Help?
 
 ```bash
+/wicked-garden:setup                   # verify required peers + onboard
 /wicked-garden:help                    # list all commands
-/wicked-garden:{domain}:help           # domain-specific help
-/wicked-garden:smaht:onboard           # guided codebase onboarding
+/wicked-garden:where-am-i              # show current session state
 ```

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,0 +1,87 @@
+# The Compiler
+
+`/wicked-garden:compile` takes any repo and emits a **self-contained,
+vault-backed build gate** into `<repo>/.wicked/` — a gate that proves the
+build's claims and runs with **no wicked-garden runtime present**.
+
+The compiler is in `scripts/compiler/compile.py`. The detection pass is
+`scripts/compiler/phase0/detect.py`.
+
+## What it does
+
+The compiler reads a repo and works out how to gate it:
+
+1. **Detect the bindings** (`phase0/detect.py`) — test / lint / build
+   commands, the ecosystem, any structured `claims:` docs, and the repo's
+   risk surfaces.
+2. **Derive a contract** — a multi-claim wicked-vault contract built from
+   what it found.
+3. **Emit a harness** into `<repo>/.wicked/` (see below).
+
+## What it emits
+
+Everything lands in `<repo>/.wicked/`:
+
+| File | What it is |
+|------|------------|
+| `bindings.json` | The detected test/lint/build commands + ecosystem |
+| `contract.json` | The derived multi-claim vault contract |
+| `gate.py` | A **stdlib-only** gate — imports nothing from wicked-garden |
+| `claims_lint.py` | Emitted only when the repo has structured `claims:` docs |
+| `README.md` | How to run and wire up the emitted gate |
+
+## Runs with no wicked-garden present
+
+This is the property that makes the compiler worth having: the emitted
+`gate.py` carries **no dependency on the wicked-garden runtime**. It
+resolves the vault via `npx` and re-derives the build's claims itself —
+records the test/lint/build commands, then cross-checks. A
+claimed-but-false "tests pass" gets **REJECTED**; a missing vault **fails
+closed** rather than waving the build through.
+
+You compile once; the gate then lives in the target repo and runs on its
+own, in CI or on a developer's machine, with nothing of the garden
+installed.
+
+## The on-switch rule
+
+Compile the **trigger** and the **enforcement**; never compile the
+**tool**.
+
+The vault is a runtime-resolved utility — resolved via `npx`, skippable,
+and not something the compiler bakes into the repo. The *trigger* that
+fires the gate, on the other hand, is exactly what the compiler installs.
+You don't ship a copy of the tool; you ship the on-switch and the rule it
+enforces.
+
+## Triggers
+
+Optionally, the compiler installs what actually fires the gate:
+
+- **Git pre-push hook** — idempotent, never clobbers a foreign hook, and
+  resolves the gitdir pointer so it works inside worktrees.
+- **GitHub Actions workflow** — its toolchain setup is derived from the
+  detected ecosystem.
+
+Pass `--trigger hook,ci` (or `all`) to install them.
+
+## Usage
+
+```bash
+# Detect + emit the harness into the repo's .wicked/
+/wicked-garden:compile ~/path/to/repo
+
+# Also install the triggers that fire the gate
+/wicked-garden:compile ~/path/to/repo --trigger hook,ci
+/wicked-garden:compile ~/path/to/repo --trigger all
+
+# Run the emitted gate (exit 0 = PASS)
+python3 .wicked/gate.py
+python3 .wicked/gate.py --check      # don't kick off a new run
+python3 .wicked/gate.py --dry-run    # show what would run
+```
+
+## Proven
+
+The compiler was tested on an unseen repo (memos) and self-hosted on
+wicked-garden itself.

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -1,206 +1,38 @@
 # Domains
 
-Wicked Garden is organized into **13 domains**. Each domain ships its own commands, agents, skills, and scenarios. Every domain works independently — the ecosystem is additive, not required.
+Domains are **skill and agent families** — the discipline expertise wicked-garden ships. They are not an orchestrator and they do not run a workflow on their own.
 
-**Specialist discovery is dynamic.** v6 removed the static `enhances` map. The facilitator skill reads `agents/**/*.md` frontmatter at runtime and matches each agent's description + `subagent_type` to the 9-factor rubric. Add an agent to disk with a `subagent_type: wicked-garden:{domain}:{name}` front-matter line and the facilitator can route to it next session.
+Work is shaped by the **9 archetypes** (triage, explore, specify, decide, ship, review, incident, build, migrate — see [Archetypes](v11/archetypes.md)). When an archetype's playbook needs domain expertise — a code review, a security scan, a requirements pass, a structural lookup — it **invokes a domain skill or agent** to get it. You can also call any domain command directly, without an archetype, when you just want that capability.
 
-## Workflow & Intelligence
+Every command follows the pattern `/wicked-garden:{domain}:{command}`. Every agent declares `subagent_type: wicked-garden:{domain}:{name}` for Task-tool dispatch.
 
-### crew — Workflow Engine
-
-The orchestrator. Runs the facilitator (`skills/propose-process/`) to score 9 factors, detect 1 of 7 archetypes, pick specialists from agent frontmatter, select phases from `phases.json`, and set rigor tier. Enforces quality gates via `gate-policy.json`. Tracks artifact convergence through 6 states.
-
-| Command | What It Does |
-|---------|-------------|
-| `crew:start` | Start a facilitator-driven workflow for any task |
-| `crew:execute` | Execute the current phase with adaptive routing |
-| `crew:just-finish` | Execute remaining work with maximum autonomy + guardrails |
-| `crew:status` | Show project state, phase, and next steps |
-| `crew:approve` | Approve a phase gate and advance |
-| `crew:gate` | Run QE analysis on a target at configurable rigor |
-| `crew:archive` | Archive or unarchive a project |
-| `crew:evidence` | Show evidence summary for a task |
-| `crew:convergence` | Show artifact convergence lifecycle — states, stalls, verdict |
-| `crew:swarm` | Check for quality-crisis swarm trigger |
-| `crew:yolo` / `crew:auto-approve` | Grant or revoke APPROVE-verdict auto-advance with guardrails |
-| `crew:explain` | Translate jargon-heavy crew output into plain, grade-8 English |
-| `crew:retro` | Generate a retrospective from operate-phase data |
-| `crew:incident` | Log a production incident linked to the current project |
-| `crew:feedback` | Capture user or stakeholder feedback |
-| `crew:operate` | Enter and manage the operate phase |
-| `crew:profile` | Configure crew preferences |
-| `crew:cutover` | Cut an in-flight project to mode-3 formal dispatch |
-| `crew:migrate-gates` | Migrate in-flight projects to strict gate enforcement |
-| `crew:activity` | Query the unified event log for cross-domain project activity |
-| `crew:help` | Show available crew commands |
-
-**v6 Capabilities**:
-- **Facilitator rubric** — 9-factor scoring picks specialists and phases inline, no keyword signals
-- **Archetype detection** — 7 archetypes (`archetype_detect.py`) drive per-archetype evidence expectations
-- **Phase-boundary gate adjudicator** — `gate-adjudicator` agent replaces `test-strategist` at `testability` and `evidence-quality` gates; reads archetype for per-type test/evidence guidance
-- **Challenge gate + contrarian agent** — auto-inserted at complexity ≥ 4; runs a structured steelman of the alternative path
-- **Convergence lifecycle** — Designed → Built → Wired → Tested → Integrated → Verified with stall detection; `convergence-verify` gate blocks review approval until every artifact reaches Integrated
-- **Semantic reviewer** — extracts numbered AC/FR/REQ from clarify artifacts, emits a Gap Report (`aligned`/`divergent`/`missing`) at the review gate for complexity ≥ 3
-- **Gate enforcement** — `gate-policy.json` codifies reviewer × rigor × dispatch-mode. APPROVE / CONDITIONAL / REJECT verdicts are binding
-- **BLEND aggregation** — multi-reviewer score = `0.4 × min + 0.6 × avg`
-- **Blind reviewer** — reviewers see deliverables + evidence, not prior gate verdicts
-- **HMAC dispatch log** — every specialist dispatch signed and appended; orphan gate-results → CONDITIONAL
-- **Pre-flip monitoring** — T>7 silent, 1≤T≤7 `PreFlipNotice WARN`, T=0 StrictMode with post-flip latch
-- **Yolo guardrails** — full-rigor grants require justification + sentinel; CONDITIONAL needs explicit `--override-gate`
-- **Gate-result security** — schema validator, content sanitizer, orphan detection, append-only audit log (rollback via `WG_GATE_RESULT_*` env vars)
-- **Persistent process memory + kaizen backlog** — operate retro auto-populates facilitator-context digest for future projects
-
-**Agents (10)**: `facilitator`, `phase-executor`, `gate-evaluator`, `independent-reviewer`, `contrarian`, `gate-adjudicator`, `qe-orchestrator`, `implementer`, `researcher`, `reviewer`
-
-**When to use**: Any task that benefits from structured delivery — features, migrations, refactors, bug investigations, compliance work. The facilitator adapts rigor to the work: a docs-only change gets minimal tier and self-check gates; a schema migration gets full tier, multi-reviewer panels, and per-archetype evidence demands.
-
-### smaht — Context Assembly
-
-The "brain" of the plugin. Intercepts every prompt via `UserPromptSubmit` and assembles context on demand. v6 replaced v5's push-based briefings with **pull-model** adapters that answer only what the current prompt needs.
-
-| Command | What It Does |
-|---------|-------------|
-| `smaht:onboard` | Guided codebase walkthrough + brain ingest |
-| `smaht:smaht` | On-demand context pull for the current topic |
-| `smaht:context` | Build a structured context package for subagents |
-| `smaht:state` | Snapshot and report current session state |
-| `smaht:briefing` | Session briefing — what happened since last time |
-| `smaht:events-import` | Import existing domain JSON records into the event log |
-| `smaht:collaborate` | Multi-AI CLI collaboration (discover, review, council) |
-| `smaht:help` | Show available smaht commands |
-
-**Behind the scenes**: four-tier routing keeps simple prompts fast and complex ones thorough:
-- **HOT** (<100ms): continuations / confirmations → session state only
-- **FAST** (<1s): clear-intent prompts → pattern-based adapter fan-out
-- **SLOW** (2–5s): complex / ambiguous → full adapter fan-out + history condenser
-- **SYNTHESIZE**: complex + risky → agentic synthesis skill before the orchestrator
-
-**Six adapters** (v6): `domain`, `brain`, `events`, `context7`, `tools`, `delegation`. The v4 `mem` / `search` / `kanban` / `crew` / `jam` adapters were consolidated into `domain` + `brain` + `events`. Intent classification is an inline heuristic in `hooks/scripts/prompt_submit.py` (the v5 `router.py` intent classifier was deleted in #428).
-
-**Brain as primary knowledge layer**: when wicked-brain is installed, the brain adapter queries the FTS5 index first. Budget enforcer source priority: `mem=10, search=9, brain=8, crew=6, context7=4, jam=3, tools=2, delegation=1`.
-
-### mem — Cross-Session Memory
-
-Decisions, patterns, and preferences persist across sessions. 3-tier store with auto-consolidation. Phase-aware recall weights memories by affinity to the current crew phase.
-
-| Command | What It Does |
-|---------|-------------|
-| `mem:store` | Save a decision, pattern, or preference |
-| `mem:recall` | Search memories by query |
-| `mem:review` | Browse and manage memories |
-| `mem:stats` | Show memory statistics |
-| `mem:forget` | Archive or delete a memory |
-| `mem:consolidate` | Manually trigger cross-tier consolidation |
-| `mem:retag` | Backfill search tags on existing memories |
-| `mem:help` | Show available memory commands |
-
-**Agents (3)**: `memory-archivist`, `memory-learner`, `memory-recaller`
-
-**3 tiers**: working (transient, auto-consolidates) → episodic (sprint-level) → semantic (durable project knowledge, prioritized in recall). Phase affinity: during `build`, `design` and `clarify` memories boost 1.5×; during `test-strategy`, test patterns boost.
-
-### search — Code Intelligence
-
-Structural understanding across 73 languages via tree-sitter. Not text search — symbol-level intelligence with blast radius, lineage, and service-map detection.
-
-| Command | What It Does |
-|---------|-------------|
-| `search:code` | Find functions, classes, methods by name |
-| `search:refs` | Find where a symbol is referenced |
-| `search:blast-radius` | Dependencies and dependents of a symbol |
-| `search:impact` | Reverse-lineage analysis for a change |
-| `search:lineage` | Trace data from UI to DB (or reverse) |
-| `search:service-map` | Detect service architecture from infra files |
-| `search:hotspots` | Most-referenced symbols |
-| `search:categories` | Symbol categories, layers, and directory groupings |
-| `search:docs` | Search documents (PDF, markdown, Office) |
-| `search:impl` | Find code implementing a documented feature |
-| `search:scout` | Quick pattern reconnaissance (no index required) |
-| `search:sources` | Manage external content sources |
-| `search:index` | Build/rebuild the code index |
-| `search:stats` | Show index statistics |
-| `search:validate` | Validate index consistency |
-| `search:quality` | Run quality crew to improve index accuracy |
-| `search:coverage` | Report lineage coverage |
-| `search:search` | Search across all code and documents |
-| `search:help` | Show available search commands |
-
-Lifecycle scoring (`lifecycle_scoring.py`) ranks results by phase affinity, recency, traceability, and gate status. RRF is opt-in for multi-ranker fusion.
-
-**Requires**: tree-sitter (auto-detected). Falls back to grep-based search without it.
-
-### jam — AI Brainstorming
-
-Dynamic focus groups with AI personas plus structured multi-model council sessions using external LLM CLIs.
-
-| Command | What It Does |
-|---------|-------------|
-| `jam:brainstorm` | Full multi-perspective session |
-| `jam:quick` | Lightweight exploration (fewer personas, one round) |
-| `jam:council` | Multi-model evaluation using external LLM CLIs |
-| `jam:perspectives` | Get multiple perspectives on a decision |
-| `jam:thinking` | View individual persona perspectives pre-synthesis |
-| `jam:transcript` | View full conversation transcript |
-| `jam:persona` | View a specific persona's contributions |
-| `jam:revisit` | Revisit a past brainstorm decision |
-| `jam:help` | Show available jam commands |
-
-**Agents (2)**: `brainstorm-facilitator` (renamed from `facilitator` in v6.3.2 to avoid collision with crew's facilitator), `council`
-
-Structured consensus protocol with explicit dissent tracking: proposals → cross-review → synthesis with clustered agreements + classified dissents (strong / moderate / mild).
+There are **10 domains**: engineering, platform, product, data, jam, search, agentic, persona, delivery, smaht.
 
 ---
 
-## Specialist Disciplines
+## engineering — Software Engineering
 
-Specialists are discovered by the facilitator reading `agents/**/*.md` frontmatter. Every agent declares `subagent_type: wicked-garden:{domain}:{name}` for Task-tool routing.
-
-### engineering — Software Engineering
-
-Senior engineer, solution architect, system designer, backend/frontend specialists, debugger, technical writer, API documentarian, developer-experience engineer, migration engineer.
+Senior engineer, solution architect, system designer, backend/frontend specialists, debugger, technical writer, API documentarian, developer-experience and migration engineers. The workhorse for `build` and `migrate` work.
 
 | Command | What It Does |
 |---------|-------------|
-| `engineering:review` | Multi-pass code review with domain routing |
+| `engineering:review` | Code review from a senior engineering perspective |
 | `engineering:arch` | Architecture analysis and recommendations |
 | `engineering:debug` | Systematic debugging with root cause analysis |
-| `engineering:docs` | Generate or improve documentation |
-| `engineering:plan` | Review changes against codebase and plan steps |
-| `engineering:rename` | Rename a field/symbol across all usages |
-| `engineering:add-field` | Add a field to an entity and propagate |
-| `engineering:remove` | Remove a field and all its usages |
-| `engineering:apply` | Apply patches from a saved JSON file |
+| `engineering:plan` | Review changes against the codebase and plan steps |
 | `engineering:patch-plan` | Show what a change would affect without patching |
+| `engineering:apply` | Apply patches from a saved JSON file |
+| `engineering:rename` | Rename a field/symbol across all usages |
+| `engineering:add-field` | Add a field to an entity and propagate it |
+| `engineering:remove` | Remove a field and all its usages |
+| `engineering:docs` | Generate or improve documentation |
 | `engineering:new-generator` | Create a language generator for wicked-patch |
-| `engineering:help` | Show available engineering commands |
 
-**Agents (10)**: `senior-engineer`, `solution-architect`, `system-designer`, `backend-engineer`, `frontend-engineer`, `debugger`, `technical-writer`, `api-documentarian`, `devex-engineer`, `migration-engineer`
+**Agents**: `senior-engineer`, `solution-architect`, `system-designer`, `backend-engineer`, `frontend-engineer`, `debugger`, `technical-writer`, `api-documentarian`, `devex-engineer`, `migration-engineer`
 
-### product — Product Management & Design
+## platform — DevSecOps
 
-Requirements analysis, UX, customer voice, market / value strategy, accessibility, visual design review. v6 consolidated several overlapping roles (business-strategist → market-strategist, value-analyst + alignment-lead → value-strategist, feedback-analyst + customer-advocate → user-voice, visual-reviewer → ui-reviewer) and added `ux-analyst`.
-
-| Command | What It Does |
-|---------|-------------|
-| `product:elicit` | Requirements elicitation through structured inquiry |
-| `product:listen` | Aggregate customer feedback from available sources |
-| `product:analyze` | Analyze feedback for themes and sentiment |
-| `product:synthesize` | Generate actionable recommendations |
-| `product:acceptance` | Define acceptance criteria from requirements |
-| `product:align` | Facilitate stakeholder alignment |
-| `product:strategy` | ROI, value proposition, competitive analysis |
-| `product:ux-review` | UX and design quality review |
-| `product:review` | Design system consistency review |
-| `product:mockup` | Wireframe and prototype generation |
-| `product:ux` | UX flow design and analysis |
-| `product:screenshot` | Screenshot-based UI review (multimodal) |
-| `product:a11y` | WCAG 2.1 AA accessibility audit |
-| `product:help` | Show available product commands |
-
-**Agents (11)**: `product-manager`, `requirements-analyst`, `ux-designer`, `ux-analyst`, `user-researcher`, `user-voice`, `market-strategist`, `value-strategist`, `a11y-expert`, `ui-reviewer`, `mockup-generator`
-
-### platform — DevSecOps
-
-SRE, security, compliance, incident response, infrastructure, DevOps, release, auditing, privacy. v6 added `chaos-engineer` and `observability-engineer` for resilience and SLI/SLO work.
+SRE, security, compliance, incident response, infrastructure, DevOps, release, auditing, privacy, chaos and observability engineering. Backs `ship`, `incident`, and `review` work.
 
 | Command | What It Does |
 |---------|-------------|
@@ -209,94 +41,103 @@ SRE, security, compliance, incident response, infrastructure, DevOps, release, a
 | `platform:audit` | Collect audit evidence |
 | `platform:health` | System health and reliability assessment |
 | `platform:incident` | Incident response and triage |
-| `platform:actions` | GitHub Actions workflow generation |
 | `platform:infra` | Infrastructure review and IaC analysis |
-| `platform:errors` | Error pattern analysis |
+| `platform:actions` | GitHub Actions workflow generation |
 | `platform:traces` | Distributed tracing analysis |
-| `platform:gh` | GitHub CLI power utilities |
 | `platform:toolchain` | Discover and query monitoring tools |
-| `platform:logs` | View operational logs |
-| `platform:plugin-debug` | View/set plugin log verbosity |
-| `platform:plugin-health` | Health probes against installed plugins |
-| `platform:plugin-traces` | Query hook execution traces |
+| `platform:gh` | GitHub CLI power utilities |
 | `platform:assert` | Contract assertions against subprocess outputs |
-| `platform:help` | Show available platform commands |
+| `platform:plugin-health` | Health probes against installed plugins |
 
-**Agents (11)**: `security-engineer`, `sre`, `compliance-officer`, `incident-responder`, `infrastructure-engineer`, `devops-engineer`, `release-engineer`, `auditor`, `privacy-expert`, `chaos-engineer`, `observability-engineer`
+**Agents**: `security-engineer`, `sre`, `compliance-officer`, `incident-responder`, `infrastructure-engineer`, `devops-engineer`, `release-engineer`, `auditor`, `privacy-expert`, `chaos-engineer`, `observability-engineer`
 
-### qe — Quality Engineering
+## product — Product Management & Design
 
-Test strategist, test designer, automation engineer, risk assessor, testability reviewer, code analyzer, continuous quality monitor, production quality engineer, requirements quality analyst, contract testing engineer, and the v6 additions: `semantic-reviewer` (spec-to-code alignment) and `gate-adjudicator` (phase-boundary evidence evaluator).
-
-v6 consolidated the former three-agent acceptance pipeline (`acceptance-test-writer` / `executor` / `reviewer`) into a single `test-designer` that owns Write → Execute → Analyze → Verdict in one role. `tdd-coach` folded into `test-strategist`.
+Requirements, UX, customer voice, market/value strategy, accessibility, visual design review. Backs `specify` and `explore` work.
 
 | Command | What It Does |
 |---------|-------------|
-| `qe:qe` | Full quality engineering review |
-| `qe:scenarios` | Generate test scenarios from requirements |
-| `qe:acceptance` | Evidence-gated acceptance testing (Write → Execute → Review) |
-| `qe:automate` | Generate test code from scenarios |
-| `qe:qe-plan` | Comprehensive test plan generation |
-| `qe:qe-review` | Review test quality and coverage |
-| `qe:run` | Execute an E2E test scenario |
-| `qe:list` | List available scenarios with tool status |
-| `qe:check` | Validate scenario file format |
-| `qe:setup` | Install required CLI tools |
-| `qe:report` | File issues from test failures |
-| `qe:help` | Show available qe commands |
+| `product:elicit` | Requirements elicitation through structured inquiry |
+| `product:acceptance` | Define acceptance criteria from requirements |
+| `product:listen` | Aggregate customer feedback from available sources |
+| `product:analyze` | Analyze feedback for themes and sentiment |
+| `product:synthesize` | Generate actionable recommendations |
+| `product:align` | Facilitate stakeholder alignment |
+| `product:strategy` | ROI, value proposition, competitive analysis |
+| `product:ux` | UX flow design and analysis |
+| `product:ux-review` | UX and design quality review |
+| `product:mockup` | Wireframe and prototype generation |
+| `product:screenshot` | Screenshot-based UI review (multimodal) |
+| `product:a11y` | WCAG 2.1 AA accessibility audit |
 
-**Agents (11)**: `test-strategist`, `test-designer`, `test-automation-engineer`, `testability-reviewer`, `semantic-reviewer`, `risk-assessor`, `requirements-quality-analyst`, `code-analyzer`, `continuous-quality-monitor`, `production-quality-engineer`, `contract-testing-engineer`
+**Agents**: `product-manager`, `requirements-analyst`, `ux-designer`, `ux-analyst`, `user-researcher`, `user-voice`, `market-strategist`, `value-strategist`, `a11y-expert`, `ui-reviewer`, `mockup-generator`
 
-### data — Data Engineering
+## data — Data Engineering
 
-Data analyst, data engineer, ML engineer, unified data architect (v6 merged `engineering:data-architect` + `data:analytics-architect` into `data:data-architect` for the full OLTP + OLAP design).
+Data analyst, data engineer, ML engineer, and a unified data architect for OLTP + OLAP design.
 
 | Command | What It Does |
 |---------|-------------|
 | `data:analyze` | Interactive data analysis on files |
-| `data:numbers` | DuckDB SQL on CSV/Excel (10GB+, plain English) |
 | `data:data` | Data profiling and schema validation |
-| `data:analysis` | Alias for `data:analyze` |
 | `data:pipeline` | Data pipeline design and review |
 | `data:ml` | ML model review and training pipeline |
 | `data:ontology` | Dataset ontology recommendations |
-| `data:help` | Show available data commands |
 
-**Agents (4)**: `data-analyst`, `data-engineer`, `data-architect`, `ml-engineer`
+**Agents**: `data-analyst`, `data-engineer`, `data-architect`, `ml-engineer`
 
-### delivery — Delivery Management
+## jam — AI Brainstorming
 
-Delivery manager, stakeholder reporter, rollout manager, experiment designer, risk monitor, progress tracker, and unified cloud-cost intelligence (v6 merged `finops-analyst` + `cost-optimizer`).
-
-| Command | What It Does |
-|---------|-------------|
-| `delivery:report` | Multi-perspective stakeholder reports |
-| `delivery:setup` | Configure delivery metrics (cost model, sprint cadence) |
-| `delivery:rollout` | Progressive rollout plans with risk management |
-| `delivery:experiment` | A/B test design with statistical rigor |
-| `delivery:process-health` | Surface process memory — kaizen status, unresolved action items |
-| `delivery:help` | Show available delivery commands |
-
-**Agents (7)**: `delivery-manager`, `stakeholder-reporter`, `rollout-manager`, `experiment-designer`, `risk-monitor`, `progress-tracker`, `cloud-cost-intelligence`
-
-### agentic — Agentic Architecture
-
-Architecture reviewer, safety auditor, pattern advisor, performance analyst, framework researcher. For reviewing and designing AI agent systems.
+Dynamic focus groups with AI personas plus structured multi-model council sessions using external LLM CLIs. The natural fit for `explore` work.
 
 | Command | What It Does |
 |---------|-------------|
-| `agentic:review` | Full agentic codebase review |
+| `jam:brainstorm` | Full multi-perspective session with dynamic focus groups |
+| `jam:quick` | Lightweight exploration (fewer personas, one round) |
+| `jam:council` | Structured multi-model evaluation via external LLM CLIs |
+| `jam:perspectives` | Get multiple perspectives on a decision (no synthesis) |
+| `jam:thinking` | View individual persona perspectives pre-synthesis |
+| `jam:persona` | View a specific persona's contributions |
+| `jam:transcript` | View the full conversation transcript |
+| `jam:revisit` | Revisit a past brainstorm decision |
+
+**Agents**: `brainstorm-facilitator`, `quick-facilitator`, `council`
+
+## search — Code Intelligence
+
+Structural understanding via tree-sitter — symbol-level, not text search. Blast radius, lineage, and service-map detection. Heavily used during `build`, `migrate`, and `review` to ground changes.
+
+| Command | What It Does |
+|---------|-------------|
+| `search:index` | Build/rebuild the unified code + document index |
+| `search:blast-radius` | Dependencies and dependents of a symbol |
+| `search:lineage` | Trace data from UI to DB (or reverse) |
+| `search:service-map` | Detect service architecture from infra files |
+| `search:hotspots` | Most-referenced symbols |
+| `search:categories` | Symbol categories, layers, and directory groupings |
+| `search:coverage` | Report lineage coverage |
+| `search:sources` | Manage external content sources |
+| `search:quality` | Improve index accuracy |
+| `search:validate` | Validate index consistency |
+
+> For open-ended symbol and concept search, prefer `wicked-brain:search` / `wicked-brain:query` when the brain index is available; the `search:*` commands cover structural analysis the brain doesn't.
+
+## agentic — Agentic Architecture
+
+Architecture review, safety auditing, pattern advice, performance analysis, framework research — for reviewing and designing AI agent systems.
+
+| Command | What It Does |
+|---------|-------------|
+| `agentic:review` | Full agentic codebase review with framework detection |
 | `agentic:design` | Interactive architecture design guide |
 | `agentic:audit` | Trust and safety audit |
-| `agentic:ask` | Ask about agentic patterns and frameworks |
 | `agentic:frameworks` | Research and compare frameworks |
-| `agentic:help` | Show available agentic commands |
 
-**Agents (5)**: `architect`, `safety-reviewer`, `pattern-advisor`, `performance-analyst`, `framework-researcher`
+**Agents**: `architect`, `safety-reviewer`, `pattern-advisor`, `performance-analyst`, `framework-researcher`
 
-### persona — On-Demand Personas
+## persona — On-Demand Personas
 
-Invoke any specialist persona directly without crew or jam. Define custom personas with personality, constraints, memories, and preferences.
+Invoke any specialist persona directly. Define custom personas with personality, constraints, and preferences.
 
 | Command | What It Does |
 |---------|-------------|
@@ -305,23 +146,43 @@ Invoke any specialist persona directly without crew or jam. Define custom person
 | `persona:list` | List all available personas |
 | `persona:submit` | PR a persona to the built-in registry |
 
-**Agents (1)**: `persona-agent`
+**Agents**: `persona-agent`
+
+## delivery — Delivery Management
+
+Delivery manager, stakeholder reporter, rollout manager, experiment designer, risk and progress tracking, cloud-cost intelligence. Backs `ship` and post-ship reporting.
+
+| Command | What It Does |
+|---------|-------------|
+| `delivery:rollout` | Progressive rollout plans with risk management |
+| `delivery:experiment` | A/B test design with statistical rigor |
+| `delivery:report` | Multi-perspective stakeholder reports |
+| `delivery:setup` | Configure delivery metrics (cost model, sprint cadence) |
+| `delivery:process-health` | Surface process health and unresolved action items |
+
+**Agents**: `delivery-manager`, `stakeholder-reporter`, `rollout-manager`, `experiment-designer`, `risk-monitor`, `progress-tracker`, `cloud-cost-intelligence`
+
+## smaht — Context Assembly
+
+On-demand context assembly over wicked-brain and the search index. A pull-model skill — archetypes and subagents call it when they need a briefing, rather than pushing context onto every prompt.
+
+| Command | What It Does |
+|---------|-------------|
+| `smaht:briefing` | What happened since the last session — recent events and updates |
+| `smaht:state` | Snapshot and report current session state |
+| `smaht:events-import` | Import existing domain JSON records into the event log |
+| `smaht:propose-skills` | Suggest skills worth adding based on observed work |
 
 ---
 
-## Cross-Cutting Capabilities
+## How archetypes invoke domains
 
-Skills and modules that apply across all domains:
+An archetype playbook (`skills/archetype/refs/{archetype}.md`) doesn't hardcode a domain pipeline — it reaches for whatever expertise the work needs:
 
-| Capability | What It Does |
-|-----------|-------------|
-| **propose-process** | The facilitator rubric. Scores 9 factors, detects archetype, picks specialists + phases, sets rigor tier, emits `process-plan.md` and the full task chain |
-| **adopt-legacy** | Detects v5 project markers and transforms them idempotently to v6 format |
-| **workflow** | v6 entry-point skill documenting interaction modes, rigor tiers, phase plan, and gate-policy reviewer assignment |
-| **acceptance-testing** | Evidence-gated three-stage pipeline: Writer designs plans, Executor runs + captures evidence, Reviewer renders verdict |
-| **unified-search** | Routes code + document queries to the right backend (brain FTS5, tree-sitter, grep) |
-| **deliberate** | Critical-thinking framework applied before work. Challenges assumptions, finds root causes, spots adjacent opportunities |
-| **multi-model** | Multi-LLM council reviews using external CLIs (Codex, Gemini, OpenCode) |
-| **smaht** | On-demand context assembly over wicked-brain + unified-search |
-| **cross-phase intelligence** | Traceability, artifact states, verification protocol, impact analysis, convergence lifecycle, knowledge graph, phase-aware memory |
-| **deliberate** | Five-lens critical thinking — use before committing to an approach |
+- A `build` reaches for `engineering` to implement and review, `search` to ground changes, and `wicked-testing` for evidence.
+- A `review` reaches for `engineering:review`, `platform:security`, and `agentic:review` depending on the target.
+- An `explore` reaches for `jam` to diverge across perspectives.
+- A `specify` reaches for `product:elicit` and `product:acceptance`.
+- A `ship` reaches for `delivery:rollout` and `platform:health`.
+
+Domains are the *how*; archetypes are the *when* and *what shape*. The two compose — neither replaces the other.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,100 +6,129 @@
 claude plugins add mikeparcewski/wicked-garden
 ```
 
-No API keys, no external services, no cloud — everything runs locally. Two companion plugins are required (below); like wicked-garden itself, both install locally via npm.
+No API keys, no external services, no cloud — everything runs locally.
 
 ### Required peer plugins
 
-Two companion plugins are **required** — `/wicked-garden:setup` verifies both and blocks until they are present:
+Four companion plugins are **required** — `/wicked-garden:setup` verifies all four and blocks until they are present. They are required at install but resilient at runtime (the garden degrades gracefully if one goes missing mid-session).
 
 ```bash
-npx wicked-vault-install      # wicked-vault (≥0.3) — vault-backed evidence
-npx wicked-testing install    # wicked-testing (≥0.3) — evidence-gated testing
+npx wicked-testing install    # wicked-testing — evidence-gated testing
+npx wicked-vault-install      # wicked-vault — vault-backed evidence (gates re-derive against it)
+/plugin install wicked-brain  # wicked-brain — cross-session memory + search
+/plugin install wicked-bus    # wicked-bus — event bridge
 ```
 
-### Optional companions
-
-[wicked-brain](https://github.com/mikeparcewski/wicked-brain) (cross-session memory) and [wicked-bus](https://github.com/mikeparcewski/wicked-bus) (event bridge) are optional but recommended — install them when you want those capabilities.
+`wicked-testing` and `wicked-vault` install locally via npm; `wicked-brain` and `wicked-bus` install as Claude Code plugins. Gates re-derive "done" through wicked-vault (fail-closed) — a claim is never self-asserted.
 
 ## Your First Session
 
-After installing, you can use any command immediately. Here are six ways to start:
+There is no fixed pipeline. Work is organized around **9 work-shape archetypes** — `triage`, `explore`, `specify`, `decide`, `ship`, `review`, `incident`, `build`, and `migrate`. Each archetype owns its own phase shape, what it produces, and how much human-in-the-loop discipline it demands. After installing, you can use any command immediately. Here are five ways to start:
 
-### 1. Run a Full Workflow
+### 1. Just Describe What You Want
 
-For any non-trivial task, crew orchestrates the entire delivery:
+Type a plain prompt and wicked-garden classifies it into one or more archetypes automatically:
 
-```bash
-/wicked-garden:crew:start "Add user authentication with OAuth2"
+```
+Add user authentication with OAuth2
 ```
 
-The facilitator (`skills/propose-process/`) scores 9 factors, detects one of 7 project archetypes, picks specialists by reading their `subagent_type` frontmatter, and selects phases from `phases.json`. A minimal-rigor task gets advisory self-check gates and finishes fast. A full-rigor task (compliance scope, high blast radius, schema migrations) gets multi-reviewer panels, per-archetype evidence demands, and a convergence-verify gate that blocks sign-off until every artifact is integrated.
+A schema-changing feature classifies as `build + migrate`; a risky deploy as `ship + review`. The detector returns a *set*, not a single match, and runs them in dependency order. Each archetype then runs its own phase shape — `build` plans, implements, tests, and reviews; `migrate` expands, backfills, cuts over, and contracts.
 
-### 2. Get a Code Review
+### 2. Invoke an Archetype Directly
 
-```bash
-/wicked-garden:engineering:review
-```
-
-Runs a multi-pass review from a senior engineering perspective — architecture, correctness, security, and maintainability. Works on your current diff or staged changes.
-
-### 3. Search Your Codebase Structurally
+When you already know the shape of the work, skip auto-routing and call the archetype yourself:
 
 ```bash
-wicked-brain:search "handleAuth"
+/wicked-garden:archetype:build "Add user authentication with OAuth2"
+/wicked-garden:archetype:incident "checkout 500s spiking in prod"
+/wicked-garden:archetype:migrate "split orders table into orders + line_items"
+/wicked-garden:archetype:decide "Redis vs Postgres for session storage"
 ```
 
-Not grep — structural code intelligence across 73 languages. Find functions, classes, and methods by name. Trace data lineage from UI to database. Analyze blast radius before changing a symbol.
+All nine are available: `triage`, `explore`, `specify`, `decide`, `ship`, `review`, `incident`, `build`, `migrate`. Gates re-derive "done" through wicked-vault (fail-closed) — sign-off is evidence-backed, never self-asserted.
 
-### 4. Brainstorm a Decision
+### 3. Use a Domain Skill Directly
+
+Archetypes invoke the domain skill/agent families (engineering, platform, product, data, jam, search, agentic, persona, delivery, smaht) under the hood, but you can call them directly when you want a single focused pass:
 
 ```bash
-/wicked-garden:jam:quick "Redis vs Postgres for session storage?"
+/wicked-garden:engineering:review                          # senior-perspective code review
+/wicked-garden:jam:quick "Redis vs Postgres for sessions?" # multi-persona debate, ~60s
+/wicked-garden:data:analyze sales.csv "top 10 by revenue"  # plain English → SQL via DuckDB
 ```
 
-4-6 AI personas debate your question from technical, user, business, and process angles. Returns a synthesis with tradeoffs and a recommendation in about 60 seconds.
-
-### 5. Analyze Data
-
-```bash
-/wicked-garden:data:analyze sales.csv "top 10 customers by revenue"
-```
-
-Plain English to SQL results via DuckDB. Works on CSV, Excel, Parquet — files up to 10GB+. Zero setup.
-
-### 6. Compile a Standalone Build Gate
+### 4. Compile a Standalone Build Gate
 
 ```bash
 /wicked-garden:compile ./my-service --trigger hook,ci  # emit a vault-backed gate into ./my-service/.wicked/
 ```
 
-Detects the repo's test/lint/build commands and emits a self-contained `gate.py` that re-derives the build's claims through wicked-vault — runs with no wicked-garden runtime present (resolves the vault via npx). The `--trigger` flag installs a git pre-push hook and/or GitHub Actions workflow.
+Detects the repo's test/lint/build commands and emits a self-contained `gate.py` that re-derives the build's claims through wicked-vault — runs with **no wicked-garden runtime present** (resolves the vault via npx). The `--trigger` flag installs a git pre-push hook and/or GitHub Actions workflow.
+
+### 5. Remember Decisions Across Sessions
+
+Memory is provided by the [wicked-brain](https://github.com/mikeparcewski/wicked-brain) peer plugin:
+
+```
+Skill(skill="wicked-brain:memory", args="store \"Chose Postgres over Redis for sessions — need transactions\" --type decision")
+# ... 30 sessions later ...
+Skill(skill="wicked-brain:memory", args="recall \"session storage decisions\" --filter_type decision")
+```
+
+Search the same brain instead of grep — `wicked-brain:search "handleAuth"` gives structural code intelligence, lineage, and blast radius.
 
 ## Common Workflows
 
 ### "I have a bug to fix"
 
 ```bash
-/wicked-garden:engineering:debug          # systematic root cause analysis
-/wicked-garden:search:blast-radius buggyFunction  # what depends on it?
+/wicked-garden:engineering:debug                   # systematic root cause analysis
+/wicked-garden:search:blast-radius buggyFunction   # what depends on it?
+```
+
+### "Something is on fire in prod"
+
+```bash
+/wicked-garden:archetype:incident "checkout 500s spiking"  # triage → investigate → mitigate → resolve → followup
 ```
 
 ### "I need to understand this codebase"
 
 ```bash
-/wicked-garden:smaht:onboard             # guided walkthrough of architecture
 /wicked-garden:search:service-map         # detect service architecture
 /wicked-garden:search:hotspots            # most-referenced symbols
+wicked-brain:search "auth flow"           # structural search across the brain
 ```
 
-### "I need to plan a feature"
+### "I need to plan and build a feature"
 
 ```bash
-/wicked-garden:crew:start "Add real-time notifications"  # full workflow
-# OR standalone:
-/wicked-garden:product:elicit             # requirements elicitation
-/wicked-garden:jam:brainstorm "notification architecture" # explore approaches
-/wicked-garden:engineering:arch           # architecture analysis
+/wicked-garden:archetype:build "Add real-time notifications"  # plan → implement → test → review
+# OR break it down by hand:
+/wicked-garden:archetype:specify "real-time notifications"    # elicit → structure → validate (SMART criteria)
+/wicked-garden:archetype:explore "notification architecture"  # frame → diverge → converge
+/wicked-garden:engineering:arch                               # architecture analysis
+```
+
+### "I need to make a decision"
+
+```bash
+/wicked-garden:archetype:decide "monolith vs microservices"  # brief → options → score → record (produces an ADR)
+/wicked-garden:jam:council "should we adopt event sourcing?"  # independent multi-model perspectives
+```
+
+### "I need to ship and review a change"
+
+```bash
+/wicked-garden:archetype:ship "v2 rollout"     # canary → ramp → full → soak
+/wicked-garden:archetype:review                # scope → assess → findings → remediate-or-accept
+```
+
+### "I need to migrate a schema"
+
+```bash
+/wicked-garden:archetype:migrate "split orders into orders + line_items"  # plan → expand → backfill → cutover → contract
 ```
 
 ### "I need to check security/compliance"
@@ -115,62 +144,37 @@ Detects the repo's test/lint/build commands and emits a self-contained `gate.py`
 ```bash
 /wicked-testing:authoring "checkout flow"  # generate test scenarios
 /wicked-testing:execution                  # evidence-gated acceptance testing
-/wicked-testing:authoring                  # generate test code
 ```
-
-### "I want to remember decisions across sessions"
-
-Memory is provided by the [wicked-brain](https://github.com/mikeparcewski/wicked-brain) companion plugin. Install it first, then:
-
-```
-Skill(skill="wicked-brain:memory", args="store \"Chose Postgres over Redis for sessions — need transactions\" --type decision")
-# ... 30 sessions later ...
-Skill(skill="wicked-brain:memory", args="recall \"session storage decisions\" --filter_type decision")
-```
-
-Alternatively, the Stop hook auto-promotes learnings from completed tasks to wicked-brain at session end — no manual store needed.
-
-### "I need to trace decisions across phases"
-
-```bash
-/wicked-garden:crew:evidence            # show evidence and traceability for current project
-/wicked-garden:crew:status              # see phase state, artifact lifecycle, linked deliverables
-```
-
-Crew automatically creates traceability links between phase deliverables — a design decision in the clarify phase is linked forward to the architecture artifact, implementation, and test plan. Use `crew:evidence` to see the full chain.
 
 ## How Commands Work
 
-All commands follow the pattern `/wicked-garden:{domain}:{command}`:
+Archetype commands follow `/wicked-garden:archetype:{name}`; domain commands follow `/wicked-garden:{domain}:{command}`:
 
 ```bash
-/wicked-garden:crew:start        # crew domain, start command
+/wicked-garden:archetype:build   # archetype namespace, build work-shape
 /wicked-garden:search:lineage    # search domain, lineage command
 /wicked-garden:platform:security # platform domain, security command
 ```
 
-Every domain also has a help command:
+To list everything:
 
 ```bash
-/wicked-garden:crew:help
-/wicked-garden:engineering:help
-/wicked-garden:help              # list everything
+/wicked-garden:help              # list every command
 ```
 
 ## What Happens Behind the Scenes
 
-When you run a command, a context assembly layer called **smaht** intercepts your prompt and enriches it with relevant context — recent memory, active crew projects, native tasks, and code intelligence. This happens automatically on every prompt, not just wicked-garden commands.
+When you submit a prompt, a `UserPromptSubmit` hook runs the archetype detector and emits a steering reminder for the matched work-shape(s). The selected archetype then drives its own phase shape — there is no universal pipeline forcing every kind of work through the same gates.
 
-Every `TaskCreate` / `TaskUpdate` carries a structured metadata envelope (`chain_id`, `event_type`, `source_agent`, `phase`, `archetype`) validated by a PreToolUse hook. A SubagentStart hook reads the event type and injects the matching procedure bundle — R1–R6 bulletproof standards for coding-tasks, the Gate Finding Protocol for gate-findings, and per-role procedures for other types.
+A context assembly layer called **smaht** enriches prompts with relevant context — recent memory, active work, native tasks, and code intelligence. Every `TaskCreate` / `TaskUpdate` carries a structured metadata envelope (`chain_id`, `event_type`, `source_agent`, `phase`, `archetype`) validated by a PreToolUse hook, and a SubagentStart hook injects the matching procedure bundle — R1–R6 bulletproof standards for coding tasks, the Gate Finding Protocol for review findings, and per-role procedures otherwise.
 
-During crew workflows, the system also tracks **traceability links** between phase deliverables (so a clarify decision connects forward to design artifacts and implementation), manages **artifact states** through a 6-state convergence lifecycle (Designed → Built → Wired → Tested → Integrated → Verified) with stall detection, and runs a **verification protocol** at quality gates to ensure evidence-based advancement.
+Gates re-derive every claim through wicked-vault (fail-closed): "done" is *re-derived from evidence*, never self-asserted. Hard gates (incident mitigate, migrate cutover, review final-verdict) require explicit human approval; discrete gates auto-pass only when their produces contract is met.
 
 Your data is stored locally in `~/.something-wicked/wicked-garden/` as JSON files, scoped per working directory. No data leaves your machine unless you configure external integrations.
 
 ## Next Steps
 
-- [Domains](domains.md) — browse all 13 domains and their commands
-- [Crew Workflow](crew-workflow.md) — facilitator rubric, archetype detection, gates, convergence
-- [Architecture](architecture.md) — storage, native task metadata, gate policy, context assembly
-- [Advanced Usage](advanced.md) — multi-model reviews, yolo mode, customization, dev tools
-- [Cross-Phase Intelligence](cross-phase-intelligence.md) — traceability, verification, convergence, knowledge graph
+- [Archetypes](v11/archetypes.md) — the 9 work-shapes: phases, produces, HITL discipline, cost bands
+- [Required Peers](required-peers.md) — wicked-testing, wicked-vault, wicked-brain, wicked-bus
+- [Compiler](compiler.md) — emit a standalone, vault-backed build gate into any repo
+- [Domains](domains.md) — browse the domain skill/agent families and their commands

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,11 @@
 # Getting Started
 
-This guide gets wicked-garden installed and shows five ways to start your first session.
+Wicked Garden is an evidence-driven SDLC for Claude Code: it detects the shape
+of your work, applies the rigor that shape needs, and won't call anything "done"
+without re-derivable proof. (The *why* lives in [`ETHOS.md`](../ETHOS.md); this
+guide is the *how-to-start*.)
+
+This guide gets it installed and shows five ways to start your first session.
 
 ## Installation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+This guide gets wicked-garden installed and shows five ways to start your first session.
+
 ## Installation
 
 ```bash
@@ -10,7 +12,7 @@ No API keys, no external services, no cloud — everything runs locally.
 
 ### Required peer plugins
 
-Four companion plugins are **required** — `/wicked-garden:setup` verifies all four and blocks until they are present. They are required at install but resilient at runtime (the garden degrades gracefully if one goes missing mid-session).
+Four companion plugins are **required** — `/wicked-garden:setup` verifies all four and blocks until they are present. They are required at install but resilient at runtime (the garden degrades gracefully if one goes missing mid-session). Graceful degradation means a session continues where it's safe to; it never means a gate treats missing evidence as a pass — that path fails closed.
 
 ```bash
 npx wicked-testing install    # wicked-testing — evidence-gated testing
@@ -174,7 +176,7 @@ Your data is stored locally in `~/.something-wicked/wicked-garden/` as JSON file
 
 ## Next Steps
 
-- [Archetypes](v11/archetypes.md) — the 9 work-shapes: phases, produces, HITL discipline, cost bands
+- [Archetypes](v11/archetypes.md) — the 9 work-shapes: phases, produces, human-in-the-loop (HITL) discipline, cost bands
 - [Required Peers](required-peers.md) — wicked-testing, wicked-vault, wicked-brain, wicked-bus
 - [Compiler](compiler.md) — emit a standalone, vault-backed build gate into any repo
 - [Domains](domains.md) — browse the domain skill/agent families and their commands

--- a/docs/required-peers.md
+++ b/docs/required-peers.md
@@ -33,6 +33,9 @@ contradiction and isn't.
 - **Resilient at runtime.** A transient outage — the brain server
   momentarily down, the bus briefly unavailable — **degrades gracefully**
   and does **not** crash your session. A hiccup won't brick you.
+  Graceful degradation means a session continues where it's safe to; it
+  never means a gate treats missing evidence as a pass — that path fails
+  closed.
 
 "Required" means *you must install it*. "Resilient" means *a runtime
 hiccup won't take down the session*. Those answer two different

--- a/docs/required-peers.md
+++ b/docs/required-peers.md
@@ -1,0 +1,66 @@
+# Required Peers
+
+Wicked Garden does not stand alone. As of **v12**, four peer plugins are
+**required infrastructure** — not optional integrations you bolt on for
+extra credit. The garden's honest-evidence model is load-bearing on all
+four; remove any one and "done" stops being re-derivable.
+
+This is a deliberate shift. Earlier versions framed wicked-brain and
+wicked-bus as *recommended companions* — nice to have, fine to skip.
+v12 retired that framing. The four peers below are what the garden is
+built on, and `/wicked-garden:setup` treats them that way.
+
+## The four peers
+
+| Peer | What it does | Install | How it's verified |
+|------|--------------|---------|-------------------|
+| **wicked-testing** | Evidence-gated acceptance testing with three-agent writer/executor/reviewer separation — the writer designs, the executor collects artifacts, the reviewer judges independently. Eliminates self-graded "it passed." | `npx wicked-testing install` (npm; pinned `^0.3.0` in `plugin.json`) | `/wicked-garden:setup` verifies at install |
+| **wicked-vault** | The honest-evidence backend every archetype gate re-derives against: record → re-hash + re-run the verifier → cross-check. Never trusts a cached status. | `npx wicked-vault-install` (npm; pinned `^0.3.0`) | `/wicked-garden:setup` verifies at install; resolved at runtime via `WICKED_VAULT_BIN` → config → `PATH` → `node_modules` → `npx wicked-vault` |
+| **wicked-brain** | Cross-session memory and cited search — the knowledge layer that carries decisions, gotchas, and patterns from session 1 to session 47. Runs a local server. | `/plugin install wicked-brain` (also on npm `0.14.0`) | SessionStart bootstrap probe |
+| **wicked-bus** | The event audit substrate — fire-and-forget events that record what happened. | `/plugin install wicked-bus` (also on npm `2.0.0`) | SessionStart bootstrap probe |
+
+`/wicked-garden:setup` verifies all four and **blocks** without them. The
+SessionStart bootstrap hook independently probes for them and **warns**
+(non-blocking) when one isn't resolvable.
+
+## The stance: required at install, resilient at runtime
+
+This is the part worth reading twice, because it looks like a
+contradiction and isn't.
+
+- **Required at install.** You must install all four. Setup will not let
+  you skip them. The garden assumes they are present.
+- **Resilient at runtime.** A transient outage — the brain server
+  momentarily down, the bus briefly unavailable — **degrades gracefully**
+  and does **not** crash your session. A hiccup won't brick you.
+
+"Required" means *you must install it*. "Resilient" means *a runtime
+hiccup won't take down the session*. Those answer two different
+questions. The first is about setup-time guarantees; the second is about
+defense-in-depth at runtime. Holding both is deliberate: we want the
+strong guarantee that the infrastructure exists, and we want the system
+to survive the moment that infrastructure flickers.
+
+The vault carries a literal kill-switch for the same reason — set
+`WICKED_VAULT_BIN=""` and the runtime resolution short-circuits cleanly
+rather than thrashing.
+
+## Why each is load-bearing
+
+The four together are the garden's infrastructure, and each holds up a
+different beam:
+
+- **wicked-testing proves behavior.** Without it, "the tests pass" is a
+  claim no independent party checked.
+- **wicked-vault makes "done" re-derivable.** Gates re-hash the evidence
+  and re-run the verifier instead of trusting a status field. A
+  claimed-but-false pass is rejected; a missing vault fails closed.
+- **wicked-brain carries knowledge across sessions.** Without it, every
+  session starts from scratch and guesses at history it can't see.
+- **wicked-bus carries the audit trail.** Without it, there's no record
+  of what the archetypes actually did.
+
+Make any one of them merely optional and the honest-evidence model
+springs a leak: behavior goes unproven, "done" becomes self-asserted,
+context evaporates between sessions, or the audit trail goes dark. That
+is why they are required — and why the runtime stays resilient anyway.

--- a/docs/v11/archetypes.md
+++ b/docs/v11/archetypes.md
@@ -40,7 +40,7 @@ of what kind of work was happening.
 ## The dogfood that surfaced the structural issue
 
 Across a single session in May 2026, seven dogfooding bugs were filed
-(#854 through #860) and fixed:
+(#846 through #852) and fixed:
 
 1. Hardcoded `architecture.md` deliverable in design phase (#849)
 2. Missing `recorded_at` field in qe-orchestrator's gate-result example (#850)
@@ -214,11 +214,15 @@ That's it. No phase machinery to extend. No gate matrix to update.
   If two archetypes co-fire and the agent runs them out of order,
   v11 doesn't catch it. We may need an explicit "must come after"
   field if this surfaces as a real issue.
-- **HITL `hard:*` enforcement is doctrine, not code.** The playbook
-  tells the agent to stop and ask. There's no runtime gate that
-  refuses to advance until the user has confirmed. v11 trusts the
-  agent to follow the playbook. If that trust breaks down, we add
-  enforcement; we don't pre-emptively over-engineer.
+- **HITL `hard:*` enforcement is now code, not just doctrine.**
+  `scripts/crew/phase_manager.py` (`_HARD_GATE_PHASES`) refuses to advance
+  past a hard gate at runtime, and the produces-gate re-derives evidence
+  through wicked-vault (fail-closed) rather than trusting playbook prose
+  (see "What 'produces contract met' means now" above). *Discrete* gates
+  remain doctrine-driven (auto-pass when the contract is met). Watch that
+  the runtime hard-gate map and each archetype's declared HITL stay in
+  sync — `_HARD_GATE_PHASES` currently also flags `specify.validate` and
+  `decide.record`, which the table lists as `discrete:*`.
 - **The `triage` archetype is the safety net for anything else.**
   When the detector returns only `triage`, it means the prompt
   didn't match anything cleanly. The agent should ASK, not GUESS.

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -686,6 +686,89 @@ def _check_vault_dependency():
 
 
 # ---------------------------------------------------------------------------
+# wicked-bus dependency check (required event backbone)
+# ---------------------------------------------------------------------------
+
+def _check_bus_dependency():
+    """Return a briefing note if wicked-bus is not installed, else None.
+
+    wicked-bus is a required peer (sibling to wicked-brain / wicked-vault /
+    wicked-testing): the garden's archetype events flow through it. When it
+    is absent, cross-plugin event wiring is silently dropped, so we surface a
+    one-line install pointer at SessionStart.
+
+    Detection mirrors ``_check_brain_dependency`` — wicked-bus installs as a
+    Claude Code *plugin*, not an npx CLI, so we verify by presence:
+      1. ``enabledPlugins`` in ~/.claude/settings.json, project-local
+         .claude/settings.json, and CLAUDE_CONFIG_DIR/settings.json.
+      2. Loose skill installs at ``skills/wicked-bus-*`` under the home and
+         CLAUDE_CONFIG_DIR skills directories.
+
+    Fast + stdlib-only (no subprocess). Always fails open — never blocks the
+    session.
+    """
+    try:
+        # Settings file locations to check (global first, then project-local)
+        settings_candidates = [
+            Path.home() / ".claude" / "settings.json",
+            Path(".claude") / "settings.json",
+        ]
+
+        # Also honour CLAUDE_CONFIG_DIR if set
+        config_dir_env = os.environ.get("CLAUDE_CONFIG_DIR")
+        if config_dir_env:
+            settings_candidates.append(Path(config_dir_env) / "settings.json")
+
+        bus_installed = False
+
+        # Check 1: enabledPlugins in settings.json (plugin-style install)
+        for settings_path in settings_candidates:
+            try:
+                if not settings_path.exists():
+                    continue
+                settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                enabled = settings.get("enabledPlugins", {})
+                if isinstance(enabled, dict) and "wicked-bus" in enabled:
+                    bus_installed = True
+                    break
+                if isinstance(enabled, list) and "wicked-bus" in enabled:
+                    bus_installed = True
+                    break
+            except (json.JSONDecodeError, OSError):
+                continue
+
+        # Check 2: loose skill installs at skills/wicked-bus-* under the home
+        # and CLAUDE_CONFIG_DIR skills directories.
+        if not bus_installed:
+            skill_roots = [Path.home() / ".claude" / "skills"]
+            if config_dir_env:
+                skill_roots.append(Path(config_dir_env) / "skills")
+            for root in skill_roots:
+                try:
+                    if root.exists():
+                        for entry in root.iterdir():
+                            if entry.is_dir() and entry.name.startswith("wicked-bus"):
+                                bus_installed = True
+                                break
+                except OSError:
+                    continue  # fail open
+                if bus_installed:
+                    break
+
+        if not bus_installed:
+            return (
+                "[wicked-bus] REQUIRED but not installed.\n"
+                "Install now: /plugin install wicked-bus\n"
+                "wicked-bus is the event backbone the garden's archetype events "
+                "flow through — without it, cross-plugin event wiring is silently dropped."
+            )
+
+        return None
+    except Exception:
+        return None  # Fail open — never block session start
+
+
+# ---------------------------------------------------------------------------
 # Discovery: contextual command suggestions based on project type (Issue #322)
 # ---------------------------------------------------------------------------
 
@@ -1351,6 +1434,10 @@ def main():
         _vault_note = _check_vault_dependency()
         if _vault_note:
             mode_notes.append(_vault_note)
+        # Required-peer check: wicked-bus (the event backbone for archetype events).
+        _bus_note = _check_bus_dependency()
+        if _bus_note:
+            mode_notes.append(_bus_note)
         if onedrive_path:
             mode_notes.append(
                 f"[Path] OneDrive directory detected. Resolved base: {onedrive_path}. "


### PR DESCRIPTION
Rethink, not patch. The docs were organized around the **deleted v6 crew model** — `docs/README.md` indexed four deleted guides, `domains.md` was built around the facilitator/9-factor orchestrator, and ETHOS had two beliefs that v12 had inverted. This reorients the docs to v12's actual shape and makes **all four siblings required infrastructure**.

### Decision captured: all four peers required (resilient at runtime)
wicked-testing + wicked-vault + **wicked-brain + wicked-bus** are now required at install (`/wicked-garden:setup` blocks without them), but a transient runtime outage degrades gracefully — it doesn't brick a session.

- `plugin.json`: pin all four (`wicked_brain_version` ^0.14.0, `wicked_bus_version` ^2.0.0).
- `commands/setup.md`: blocking verify for brain + bus (plugin-presence based).
- `hooks/scripts/bootstrap.py`: `_check_bus_dependency()` (brain already had one), WARN-only/fail-open.
- `README.md`: brain + bus → required×4.

### ETHOS rewrite — resolves the two contradictions the audit found
- "optional integrations never gate" → **"required infrastructure, resilient at runtime"**
- dropped the now-false "no npm-only"
- replaced stale v6 claims (9-factor/1-of-7, signed-dispatch-as-gate, rigor-tier targets, score bands) with v12 truths (re-derived evidence, runtime hard-gate enforcement, the compiler); fixed the broken `docs/v9` link.

### docs/ sweep
- `docs/README.md`: lean v12 index (removed 4 dead links + the `(v6)` label).
- `docs/domains.md`: reframed as the 10 domain skill/agent families archetypes invoke (−359/+188).
- `docs/getting-started.md`: body reoriented to archetypes + 4 peers + compiler.
- **new:** `docs/required-peers.md`, `docs/compiler.md`.
- `docs/v11/archetypes.md`: fixed the "doctrine, not code" disclaimer (hard gates ARE enforced at runtime now) + issue range.

validate PASS (0/0); 422 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)