### PR TITLE
release: v12.1.0 — all four peers required + work-mode status line

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "12.0.0"
+      "version": "12.1.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires four sibling peers verified at setup — wicked-testing, wicked-vault, wicked-brain, wicked-bus — required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ dial) that was replaced wholesale.
 
 ---
 
+## [12.1.0] — 2026-05-25
+
+**All four siblings are now required, and the work mode is visible on screen.**
+
+### Required peers (all four)
+
+- **wicked-brain and wicked-bus join wicked-testing and wicked-vault as required peers.** `/wicked-garden:setup` now verifies all four and blocks without them; the SessionStart hook warns. `plugin.json` pins all four (`wicked_brain_version` `^0.14.0`, `wicked_bus_version` `^2.0.0`). The stance is **required at install, resilient at runtime**: a transient outage (brain server down, bus unavailable) degrades gracefully and never bricks a session — it never means a gate treats missing evidence as a pass (that path fails closed). See [`docs/required-peers.md`](docs/required-peers.md).
+
+### Features
+
+- **A work-mode status line** (`scripts/statusline.py`, opt-in via `settings.json` — see getting-started or `/wicked-garden:setup` step 6.6). Renders the live archetype · intent · phase · gate verdict at the bottom of the screen — `🌱 wg │ build·migrate │ intent: feature │ phase: implement │ ⚖ PASS`. Reads existing session state only (one read), fail-soft (degrades to `🌱 wg │ idle`, never blocks a render).
+
+### Documentation
+
+- **Rethought, not patched.** The docs were reoriented from the deleted v6 crew model to v12. README restructured around what/why/how (leads with the re-derived-evidence trust pitch, not the pipeline rationale); ETHOS rewritten (required-infrastructure / resilient-at-runtime; the nine archetypes named; the *"done is not claimed; done is re-derived"* slogan); `docs/domains.md` reframed off the dead orchestrator; new [`docs/required-peers.md`](docs/required-peers.md) + [`docs/compiler.md`](docs/compiler.md); `docs/v11/archetypes.md` corrected (hard gates are enforced at runtime). Stale `crew:*` references removed from setup.
+
+### Notes
+
+- The status line's two bugs (wrong field name, mismatched sanitization) were caught by independent review, not by the tests that shipped CI-green — those were tautological. The fix added a guard test cross-checking the renderer's fields against the real `SessionState` schema. *Honest verdicts beat green dashboards.*
+
+---
+
 ## [12.0.0] — 2026-05-25
 
 **"Done" is re-derived, not asserted — and the garden can compile that guarantee onto any repo.**


### PR DESCRIPTION
Release PR for **v12.1.0** (minor). Batches the two features merged since 12.0.0:
- **#882** — wicked-brain + wicked-bus join testing + vault as required peers (setup blocks; resilient at runtime); + the v12 docs rethink.
- **#883** — the work-mode status line (`scripts/statusline.py`, opt-in).

plugin.json + marketplace.json → 12.1.0 (in sync; validator PASS). Curated CHANGELOG entry. Tag `wicked-garden-v12.1.0` + GitHub release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)