### PR TITLE
feat(#878): worktree cwd-leak guard on Bash PreToolUse

### DIFF
--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -10,7 +10,8 @@ Dispatches by tool_name from hook payload:
   TaskUpdate    → validate event metadata envelope on updates
   EnterPlanMode → deny and redirect to crew workflow
   Write / Edit  → MEMORY.md write guard (AGENTS.md writes allowed, synced via PostToolUse)
-  Bash          → crew gate preflight for phase_manager.py approve calls
+  Bash          → crew gate preflight (phase_manager.py approve calls) +
+                  worktree cwd-leak guard (#878, hooks/scripts/worktree_guard.py)
 
 Always fails open — any unhandled exception returns permissionDecision: "allow".
 """
@@ -25,6 +26,8 @@ from pathlib import Path
 # Add shared scripts directory to path
 _PLUGIN_ROOT = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
+# Allow importing sibling hook modules (e.g. worktree_guard) in any context.
+sys.path.append(str(Path(__file__).resolve().parent))
 
 
 # ---------------------------------------------------------------------------
@@ -1181,22 +1184,34 @@ def _crew_gate_preflight(command: str) -> dict:
     return {"ok": True, "_warning": warning}
 
 
-def _handle_bash(tool_input: dict) -> str:
-    """Run crew gate preflight on Bash calls that invoke phase_manager.py approve."""
+def _handle_bash(tool_input: dict, cwd: str = "") -> str:
+    """Bash preflight: crew gate check + worktree cwd-leak guard (#878)."""
     command = tool_input.get("command", "") or ""
 
-    # Fast path — non-approve Bash commands take <1ms
+    # Crew gate preflight first — a hard deny here blocks regardless of cwd.
+    # Fast path — non-approve Bash commands take <1ms.
     result = _crew_gate_preflight(command)
-
     if not result.get("ok"):
-        reason = result.get("reason", "Gate preflight check failed.")
-        return _deny(reason)
+        return _deny(result.get("reason", "Gate preflight check failed."))
+    warning = result.get("_warning", "") or None
 
-    warning = result.get("_warning", "")
-    if warning:
-        return _allow(system_message=warning)
+    # Worktree cwd-leak guard (#878): when an isolated-worktree agent runs a
+    # Bash command, anchor it in the worktree (cd <root> && ...) so a leaked
+    # persistent cwd cannot land commits in the main repo. Fail-open by design.
+    try:
+        from worktree_guard import evaluate as _wt_evaluate
+        decision = _wt_evaluate(command, cwd)
+    except Exception:
+        decision = None
+    if decision:
+        if decision.get("action") == "deny":
+            return _deny(decision["reason"])
+        if decision.get("action") == "rewrite":
+            updated = dict(tool_input)
+            updated["command"] = decision["command"]
+            return _allow(updated_input=updated, system_message=warning)
 
-    return _allow()
+    return _allow(system_message=warning)
 
 
 # ---------------------------------------------------------------------------
@@ -1244,7 +1259,7 @@ def main():
             return
 
         if tool_name == "Bash":
-            result = _handle_bash(tool_input)
+            result = _handle_bash(tool_input, input_data.get("cwd", "") or "")
             _log("pretool", "debug", "hook.end", ms=int((time.monotonic() - _t0) * 1000))
             print(result)
             return

--- a/hooks/scripts/worktree_guard.py
+++ b/hooks/scripts/worktree_guard.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""worktree_guard.py — prevent the agent-worktree cwd leak (issue #878).
+
+When a subagent runs with ``isolation: worktree``, the Bash tool's persistent
+cwd can drift back to the MAIN repo checkout between calls. Commits then land
+on the agent's branch but in the main worktree — silently defeating isolation.
+The only post-hoc tell is an unexpected entry in ``git worktree list``.
+
+This guard is invoked from ``pre_tool.py``'s Bash handler. Given the command
+and the PreToolUse payload ``cwd``, it returns one of:
+
+  * ``None``                                   — not a worktree agent / no-op
+  * ``{"action": "rewrite", "command": ...}``  — anchor execution in the worktree
+  * ``{"action": "deny",    "reason":  ...}``  — command explicitly targets main repo
+
+The rewrite prepends ``cd <worktree-root> &&`` so persistent-cwd state cannot
+drag a later call into the wrong directory. Claude Code honors ``updatedInput``
+for PreToolUse Bash hooks, so the rewrite takes effect transparently.
+
+Contract: **pure and fail-open** — stdlib only, no raises escape ``evaluate``;
+any internal error returns ``None`` so the guard can never break an agent run.
+Main-repo path is derived generally via ``git rev-parse --git-common-dir`` —
+nothing about any specific repo is hardcoded.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+
+# Signature of an isolated agent worktree: <main>/.claude/worktrees/agent-<id>.
+# Captures everything up to and including the agent-<id> segment, so a cwd that
+# is a deeper subdirectory of the worktree still resolves to the worktree root.
+_WORKTREE_SIG = re.compile(r"^(.*/\.claude/worktrees/agent-[^/]+)")
+
+# `-C <path>` arguments (git, make, etc.) and a leading `cd <path>`.
+_DASH_C = re.compile(r"(?:^|\s)-C\s+(\S+)")
+_LEADING_CD = re.compile(r"^\s*cd\s+(\S+)")
+
+
+def worktree_root(cwd: "str | None") -> "str | None":
+    """Return the agent-worktree root if ``cwd`` is inside one, else ``None``."""
+    if not cwd:
+        return None
+    m = _WORKTREE_SIG.match(cwd)
+    return m.group(1) if m else None
+
+
+def _main_repo_root(cwd: str) -> "str | None":
+    """Best-effort main-repo root via ``git rev-parse --git-common-dir``.
+
+    From inside a linked worktree the common dir is the MAIN repo's ``.git``;
+    its parent is the main repo root. Returns ``None`` on any failure — callers
+    must treat an unknown main root as "cannot prove a main-repo reference".
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if out.returncode != 0:
+            return None
+        common = out.stdout.strip()
+        if not common:
+            return None
+        if not os.path.isabs(common):
+            common = os.path.abspath(os.path.join(cwd, common))
+        # common dir is typically ``<main>/.git`` — main root is its parent.
+        if os.path.basename(common) == ".git":
+            common = os.path.dirname(common)
+        return os.path.normpath(common)
+    except Exception:
+        return None
+
+
+def _norm(path: str, base: str) -> str:
+    """Normalize ``path`` to an absolute path, resolving relatives against ``base``."""
+    path = path.strip().strip('"').strip("'")
+    if not os.path.isabs(path):
+        path = os.path.join(base, path)
+    return os.path.normpath(path)
+
+
+def _references_main_repo(command: str, main_root: "str | None", wt_root: str) -> bool:
+    """True if ``command`` explicitly targets the main repo root (not the worktree).
+
+    Compares normalized *full paths* for equality rather than substring matching,
+    because the main repo root is a path *prefix* of the worktree root — a naive
+    substring check would flag every command.
+    """
+    if not main_root or main_root == wt_root:
+        return False
+    candidates = list(_DASH_C.findall(command))
+    lead = _LEADING_CD.match(command)
+    if lead:
+        candidates.append(lead.group(1))
+    main_norm = os.path.normpath(main_root)
+    for c in candidates:
+        if _norm(c, wt_root) == main_norm:
+            return True
+    return False
+
+
+def _anchor_prefix(wt_root: str) -> str:
+    """The ``cd <worktree> && `` prefix, with the path safely shell-quoted."""
+    return f"cd {shlex.quote(wt_root)} && "
+
+
+def evaluate(command: "str | None", cwd: "str | None") -> "dict | None":
+    """Decide what to do with a Bash ``command`` given the PreToolUse ``cwd``.
+
+    Returns a decision dict (``rewrite`` / ``deny``) or ``None`` for a no-op.
+    Never raises — fail-open is the contract.
+    """
+    try:
+        if not command or not command.strip():
+            return None
+
+        wt_root = worktree_root(cwd)
+        if not wt_root or not cwd:
+            return None  # normal session — the guard does not engage
+
+        main_root = _main_repo_root(cwd)
+        if _references_main_repo(command, main_root, wt_root):
+            return {
+                "action": "deny",
+                "reason": (
+                    "[wicked-garden] worktree guard: this command targets the "
+                    f"main repo ({main_root}) from inside an isolated worktree "
+                    f"({wt_root}). Running it there would defeat worktree "
+                    "isolation — changes/commits would land in the wrong "
+                    "checkout. Drop the main-repo path / `-C` reference and run "
+                    "against the worktree instead."
+                ),
+            }
+
+        prefix = _anchor_prefix(wt_root)
+        if command.lstrip().startswith(prefix):
+            return None  # already anchored — idempotent, do not double-prefix
+
+        return {"action": "rewrite", "command": prefix + command}
+    except Exception:
+        return None  # fail open — never break an agent run

--- a/tests/hooks/test_worktree_guard.py
+++ b/tests/hooks/test_worktree_guard.py
@@ -1,0 +1,215 @@
+"""Unit tests for hooks/scripts/worktree_guard.py (issue #878).
+
+The worktree guard prevents the agent-worktree cwd leak: when a subagent runs
+with isolation:worktree, the Bash tool's persistent cwd can drift to the MAIN
+repo, so commits land in the wrong checkout. The guard anchors every Bash
+command in the agent's worktree (cd <worktree-root> && ...) and denies commands
+that explicitly target the main repo from inside a worktree.
+
+The six scenarios enumerated in #878 are the spec:
+  1. Not in worktree            → no-op (None)
+  2. In worktree + safe command → rewrite with `cd <worktree> &&` prefix
+  3. In worktree + main-repo ref → deny with actionable message
+  4. Non-Bash tool              → guard never engages (dispatch-level; see pre_tool test)
+  5. Idempotency                → already-anchored command is not double-prefixed
+  6. Malformed input            → fail open (None)
+
+Stdlib + unittest only. The guard is pure and fail-open by contract.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shlex
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# worktree_guard.py + pre_tool.py live at hooks/scripts/, not under scripts/.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOKS_SCRIPTS = _REPO_ROOT / "hooks" / "scripts"
+_SCRIPTS = _REPO_ROOT / "scripts"
+for _p in (_HOOKS_SCRIPTS, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import pre_tool  # noqa: E402
+import worktree_guard  # noqa: E402
+
+
+_MAIN = "/Users/dev/myproj"
+_WT = "/Users/dev/myproj/.claude/worktrees/agent-7f3a9b"
+_WT_SUBDIR = _WT + "/src/pkg"
+
+
+def _anchor(cmd: str, root: str = _WT) -> str:
+    return f"cd {shlex.quote(root)} && {cmd}"
+
+
+class WorktreeRootDetection(unittest.TestCase):
+    def test_detects_worktree_root_from_cwd(self):
+        self.assertEqual(worktree_guard.worktree_root(_WT), _WT)
+
+    def test_detects_root_even_from_a_subdir_of_the_worktree(self):
+        # cwd deeper than the worktree root still resolves to the agent root
+        self.assertEqual(worktree_guard.worktree_root(_WT_SUBDIR), _WT)
+
+    def test_returns_none_for_normal_repo_path(self):
+        self.assertIsNone(worktree_guard.worktree_root(_MAIN))
+
+    def test_returns_none_for_empty_or_none(self):
+        self.assertIsNone(worktree_guard.worktree_root(""))
+        self.assertIsNone(worktree_guard.worktree_root(None))
+
+
+class Scenario1_NotInWorktree(unittest.TestCase):
+    def test_noop_when_cwd_is_not_a_worktree(self):
+        self.assertIsNone(worktree_guard.evaluate("git commit -m x", _MAIN))
+
+
+class Scenario2_SafeCommandRewrite(unittest.TestCase):
+    def test_rewrites_with_cd_prefix(self):
+        # git resolution will fail on this fake path → no main-repo ref → rewrite
+        decision = worktree_guard.evaluate("git status", _WT)
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision["action"], "rewrite")
+        self.assertEqual(decision["command"], _anchor("git status"))
+
+    def test_rewrite_anchors_to_root_even_from_subdir(self):
+        decision = worktree_guard.evaluate("ls", _WT_SUBDIR)
+        self.assertEqual(decision["action"], "rewrite")
+        self.assertEqual(decision["command"], _anchor("ls"))
+
+    def test_rewrite_preserves_complex_command(self):
+        cmd = "npm ci && npm test -- --runInBand"
+        decision = worktree_guard.evaluate(cmd, _WT)
+        self.assertEqual(decision["command"], _anchor(cmd))
+
+
+class Scenario3_MainRepoReferenceDeny(unittest.TestCase):
+    def test_denies_git_dash_C_main_repo(self):
+        with patch.object(worktree_guard, "_main_repo_root", return_value=_MAIN):
+            decision = worktree_guard.evaluate(f"git -C {_MAIN} commit -m x", _WT)
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision["action"], "deny")
+        self.assertIn(_MAIN, decision["reason"])
+        self.assertIn(_WT, decision["reason"])
+
+    def test_denies_leading_cd_to_main_repo(self):
+        with patch.object(worktree_guard, "_main_repo_root", return_value=_MAIN):
+            decision = worktree_guard.evaluate(f"cd {_MAIN} && git status", _WT)
+        self.assertEqual(decision["action"], "deny")
+
+    def test_does_not_deny_dash_C_into_the_worktree_itself(self):
+        # -C pointing at the worktree (which has the main repo as a path prefix)
+        # must NOT be mistaken for a main-repo reference → it rewrites, not denies.
+        with patch.object(worktree_guard, "_main_repo_root", return_value=_MAIN):
+            decision = worktree_guard.evaluate(f"git -C {_WT} status", _WT)
+        self.assertEqual(decision["action"], "rewrite")
+
+    def test_no_deny_when_main_repo_unresolvable(self):
+        with patch.object(worktree_guard, "_main_repo_root", return_value=None):
+            decision = worktree_guard.evaluate(f"git -C {_MAIN} status", _WT)
+        # can't prove it's the main repo → safe default is rewrite, not deny
+        self.assertEqual(decision["action"], "rewrite")
+
+
+class Scenario5_Idempotency(unittest.TestCase):
+    def test_already_anchored_command_is_noop(self):
+        already = _anchor("git status")
+        self.assertIsNone(worktree_guard.evaluate(already, _WT))
+
+    def test_anchored_with_leading_whitespace_is_noop(self):
+        already = "   " + _anchor("ls")
+        self.assertIsNone(worktree_guard.evaluate(already, _WT))
+
+
+class Scenario6_FailOpen(unittest.TestCase):
+    def test_none_command_is_noop(self):
+        self.assertIsNone(worktree_guard.evaluate(None, _WT))
+
+    def test_empty_command_is_noop(self):
+        self.assertIsNone(worktree_guard.evaluate("   ", _WT))
+
+    def test_none_cwd_is_noop(self):
+        self.assertIsNone(worktree_guard.evaluate("ls", None))
+
+    def test_internal_error_fails_open(self):
+        # Force an internal explosion → must swallow and return None
+        with patch.object(worktree_guard, "worktree_root", side_effect=RuntimeError("boom")):
+            self.assertIsNone(worktree_guard.evaluate("ls", _WT))
+
+
+class ReferencesMainRepoPure(unittest.TestCase):
+    """Direct tests of the pure path-comparison helper."""
+
+    def test_true_for_exact_main_root_via_dash_C(self):
+        self.assertTrue(
+            worktree_guard._references_main_repo(f"git -C {_MAIN} log", _MAIN, _WT)
+        )
+
+    def test_false_for_worktree_path(self):
+        self.assertFalse(
+            worktree_guard._references_main_repo(f"git -C {_WT} log", _MAIN, _WT)
+        )
+
+    def test_false_when_main_root_missing(self):
+        self.assertFalse(
+            worktree_guard._references_main_repo(f"git -C {_MAIN} log", None, _WT)
+        )
+
+    def test_false_when_no_path_args(self):
+        self.assertFalse(
+            worktree_guard._references_main_repo("git status", _MAIN, _WT)
+        )
+
+
+class PreToolBashWiring(unittest.TestCase):
+    """Integration: the guard is wired into pre_tool._handle_bash + main()."""
+
+    def _hso(self, raw: str) -> dict:
+        return json.loads(raw)["hookSpecificOutput"]
+
+    def test_rewrite_in_worktree(self):
+        hso = self._hso(pre_tool._handle_bash({"command": "git status"}, _WT))
+        self.assertEqual(hso["permissionDecision"], "allow")
+        self.assertEqual(hso["updatedInput"]["command"], _anchor("git status"))
+
+    def test_deny_main_repo_reference(self):
+        with patch.object(worktree_guard, "_main_repo_root", return_value=_MAIN):
+            hso = self._hso(pre_tool._handle_bash({"command": f"git -C {_MAIN} push"}, _WT))
+        self.assertEqual(hso["permissionDecision"], "deny")
+
+    def test_plain_allow_outside_worktree(self):
+        hso = self._hso(pre_tool._handle_bash({"command": "git status"}, _MAIN))
+        self.assertEqual(hso["permissionDecision"], "allow")
+        self.assertNotIn("updatedInput", hso)
+
+    def test_main_threads_cwd_into_guard(self):
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": _WT}
+        )
+        buf = io.StringIO()
+        with patch.object(sys, "stdin", io.StringIO(payload)), \
+                contextlib.redirect_stdout(buf):
+            pre_tool.main()
+        hso = self._hso(buf.getvalue())
+        self.assertEqual(hso["updatedInput"]["command"], _anchor("ls"))
+
+    def test_non_bash_tool_never_engages_guard(self):
+        # Scenario 4: a non-Bash tool is not rewritten even with a worktree cwd.
+        payload = json.dumps(
+            {"tool_name": "Read", "tool_input": {"file_path": "/x"}, "cwd": _WT}
+        )
+        buf = io.StringIO()
+        with patch.object(sys, "stdin", io.StringIO(payload)), \
+                contextlib.redirect_stdout(buf):
+            pre_tool.main()
+        self.assertNotIn("updatedInput", self._hso(buf.getvalue()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #878.

## Problem
With `isolation: worktree`, the Bash tool's persistent cwd can drift back to the **main repo** between calls, so commits land on the agent's branch but in the main checkout — silently defeating isolation (only visible post-hoc via `git worktree list`). Observed in 2 of 4 parallel agents in one session.

## Fix
`hooks/scripts/worktree_guard.py`, invoked from `pre_tool.py`'s existing Bash `PreToolUse` handler (no new `hooks.json` entry):

1. **Detect** an isolated worktree via the `.claude/worktrees/agent-<id>` signature in the payload `cwd` (resolves the worktree root even from a subdir).
2. **Rewrite** to `cd <worktree-root> && <original>` via `updatedInput` so a leaked cwd can't drag a later call into the wrong dir. Idempotent. *(Confirmed against current Claude Code docs: `updatedInput` **is** honored for PreToolUse Bash — supersedes the `_TODO_329` doubt.)*
3. **Deny** commands that explicitly target the main repo from inside a worktree (`git -C <main> …`, `cd <main> && …`). Main-repo root derived generally via `git rev-parse --git-common-dir` (nothing hardcoded), compared as a normalized **full path** — not substring, since the main root is a path *prefix* of the worktree.
4. **Fail open** — any internal error → `None` / plain allow; the guard can never break an agent run.

Crew gate preflight still runs first (a hard-gate deny wins; an existing gate warning is preserved on the allow).

## Acceptance criteria (#878)
- [x] Hook script in `hooks/scripts/`
- [x] Wired as a `PreToolUse` Bash check (via the existing `pre_tool` dispatcher — single Bash hook, not a duplicate entry)
- [x] Cross-platform (stdlib-only module; `python3/python/py -3` fallback already in `hooks.json`)
- [x] The 6 documented scenarios tested
- [x] Fails open
- [x] Repo-detection generalized via `git rev-parse --git-common-dir` (no hardcoded repo name)

## Tests
`tests/hooks/test_worktree_guard.py` — 6 scenarios (no-op / rewrite / deny / non-Bash / idempotency / fail-open) as unit tests + `pre_tool` integration + end-to-end `main()` cwd-threading. **27 new tests; full hook suite (62) green.** Also smoke-tested through the real `invoke.py pre_tool` stdin path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
