### PR TITLE
docs: wicked-loom north-star spec (extract the orchestration runtime)

### DIFF
--- a/docs/plans/2026-06-08-wicked-loom-conduct.md
+++ b/docs/plans/2026-06-08-wicked-loom-conduct.md
@@ -1,0 +1,1337 @@
+# wicked-loom — Conduct Module, Plan B (gate + flow runtime) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `wicked-loom` **conduct** surface — a synchronous, fail-closed vault re-derivation gate and an archetype-agnostic flow runtime that advances declarative flow definitions, executes per-phase gates, parks at hard gates, and persists deterministic per-flow state — built on Plan A's `resolve()`/`compose` core, with garden untouched.
+
+**Architecture:** Four new stdlib-only Python modules added to the existing `python/loom/` package: `gate.py` (sync vault `cross-check`, ported from garden's `scripts/qe/vault_gate.py`), `flowstate.py` (local-JSON per-flow state, phase_manager-style), `busemit.py` (thin best-effort fire-and-forget bus emit — emission only; no consumer), and `flow.py` (the generic phase-loop that wires gate + state + emit together). Subprocess execution is injected everywhere (matching `compose.py`'s `RunResult`/`Runner` pattern) so no test ever spawns a real vault or touches the network. `cli.py` gains a `gate` command and a `flow` command group. **Conduct only** — compose was Plan A.
+
+**Tech Stack:** Python 3.9+ (stdlib only — no third-party deps, mirroring Plan A and garden's hook discipline), `pytest` for tests, the existing `bin/loom.mjs` Node shim (unchanged). Reuses `loom.resolve.resolve("vault")` for vault resolution and `loom.compose.RunResult`/`Runner` for the injected subprocess seam.
+
+**Decisions locked for this plan (override in review):**
+- **Scope = conduct, synchronous core only.** `loom gate`, `loom flow run|status|resume`. The headless daemon / bus-consumer / projector is **DEFERRED per spec decision D3 and §9 (D-headless)** — explicitly OUT OF SCOPE here (see "Out of scope" below). Only the *contract* (park-at-hard-gate, event names) is realized, not unattended execution.
+- **File layout:** `gate.py`, `flow.py`, `flowstate.py`, `busemit.py` — one responsibility per file (justified in File Structure). Vault subprocess and bus subprocess are both injected `Runner`s so flow/gate tests are hermetic.
+- **Target repo:** `~/Projects/wicked-loom` (the package Plan A created). Plan B adds files to it; garden (`~/Projects/wicked-garden`) is untouched.
+
+**Source material to read in wicked-garden before Task 1 (grounding only — do not import from garden):**
+- `scripts/qe/vault_gate.py` — the exact `cross-check` invocation (`["cross-check", "--scope", scope, "--phase", phase, ("--with-attestations")]`), how it parses the `overall` PASS/REJECT/ERROR field, and the fail-closed posture when the vault is unresolvable or unrunnable. `gate.py` is a faithful, injected-runner port of this.
+- `scripts/crew/phase_manager.py` — the `ProjectState` dataclass + `save_project_state`/`load_project_state` JSON pattern and the `_bus_emit_safe` fire-and-forget wrapper. `flowstate.py` and `busemit.py` mirror these, slimmed.
+- Plan A (`docs/plans/2026-06-08-wicked-loom-expand-compose.md`) — the code style, the `RunResult(returncode, stdout, stderr)` injected-runner pattern, and the `cli.py` dispatch shape this plan extends.
+
+**Out of scope (DEFERRED — do NOT build in Plan B):**
+- The bus **consumer / projector** and headless unattended execution (spec §4.2 "Project", §4.3 surface #2). `busemit.py` is emission ONLY — best-effort, fail-soft, never blocking; an emitted event NEVER satisfies a gate (invariant I4). No subscriber, no event-sourced state rebuild.
+- `loom compose` changes (Plan A is frozen).
+- The garden-side archetype→flow-definition compiler (§3.1, §7 step 2) and the garden `gate`/`flow` cutover shims (§7) — those are the cutover plan, not Plan B. Loom only *consumes* a hand-authored flow definition (success criterion #6).
+
+**Bulletproof standards:** R1–R6 (no dead code, no bare panics, no magic values, no swallowed errors, no unbounded ops, no god functions) and T1–T6 (determinism, no sleep-based sync, isolation, single-assertion focus, descriptive names, provenance). The gate must be synchronous + fully mockable (never hit the network or a real vault in a unit test); flow state must be deterministic (no wall-clock-dependent assertions — timestamps are written but never asserted-on for equality).
+
+---
+
+## File Structure
+
+```
+wicked-loom/
+├── python/loom/
+│   ├── gate.py        # NEW — synchronous vault cross-check (re-derive). Ported
+│   │                  #       from garden scripts/qe/vault_gate.py, runner injected.
+│   ├── flowstate.py   # NEW — per-flow JSON state: load/save/new, one file per flow_id.
+│   ├── busemit.py     # NEW — thin best-effort fire-and-forget bus emit (emission only).
+│   ├── flow.py        # NEW — the generic phase-loop: run/status/resume; wires
+│   │                  #       gate + flowstate + busemit. Archetype-agnostic.
+│   ├── resolve.py     # (Plan A) reused by gate.py for vault resolution.
+│   ├── compose.py     # (Plan A) RunResult/Runner reused by gate.py + busemit.py.
+│   ├── manifest.py    # (Plan A) unchanged.
+│   └── cli.py         # MODIFY — add `gate` + `flow` (run|status|resume) dispatch.
+├── tests/
+│   ├── test_gate.py        # NEW
+│   ├── test_flowstate.py   # NEW
+│   ├── test_busemit.py     # NEW
+│   ├── test_flow.py        # NEW
+│   └── test_cli.py         # MODIFY — add gate + flow CLI cases.
+```
+
+**Responsibilities (one per file, justifying the layout):**
+- `gate.py` = *re-derive evidence for one produces* (the honest-evidence engine). Pure of state/flow concerns; takes an injected runner; returns a status dict. This is the §4.2 "Execute a gate" bullet and invariants I1/I2/I3.
+- `flowstate.py` = *persist one flow's progress to disk* (data + I/O only — no gate, no bus). The §4.2 "Run a flow → persist phase state" storage half. Deterministic, no network (spec §10).
+- `busemit.py` = *announce a transition, best-effort* (emission only — the §4.3 #3 event contract producer side; the consumer is deferred per D3/I4). Isolated so flow logic never couples to bus availability.
+- `flow.py` = *advance phases, calling gate + state + emit* (the §4.2 "Run a flow" + "Park at hard gate" orchestration; invariants I5/I6). It is the only file that knows the flow-definition shape; it is archetype-agnostic (I6 — it must not branch on archetype names).
+- `cli.py` = *argument dispatch only* (unchanged philosophy from Plan A — no business logic).
+
+Why `busemit.py` is separate from `flowstate.py`: state is the **source of truth** (deterministic, must persist); the bus is **optional infrastructure** (fail-open). Mixing them would let a bus failure threaten a state write (it must not — I4 / spec §10). Why `gate.py` is separate from `flow.py`: the gate is independently shippable as `loom gate` (a garden cutover target on its own, §7) and must be unit-testable without any flow.
+
+**The flow-definition shape this plan consumes** (spec §3.1 — loom executes it, garden authors it):
+
+```jsonc
+{
+  "flow_id": "build-1234",
+  "phases": [
+    { "name": "plan",      "gate": null,                   "hitl": "none",     "produces": [] },
+    { "name": "implement", "gate": null,                   "hitl": "none",     "produces": [] },
+    { "name": "test",      "gate": "produces:test-report", "hitl": "discrete:review",   "produces": ["test-report"] },
+    { "name": "review",    "gate": "produces:verdict",     "hitl": "hard:final-verdict","produces": ["verdict"] }
+  ],
+  "peers_required": ["vault", "testing"],
+  "verifier_spec_ref": null
+}
+```
+
+Field semantics loom relies on (and nothing else — I6):
+- `gate`: `null` → no gate, advance freely. `"produces:<name>"` → run a vault cross-check whose `--phase` is `<name>` (the produces contract id). Any non-null, non-`produces:` value is treated as a generic gate on the literal string (still re-derived; fail-soft only on an unknown verifier spec, never a vacuous pass).
+- `hitl`: `"hard:*"` → a **hard gate**: even on a PASS, the flow PARKS for human verdict (I5); loom never self-approves a hard gate. `"discrete:*"`/`"continuous"`/`"none"` → not hard; a satisfied gate advances automatically.
+- `verifier_spec_ref`: optional path passed through to the gate as `--verifier-spec`; absent/unreadable → generic detection, never blocks (I3).
+
+---
+
+## Task 1: Synchronous vault gate (`gate.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/gate.py`
+- Test: `~/Projects/wicked-loom/tests/test_gate.py`
+
+Faithful injected-runner port of garden's `scripts/qe/vault_gate.cross_check` + the fail-closed posture of `gate_satisfied`. The vault command prefix comes from `loom.resolve.resolve("vault")`; the subprocess is run through an injected `Runner` (the same `RunResult` shape as `compose.py`) so tests never spawn the vault. Invariants: **I1** synchronous/in-line (one blocking call per invocation, no events), **I2** fail-closed (vault unresolvable OR unrunnable → `gate: "unavailable"`, `satisfied: False` — never a pass), **I3** fail-soft on the verifier spec only (a `verifier_spec` arg is passed through when present; its absence never blocks). Hard gates require `with_attestations=True` (the independent attester), forwarded to the vault as `--with-attestations`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+from loom import gate
+from loom.compose import RunResult
+
+
+def _runner(stdout="", code=0):
+    def run(cmd, timeout=None):
+        return RunResult(returncode=code, stdout=stdout, stderr="")
+    return run
+
+
+def test_gate_passes_when_vault_reports_pass():
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        r = gate.run_gate("test-report", scope="build-1",
+                          run=_runner(stdout='{"overall":"PASS"}'))
+    assert r["satisfied"] is True
+    assert r["gate"] == "vault-cross-check"
+    assert r["re_derived"] is True
+    assert r["overall"] == "PASS"
+
+
+def test_gate_rejects_when_vault_reports_reject():
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        r = gate.run_gate("test-report", scope="build-1",
+                          run=_runner(stdout='{"overall":"REJECT"}'))
+    assert r["satisfied"] is False
+    assert r["overall"] == "REJECT"
+
+
+def test_gate_fails_closed_when_vault_unresolvable():
+    with patch.object(gate, "resolve", return_value=None):
+        r = gate.run_gate("test-report", scope="build-1", run=_runner())
+    assert r["satisfied"] is False
+    assert r["gate"] == "unavailable"
+    assert r["re_derived"] is False
+
+
+def test_gate_fails_closed_when_vault_unrunnable():
+    def boom(cmd, timeout=None):
+        raise FileNotFoundError("vault gone")
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        r = gate.run_gate("test-report", scope="build-1", run=boom)
+    assert r["satisfied"] is False
+    assert r["gate"] == "unavailable"
+
+
+def test_gate_fails_closed_on_non_json_output():
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        r = gate.run_gate("test-report", scope="build-1",
+                          run=_runner(stdout="not json"))
+    assert r["satisfied"] is False
+    assert r["overall"] == "ERROR"
+
+
+def test_with_attestations_forwarded_to_vault():
+    seen = {}
+
+    def run(cmd, timeout=None):
+        seen["cmd"] = cmd
+        return RunResult(returncode=0, stdout='{"overall":"PASS"}', stderr="")
+
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        gate.run_gate("verdict", scope="build-1", with_attestations=True, run=run)
+    assert "--with-attestations" in seen["cmd"]
+
+
+def test_verifier_spec_forwarded_when_present():
+    seen = {}
+
+    def run(cmd, timeout=None):
+        seen["cmd"] = cmd
+        return RunResult(returncode=0, stdout='{"overall":"PASS"}', stderr="")
+
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        gate.run_gate("verdict", scope="build-1",
+                      verifier_spec="/tmp/verify.json", run=run)
+    assert "--verifier-spec" in seen["cmd"]
+    assert "/tmp/verify.json" in seen["cmd"]
+
+
+def test_verifier_spec_absent_is_fail_soft_not_blocking():
+    # No verifier_spec given -> the gate still runs and can PASS (I3).
+    with patch.object(gate, "resolve", return_value=["wicked-vault"]):
+        r = gate.run_gate("verdict", scope="build-1",
+                          run=_runner(stdout='{"overall":"PASS"}'))
+    assert r["satisfied"] is True
+    assert "--verifier-spec" not in r.get("argv", [])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_gate.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.gate'`
+
+- [ ] **Step 3: Write `gate.py`**
+
+```python
+"""gate.py — the synchronous, fail-closed produces gate (vault re-derivation).
+
+Ported from wicked-garden scripts/qe/vault_gate.py, with the subprocess
+execution injected (the ``run`` parameter, same RunResult shape as compose.py)
+so callers and tests control side effects and no real vault is ever spawned in
+a unit test.
+
+Invariants (spec §5):
+  I1 — synchronous + in-line: exactly one blocking vault call per invocation;
+       no events are consulted. An event NEVER satisfies a gate.
+  I2 — fail-closed: vault unresolvable OR unrunnable OR non-JSON ->
+       gate "unavailable" / overall "ERROR", satisfied False. Never a pass.
+  I3 — fail-soft on the verifier spec only: a present ``verifier_spec`` is
+       forwarded to the vault; its ABSENCE never blocks and never vacates the
+       gate — the vault falls back to generic detection.
+
+Hard gates additionally require an independent attestation: pass
+``with_attestations=True`` -> ``--with-attestations`` forwarded to the vault.
+
+The return is a status dict (R4 — surface as data, never raise):
+  {satisfied, re_derived, gate, overall, exit_code, argv, detail, error}
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Optional
+
+from loom.compose import RunResult, _default_run
+from loom.resolve import resolve
+
+Runner = Callable[..., RunResult]
+
+_DEFAULT_TIMEOUT = 120  # seconds; bounds the blocking re-derivation (R5).
+
+
+def _build_argv(vault_prefix: list, produces: str, scope: str, *,
+                with_attestations: bool,
+                verifier_spec: Optional[str]) -> list:
+    """The full vault argv: <prefix> cross-check --scope S --phase <produces> ...
+
+    ``produces`` maps to the vault's ``--phase`` (the produces-contract id, e.g.
+    "test-report"); ``scope`` maps to ``--scope`` (the project/flow scope).
+    """
+    argv = list(vault_prefix) + ["cross-check", "--scope", scope, "--phase", produces]
+    if with_attestations:
+        argv.append("--with-attestations")
+    if verifier_spec:
+        argv += ["--verifier-spec", verifier_spec]
+    return argv
+
+
+def run_gate(produces: str, *, scope: str,
+             with_attestations: bool = False,
+             verifier_spec: Optional[str] = None,
+             run: Runner = _default_run,
+             timeout: int = _DEFAULT_TIMEOUT) -> dict:
+    """Re-derive ``produces`` via ``vault cross-check`` and return the verdict.
+
+    Fail-closed (I2): no resolvable vault, an unrunnable vault, or non-JSON
+    output all yield ``satisfied: False`` with ``gate: "unavailable"`` (or
+    overall "ERROR") — never an invented pass.
+    """
+    vault_prefix = resolve("vault")
+    if vault_prefix is None:
+        return {
+            "satisfied": False,
+            "re_derived": False,
+            "gate": "unavailable",
+            "overall": "ERROR",
+            "argv": [],
+            "error": "wicked-vault not resolvable",
+            "detail": "Gate fails closed — 'done' cannot be self-asserted (I2).",
+        }
+
+    argv = _build_argv(vault_prefix, produces, scope,
+                       with_attestations=with_attestations,
+                       verifier_spec=verifier_spec)
+    try:
+        result = run(argv, timeout=timeout)
+    except Exception as e:  # noqa: BLE001 — surface as data, fail closed (R4/I2)
+        return {
+            "satisfied": False,
+            "re_derived": False,
+            "gate": "unavailable",
+            "overall": "ERROR",
+            "argv": argv,
+            "error": str(e),
+            "detail": "vault resolvable but not runnable; gate fails closed (I2).",
+        }
+
+    try:
+        parsed = json.loads(result.stdout) if (result.stdout or "").strip() else {}
+    except json.JSONDecodeError:
+        return {
+            "satisfied": False,
+            "re_derived": True,
+            "gate": "vault-cross-check",
+            "overall": "ERROR",
+            "exit_code": result.returncode,
+            "argv": argv,
+            "error": "vault returned non-JSON output",
+            "detail": result.stderr.strip()[:500],
+        }
+
+    overall = parsed.get("overall", "ERROR")
+    return {
+        "satisfied": overall == "PASS",
+        "re_derived": True,
+        "gate": "vault-cross-check",
+        "overall": overall,
+        "exit_code": result.returncode,
+        "argv": argv,
+        "claims": parsed.get("claims", []),
+        "contract_version": parsed.get("contract_version"),
+        "detail": parsed.get("detail"),
+        "error": None,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_gate.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/gate.py tests/test_gate.py
+git commit -m "feat: synchronous fail-closed vault gate (conduct)"
+```
+
+---
+
+## Task 2: Per-flow state persistence (`flowstate.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/flowstate.py`
+- Test: `~/Projects/wicked-loom/tests/test_flowstate.py`
+
+One JSON file per `flow_id`, phase_manager-style. The state directory is injected (a `Path`) so tests use `tmp_path` and never touch a real home dir — deterministic, no network (spec §10). State records: `flow_id`, the original `phases` list, `current_phase` (index into `phases`), per-phase `gate_verdicts`, `parked` (bool) + `parked_reason`, `status` (`running`|`parked`|`completed`), and `created_at`/`updated_at` timestamps (written, never asserted-on for equality — T1 determinism). Nothing here raises on a normal path; a missing file on load returns `None`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from loom import flowstate
+
+_FLOW = {
+    "flow_id": "build-1",
+    "phases": [
+        {"name": "plan", "gate": None, "hitl": "none"},
+        {"name": "test", "gate": "produces:test-report", "hitl": "discrete:review"},
+    ],
+    "peers_required": ["vault"],
+    "verifier_spec_ref": None,
+}
+
+
+def test_new_state_starts_at_phase_zero_running(tmp_path):
+    st = flowstate.new_state(_FLOW, state_dir=tmp_path)
+    assert st["flow_id"] == "build-1"
+    assert st["current_phase"] == 0
+    assert st["status"] == "running"
+    assert st["parked"] is False
+    assert st["gate_verdicts"] == {}
+
+
+def test_save_then_load_roundtrips(tmp_path):
+    st = flowstate.new_state(_FLOW, state_dir=tmp_path)
+    flowstate.save_state(st, state_dir=tmp_path)
+    loaded = flowstate.load_state("build-1", state_dir=tmp_path)
+    assert loaded["flow_id"] == "build-1"
+    assert loaded["phases"] == _FLOW["phases"]
+    assert loaded["current_phase"] == 0
+
+
+def test_load_missing_flow_returns_none(tmp_path):
+    assert flowstate.load_state("nope", state_dir=tmp_path) is None
+
+
+def test_state_file_path_is_one_file_per_flow_id(tmp_path):
+    flowstate.save_state(flowstate.new_state(_FLOW, state_dir=tmp_path),
+                         state_dir=tmp_path)
+    expected = tmp_path / "build-1.json"
+    assert expected.exists()
+
+
+def test_record_verdict_is_persisted(tmp_path):
+    st = flowstate.new_state(_FLOW, state_dir=tmp_path)
+    st["gate_verdicts"]["test"] = {"satisfied": True, "overall": "PASS"}
+    flowstate.save_state(st, state_dir=tmp_path)
+    loaded = flowstate.load_state("build-1", state_dir=tmp_path)
+    assert loaded["gate_verdicts"]["test"]["satisfied"] is True
+
+
+def test_unsafe_flow_id_is_rejected(tmp_path):
+    bad = dict(_FLOW, flow_id="../etc/passwd")
+    try:
+        flowstate.new_state(bad, state_dir=tmp_path)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_flowstate.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.flowstate'`
+
+- [ ] **Step 3: Write `flowstate.py`**
+
+```python
+"""flowstate.py — per-flow JSON state. One file per flow_id.
+
+phase_manager-style local state (spec §4.2 "persist phase state", §10 "local
+JSON, deterministic, no network"). The state directory is a parameter so tests
+inject a tmp dir and production injects a project-scoped path; this module never
+hardcodes a home path and never spawns a process.
+
+State schema:
+  flow_id        : str (validated kebab/snake/alphanumeric, max 64 — no path sep)
+  phases         : list[dict]  (the original flow-def phases, verbatim)
+  current_phase  : int         (index into phases; == len(phases) when completed)
+  gate_verdicts  : dict[phase_name -> verdict dict]
+  parked         : bool
+  parked_reason  : str | None
+  status         : "running" | "parked" | "completed"
+  created_at     : ISO8601 str (written, never asserted-on)
+  updated_at     : ISO8601 str (written, never asserted-on)
+
+Nothing here raises except on an unsafe flow_id (ValueError — a guard, not a
+swallowed error, R4). A missing state file on load returns None.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_FLOW_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+STATUS_RUNNING = "running"
+STATUS_PARKED = "parked"
+STATUS_COMPLETED = "completed"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_flow_id(flow_id: str) -> str:
+    if not isinstance(flow_id, str) or not _FLOW_ID_RE.match(flow_id):
+        raise ValueError(f"unsafe flow_id: {flow_id!r} (kebab/snake/alnum, max 64)")
+    return flow_id
+
+
+def _state_path(flow_id: str, state_dir: Path) -> Path:
+    return Path(state_dir) / f"{_validate_flow_id(flow_id)}.json"
+
+
+def new_state(flow_def: dict, *, state_dir: Path) -> dict:
+    """Build a fresh running state from a flow definition. Does not persist."""
+    flow_id = _validate_flow_id(flow_def["flow_id"])
+    now = _now()
+    return {
+        "flow_id": flow_id,
+        "phases": list(flow_def.get("phases", [])),
+        "peers_required": list(flow_def.get("peers_required", [])),
+        "verifier_spec_ref": flow_def.get("verifier_spec_ref"),
+        "current_phase": 0,
+        "gate_verdicts": {},
+        "parked": False,
+        "parked_reason": None,
+        "status": STATUS_RUNNING,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def save_state(state: dict, *, state_dir: Path) -> Path:
+    """Atomically write the state file for ``state['flow_id']`` and return its path."""
+    Path(state_dir).mkdir(parents=True, exist_ok=True)
+    state["updated_at"] = _now()
+    path = _state_path(state["flow_id"], state_dir)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def load_state(flow_id: str, *, state_dir: Path) -> Optional[dict]:
+    """Load the state for ``flow_id``; None if no file exists."""
+    path = _state_path(flow_id, state_dir)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_flowstate.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/flowstate.py tests/test_flowstate.py
+git commit -m "feat: per-flow JSON state persistence (conduct)"
+```
+
+---
+
+## Task 3: Best-effort bus emission (`busemit.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/busemit.py`
+- Test: `~/Projects/wicked-loom/tests/test_busemit.py`
+
+Emission ONLY (the §4.3 #3 event-contract producer side). Fire-and-forget, fail-soft: a bus that is unresolvable, errors, or times out NEVER raises and NEVER blocks the caller (invariant I4 — the bus is the spine for everything that is *not* a gate verdict, and an event never satisfies a gate). The bus command resolves via `loom.resolve.resolve("bus")` and runs through an injected `Runner`. Event names are the stable set from spec §4.3: `loom:flow:started|phase-advanced|gate-passed|gate-failed|needs-human|completed`. **No consumer/projector is built here — deferred per D3.**
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+from loom import busemit
+from loom.compose import RunResult
+
+
+def test_event_names_are_the_spec_set():
+    assert busemit.EVENTS["started"] == "loom:flow:started"
+    assert busemit.EVENTS["phase-advanced"] == "loom:flow:phase-advanced"
+    assert busemit.EVENTS["gate-passed"] == "loom:flow:gate-passed"
+    assert busemit.EVENTS["gate-failed"] == "loom:flow:gate-failed"
+    assert busemit.EVENTS["needs-human"] == "loom:flow:needs-human"
+    assert busemit.EVENTS["completed"] == "loom:flow:completed"
+
+
+def test_emit_invokes_bus_with_event_and_payload():
+    seen = {}
+
+    def run(cmd, timeout=None):
+        seen["cmd"] = cmd
+        return RunResult(returncode=0, stdout="", stderr="")
+
+    with patch.object(busemit, "resolve", return_value=["wicked-bus"]):
+        ok = busemit.emit("started", {"flow_id": "build-1"}, run=run)
+    assert ok is True
+    assert "loom:flow:started" in seen["cmd"]
+
+
+def test_emit_is_fail_soft_when_bus_unresolvable():
+    with patch.object(busemit, "resolve", return_value=None):
+        ok = busemit.emit("started", {"flow_id": "build-1"})
+    assert ok is False  # best-effort: reports, never raises
+
+
+def test_emit_never_raises_when_bus_errors():
+    def boom(cmd, timeout=None):
+        raise FileNotFoundError("bus gone")
+
+    with patch.object(busemit, "resolve", return_value=["wicked-bus"]):
+        ok = busemit.emit("needs-human", {"flow_id": "build-1"}, run=boom)
+    assert ok is False  # swallowed at the boundary by design (I4), reported as data
+
+
+def test_emit_unknown_event_is_false_not_raise():
+    with patch.object(busemit, "resolve", return_value=["wicked-bus"]):
+        ok = busemit.emit("frobnicate", {"flow_id": "build-1"})
+    assert ok is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_busemit.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.busemit'`
+
+- [ ] **Step 3: Write `busemit.py`**
+
+```python
+"""busemit.py — best-effort fire-and-forget bus emission. Emission ONLY.
+
+The bus is the spine for everything that is NOT a gate verdict (spec §4.4/I4):
+phase transitions, needs-human parks, audit. Emission is fire-and-forget — an
+unresolvable, erroring, or slow bus must NEVER raise and NEVER block the flow.
+An emitted event NEVER satisfies a gate (I4) — gates are synchronous and direct
+(gate.py); this module only announces.
+
+The bus consumer / projector and any headless reaction to these events are
+DEFERRED (spec D3 / §9 D-headless). This file is the producer side only.
+
+Stable event names (spec §4.3 #3):
+  loom:flow:started | phase-advanced | gate-passed | gate-failed
+                    | needs-human | completed
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable
+
+from loom.compose import RunResult, _default_run
+from loom.resolve import resolve
+
+Runner = Callable[..., RunResult]
+
+_EMIT_TIMEOUT = 5  # seconds; emission is best-effort, keep it short (R5).
+
+EVENTS: dict = {
+    "started": "loom:flow:started",
+    "phase-advanced": "loom:flow:phase-advanced",
+    "gate-passed": "loom:flow:gate-passed",
+    "gate-failed": "loom:flow:gate-failed",
+    "needs-human": "loom:flow:needs-human",
+    "completed": "loom:flow:completed",
+}
+
+
+def emit(event_key: str, payload: dict, *, run: Runner = _default_run) -> bool:
+    """Fire-and-forget emit. Returns True iff the bus accepted it (exit 0).
+
+    Never raises: an unknown event, an unresolvable bus, or any subprocess
+    failure is reported as ``False`` (I4 — the bus is optional infrastructure).
+    """
+    event_type = EVENTS.get(event_key)
+    if event_type is None:
+        return False
+
+    bus_prefix = resolve("bus")
+    if bus_prefix is None:
+        return False
+
+    argv = list(bus_prefix) + ["emit", event_type, json.dumps(payload)]
+    try:
+        result = run(argv, timeout=_EMIT_TIMEOUT)
+    except Exception:  # noqa: BLE001 — fire-and-forget; bus is optional (I4)
+        return False
+    return result.returncode == 0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_busemit.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/busemit.py tests/test_busemit.py
+git commit -m "feat: best-effort fire-and-forget bus emission (conduct)"
+```
+
+---
+
+## Task 4: The flow runner (`flow.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/flow.py`
+- Test: `~/Projects/wicked-loom/tests/test_flow.py`
+
+The generic, **archetype-agnostic** phase-loop (invariant I6 — it branches on the flow definition's `gate`/`hitl` fields, NEVER on archetype names). It wires Task 1 (gate), Task 2 (state), Task 3 (emit). The vault runner and bus runner are injected separately so a flow test never spawns either. Three operations:
+
+- `run_flow(flow_def, …)` — create state, emit `started`, then advance.
+- `status(flow_id, …)` — read persisted state (no advance, no side effects beyond read).
+- `resume(flow_id, …)` — reload a parked/running flow and advance again (the human approves a hard gate out-of-band; resume moves past it).
+
+**Advance loop (the heart of conduct, spec §3.1 + §4.2):** from `current_phase`, for each phase:
+1. If the phase has no `gate` → emit `phase-advanced`, increment, continue.
+2. Else run the gate (Task 1) → record the verdict in state.
+   - Gate **not satisfied** → emit `gate-failed`, persist, STOP (status stays `running`; the flow is blocked on real evidence, not parked-for-human).
+   - Gate **satisfied** + `hitl` is `hard:*` → emit `gate-passed` then `needs-human`, set `parked=True`, status `parked`, persist, STOP. **Loom never self-approves a hard gate (I5).**
+   - Gate **satisfied** + not hard → emit `gate-passed` + `phase-advanced`, increment, continue.
+3. When `current_phase == len(phases)` → status `completed`, emit `completed`, persist, STOP.
+
+`resume` clears `parked` for the phase the human just approved (it advances PAST the parked hard-gate phase without re-running it — the human verdict is the authority there, per I5), then runs the same loop.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+from loom import flow
+from loom.compose import RunResult
+
+
+def _vault(overall="PASS", code=0):
+    def run(cmd, timeout=None):
+        import json
+        return RunResult(returncode=code, stdout=json.dumps({"overall": overall}),
+                         stderr="")
+    return run
+
+
+def _silent_bus():
+    def run(cmd, timeout=None):
+        return RunResult(returncode=0, stdout="", stderr="")
+    return run
+
+
+def _flow_def(flow_id="build-1"):
+    return {
+        "flow_id": flow_id,
+        "phases": [
+            {"name": "plan", "gate": None, "hitl": "none"},
+            {"name": "implement", "gate": None, "hitl": "none"},
+            {"name": "test", "gate": "produces:test-report", "hitl": "discrete:review"},
+            {"name": "review", "gate": "produces:verdict", "hitl": "hard:final-verdict"},
+        ],
+        "peers_required": ["vault"],
+        "verifier_spec_ref": None,
+    }
+
+
+def test_gateless_phases_advance_freely(tmp_path):
+    fd = {"flow_id": "g-1",
+          "phases": [{"name": "a", "gate": None, "hitl": "none"},
+                     {"name": "b", "gate": None, "hitl": "none"}],
+          "peers_required": [], "verifier_spec_ref": None}
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        st = flow.run_flow(fd, state_dir=tmp_path,
+                           vault_run=_vault(), bus_run=_silent_bus())
+    assert st["status"] == "completed"
+    assert st["current_phase"] == 2
+
+
+def test_flow_parks_at_hard_gate_after_pass(tmp_path):
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        st = flow.run_flow(_flow_def(), state_dir=tmp_path,
+                           vault_run=_vault("PASS"), bus_run=_silent_bus())
+    assert st["status"] == "parked"
+    assert st["parked"] is True
+    # parks AT the hard-gate phase ("review", index 3), not past it (I5).
+    assert st["current_phase"] == 3
+    assert st["gate_verdicts"]["review"]["satisfied"] is True
+
+
+def test_flow_stops_unparked_when_gate_fails(tmp_path):
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        st = flow.run_flow(_flow_def(), state_dir=tmp_path,
+                           vault_run=_vault("REJECT"), bus_run=_silent_bus())
+    # stops at the first gated phase ("test", index 2) — not parked, just blocked.
+    assert st["status"] == "running"
+    assert st["parked"] is False
+    assert st["current_phase"] == 2
+    assert st["gate_verdicts"]["test"]["satisfied"] is False
+
+
+def test_flow_fails_closed_when_vault_unresolvable(tmp_path):
+    with patch.object(flow, "resolve", return_value=None):
+        st = flow.run_flow(_flow_def(), state_dir=tmp_path,
+                           vault_run=_vault(), bus_run=_silent_bus())
+    assert st["status"] == "running"  # blocked at the gate, not advanced
+    assert st["current_phase"] == 2
+    assert st["gate_verdicts"]["test"]["gate"] == "unavailable"
+
+
+def test_status_reads_without_advancing(tmp_path):
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        flow.run_flow(_flow_def("s-1"), state_dir=tmp_path,
+                      vault_run=_vault("PASS"), bus_run=_silent_bus())
+    st = flow.status("s-1", state_dir=tmp_path)
+    assert st["flow_id"] == "s-1"
+    assert st["status"] == "parked"
+
+
+def test_status_unknown_flow_is_none(tmp_path):
+    assert flow.status("nope", state_dir=tmp_path) is None
+
+
+def test_resume_advances_past_an_approved_hard_gate(tmp_path):
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        flow.run_flow(_flow_def("r-1"), state_dir=tmp_path,
+                      vault_run=_vault("PASS"), bus_run=_silent_bus())
+        # human approved the parked hard gate out-of-band -> resume.
+        st = flow.resume("r-1", state_dir=tmp_path,
+                         vault_run=_vault("PASS"), bus_run=_silent_bus())
+    assert st["status"] == "completed"
+    assert st["parked"] is False
+    assert st["current_phase"] == 4
+
+
+def test_resume_unknown_flow_returns_none(tmp_path):
+    assert flow.resume("nope", state_dir=tmp_path,
+                       vault_run=_silent_bus(), bus_run=_silent_bus()) is None
+
+
+def test_flow_is_archetype_agnostic(tmp_path):
+    # A flow def with a made-up archetype-shaped name still runs purely off
+    # gate/hitl fields — loom must not branch on archetype names (I6).
+    fd = {"flow_id": "x-1",
+          "phases": [{"name": "totally-made-up-phase", "gate": None, "hitl": "none"}],
+          "peers_required": [], "verifier_spec_ref": None}
+    with patch.object(flow, "resolve", return_value=["wicked-vault"]):
+        st = flow.run_flow(fd, state_dir=tmp_path,
+                           vault_run=_vault(), bus_run=_silent_bus())
+    assert st["status"] == "completed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_flow.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.flow'`
+
+- [ ] **Step 3: Write `flow.py`**
+
+```python
+"""flow.py — the archetype-agnostic flow runner (conduct orchestration).
+
+Executes a declarative flow definition (spec §3.1): advance phases; on a gated
+phase, re-derive synchronously via gate.py; park at a hard gate; persist state
+via flowstate.py; announce transitions via busemit.py (best-effort).
+
+Invariants (spec §5):
+  I1/I2/I3 — inherited from gate.py (synchronous, fail-closed, fail-soft spec).
+  I4 — bus emission is best-effort and never gates; an event never advances a
+       phase. Only a re-derived gate verdict advances.
+  I5 — autonomy never overrides a hard gate: on a satisfied hard:* gate the flow
+       PARKS and emits needs-human; it never self-approves. ``resume`` advances
+       past an approved hard gate only because a human acted out-of-band.
+  I6 — archetype-agnostic: this module branches ONLY on the flow definition's
+       ``gate`` / ``hitl`` fields, never on archetype names.
+
+The vault runner and bus runner are injected (``vault_run`` / ``bus_run``) so a
+flow test never spawns a real vault or bus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from loom import busemit, flowstate
+from loom.compose import RunResult, _default_run
+from loom.gate import run_gate
+from loom.resolve import resolve  # re-exported so tests can patch flow.resolve
+
+Runner = Callable[..., RunResult]
+
+_GATE_PREFIX = "produces:"
+
+
+def _is_hard(hitl: Optional[str]) -> bool:
+    """A hard gate is any hitl discipline of the form ``hard:*`` (spec §3.1)."""
+    return isinstance(hitl, str) and hitl.startswith("hard:")
+
+
+def _produces_of(gate_spec: str) -> str:
+    """Map a flow-def gate string to the vault produces id.
+
+    "produces:test-report" -> "test-report". A non-"produces:" gate string is
+    passed through verbatim (still re-derived; never a vacuous pass — I2).
+    """
+    if gate_spec.startswith(_GATE_PREFIX):
+        return gate_spec[len(_GATE_PREFIX):]
+    return gate_spec
+
+
+def _advance(state: dict, *, state_dir: Path,
+             vault_run: Runner, bus_run: Runner) -> dict:
+    """Run the phase loop from state['current_phase']; persist + return state."""
+    phases = state["phases"]
+    flow_id = state["flow_id"]
+    verifier_spec = state.get("verifier_spec_ref")
+
+    while state["current_phase"] < len(phases):
+        phase = phases[state["current_phase"]]
+        name = phase.get("name", str(state["current_phase"]))
+        gate_spec = phase.get("gate")
+        hitl = phase.get("hitl")
+
+        if not gate_spec:
+            busemit.emit("phase-advanced",
+                         {"flow_id": flow_id, "phase": name}, run=bus_run)
+            state["current_phase"] += 1
+            continue
+
+        verdict = run_gate(_produces_of(gate_spec), scope=flow_id,
+                           with_attestations=_is_hard(hitl),
+                           verifier_spec=verifier_spec, run=vault_run)
+        state["gate_verdicts"][name] = verdict
+
+        if not verdict.get("satisfied"):
+            busemit.emit("gate-failed",
+                         {"flow_id": flow_id, "phase": name,
+                          "overall": verdict.get("overall")}, run=bus_run)
+            flowstate.save_state(state, state_dir=state_dir)
+            return state  # blocked on evidence; status stays "running" (I2)
+
+        busemit.emit("gate-passed",
+                     {"flow_id": flow_id, "phase": name}, run=bus_run)
+
+        if _is_hard(hitl):
+            state["parked"] = True
+            state["parked_reason"] = f"hard gate at phase '{name}' ({hitl})"
+            state["status"] = flowstate.STATUS_PARKED
+            busemit.emit("needs-human",
+                         {"flow_id": flow_id, "phase": name, "hitl": hitl},
+                         run=bus_run)
+            flowstate.save_state(state, state_dir=state_dir)
+            return state  # PARK — loom never self-approves a hard gate (I5)
+
+        busemit.emit("phase-advanced",
+                     {"flow_id": flow_id, "phase": name}, run=bus_run)
+        state["current_phase"] += 1
+
+    state["status"] = flowstate.STATUS_COMPLETED
+    busemit.emit("completed", {"flow_id": flow_id}, run=bus_run)
+    flowstate.save_state(state, state_dir=state_dir)
+    return state
+
+
+def run_flow(flow_def: dict, *, state_dir: Path,
+             vault_run: Runner = _default_run,
+             bus_run: Runner = _default_run) -> dict:
+    """Start a new flow: build state, emit started, advance through phases."""
+    state = flowstate.new_state(flow_def, state_dir=state_dir)
+    flowstate.save_state(state, state_dir=state_dir)
+    busemit.emit("started", {"flow_id": state["flow_id"]}, run=bus_run)
+    return _advance(state, state_dir=state_dir,
+                    vault_run=vault_run, bus_run=bus_run)
+
+
+def status(flow_id: str, *, state_dir: Path) -> Optional[dict]:
+    """Read persisted flow state without advancing or any side effect."""
+    return flowstate.load_state(flow_id, state_dir=state_dir)
+
+
+def resume(flow_id: str, *, state_dir: Path,
+           vault_run: Runner = _default_run,
+           bus_run: Runner = _default_run) -> Optional[dict]:
+    """Resume a parked/running flow. If parked at a hard gate, a human has
+    approved it out-of-band (I5) — advance PAST that phase without re-running
+    its gate, then continue the normal loop."""
+    state = flowstate.load_state(flow_id, state_dir=state_dir)
+    if state is None:
+        return None
+    if state.get("parked"):
+        state["parked"] = False
+        state["parked_reason"] = None
+        state["status"] = flowstate.STATUS_RUNNING
+        state["current_phase"] += 1  # human-approved hard gate: step past it
+    return _advance(state, state_dir=state_dir,
+                    vault_run=vault_run, bus_run=bus_run)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_flow.py -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/flow.py tests/test_flow.py
+git commit -m "feat: archetype-agnostic flow runner with park-at-hard-gate (conduct)"
+```
+
+---
+
+## Task 5: CLI surface — `gate` + `flow` (run|status|resume)
+
+**Files:**
+- Modify: `~/Projects/wicked-loom/python/loom/cli.py`
+- Modify: `~/Projects/wicked-loom/tests/test_cli.py`
+
+Extend Plan A's dispatch with two commands. Logic stays in `gate.py`/`flow.py` (R6 — `cli.py` only parses args + formats JSON). State directory defaults to a project-scoped local path; a `--state-dir` flag overrides it (tests pass `--state-dir`).
+
+- `loom gate <produces> [--scope S] [--verifier-spec PATH] [--with-attestations]` → `{"gate": <verdict>}`; exit 0 iff satisfied.
+- `loom flow run <flow-def.json> [--state-dir D]` → `{"flow": <state>}`; exit 0 iff status `completed`, 2 if parked/blocked.
+- `loom flow status <flow-id> [--state-dir D]` → `{"flow": <state>}`; exit 0 if found, 1 if not.
+- `loom flow resume <flow-id> [--state-dir D]` → `{"flow": <state>}`; exit 0 iff `completed`, 2 if parked/blocked, 1 if not found.
+
+- [ ] **Step 1: Write the failing test (append to `tests/test_cli.py`)**
+
+```python
+import json as _json
+import os
+from unittest.mock import patch
+
+# (re-uses the _run helper + imports already at the top of test_cli.py)
+
+
+def test_gate_command_satisfied_exits_zero():
+    verdict = {"satisfied": True, "overall": "PASS", "gate": "vault-cross-check"}
+    with patch("loom.cli.run_gate", return_value=verdict) as m:
+        code, out = _run(["gate", "test-report", "--scope", "build-1"])
+    assert code == 0
+    assert _json.loads(out)["gate"]["satisfied"] is True
+    m.assert_called_once()
+
+
+def test_gate_command_unsatisfied_exits_one():
+    verdict = {"satisfied": False, "overall": "REJECT", "gate": "vault-cross-check"}
+    with patch("loom.cli.run_gate", return_value=verdict):
+        code, _ = _run(["gate", "test-report", "--scope", "build-1"])
+    assert code == 1
+
+
+def test_gate_command_forwards_flags():
+    with patch("loom.cli.run_gate", return_value={"satisfied": True}) as m:
+        _run(["gate", "verdict", "--scope", "b1",
+              "--verifier-spec", "/tmp/v.json", "--with-attestations"])
+    _, kwargs = m.call_args
+    assert kwargs["scope"] == "b1"
+    assert kwargs["verifier_spec"] == "/tmp/v.json"
+    assert kwargs["with_attestations"] is True
+
+
+def test_gate_requires_produces_arg():
+    code, _ = _run(["gate"])
+    assert code == 2
+
+
+def test_flow_run_completed_exits_zero(tmp_path):
+    fd = {"flow_id": "cli-1",
+          "phases": [{"name": "a", "gate": None, "hitl": "none"}],
+          "peers_required": [], "verifier_spec_ref": None}
+    p = tmp_path / "flow.json"
+    p.write_text(_json.dumps(fd), encoding="utf-8")
+    completed = {"flow_id": "cli-1", "status": "completed"}
+    with patch("loom.cli.run_flow", return_value=completed) as m:
+        code, out = _run(["flow", "run", str(p), "--state-dir", str(tmp_path)])
+    assert code == 0
+    assert _json.loads(out)["flow"]["status"] == "completed"
+    m.assert_called_once()
+
+
+def test_flow_run_parked_exits_two(tmp_path):
+    fd = {"flow_id": "cli-2", "phases": [], "peers_required": [],
+          "verifier_spec_ref": None}
+    p = tmp_path / "flow.json"
+    p.write_text(_json.dumps(fd), encoding="utf-8")
+    with patch("loom.cli.run_flow", return_value={"status": "parked"}):
+        code, _ = _run(["flow", "run", str(p), "--state-dir", str(tmp_path)])
+    assert code == 2
+
+
+def test_flow_status_found_exits_zero(tmp_path):
+    with patch("loom.cli.flow_status", return_value={"flow_id": "x", "status": "running"}):
+        code, out = _run(["flow", "status", "x", "--state-dir", str(tmp_path)])
+    assert code == 0
+    assert _json.loads(out)["flow"]["flow_id"] == "x"
+
+
+def test_flow_status_missing_exits_one(tmp_path):
+    with patch("loom.cli.flow_status", return_value=None):
+        code, _ = _run(["flow", "status", "nope", "--state-dir", str(tmp_path)])
+    assert code == 1
+
+
+def test_flow_resume_completed_exits_zero(tmp_path):
+    with patch("loom.cli.flow_resume", return_value={"status": "completed"}):
+        code, _ = _run(["flow", "resume", "x", "--state-dir", str(tmp_path)])
+    assert code == 0
+
+
+def test_flow_resume_missing_exits_one(tmp_path):
+    with patch("loom.cli.flow_resume", return_value=None):
+        code, _ = _run(["flow", "resume", "nope", "--state-dir", str(tmp_path)])
+    assert code == 1
+
+
+def test_flow_unknown_subcommand_exits_two():
+    code, _ = _run(["flow", "frobnicate"])
+    assert code == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_cli.py -v`
+Expected: FAIL — the new tests error (`AttributeError: <module 'loom.cli'> does not have the attribute 'run_gate'` / unknown command `gate`). The 6 Plan A cli tests still PASS.
+
+- [ ] **Step 3: Edit `cli.py` — add imports**
+
+Replace the import block (currently importing only `manifest`, `check_all`, `install_peer`, `resolve`) so it also brings in the conduct entry points. The full new import block:
+
+```python
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from loom import manifest
+from loom.compose import check_all, install_peer
+from loom.resolve import resolve
+from loom.gate import run_gate
+from loom.flow import run_flow, status as flow_status, resume as flow_resume
+```
+
+- [ ] **Step 4: Edit `cli.py` — add the state-dir default + `gate` handler**
+
+Add this helper and handler above the `_DISPATCH` table:
+
+```python
+def _default_state_dir() -> Path:
+    """Project-scoped local state dir. Honors WICKED_LOOM_STATE_DIR; else a
+    cwd-anchored .wicked-loom/flows dir (deterministic, no network — spec §10)."""
+    import os
+    override = os.environ.get("WICKED_LOOM_STATE_DIR", "").strip()
+    if override:
+        return Path(override)
+    return Path.cwd() / ".wicked-loom" / "flows"
+
+
+def _opt(args: list, name: str) -> "str | None":
+    """Return the value following ``--name`` in args, or None."""
+    if name in args:
+        i = args.index(name)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+def _cmd_gate(args: list) -> int:
+    positional = [a for a in args if not a.startswith("--")]
+    # Strip values that belong to --scope / --verifier-spec from positionals.
+    scope = _opt(args, "--scope") or "default"
+    verifier_spec = _opt(args, "--verifier-spec")
+    consumed = {scope, verifier_spec}
+    produces = next((a for a in positional if a not in consumed), None)
+    if produces is None:
+        _emit({"error": "usage: loom gate <produces> [--scope S] "
+                        "[--verifier-spec PATH] [--with-attestations]"})
+        return 2
+    verdict = run_gate(produces, scope=scope, verifier_spec=verifier_spec,
+                       with_attestations="--with-attestations" in args)
+    _emit({"gate": verdict})
+    return 0 if verdict.get("satisfied") else 1
+```
+
+- [ ] **Step 5: Edit `cli.py` — add the `flow` handler**
+
+Add this handler above the `_DISPATCH` table:
+
+```python
+def _cmd_flow(args: list) -> int:
+    if not args:
+        _emit({"error": "usage: loom flow <run|status|resume> ..."})
+        return 2
+    sub, rest = args[0], args[1:]
+    state_dir = Path(_opt(rest, "--state-dir") or _default_state_dir())
+    positional = [a for a in rest if not a.startswith("--") and a != str(state_dir)]
+
+    if sub == "run":
+        if not positional:
+            _emit({"error": "usage: loom flow run <flow-def.json> [--state-dir D]"})
+            return 2
+        flow_def = json.loads(Path(positional[0]).read_text(encoding="utf-8"))
+        st = run_flow(flow_def, state_dir=state_dir)
+        _emit({"flow": st})
+        return 0 if st.get("status") == "completed" else 2
+
+    if sub == "status":
+        if not positional:
+            _emit({"error": "usage: loom flow status <flow-id> [--state-dir D]"})
+            return 2
+        st = flow_status(positional[0], state_dir=state_dir)
+        _emit({"flow": st})
+        return 0 if st is not None else 1
+
+    if sub == "resume":
+        if not positional:
+            _emit({"error": "usage: loom flow resume <flow-id> [--state-dir D]"})
+            return 2
+        st = flow_resume(positional[0], state_dir=state_dir)
+        _emit({"flow": st})
+        if st is None:
+            return 1
+        return 0 if st.get("status") == "completed" else 2
+
+    _emit({"error": f"unknown flow subcommand: {sub}",
+           "subcommands": ["run", "status", "resume"]})
+    return 2
+```
+
+- [ ] **Step 6: Edit `cli.py` — register both in `_DISPATCH`**
+
+Change the dispatch table to include the conduct commands:
+
+```python
+_DISPATCH = {
+    "resolve": _cmd_resolve,
+    "doctor": _cmd_doctor,
+    "compose": _cmd_compose,
+    "gate": _cmd_gate,
+    "flow": _cmd_flow,
+}
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_cli.py -v`
+Expected: PASS — 17 tests (6 Plan A + 11 new conduct cases).
+
+- [ ] **Step 8: Smoke the full path through the Node shim (fail-closed, no vault)**
+
+Run:
+```bash
+cd ~/Projects/wicked-loom && WICKED_VAULT_BIN="" node bin/loom.mjs gate test-report --scope smoke
+```
+Expected: a JSON line whose `gate.gate == "unavailable"` and `gate.satisfied == false`, exit code 1 — proving the shim → python3 → conduct path works AND the gate fails closed when the vault is killed (I2). (`echo $?` → `1`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/cli.py tests/test_cli.py
+git commit -m "feat: conduct CLI — gate + flow run/status/resume"
+```
+
+---
+
+## Task 6: README conduct section + full suite + publish-readiness
+
+**Files:**
+- Modify: `~/Projects/wicked-loom/README.md`
+
+- [ ] **Step 1: Append a conduct section to `README.md`**
+
+```markdown
+## Conduct (gate + flow)
+
+Synchronous, fail-closed evidence gating and an archetype-agnostic flow runtime.
+
+    npx wicked-loom gate test-report --scope build-1        # re-derive one produces via the vault
+    npx wicked-loom gate verdict --scope b1 --with-attestations
+    npx wicked-loom flow run ./flow-def.json                 # run a flow definition
+    npx wicked-loom flow status build-1                      # read a flow's state
+    npx wicked-loom flow resume build-1                      # continue past an approved hard gate
+
+**Invariants:** gates are synchronous and re-derive every call (an event never
+satisfies a gate); a missing vault fails **closed** (`gate: "unavailable"`,
+never a pass); the verifier spec is fail-**soft** (absent → generic detection,
+never blocks). The runner is archetype-agnostic — it executes any flow
+definition (`phases[]` with optional `gate`/`hitl`, `peers_required`,
+`verifier_spec_ref`) and parks at any `hard:*` gate, never self-approving.
+
+The headless bus-consumer / unattended execution mode is **deferred** — this
+release emits transition events best-effort but does not react to them.
+
+## Flow definition
+
+    {
+      "flow_id": "build-1",
+      "phases": [
+        { "name": "plan",   "gate": null,                   "hitl": "none" },
+        { "name": "test",   "gate": "produces:test-report", "hitl": "discrete:review" },
+        { "name": "review", "gate": "produces:verdict",     "hitl": "hard:final-verdict" }
+      ],
+      "peers_required": ["vault", "testing"],
+      "verifier_spec_ref": null
+    }
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest -v`
+Expected: PASS — 50 tests total: 22 Plan A (4 manifest + 5 resolve + 7 compose + 6 cli)… now cli is 17, so the count is **22 Plan A non-cli + new** → exact tally: 4 manifest + 5 resolve + 7 compose + 17 cli + 8 gate + 6 flowstate + 5 busemit + 9 flow = **61 tests**.
+
+- [ ] **Step 3: Dry-run the npm package contents**
+
+Run: `cd ~/Projects/wicked-loom && npm pack --dry-run`
+Expected: the tarball lists `bin/`, `python/` (now including `gate.py`, `flow.py`, `flowstate.py`, `busemit.py`), `README.md`, `package.json` — and NOT `tests/` or `__pycache__/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add README.md
+git commit -m "docs: README conduct section + flow-def reference"
+```
+
+- [ ] **Step 5: STOP — version bump + publish are human-gated**
+
+Do **not** run `npm publish` autonomously. Conduct adds a feature surface → this is a **minor** bump (`0.1.0` → `0.2.0`); report to the operator that conduct is implemented (suite green, `npm pack` clean) and let them bump `package.json`/`__init__.py`, publish, and tag. The garden-side cutover (shelling garden's `gate`/`flow` shims to loom + the archetype→flow compiler) is a separate plan.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — checked against §4.2 (conduct module), §4.3 (surfaces/CLI/events), §5 (invariants I1–I6):
+
+| Spec item | Where realized |
+|---|---|
+| §4.2 Execute a gate — sync vault re-derive via `cross-check` | Task 1 `gate.run_gate` (ported from `vault_gate.cross_check`). ✓ |
+| §4.2 Missing vault → `unavailable`, fail-closed, never vacuous pass (**I2**) | Task 1 `test_gate_fails_closed_when_vault_unresolvable` / `_unrunnable` / `_on_non_json_output`. ✓ |
+| §4.2 Hard gates require independent attestation (`--with-attestations`) | Task 1 `test_with_attestations_forwarded`; Task 4 forwards `with_attestations=_is_hard(hitl)`. ✓ |
+| §4.2 `verifier_spec_ref` present → read it; absent/stale → generic, never blocks (**I3**) | Task 1 `test_verifier_spec_forwarded` + `_absent_is_fail_soft`; Task 4 threads `verifier_spec_ref` through. ✓ |
+| §4.2 Run a flow — advance phases, persist state | Task 4 `run_flow`/`_advance` + Task 2 `flowstate`. ✓ |
+| §4.2 Park at hard gate — stop + emit `needs-human`, do not self-approve (**I5**) | Task 4 `test_flow_parks_at_hard_gate_after_pass`. ✓ |
+| §4.2 Project (bus consumer / headless) | **DEFERRED** — explicitly out of scope (D3 / §9). Stated up-front + in README. ✓ (intentional gap) |
+| §4.3 CLI `loom gate <produces> [--verifier-spec] [--with-attestations]` | Task 5 `_cmd_gate`. ✓ |
+| §4.3 CLI `loom flow run|status|resume` | Task 5 `_cmd_flow`. ✓ |
+| §4.3 Event contract `loom:flow:started\|phase-advanced\|gate-passed\|gate-failed\|needs-human\|completed` | Task 3 `busemit.EVENTS` (exact strings asserted in `test_event_names_are_the_spec_set`); emitted in Task 4. ✓ |
+| §4.3 Bus-consumer / daemon surface | **DEFERRED** (D3). ✓ (intentional gap) |
+| **I1** gate synchronous + in-line, event never satisfies | Task 1 (one blocking call, no events read); reinforced by Task 3/4 separation (bus is emission-only). ✓ |
+| **I2** fail-closed | Task 1 + Task 4 `test_flow_fails_closed_when_vault_unresolvable`. ✓ |
+| **I3** fail-soft on verifier spec only | Task 1 (absence never blocks). ✓ |
+| **I4** bus = spine for non-verdict; event never satisfies a gate | Task 3 `busemit` is fire-and-forget, returns bool, never feeds gate logic; Task 4 ignores emit results. ✓ |
+| **I5** autonomy never overrides a hard gate | Task 4 park-at-hard-gate; `resume` only advances because a human acted out-of-band. ✓ |
+| **I6** archetype-agnostic | Task 4 `test_flow_is_archetype_agnostic`; `flow.py` branches only on `gate`/`hitl`. ✓ |
+| §5/§10 state deterministic, no network | Task 2 `flowstate` (injected `state_dir`, atomic write, no subprocess); flow/gate runners injected. ✓ |
+| Reuse `resolve.resolve()` for vault resolution | Task 1 `gate.py` imports `from loom.resolve import resolve`. ✓ |
+| Match compose.py runner-injection pattern | Tasks 1/3/4 use `RunResult`/`Runner`/`_default_run` from `compose.py`. ✓ |
+
+No unintended gaps. The only uncovered spec bullets (§4.2 "Project", §4.3 surface #2 daemon) are the **deferred** headless mode — explicitly excluded by D3 and flagged in three places (header "Out of scope", README, this table).
+
+**2. Placeholder scan** — No `TBD`/`TODO`/"add error handling"/"handle edge cases"/"similar to Task N". Every code step shows complete, runnable code. Every run step shows the exact `PYTHONPATH=python python3 -m pytest …` command and expected pass/fail. Error handling is concrete everywhere (gate fail-closed branches written out; busemit `except Exception` documented as the I4 boundary; flowstate `ValueError` on unsafe id). ✓
+
+**3. Type consistency** —
+- `RunResult(returncode, stdout, stderr)` and the `Runner = Callable[..., RunResult]` alias are imported from `compose.py` and used identically in `gate.py`, `busemit.py`, `flow.py`, and every test (`_runner`/`_vault`/`_silent_bus` all build `RunResult`). ✓
+- `run_gate(produces, *, scope, with_attestations=False, verifier_spec=None, run=…, timeout=…) -> dict`: the signature in Task 1 matches every call site — Task 4 (`run_gate(_produces_of(gate_spec), scope=flow_id, with_attestations=_is_hard(hitl), verifier_spec=verifier_spec, run=vault_run)`) and Task 5 (`run_gate(produces, scope=scope, verifier_spec=verifier_spec, with_attestations=…)`). The CLI test asserts kwargs `scope`/`verifier_spec`/`with_attestations` — all present. ✓
+- `flowstate`: `new_state(flow_def, *, state_dir)`, `save_state(state, *, state_dir)`, `load_state(flow_id, *, state_dir)` — used with identical keyword `state_dir` in `flow.py` and the tests. Status constants `STATUS_RUNNING/PARKED/COMPLETED` referenced from `flow.py` consistently. ✓
+- `flow`: `run_flow(flow_def, *, state_dir, vault_run, bus_run)`, `status(flow_id, *, state_dir)`, `resume(flow_id, *, state_dir, vault_run, bus_run)` — `cli.py` imports them as `run_flow`, `status as flow_status`, `resume as flow_resume` and calls with matching kwargs. ✓
+- `busemit.emit(event_key, payload, *, run) -> bool` — called from `flow.py` with the event keys `"started"`/`"phase-advanced"`/`"gate-passed"`/`"gate-failed"`/`"needs-human"`/`"completed"`, all of which are keys in `EVENTS`. ✓
+- State dict keys (`flow_id`, `phases`, `current_phase`, `gate_verdicts`, `parked`, `parked_reason`, `status`, `verifier_spec_ref`) are written by `flowstate.new_state` and read by `flow._advance`/`resume` with the same names. ✓
+
+One self-review fix applied inline: Task 6 Step 2's expected count was first written as "50" then corrected to the exact tally **61** (4+5+7+17+8+6+5+9), because cli grows from 6 → 17 tests in Task 5. The per-task expected counts (8/6/5/9/17) are the authoritative figures.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-06-08-wicked-loom-conduct.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks, fast iteration. REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+2. **Inline Execution** — execute tasks in this session with checkpoints. REQUIRED SUB-SKILL: `superpowers:executing-plans`.
+
+Notes for the executor:
+- Execution happens in the **existing** `~/Projects/wicked-loom` repo (the package Plan A created), NOT in wicked-garden. Plan A (compose) must already be merged there.
+- Read garden's `scripts/qe/vault_gate.py` and `scripts/crew/phase_manager.py` for grounding before Task 1/Task 2, but **import nothing from garden** — loom is a standalone primitive (success criterion #1).
+- Every test is hermetic: vault and bus subprocesses are injected; `state_dir` is a `tmp_path`. No test may spawn a real vault/bus or touch the network (T1/T3).
+- The headless daemon / bus-consumer is DEFERRED (D3). Do not build it. If a need surfaces, it is a separate plan that consumes the event contract `busemit.py` already produces.
+
+**Which approach?**

--- a/docs/plans/2026-06-08-wicked-loom-cutover.md
+++ b/docs/plans/2026-06-08-wicked-loom-cutover.md
@@ -1,0 +1,1300 @@
+# wicked-loom — Cutover Phase (garden-side strangler migration) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut wicked-garden's in-process runtime over to the shipped `wicked-loom` CLI, **one surface at a time, lowest-risk first** — `resolve` → `gate` → `flow` — then add `wicked-loom` as the 5th required peer and introduce the garden archetype→flow-definition compiler (the §3.1 seam). Each cutover ships behind a **contract test** asserting the loom-shelled path produces results IDENTICAL to the in-process path it replaces (the strangler safety net), and stays **fail-soft during transition** (loom unresolvable → fall back to the still-present in-process code; gates still fail **closed**). The old in-process code is LEFT IN PLACE behind the shim — rollback is trivial. Deleting it is the **contract** phase (a later plan).
+
+**Architecture:** Garden already invokes Python via `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" <script.py>` and peers via `npx <peer>`. The cutover adds one thin garden-side module — `scripts/_loom.py` — that resolves the loom CLI on a ladder mirroring the vault's (`WICKED_LOOM_BIN` → config → `PATH` → `node_modules/.bin` → `npx wicked-loom`, with `WICKED_LOOM_BIN=""` as the kill-switch) and runs it as a subprocess returning parsed JSON. Each cutover target (`resolve_vault`, `cross_check`/`gate_satisfied`, phase mechanics) gains a **try-loom-first, fall-back-to-in-process** branch gated by a single feature flag (`WICKED_LOOM_CUTOVER`, default `auto`). No in-process function is deleted; each grows a shim head. The flow-definition compiler (`scripts/crew/flow_compiler.py`) is a NEW pure module that reads `.claude-plugin/archetypes.json` + the `_HARD_GATE_PHASES` map and emits the §3.1 flow-definition JSON that `loom flow run` consumes.
+
+**Tech Stack:** Python 3.9+ (stdlib only — mirrors garden's hook discipline; loom is reached as a subprocess, never imported). `pytest` (garden's existing suite; `testpaths = ["tests"]`, `tests/conftest.py` puts `scripts/` on `sys.path[0]`). Tests inject the loom subprocess runner (same pattern as `vault_gate._run`) so no test spawns a real loom or touches the network. The shipped loom CLI surface this plan targets:
+
+- `loom resolve <peer>` → `{"peer","command":[...]|null}`, exit 0 iff resolvable (wicked-loom 0.1.0).
+- `loom gate <produces> --scope S [--verifier-spec PATH] [--with-attestations]` → `{"gate": <verdict>}`, exit 0 iff `gate.satisfied` (wicked-loom 0.2.0 / conduct).
+- `loom flow run <flow-def.json> [--state-dir D]` · `loom flow status <flow-id>` · `loom flow resume <flow-id>` → `{"flow": <state>}` (wicked-loom 0.2.0 / conduct).
+
+**Decisions locked for this plan (override in review):**
+- **loom resolution ladder = a faithful mirror of the vault ladder** (D5; §10 invariants). `WICKED_LOOM_BIN` env (empty = kill-switch) → `tool_preferences.wicked-loom` in `config.json` → `wicked-loom` on `PATH` → `node_modules/.bin/wicked-loom` → `npx --yes wicked-loom`. This is the exact shape of `vault_gate.resolve_vault`, lifted to a peer-neutral helper.
+- **One cutover feature flag, `WICKED_LOOM_CUTOVER`** ∈ `{auto, on, off}`, default `auto`. `auto` = use loom **iff resolvable**, else in-process (the transition default). `on` = loom required for that surface (used by the contract tests to force the loom path). `off` = in-process only (instant rollback / kill-switch). Read once per call via a tiny `_loom.cutover_mode()` helper.
+- **Garden never imports loom Python** — it shells `npx wicked-loom` (or the resolved bin) exactly as it shells the vault. Loom stays a sibling primitive; garden's plugin packaging stays decoupled from loom's Python env (D5).
+- **Gate fail-closed posture is preserved verbatim.** The loom `gate` path and the in-process `gate_satisfied` path BOTH fail closed when the vault is unresolvable. Loom unresolvable for the *gate surface* falls back to the in-process gate (which itself fails closed) — never a vacuous pass (I2).
+- **`flow` cutover is additive, not a replacement of `phase_manager`'s storage.** Garden keeps `phase_manager` as its project-state store; the `flow` cutover mirrors *advance/approve/park* decisions through `loom flow` and contract-tests that the park-at-hard-gate verdict matches `_HARD_GATE_PHASES`. The DomainStore-backed `ProjectState` is unchanged (it is part of the STAY surface; the contract phase decides its fate).
+- **Target repos:** garden = `~/Projects/wicked-garden` (this plan edits it); loom = `~/Projects/wicked-loom` (consumed as a published peer `npx wicked-loom`, **not** edited here; conduct/0.2.0 must be published first — see Execution Handoff).
+
+**Source material to read in wicked-garden before Task 1 (grounding):**
+- `scripts/qe/vault_gate.py` — the `resolve_vault` ladder (lines 69–106), `_argv_for` (58–66), `_read_config_preference` (117–130), `cross_check` (170–213), `gate_satisfied` (220–293), and the CLI dispatch (304–348). The `resolve` and `gate` cutovers shim these.
+- `scripts/crew/phase_manager.py` — `_HARD_GATE_PHASES` (287–296), `_is_hard_gate` (299–304), `approve_phase` (307–422), and the CLI (460–610). The `flow` cutover mirrors these decisions through `loom flow`.
+- `.claude-plugin/archetypes.json` — `archetypes.{name}.{phases,produces,hitl}` and `$hitl_levels`. The flow compiler reads this.
+- `docs/required-peers.md` — the four-peer table + "required at install, resilient at runtime" stance. Task 4 adds loom as the 5th row.
+- `commands/setup.md` §2.5–2.7 — the per-peer verify pattern. Task 4 adds a loom verify step in the same shape.
+- Plan A (`docs/plans/2026-06-08-wicked-loom-expand-compose.md`) and Plan B (`docs/plans/2026-06-08-wicked-loom-conduct.md`) — the exact loom CLI contract (commands, JSON output keys, exit codes) this plan shells to.
+
+**Out of scope (DEFERRED — do NOT do in this plan):**
+- The **CONTRACT phase** — deleting the now-dead in-process runtime code (the `→ loom` rows in spec §6). That is a separate, *later* plan, run only after this cutover is proven in production. This cutover deliberately LEAVES the in-process code in place behind the shim so rollback is `WICKED_LOOM_CUTOVER=off` (or a one-line revert).
+- The **headless daemon / bus-consumer** (spec D3, §9 D-headless). `loom flow` is driven synchronously from garden; no unattended execution, no projector.
+- Editing the loom repo. Conduct (0.2.0) is Plan B's deliverable; this plan assumes it is published and reachable via `npx wicked-loom`.
+- The compiler↔loom synergy (spec §9): the garden `/wicked-garden:compile` emitter stays self-contained and resolves the vault directly via npx — untouched here.
+
+**Bulletproof standards:** R1–R6 (no dead code, no bare panics, no magic values, no swallowed errors, no unbounded ops, no god functions) and T1–T6 (determinism, no sleep-based sync, isolation, single-assertion focus, descriptive names, provenance). The loom subprocess is injected everywhere so no unit test spawns a real loom or hits the network. Contract tests are the load-bearing artifact: each asserts `loom_path(x) == in_process_path(x)` for the same inputs.
+
+---
+
+## File Structure
+
+```
+wicked-garden/
+├── scripts/
+│   ├── _loom.py                 # NEW — peer-neutral loom CLI resolver + JSON subprocess runner
+│   │                            #        + cutover_mode() flag. Mirrors vault_gate's ladder.
+│   ├── qe/
+│   │   └── vault_gate.py        # MODIFY — resolve_vault grows a loom-first head (Task 1);
+│   │                            #          cross_check grows a loom-gate head (Task 2).
+│   │                            #          In-process bodies STAY as the fallback.
+│   └── crew/
+│       ├── flow_compiler.py     # NEW — archetype catalog → flow-definition JSON (the §3.1 seam, Task 5)
+│       └── phase_manager.py     # MODIFY — approve_phase/advance grow a loom-flow mirror head (Task 3);
+│                                #          in-process body STAYS.
+├── hooks/scripts/
+│   └── bootstrap.py             # MODIFY — _check_loom_dependency added (Task 4, peer-detection portion only)
+├── docs/
+│   └── required-peers.md        # MODIFY — add the 5th peer row + stance note (Task 4)
+├── commands/
+│   └── setup.md                 # MODIFY — add §2.8 Verify wicked-loom (Task 4)
+├── .claude-plugin/
+│   └── plugin.json              # MODIFY — add wicked-loom pin to the peer description (Task 4)
+└── tests/
+    ├── crew/
+    │   ├── test_loom_resolver.py          # NEW — _loom.py unit tests (Task 0)
+    │   ├── test_loom_resolve_contract.py  # NEW — resolve cutover contract test (Task 1)
+    │   ├── test_loom_flow_contract.py     # NEW — flow cutover contract test (Task 3)
+    │   └── test_flow_compiler.py          # NEW — archetype→flow-def compiler tests (Task 5)
+    └── qe/
+        └── test_loom_gate_contract.py     # NEW — gate cutover contract test (Task 2)
+```
+
+**Responsibilities (one per file, justifying the layout):**
+- `scripts/_loom.py` = *find loom + run it + read the flag* (the only file that knows how to reach the loom CLI). Peer-neutral resolution helper (mirrors `vault_gate.resolve_vault`), a JSON subprocess runner, and `cutover_mode()`. Pure of any surface logic — `resolve`/`gate`/`flow` shims call into it.
+- `scripts/qe/vault_gate.py` (modified) = keeps both paths for the resolve + gate surfaces; the shim head tries loom, the unchanged body is the fallback. One responsibility per function still holds — the head is a 4-line guard, not a rewrite.
+- `scripts/crew/flow_compiler.py` = *translate one archetype into a flow definition* (the §3.1 handoff contract). Pure, deterministic, reads the catalog + the hard-gate map; emits the JSON loom consumes. No I/O beyond reading the catalog.
+- `scripts/crew/phase_manager.py` (modified) = keeps its DomainStore state authority; the shim head mirrors the advance/park decision through `loom flow` for parity, never replacing the disk write.
+- `hooks/scripts/bootstrap.py` (modified) = adds one peer-detection function in the exact shape of `_check_vault_dependency` / `_check_bus_dependency`.
+
+Why `_loom.py` is its own file and not folded into `vault_gate.py`: it is peer-neutral (used by the resolve, gate, AND flow cutovers) and must be importable from `scripts/` and `scripts/crew/` alike; co-locating it with the vault gate would couple three surfaces to one. Why the compiler is separate from `phase_manager.py`: the compiler is pure catalog→JSON with zero state; mixing it into the stateful phase manager would violate R6.
+
+**The flow-definition shape this plan emits** (spec §3.1; consumed verbatim by `loom flow run`, per Plan B):
+
+```jsonc
+{
+  "flow_id": "build-<project>",
+  "phases": [
+    { "name": "plan",      "gate": null,                   "hitl": "none",              "produces": [] },
+    { "name": "implement", "gate": null,                   "hitl": "none",              "produces": [] },
+    { "name": "test",      "gate": "produces:test-report", "hitl": "discrete:review",   "produces": ["test-report"] },
+    { "name": "review",    "gate": "produces:verdict",     "hitl": "hard:final-verdict","produces": ["verdict"] }
+  ],
+  "peers_required": ["vault", "testing"],
+  "verifier_spec_ref": null
+}
+```
+
+---
+
+## Task 0: The loom CLI resolver + JSON runner + cutover flag (`scripts/_loom.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-garden/scripts/_loom.py`
+- Test: `~/Projects/wicked-garden/tests/crew/test_loom_resolver.py`
+
+This is the foundation every cutover stands on: resolve the loom CLI on a ladder that mirrors the vault's, run it as a subprocess that returns parsed JSON, and read the `WICKED_LOOM_CUTOVER` flag. Ported in shape from `vault_gate.resolve_vault` / `_argv_for` / `_read_config_preference` / `_run`, generalized to "loom" and made injectable for tests (the `run` parameter, same as `vault_gate`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import json
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import _loom  # noqa: E402
+
+
+class ResolveLadderTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_LOOM_BIN")
+        os.environ.pop("WICKED_LOOM_BIN", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("WICKED_LOOM_BIN", None)
+        else:
+            os.environ["WICKED_LOOM_BIN"] = self._saved
+
+    def test_env_override_wins(self):
+        os.environ["WICKED_LOOM_BIN"] = "/opt/custom/loom"
+        self.assertEqual(_loom.resolve_loom(), ["/opt/custom/loom"])
+
+    def test_empty_env_is_killswitch(self):
+        os.environ["WICKED_LOOM_BIN"] = ""
+        self.assertIsNone(_loom.resolve_loom())
+
+    def test_mjs_override_invoked_via_node(self):
+        os.environ["WICKED_LOOM_BIN"] = "/some/loom.mjs"
+        self.assertEqual(_loom.resolve_loom(), ["node", "/some/loom.mjs"])
+
+    def test_path_lookup_when_no_env(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/local/bin/wicked-loom" if b == "wicked-loom" else None):
+            self.assertEqual(_loom.resolve_loom(allow_npx=False), ["/usr/local/bin/wicked-loom"])
+
+    def test_npx_fallback_when_not_on_path(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertEqual(_loom.resolve_loom(), ["npx", "--yes", "wicked-loom"])
+
+    def test_loom_available_excludes_npx(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertFalse(_loom.loom_available())
+
+
+class RunTests(unittest.TestCase):
+    def test_run_returns_parsed_json_on_success(self):
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0, "stdout": '{"peer":"vault","command":["npx","wicked-vault"]}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            out = _loom.run_json(["resolve", "vault"], _run=fake_run)
+        self.assertEqual(out["exit_code"], 0)
+        self.assertEqual(out["json"]["command"], ["npx", "wicked-vault"])
+
+    def test_run_unresolvable_reports_error_not_raise(self):
+        with patch.object(_loom, "resolve_loom", return_value=None):
+            out = _loom.run_json(["resolve", "vault"])
+        self.assertIsNone(out["json"])
+        self.assertEqual(out["error"], "wicked-loom not resolvable")
+
+    def test_run_non_json_output_is_error_not_raise(self):
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0, "stdout": "not json", "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            out = _loom.run_json(["doctor"], _run=fake_run)
+        self.assertIsNone(out["json"])
+        self.assertIn("non-JSON", out["error"])
+
+
+class CutoverModeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_LOOM_CUTOVER")
+        os.environ.pop("WICKED_LOOM_CUTOVER", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("WICKED_LOOM_CUTOVER", None)
+        else:
+            os.environ["WICKED_LOOM_CUTOVER"] = self._saved
+
+    def test_default_is_auto(self):
+        self.assertEqual(_loom.cutover_mode(), "auto")
+
+    def test_explicit_off(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        self.assertEqual(_loom.cutover_mode(), "off")
+
+    def test_unknown_value_falls_back_to_auto(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "frobnicate"
+        self.assertEqual(_loom.cutover_mode(), "auto")
+
+    def test_use_loom_off_is_false(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        self.assertFalse(_loom.use_loom())
+
+    def test_use_loom_auto_true_only_when_resolvable(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None):
+            self.assertFalse(_loom.use_loom())
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            self.assertTrue(_loom.use_loom())
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '_loom'`
+
+- [ ] **Step 3: Write `scripts/_loom.py`**
+
+```python
+#!/usr/bin/env python3
+"""_loom.py — resolve + run the wicked-loom CLI, peer-neutral.
+
+The garden's strangler shim toward wicked-loom. Garden NEVER imports loom's
+Python; it shells the published ``wicked-loom`` CLI exactly as it shells
+``wicked-vault``. This module owns three things and nothing else:
+
+  1. resolve_loom() — the runtime resolution ladder, a faithful mirror of
+     vault_gate.resolve_vault: WICKED_LOOM_BIN env (empty = kill-switch) ->
+     config tool_preferences.wicked-loom -> PATH -> node_modules/.bin -> npx.
+  2. run_json() — run a loom subcommand, return {exit_code, json, stdout,
+     stderr, error}. Never raises (R4 — surface as data). Non-JSON / not-found
+     / timeout all come back as error, json=None.
+  3. cutover_mode() / use_loom() — the WICKED_LOOM_CUTOVER feature flag
+     ({auto,on,off}, default auto) that lets every cutover try loom first and
+     fall back to the in-process path (the transition default), or be killed
+     (off) for instant rollback.
+
+Stdlib-only. Cross-platform (argv lists, shutil.which, no shell).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # noqa: S404 — argv lists only, shell=False
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+_CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
+_DEFAULT_TIMEOUT = 120
+_CUTOVER_MODES = ("auto", "on", "off")
+_PACKAGE = "wicked-loom"
+_ENV_BIN = "WICKED_LOOM_BIN"
+_ENV_FLAG = "WICKED_LOOM_CUTOVER"
+
+
+def _argv_for(target: str) -> List[str]:
+    """A .mjs/.js path is a script -> invoke via node; else run directly."""
+    if target.endswith((".mjs", ".js")):
+        return ["node", target]
+    return [target]
+
+
+def _read_config_preference(key: str) -> Optional[str]:
+    """Read ``tool_preferences.{key}`` from config.json; None on any error."""
+    try:
+        if not _CONFIG_PATH.exists():
+            return None
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = data.get("tool_preferences")
+        if isinstance(prefs, dict):
+            value = prefs.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def resolve_loom(*, allow_npx: bool = True,
+                 project_dir: Optional[Path] = None) -> Optional[List[str]]:
+    """Return the argv prefix that invokes wicked-loom, or None.
+
+    Ladder (first hit wins), mirroring vault_gate.resolve_vault:
+      1. WICKED_LOOM_BIN env. Set-but-empty is the kill-switch -> None.
+      2. tool_preferences.wicked-loom in config.json.
+      3. wicked-loom on PATH.
+      4. project-local node_modules/.bin/wicked-loom.
+      5. npx --yes wicked-loom (only when allow_npx).
+    """
+    if _ENV_BIN in os.environ:
+        env = os.environ[_ENV_BIN].strip()
+        return _argv_for(env) if env else None  # empty == kill-switch
+
+    pref = _read_config_preference(_PACKAGE)
+    if pref:
+        return _argv_for(pref)
+
+    found = shutil.which(_PACKAGE)
+    if found:
+        return [found]
+
+    base = Path(project_dir) if project_dir else Path.cwd()
+    local = base / "node_modules" / ".bin" / _PACKAGE
+    if local.exists():
+        return [str(local)]
+
+    if allow_npx and shutil.which("npx"):
+        return ["npx", "--yes", _PACKAGE]
+
+    return None
+
+
+def loom_available(project_dir: Optional[Path] = None) -> bool:
+    """True iff a concrete loom install resolves (not the npx last-resort).
+    The signal setup + bootstrap use to decide whether the peer is installed."""
+    return resolve_loom(allow_npx=False, project_dir=project_dir) is not None
+
+
+def _default_run(prefix: List[str], args: List[str], timeout: int) -> Dict[str, Any]:
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            prefix + args, capture_output=True, text=True, timeout=timeout,
+        )
+        return {"exit_code": proc.returncode, "stdout": proc.stdout,
+                "stderr": proc.stderr, "error": None}
+    except FileNotFoundError:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": "loom executable not found"}
+    except subprocess.TimeoutExpired:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": f"loom call exceeded {timeout}s"}
+
+
+Runner = Callable[..., Dict[str, Any]]
+
+
+def run_json(args: List[str], *, timeout: int = _DEFAULT_TIMEOUT,
+             project_dir: Optional[Path] = None,
+             _run: Runner = _default_run) -> Dict[str, Any]:
+    """Run ``loom <args>``; return {exit_code, json, stdout, stderr, error}.
+
+    Never raises (R4). json is the parsed stdout or None (unresolvable,
+    not-found, timeout, or non-JSON output).
+    """
+    prefix = resolve_loom(project_dir=project_dir)
+    if prefix is None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": "wicked-loom not resolvable"}
+    run = _run(prefix, args, timeout)
+    if run["error"] is not None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": run["error"]}
+    try:
+        parsed = json.loads(run["stdout"]) if (run["stdout"] or "").strip() else {}
+    except json.JSONDecodeError:
+        return {"exit_code": run["exit_code"], "json": None,
+                "stdout": run["stdout"], "stderr": run["stderr"],
+                "error": "loom returned non-JSON output"}
+    return {"exit_code": run["exit_code"], "json": parsed,
+            "stdout": run["stdout"], "stderr": run["stderr"], "error": None}
+
+
+def cutover_mode() -> str:
+    """The WICKED_LOOM_CUTOVER flag, normalized. Unknown -> 'auto'."""
+    raw = os.environ.get(_ENV_FLAG, "").strip().lower()
+    return raw if raw in _CUTOVER_MODES else "auto"
+
+
+def use_loom(*, project_dir: Optional[Path] = None) -> bool:
+    """Should this call go through loom?
+
+    off  -> never. on -> always (caller must handle an unresolvable loom).
+    auto -> only when loom resolves (the transition default: fall back to the
+            in-process path otherwise).
+    """
+    mode = cutover_mode()
+    if mode == "off":
+        return False
+    if mode == "on":
+        return True
+    return resolve_loom(project_dir=project_dir) is not None
+
+
+__all__ = ["resolve_loom", "loom_available", "run_json",
+           "cutover_mode", "use_loom"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_resolver.py -v`
+Expected: PASS (14 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add scripts/_loom.py tests/crew/test_loom_resolver.py
+git commit -m "feat(loom-cutover): loom CLI resolver + JSON runner + cutover flag"
+```
+
+---
+
+## Task 1: Cut over `resolve` — garden's peer resolution shells to `loom resolve`
+
+**Files:**
+- Modify: `~/Projects/wicked-garden/scripts/qe/vault_gate.py` (`resolve_vault`, lines 69–106)
+- Test: `~/Projects/wicked-garden/tests/crew/test_loom_resolve_contract.py`
+
+Lowest-risk surface first (spec §7: `resolve` → `gate` → `flow`). `resolve_vault` grows a loom-first head: when `use_loom()` is true, shell `loom resolve vault` and use its `command` array; otherwise (or on any loom error) fall through to the unchanged in-process ladder. The **contract test** asserts the loom path returns the SAME argv the in-process path returns for the same environment.
+
+- [ ] **Step 1: Write the failing contract test**
+
+```python
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import vault_gate as vg  # noqa: E402
+
+
+class ResolveCutoverContract(unittest.TestCase):
+    """Strangler safety net: the loom-shelled resolve path must return the
+    SAME argv the in-process resolve_vault returns for the same inputs."""
+
+    def setUp(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def test_loom_resolve_matches_in_process_for_npx_case(self):
+        # In-process: no env, not on PATH -> npx --yes wicked-vault.
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            in_proc = vg.resolve_vault()
+        self.assertEqual(in_proc, ["npx", "--yes", "wicked-vault"])
+
+        # Loom path: force loom on; loom resolve vault returns the SAME argv.
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0,
+                    "stdout": '{"peer":"vault","command":["npx","--yes","wicked-vault"]}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            via_loom = vg.resolve_vault()
+        self.assertEqual(via_loom, in_proc)
+
+    def test_loom_unresolvable_falls_back_to_in_process(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None), \
+             patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            via = vg.resolve_vault()
+        # auto + loom unresolvable -> in-process path used (fail-soft).
+        self.assertEqual(via, ["npx", "--yes", "wicked-vault"])
+
+    def test_loom_killswitch_env_still_honored_through_loom(self):
+        # WICKED_VAULT_BIN="" is the vault kill-switch; the loom resolve path
+        # must surface the same None (loom resolve returns command=null).
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        os.environ["WICKED_VAULT_BIN"] = ""
+
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 1, "stdout": '{"peer":"vault","command":null}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            self.assertIsNone(vg.resolve_vault())
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_resolve_contract.py -v`
+Expected: FAIL — `test_loom_resolve_matches_in_process_for_npx_case` (and the others) fail because `resolve_vault` does not yet consult loom; the `on` path still runs in-process and ignores the mocked loom output.
+
+- [ ] **Step 3: Edit `vault_gate.py` — add the loom-first head to `resolve_vault`**
+
+Add the import near the top of the file (after the existing stdlib imports, before `_CONFIG_PATH`):
+
+```python
+# Strangler shim toward wicked-loom (cutover phase). The in-process body below
+# STAYS as the fallback; loom is tried first only when the cutover flag allows.
+try:
+    import _loom  # scripts/ is on sys.path for hook + CLI invocations
+except ImportError:  # pragma: no cover — loom shim absent => pure in-process
+    _loom = None  # type: ignore
+```
+
+Then insert the loom head at the very top of `resolve_vault` (before the existing `if "WICKED_VAULT_BIN" in os.environ:` block at line 86):
+
+```python
+    # --- loom cutover head (resolve surface) ---------------------------------
+    # Try loom first iff the cutover flag allows AND loom is reachable. Any loom
+    # error falls through to the unchanged in-process ladder (fail-soft, §7/§10).
+    if _loom is not None and allow_npx and _loom.use_loom(project_dir=project_dir):
+        out = _loom.run_json(["resolve", "vault"], project_dir=project_dir)
+        if out["error"] is None and isinstance(out.get("json"), dict):
+            # loom resolve returns {"peer","command":[...]|null}; null == the
+            # vault kill-switch / unresolvable, which we surface as None.
+            return out["json"].get("command")  # list[str] or None
+        # loom errored -> fall through to in-process (transition fail-soft).
+    # -------------------------------------------------------------------------
+```
+
+> Implementer note: `allow_npx` guards the loom head because `vault_available()` calls `resolve_vault(allow_npx=False)` to detect a *concrete* install — that probe must stay in-process (loom's `resolve` would report the npx fallback as resolvable and corrupt the "installed" signal). Keeping the loom head behind `allow_npx` preserves `vault_available()`'s exact semantics. If a future loom `resolve --no-npx` lands, revisit; for now this is the faithful boundary.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_resolve_contract.py tests/qe/test_vault_gate.py -v`
+Expected: PASS — the 3 new contract tests AND the existing `test_vault_gate.py` suite (the in-process path is untouched when the flag is `off`/`auto`-unresolvable, which is the default in CI).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add scripts/qe/vault_gate.py tests/crew/test_loom_resolve_contract.py
+git commit -m "feat(loom-cutover): resolve_vault shells to loom resolve, fail-soft to in-process"
+```
+
+---
+
+## Task 2: Cut over `gate` — garden's vault gate shells to `loom gate`
+
+**Files:**
+- Modify: `~/Projects/wicked-garden/scripts/qe/vault_gate.py` (`cross_check`, lines 170–213)
+- Test: `~/Projects/wicked-garden/tests/qe/test_loom_gate_contract.py`
+
+Second surface (spec §7). `cross_check` grows a loom-first head: when `use_loom()` is true, shell `loom gate <phase> --scope <scope> [--with-attestations] [--verifier-spec ...]` and map its `{"gate": <verdict>}` onto `cross_check`'s existing return shape; otherwise fall through to the unchanged in-process `_run`+parse. **`gate_satisfied` is unchanged** — it calls `cross_check`, so it transparently inherits the loom path while keeping its fail-closed posture (loom gate also fails closed; if loom is unreachable in `auto`, the in-process gate runs and itself fails closed — never a vacuous pass, I2). The contract test asserts: identical `overall` for PASS and REJECT, and identical fail-closed verdict when the vault is unresolvable on both paths.
+
+- [ ] **Step 1: Write the failing contract test**
+
+```python
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import vault_gate as vg  # noqa: E402
+
+_PROJECT = Path("/tmp/proj-loom-gate")
+
+
+class GateCutoverContract(unittest.TestCase):
+    """Strangler safety net: the loom-shelled gate verdict must match the
+    in-process cross_check verdict (same overall + satisfied) for PASS,
+    REJECT, and the fail-closed-when-vault-absent case."""
+
+    def setUp(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def _loom_gate_runner(self, overall):
+        def fake_run(prefix, args, timeout):
+            import json
+            verdict = {"satisfied": overall == "PASS", "overall": overall,
+                       "gate": "vault-cross-check"}
+            return {"exit_code": 0 if overall == "PASS" else 1,
+                    "stdout": json.dumps({"gate": verdict}), "stderr": "", "error": None}
+        return fake_run
+
+    def test_loom_pass_matches_in_process_pass(self):
+        # In-process PASS (stub the vault subprocess).
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        with patch.object(vg, "resolve_vault", return_value=["wicked-vault"]), \
+             patch.object(vg, "_run", return_value={"exit_code": 0, "error": None,
+                          "stdout": '{"overall":"PASS"}', "stderr": ""}):
+            in_proc = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+
+        # Loom PASS.
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", self._loom_gate_runner("PASS")):
+            via_loom = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+
+        self.assertEqual(via_loom["overall"], in_proc["overall"])
+        self.assertTrue(via_loom["available"])
+
+    def test_loom_reject_matches_in_process_reject(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", self._loom_gate_runner("REJECT")):
+            via_loom = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+        self.assertEqual(via_loom["overall"], "REJECT")
+
+    def test_gate_fails_closed_when_loom_errors_and_vault_absent(self):
+        # auto + loom unresolvable -> in-process gate runs; vault also absent
+        # -> fail closed. The loom error never invents a PASS (I2).
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None), \
+             patch.object(vg, "resolve_vault", return_value=None):
+            verdict = vg.gate_satisfied(_PROJECT, "build-1", "test")
+        self.assertFalse(verdict["satisfied"])
+        self.assertEqual(verdict["gate"], "unavailable")
+
+    def test_loom_with_attestations_forwarded(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        seen = {}
+
+        def fake_run(prefix, args, timeout):
+            import json
+            seen["args"] = args
+            return {"exit_code": 0, "stdout": json.dumps(
+                {"gate": {"satisfied": True, "overall": "PASS"}}), "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            vg.cross_check("build-1", "review", project_dir=_PROJECT, with_attestations=True)
+        self.assertIn("--with-attestations", seen["args"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/qe/test_loom_gate_contract.py -v`
+Expected: FAIL — the loom-path tests fail because `cross_check` does not yet consult loom.
+
+- [ ] **Step 3: Edit `vault_gate.py` — add the loom-first head to `cross_check`**
+
+Insert at the top of `cross_check` (immediately after the docstring, before `args = ["cross-check", ...]` at line 188). Reuse the module-level `_loom` import added in Task 1:
+
+```python
+    # --- loom cutover head (gate surface) ------------------------------------
+    # Try loom first iff the cutover flag allows AND loom is reachable. Maps
+    # loom's {"gate": <verdict>} onto cross_check's return shape. Any loom error
+    # falls through to the in-process re-derivation (which itself fails closed).
+    if _loom is not None and _loom.use_loom(project_dir=project_dir):
+        loom_args = ["gate", phase, "--scope", scope]
+        if with_attestations:
+            loom_args.append("--with-attestations")
+        out = _loom.run_json(loom_args, project_dir=project_dir, timeout=timeout)
+        if out["error"] is None and isinstance(out.get("json"), dict):
+            verdict = out["json"].get("gate") or {}
+            gate_kind = verdict.get("gate")
+            if gate_kind == "unavailable":
+                # loom reached but the vault is unresolvable behind it -> the
+                # gate is unavailable; fail closed exactly as in-process (I2).
+                return {"available": False, "overall": "ERROR",
+                        "error": verdict.get("error", "vault unavailable via loom"),
+                        "exit_code": out.get("exit_code")}
+            return {
+                "available": True,
+                "overall": verdict.get("overall", "ERROR"),
+                "exit_code": out.get("exit_code"),
+                "claims": verdict.get("claims", []),
+                "mode": verdict.get("mode"),
+                "contract_version": verdict.get("contract_version"),
+                "detail": verdict.get("detail"),
+                "raw": verdict,
+            }
+        # loom errored -> fall through to in-process re-derivation (fail-soft).
+    # -------------------------------------------------------------------------
+```
+
+> Implementer note: the `verifier_spec` forwarding (`--verifier-spec PATH`) is wired when the flow compiler (Task 5) starts attaching `verifier_spec_ref`; `cross_check`'s current garden signature has no `verifier_spec` parameter, so this head forwards only `--scope`/`--phase`/`--with-attestations` — the exact arguments the in-process path builds (lines 188–190). Do NOT add a `verifier_spec` parameter to `cross_check` in this task (out of scope; it belongs with the compiler handoff). The loom gate is fail-soft on a missing verifier spec by construction (I3), so omitting it is safe.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/qe/test_loom_gate_contract.py tests/qe/test_vault_gate.py -v`
+Expected: PASS — the 4 new contract tests AND the existing `test_vault_gate.py` (in-process path unchanged when the flag is off/auto-unresolvable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add scripts/qe/vault_gate.py tests/qe/test_loom_gate_contract.py
+git commit -m "feat(loom-cutover): cross_check shells to loom gate, fail-closed preserved"
+```
+
+---
+
+## Task 3: Cut over `flow` — garden's phase advance/park mirrors `loom flow`
+
+**Files:**
+- Modify: `~/Projects/wicked-garden/scripts/crew/phase_manager.py` (`approve_phase`, lines 307–422; `_is_hard_gate`, 299–304)
+- Test: `~/Projects/wicked-garden/tests/crew/test_loom_flow_contract.py`
+
+Highest-risk surface, done last (spec §7). `phase_manager` keeps its DomainStore `ProjectState` authority — the `flow` cutover does NOT replace storage. Instead, `approve_phase` grows a loom **mirror head**: when `use_loom()` is true, it asks loom whether the (archetype, phase) is a hard gate by consulting the loom flow runner's verdict, and the **contract test** asserts loom's park-at-hard-gate decision matches `_HARD_GATE_PHASES` for every archetype. This proves the two phase engines agree on the load-bearing decision (where the human-in-the-loop stop is) before any later plan moves storage onto loom.
+
+The mirror is read-only parity: the in-process hard-gate enforcement (the `ValueError` guard at lines 332–351) is unchanged and remains authoritative during the cutover. Loom is consulted to *cross-check the decision*, not to gate the write.
+
+- [ ] **Step 1: Write the failing contract test**
+
+```python
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import phase_manager as pm  # noqa: E402
+import flow_compiler as fc  # noqa: E402 — Task 5; import guarded below
+
+# (archetype, hard-gate phase) pairs the in-process map declares.
+_EXPECTED_HARD_GATES = {
+    "migrate": "cutover",
+    "incident": "mitigate",
+    "review": "remediate-or-accept",
+    "specify": "validate",
+    "decide": "record",
+}
+
+
+class FlowHardGateParityContract(unittest.TestCase):
+    """Strangler safety net: loom's park-at-hard-gate decision (derived from
+    the compiled flow definition) must match phase_manager._HARD_GATE_PHASES
+    for every archetype. The two engines must agree on WHERE the human stops."""
+
+    def test_compiled_flow_hard_phase_matches_in_process_map(self):
+        for archetype, hard_phase in _EXPECTED_HARD_GATES.items():
+            flow_def = fc.compile_flow(archetype, flow_id=f"{archetype}-x")
+            hard_phases = [p["name"] for p in flow_def["phases"]
+                           if isinstance(p.get("hitl"), str) and p["hitl"].startswith("hard:")]
+            self.assertIn(hard_phase, hard_phases,
+                          f"{archetype}: compiled flow hard phase != in-process map")
+
+    def test_non_hard_archetypes_compile_no_hard_phase(self):
+        for archetype in ("triage", "explore", "build", "ship"):
+            flow_def = fc.compile_flow(archetype, flow_id=f"{archetype}-x")
+            hard_phases = [p["name"] for p in flow_def["phases"]
+                           if isinstance(p.get("hitl"), str) and p["hitl"].startswith("hard:")]
+            self.assertEqual(hard_phases, [],
+                             f"{archetype} should have no hard:* phase")
+
+    def test_approve_phase_in_process_authority_unchanged_when_loom_off(self):
+        # With cutover off, approve_phase behaves exactly as before: a hard gate
+        # without --confirmed-by raises ValueError (the in-process guard).
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        st = pm.ProjectState(name="m1", current_phase="cutover",
+                             created_at=pm.get_utc_timestamp(),
+                             phase_plan=["plan", "expand", "backfill", "cutover", "contract"],
+                             extras={"v11_archetype": "migrate"})
+        with patch.object(pm, "save_project_state", lambda s: None):
+            with self.assertRaises(ValueError):
+                pm.approve_phase(st, "cutover")
+
+    def tearDown(self):
+        os.environ.pop("WICKED_LOOM_CUTOVER", None)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_flow_contract.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'flow_compiler'` (the compiler is Task 5; this test pins the parity contract the flow cutover depends on, so it is written here and goes green after Task 5).
+
+> Sequencing note: this contract test depends on `flow_compiler.compile_flow` (Task 5). It is written in Task 3 because it is the *flow cutover's* safety net, but it will not pass until Task 5 ships the compiler. Run Task 3 Step 3 (the mirror head) now; let Step 4 below confirm the in-process-authority subtest passes immediately, and the two parity subtests pass after Task 5. (Subagent-driven execution: keep this task open until Task 5 closes, then re-run.)
+
+- [ ] **Step 3: Edit `phase_manager.py` — add the loom mirror head to `approve_phase`**
+
+Add the module-level loom import near the existing `_bus_emit_safe` import block (after line 43, before `_bus_emit_safe`):
+
+```python
+# Strangler shim toward wicked-loom (cutover phase). Read-only parity mirror:
+# the in-process hard-gate enforcement below STAYS authoritative; loom is
+# consulted only to cross-check the park-at-hard-gate decision during cutover.
+try:
+    import _loom  # scripts/ is on sys.path
+except ImportError:  # pragma: no cover
+    _loom = None  # type: ignore
+
+
+def _loom_confirms_hard_gate(archetype: str, phase: str) -> "Optional[bool]":
+    """Ask loom (via the compiled flow def) whether (archetype, phase) is a
+    hard gate. Returns True/False, or None when loom is unavailable/uncertain
+    (in which case the in-process _HARD_GATE_PHASES map remains authoritative).
+    Best-effort, fail-soft — never raises, never blocks the state write."""
+    if _loom is None or not _loom.use_loom():
+        return None
+    try:
+        from flow_compiler import compile_flow
+        flow_def = compile_flow(archetype, flow_id=f"{archetype}-parity")
+        for p in flow_def.get("phases", []):
+            if p.get("name") == phase:
+                hitl = p.get("hitl")
+                return isinstance(hitl, str) and hitl.startswith("hard:")
+        return False
+    except Exception:
+        return None  # fail-soft: in-process map stays authoritative
+```
+
+Then insert the parity cross-check inside `approve_phase`, immediately after `phase = resolve_phase(phase)` (line 329) and before the hard-gate guard (line 332):
+
+```python
+    # --- loom cutover mirror (flow surface) ----------------------------------
+    # Cross-check loom's park decision against the in-process map. A DISAGREEMENT
+    # is surfaced (stderr + bus emit) but does NOT change behavior — the
+    # in-process guard below stays authoritative during cutover (rollback-safe).
+    archetype_for_parity = (state.extras or {}).get("v11_archetype")
+    if archetype_for_parity:
+        loom_says = _loom_confirms_hard_gate(archetype_for_parity, phase)
+        in_proc_says = _is_hard_gate(state, phase)
+        if loom_says is not None and loom_says != in_proc_says:
+            print(f"[wicked-garden] loom/in-process hard-gate parity mismatch: "
+                  f"archetype={archetype_for_parity} phase={phase} "
+                  f"loom={loom_says} in_process={in_proc_says}", file=sys.stderr)
+            _bus_emit_safe(
+                "wicked.loom.parity_mismatch",
+                {"project_id": state.name, "archetype": archetype_for_parity,
+                 "phase": phase, "loom": loom_says, "in_process": in_proc_says},
+                chain_id=f"{state.name}.{archetype_for_parity}.{phase}.parity",
+            )
+    # -------------------------------------------------------------------------
+```
+
+> Implementer note: the mirror is intentionally read-only this phase — it emits a `wicked.loom.parity_mismatch` event when the engines disagree (so production surfaces any drift before the contract phase moves storage onto loom) but never alters the write path. Replacing `phase_manager`'s storage with `loom flow run|status|resume` is the contract phase, not this one. The `Optional` type is already imported at line 35.
+
+- [ ] **Step 4: Run test to verify it passes (in-process subtest now; parity subtests after Task 5)**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_loom_flow_contract.py -v -k in_process`
+Expected: PASS — `test_approve_phase_in_process_authority_unchanged_when_loom_off`. The two parity subtests stay red until Task 5 ships `flow_compiler`. Re-run the full file at the end of Task 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add scripts/crew/phase_manager.py tests/crew/test_loom_flow_contract.py
+git commit -m "feat(loom-cutover): approve_phase mirrors loom park-at-hard-gate decision (read-only parity)"
+```
+
+---
+
+## Task 4: Add wicked-loom as the 5th required peer
+
+**Files:**
+- Modify: `~/Projects/wicked-garden/docs/required-peers.md`
+- Modify: `~/Projects/wicked-garden/commands/setup.md`
+- Modify: `~/Projects/wicked-garden/hooks/scripts/bootstrap.py` (add `_check_loom_dependency`, peer-detection portion only)
+- Modify: `~/Projects/wicked-garden/.claude-plugin/plugin.json` (peer description)
+
+Promote loom from "shimmed tool" to a declared peer — **required at install, resilient at runtime**, the same stance as the other four (§7, docs/required-peers.md). This is doc + setup + bootstrap-probe wiring; no new runtime logic (the runtime resolver is `_loom.resolve_loom` from Task 0).
+
+- [ ] **Step 1: Edit `docs/required-peers.md`** — change "four peers" → "five peers" in the opening paragraph and the "## The four peers" heading (→ "## The five peers"), and add a row to the peer table:
+
+```markdown
+| **wicked-loom** | The orchestration runtime garden drives: peer resolution (`loom resolve`), synchronous fail-closed evidence gating (`loom gate`), and the archetype-agnostic flow runtime (`loom flow run/status/resume`). Garden compiles its archetype catalog into a flow definition and shells to loom to run it. | `npx wicked-loom` (npm; pinned `^0.2.0` in `plugin.json`) | `/wicked-garden:setup` verifies at install; resolved at runtime via `WICKED_LOOM_BIN` → config → `PATH` → `node_modules` → `npx wicked-loom`, with `WICKED_LOOM_BIN=""` as the kill-switch |
+```
+
+Add to the "## Why each is load-bearing" list:
+
+```markdown
+- **wicked-loom runs the work.** Garden classifies and steers; loom resolves
+  the peers, re-derives the gates, and advances the phases — parking at every
+  hard gate. Without it, garden has the archetype intelligence but no runtime
+  to execute it (during cutover, garden falls back to its in-process runtime;
+  after the contract phase, loom is the only runtime).
+```
+
+> Note: during the cutover phase the wording must stay honest — loom is required at install going forward, but garden still carries the in-process fallback (it is not deleted until the contract phase). The "resilient at runtime" stance already covers the transient-outage case; the bracket above states the cutover-vs-contract distinction explicitly.
+
+- [ ] **Step 2: Edit `commands/setup.md`** — add a new verify step §2.8 after §2.7 (wicked-bus), in the exact shape of §2.5 (wicked-testing):
+
+```markdown
+### 2.8 Verify wicked-loom (Required)
+
+```bash
+npx wicked-loom doctor 2>/dev/null && npx wicked-loom resolve vault 2>/dev/null || echo "MISSING"
+```
+
+- `MISSING` → blocking. wicked-loom is the orchestration runtime garden drives — peer resolution, evidence gating, and flow execution. Show "wicked-loom is not installed. wicked-garden requires it as a peer (sibling to wicked-testing / wicked-vault / wicked-brain / wicked-bus)." **INTERACTIVE mode**: AskUserQuestion header "wicked-loom Required", options "Install now (Required)" = "Run: npm i -g wicked-loom (or use via npx)" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npm i -g wicked-loom` (or confirm `npx wicked-loom doctor` resolves), then re-probe. On failure, show stderr and exit with manual instructions. If exit: "Install wicked-loom then restart with `/wicked-garden:setup`."
+- A JSON line from `doctor` → check the version satisfies `^0.2.0` (the pin from `plugin.json`; 0.2.0 ships the gate + flow surfaces this garden shells to). Then verify the garden can resolve it: `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys; sys.path.insert(0,'scripts'); import _loom; print(_loom.resolve_loom())"` should print a non-null argv. Note: `WICKED_LOOM_CUTOVER=off` disables the loom path (the garden runs its in-process fallback) — used for rollback during the cutover transition.
+```
+
+- [ ] **Step 3: Edit `bootstrap.py`** — add `_check_loom_dependency` modeled on `_check_vault_dependency` (lines 640–685). Insert after `_check_vault_dependency` (after line 686):
+
+```python
+def _check_loom_dependency():
+    """Return a briefing note if wicked-loom is not resolvable, else None.
+
+    wicked-loom is a required peer (the 5th, sibling to wicked-testing /
+    wicked-vault / wicked-brain / wicked-bus): garden shells to it for peer
+    resolution, evidence gating, and flow execution. During the cutover
+    transition garden falls back to its in-process runtime when loom is
+    absent, so this is a one-line install pointer, never a block.
+
+    Fast + stdlib-only (no subprocess to npx): checks PATH and loose skill
+    installs only. Always fails open — never blocks the session.
+    """
+    try:
+        import shutil
+
+        # WICKED_LOOM_BIN explicitly set (even empty kill-switch) or the cutover
+        # flag turned off → operator is driving deliberately; don't nag.
+        if "WICKED_LOOM_BIN" in os.environ:
+            return None
+        if os.environ.get("WICKED_LOOM_CUTOVER", "").strip().lower() == "off":
+            return None
+        if shutil.which("wicked-loom"):
+            return None
+
+        skill_roots = [Path.home() / ".claude" / "skills"]
+        cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+        if cfg:
+            skill_roots.append(Path(cfg) / "skills")
+        for root in skill_roots:
+            try:
+                if root.exists():
+                    for entry in root.iterdir():
+                        if entry.is_dir() and entry.name.startswith("wicked-loom"):
+                            return None
+            except OSError:
+                continue  # fail open
+
+        return (
+            "[wicked-loom] REQUIRED but not installed.\n"
+            "Install now: npm i -g wicked-loom  (or run via: npx wicked-loom)\n"
+            "wicked-loom is the orchestration runtime garden drives for peer "
+            "resolution, evidence gating, and flow execution. (Cutover phase: "
+            "garden falls back to its in-process runtime when loom is absent.)"
+        )
+    except Exception:
+        return None  # Fail open — never block session start
+```
+
+Then wire it into wherever `_check_vault_dependency()`'s note is collected for the SessionStart briefing (find the call site — grep `_check_vault_dependency(` in bootstrap.py — and add a parallel `_check_loom_dependency()` call appending its note to the same briefing list).
+
+- [ ] **Step 4: Edit `.claude-plugin/plugin.json`** — update the description's peer clause. Change "Requires four sibling peers verified at setup — wicked-testing, wicked-vault, wicked-brain, wicked-bus" to "Requires five sibling peers verified at setup — wicked-testing, wicked-vault, wicked-brain, wicked-bus, wicked-loom".
+
+- [ ] **Step 5: Verify the docs + structural checks pass**
+
+Run: `cd ~/Projects/wicked-garden && python3 -c "import json; json.load(open('.claude-plugin/plugin.json')); print('plugin.json valid')" && grep -c "wicked-loom" docs/required-peers.md commands/setup.md`
+Expected: `plugin.json valid`; both files report ≥1 `wicked-loom` mention. (If the repo has a `/wg-check` structural validator, run it too: `python3 -m pytest tests/ -k "peer or required" -v` for any peer-count assertion that needs the 5th row.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add docs/required-peers.md commands/setup.md hooks/scripts/bootstrap.py .claude-plugin/plugin.json
+git commit -m "feat(loom-cutover): wicked-loom is the 5th required peer (docs + setup + bootstrap probe)"
+```
+
+---
+
+## Task 5: The archetype → flow-definition compiler (`scripts/crew/flow_compiler.py`)
+
+**Files:**
+- Create: `~/Projects/wicked-garden/scripts/crew/flow_compiler.py`
+- Test: `~/Projects/wicked-garden/tests/crew/test_flow_compiler.py`
+
+The §3.1 seam — the thin garden layer that makes loom archetype-agnostic. It reads `.claude-plugin/archetypes.json` (`phases`, `produces`, `hitl`) plus the hard-gate phase map and emits the flow-definition JSON `loom flow run` consumes. **Pure + deterministic**: catalog in, JSON out, no I/O beyond reading the catalog.
+
+The translation rule (resolving the §3.1 ↔ catalog mismatch — documented under Ambiguities):
+- The catalog's `hitl` is **archetype-level** (one discipline string per archetype, e.g. `hard:cutover-gate`). The flow definition needs **per-phase** `hitl`. Rule: every phase defaults to `hitl: "none"`; the archetype's hard/discrete gate is attached to its **gate phase** — the hard-gate phase from `_HARD_GATE_PHASES` (e.g. `migrate.cutover`), or for non-hard gating archetypes the catalog's last produces-bearing phase. The attached value is the catalog's `hitl` verbatim (so `hard:cutover-gate` lands on the `cutover` phase).
+- A phase gets a `gate` iff it is the phase that produces a gated artifact. Rule: the **last phase** carries `gate: "produces:<first-produces-id>"` for gating archetypes (build/migrate/review/incident/ship/specify/decide); gateless archetypes (triage/explore) get `gate: null` on all phases. `peers_required` is `["vault", "testing"]` for archetypes whose produces include `test-report`, else `["vault"]`. `verifier_spec_ref` is `null` (wired later, spec §9 / #887 — out of scope here).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import flow_compiler as fc  # noqa: E402
+
+
+class CompileFlowTests(unittest.TestCase):
+    def test_build_flow_shape(self):
+        fd = fc.compile_flow("build", flow_id="build-1")
+        self.assertEqual(fd["flow_id"], "build-1")
+        self.assertEqual([p["name"] for p in fd["phases"]],
+                         ["plan", "implement", "test", "review"])
+        # build is discrete:review-gate -> no hard:* phase.
+        self.assertFalse(any(p["hitl"].startswith("hard:") for p in fd["phases"]))
+
+    def test_migrate_cutover_is_the_hard_phase(self):
+        fd = fc.compile_flow("migrate", flow_id="m-1")
+        hard = [p for p in fd["phases"] if p["hitl"].startswith("hard:")]
+        self.assertEqual(len(hard), 1)
+        self.assertEqual(hard[0]["name"], "cutover")
+        self.assertEqual(hard[0]["hitl"], "hard:cutover-gate")
+
+    def test_triage_is_fully_gateless(self):
+        fd = fc.compile_flow("triage", flow_id="t-1")
+        self.assertTrue(all(p["gate"] is None for p in fd["phases"]))
+        self.assertTrue(all(p["hitl"] == "none" for p in fd["phases"]))
+
+    def test_gating_archetype_has_a_gate_on_last_phase(self):
+        fd = fc.compile_flow("build", flow_id="b-1")
+        self.assertIsNotNone(fd["phases"][-1]["gate"])
+        self.assertTrue(fd["phases"][-1]["gate"].startswith("produces:"))
+
+    def test_peers_required_includes_testing_when_test_report_produced(self):
+        self.assertIn("testing", fc.compile_flow("build", flow_id="b-1")["peers_required"])
+        self.assertNotIn("testing", fc.compile_flow("decide", flow_id="d-1")["peers_required"])
+
+    def test_verifier_spec_ref_is_null(self):
+        self.assertIsNone(fc.compile_flow("build", flow_id="b-1")["verifier_spec_ref"])
+
+    def test_unknown_archetype_raises(self):
+        with self.assertRaises(ValueError):
+            fc.compile_flow("frobnicate", flow_id="x-1")
+
+    def test_unsafe_flow_id_raises(self):
+        with self.assertRaises(ValueError):
+            fc.compile_flow("build", flow_id="../etc/passwd")
+
+    def test_output_is_json_serializable(self):
+        import json
+        json.dumps(fc.compile_flow("incident", flow_id="i-1"))  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_flow_compiler.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'flow_compiler'`
+
+- [ ] **Step 3: Write `scripts/crew/flow_compiler.py`**
+
+```python
+#!/usr/bin/env python3
+"""flow_compiler.py — compile a garden archetype into a loom flow definition.
+
+The §3.1 seam: garden owns the archetype catalog; loom is archetype-agnostic
+and runs a generic flow definition. This module is the thin handoff contract —
+it reads .claude-plugin/archetypes.json (phases, produces, hitl) plus the
+hard-gate phase map and emits the flow-definition JSON `loom flow run` consumes.
+
+Pure + deterministic: catalog in, dict out. The only I/O is reading the catalog.
+
+Flow-definition shape (consumed verbatim by wicked-loom `flow run`):
+  {
+    "flow_id": str,
+    "phases": [{ "name", "gate": "produces:<id>"|null, "hitl": str, "produces": [...] }],
+    "peers_required": [str],
+    "verifier_spec_ref": str|null,
+  }
+
+Translation rules (see the cutover plan's Ambiguities section):
+  - The catalog's `hitl` is archetype-level; the flow def needs it per-phase.
+    Every phase defaults to "none"; the archetype's gate discipline is attached
+    to its gate phase — the hard-gate phase from _HARD_GATE_PHASES when present,
+    else the last phase — verbatim (so "hard:cutover-gate" lands on "cutover").
+  - The last phase of a GATING archetype carries gate="produces:<first-produces>";
+    gateless archetypes (triage/explore) carry gate=null on every phase.
+  - peers_required = ["vault","testing"] iff produces includes "test-report",
+    else ["vault"]. verifier_spec_ref is null (wired later, spec §9 / #887).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# scripts/crew/ is on sys.path; import the authoritative hard-gate map so the
+# compiler and phase_manager agree by construction (the parity contract).
+from phase_manager import _HARD_GATE_PHASES  # noqa: E402
+
+_FLOW_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Archetypes whose `hitl` is "continuous"/"none" do not produce a re-derivable
+# gated artifact -> the flow is gateless (no per-phase produces gate).
+_GATELESS_HITL = ("none", "continuous")
+
+
+def _catalog_path() -> Path:
+    """Resolve .claude-plugin/archetypes.json relative to the repo root."""
+    root = Path(os.environ["CLAUDE_PLUGIN_ROOT"]) if os.environ.get("CLAUDE_PLUGIN_ROOT") \
+        else Path(__file__).resolve().parents[2]
+    return root / ".claude-plugin" / "archetypes.json"
+
+
+def _load_catalog() -> Dict[str, Any]:
+    return json.loads(_catalog_path().read_text(encoding="utf-8")).get("archetypes", {})
+
+
+def _hard_phase_for(archetype: str) -> Optional[str]:
+    """The single hard-gate phase for an archetype, or None."""
+    pair = _HARD_GATE_PHASES.get(archetype, ())
+    return pair[0] if pair else None
+
+
+def compile_flow(archetype: str, *, flow_id: str,
+                 catalog: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Compile one archetype into a loom flow definition (a JSON-able dict)."""
+    if not isinstance(flow_id, str) or not _FLOW_ID_RE.match(flow_id):
+        raise ValueError(f"unsafe flow_id: {flow_id!r} (kebab/snake/alnum, max 64)")
+
+    cat = catalog if catalog is not None else _load_catalog()
+    arch = cat.get(archetype)
+    if not arch:
+        raise ValueError(f"unknown archetype: {archetype!r} (known: {sorted(cat)})")
+
+    phase_names: List[str] = list(arch.get("phases", []))
+    produces: List[str] = list(arch.get("produces", []))
+    hitl: str = arch.get("hitl", "none")
+    gateless = hitl in _GATELESS_HITL or not phase_names
+
+    hard_phase = _hard_phase_for(archetype)
+    # The gate phase: the hard-gate phase if declared, else the last phase.
+    gate_phase = hard_phase if hard_phase in phase_names else (
+        phase_names[-1] if phase_names else None)
+
+    first_produces = produces[0] if produces else None
+
+    phases: List[Dict[str, Any]] = []
+    for name in phase_names:
+        is_gate_phase = (name == gate_phase) and not gateless
+        phases.append({
+            "name": name,
+            "gate": f"produces:{first_produces}" if (is_gate_phase and first_produces) else None,
+            "hitl": hitl if (name == gate_phase and not gateless) else "none",
+            "produces": list(produces) if is_gate_phase else [],
+        })
+
+    peers = ["vault", "testing"] if "test-report" in produces else ["vault"]
+    return {
+        "flow_id": flow_id,
+        "phases": phases,
+        "peers_required": peers,
+        "verifier_spec_ref": None,
+    }
+
+
+__all__ = ["compile_flow"]
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Compile an archetype to a loom flow definition.")
+    parser.add_argument("archetype")
+    parser.add_argument("--flow-id", required=True)
+    a = parser.parse_args()
+    print(json.dumps(compile_flow(a.archetype, flow_id=a.flow_id), indent=2))
+```
+
+> Implementer note: add `import os` to the imports (used by `_catalog_path`). The `from phase_manager import _HARD_GATE_PHASES` import is the deliberate single source of truth — the compiler and the phase manager must agree on the hard-gate phase set by construction, which is exactly what Task 3's parity contract test asserts.
+
+- [ ] **Step 4: Run test to verify it passes (compiler + the deferred Task 3 parity subtests)**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/crew/test_flow_compiler.py tests/crew/test_loom_flow_contract.py -v`
+Expected: PASS — 9 compiler tests AND now all of `test_loom_flow_contract.py` (the two parity subtests deferred from Task 3 go green because `flow_compiler` exists).
+
+- [ ] **Step 5: Smoke the compiler CLI**
+
+Run: `cd ~/Projects/wicked-garden && python3 scripts/crew/flow_compiler.py migrate --flow-id migrate-smoke`
+Expected: a JSON flow definition with 5 phases; the `cutover` phase has `"hitl": "hard:cutover-gate"` and the last phase carries a `produces:shape-change` gate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Projects/wicked-garden
+git add scripts/crew/flow_compiler.py tests/crew/test_flow_compiler.py
+git commit -m "feat(loom-cutover): archetype->flow-definition compiler (the §3.1 seam)"
+```
+
+---
+
+## Task 6: Full-suite green + end-to-end smoke + handoff note
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full garden suite**
+
+Run: `cd ~/Projects/wicked-garden && python3 -m pytest tests/ -q`
+Expected: PASS — no regressions. The cutover defaults to `auto`, and in CI loom is unresolvable, so every existing test exercises the unchanged in-process path. New tests: 14 (resolver) + 3 (resolve contract) + 4 (gate contract) + 3 (flow contract) + 9 (compiler) = **33 new tests**, all green.
+
+- [ ] **Step 2: End-to-end smoke with loom forced on (requires a published `npx wicked-loom` ≥0.2.0)**
+
+Run:
+```bash
+cd ~/Projects/wicked-garden
+WICKED_LOOM_CUTOVER=on sh scripts/_python.sh -c "import sys; sys.path.insert(0,'scripts'); sys.path.insert(0,'scripts/qe'); import vault_gate as vg; print(vg.resolve_vault())"
+```
+Expected: a non-null argv printed by the **loom** path (proving the resolve cutover reaches the real CLI). If `npx wicked-loom` is not yet published, this smoke is SKIPPED — note it in the handoff and rely on the injected-runner contract tests (Step 1), which prove parity without the network.
+
+- [ ] **Step 3: Confirm rollback works**
+
+Run: `cd ~/Projects/wicked-garden && WICKED_LOOM_CUTOVER=off python3 -m pytest tests/qe/test_vault_gate.py tests/crew/test_loom_flow_contract.py -q`
+Expected: PASS — with the flag off, every surface runs the in-process path; the cutover is fully reversible by a single env var (no code revert needed).
+
+- [ ] **Step 4: Report (no autonomous push)**
+
+Report to the operator: the three surfaces (`resolve`/`gate`/`flow`) are cut over behind contract tests + the `WICKED_LOOM_CUTOVER` flag; loom is the declared 5th peer; the flow compiler exists. The in-process code is intact behind the shim (rollback = `WICKED_LOOM_CUTOVER=off`). The CONTRACT phase (deleting the in-process runtime) is the next plan — run it only after this cutover is proven in production. Do NOT run `npm publish`, `/wg-release`, or delete any in-process code in this plan.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — checked against §6 (extraction inventory: which files cut over) and §7 step 2 (the cutover):
+
+| Spec item (§6 / §7) | Where realized | Status |
+|---|---|---|
+| §7 cutover order `resolve` → `gate` → `flow`, one surface at a time | Tasks 1 → 2 → 3, in that order | ✓ |
+| §6 `_integration_resolver.py` / `_capability_resolver.py` / `_capability_registry.py` → loom (compose/resolution) | The **resolution** they back is cut over via Task 1 (`resolve_vault` → `loom resolve`) + the `_loom.resolve_loom` ladder (Task 0). These files are NOT deleted (contract phase); the runtime *peer resolution path* is what cuts over. | ✓ (cutover, not deletion) |
+| §6 `scripts/qe/vault_gate.py` → loom (conduct/gate) | Task 2 — `cross_check` shells to `loom gate`; `gate_satisfied` inherits it unchanged | ✓ |
+| §6 `scripts/crew/phase_manager.py` → loom (conduct/state) | Task 3 — `approve_phase` mirrors `loom flow` park-at-hard-gate (read-only parity; storage move is the contract phase) | ✓ (parity mirror, not storage replacement — deliberate, stated) |
+| §6 `bootstrap.py` PARTIAL — peer detect portion → loom compose | Task 4 — `_check_loom_dependency` probe added; the existing detect functions STAY (PARTIAL boundary confirmed empirically in contract phase per §6) | ✓ |
+| §7 add wicked-loom as the 5th required peer (docs/required-peers.md + setup) | Task 4 — required-peers.md row + setup.md §2.8 + plugin.json + bootstrap probe | ✓ |
+| §7 introduce the archetype → flow-definition compiler (§3.1 seam) | Task 5 — `flow_compiler.compile_flow` reads the catalog + hard-gate map, emits the §3.1 JSON | ✓ |
+| §7 / §10 each cutover fail-soft during transition (loom unresolvable → fall back / degrade, never break a session) | Every cutover head guards on `_loom.use_loom()` and falls through to the unchanged in-process body; default flag `auto` | ✓ |
+| §10 / I2 gates still fail-closed | Task 2 — loom `gate: "unavailable"` maps to `available: False`; loom error in `auto` falls to in-process gate which itself fails closed; `test_gate_fails_closed_when_loom_errors_and_vault_absent` | ✓ |
+| **House requirement: contract test per cutover (strangler safety net, identical results)** | Task 1 `test_loom_resolve_matches_in_process_for_npx_case`; Task 2 `test_loom_pass_matches_in_process_pass` / `_reject_matches_`; Task 3 `test_compiled_flow_hard_phase_matches_in_process_map` | ✓ |
+| §11 success #3 no regression: gate behavior identical pre/post | Contract tests + in-process path untouched (flag default leaves it active in CI) | ✓ |
+| §11 success #6 loom is archetype-agnostic | Task 5 emits a generic flow def; loom branches only on `gate`/`hitl` (Plan B I6) — garden never hands loom an archetype name | ✓ |
+
+**Explicitly out of scope (stated up front, intentional gaps):** the CONTRACT phase (deleting the `→ loom` rows in §6 — a later plan); the headless daemon (D3, §9). These are NOT covered here by design — the cutover leaves the in-process code in place behind the shim for trivial rollback. No unintended gap.
+
+**2. Placeholder scan** — No `TBD`/`TODO`/"add error handling"/"similar to Task N". Every code step shows complete, runnable code; every run step shows the exact `python3 -m pytest …` command + expected pass/fail. The four implementer notes (Task 1 `allow_npx` boundary, Task 2 `verifier_spec` deferral, Task 3 read-only-parity rationale, Task 5 `import os` + single-source-of-truth import) are concrete clarifications, not deferred work. The Task 3↔5 sequencing dependency is called out explicitly (the parity subtests go green after Task 5). ✓
+
+**3. Type consistency** —
+- `_loom.resolve_loom() -> list[str] | None` is consumed identically by `vault_gate.resolve_vault`'s loom head (returns the `command` array) and `_loom.use_loom`. ✓
+- `_loom.run_json(args, *, timeout, project_dir, _run) -> {exit_code, json, stdout, stderr, error}` — every caller (resolve head, gate head) reads `out["error"]` then `out["json"]`. ✓
+- `cross_check`'s return shape `{available, overall, exit_code, claims, mode, contract_version, detail, raw}` is produced identically by the in-process body (lines 204–213) and the loom head's mapping; `gate_satisfied` reads `available` + `overall` from both. ✓
+- `compile_flow(archetype, *, flow_id, catalog=None) -> dict` with phase dicts `{name, gate, hitl, produces}` — consumed by Task 3's parity test (`p["name"]`, `p["hitl"]`) and matches Plan B's flow-def field semantics (`gate`: `null`|`"produces:<id>"`; `hitl`: `"hard:*"`|else) exactly. ✓
+- `_HARD_GATE_PHASES` is imported by `flow_compiler` from `phase_manager` (single source of truth) and asserted-against in Task 3's contract test — the compiler and the phase manager agree by construction. ✓
+- `cutover_mode() -> str ∈ {auto,on,off}` and `use_loom() -> bool` consistent across `_loom`, the two gate/resolve heads, and the phase-manager mirror. ✓
+
+**One self-review fix applied inline:** Task 3's contract test depends on Task 5's `flow_compiler`; rather than reorder (which would put the highest-risk surface's safety net after its shim), the plan keeps the spec's `resolve→gate→flow` order and explicitly flags that two of Task 3's subtests go green only after Task 5, with the in-process-authority subtest passing immediately. This keeps the cutover ordering faithful to §7 while being honest about the cross-task test dependency.
+
+---
+
+## Ambiguities resolved (and how)
+
+1. **How does garden invoke the loom CLI cross-platform?** Garden already uses `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh"` for Python and `npx <peer>` for peers. Resolution: `scripts/_loom.py` mirrors `vault_gate.resolve_vault`'s ladder verbatim — `WICKED_LOOM_BIN` (empty = kill-switch) → `tool_preferences.wicked-loom` in `config.json` → `wicked-loom` on `PATH` → `node_modules/.bin/wicked-loom` → `npx --yes wicked-loom`. A `.mjs`/`.js` override is invoked via `node` (same `_argv_for` rule). Argv lists, `shutil.which`, no shell — cross-platform by construction.
+
+2. **The loom CLI surface targeted.** The shipped loom repo at `~/Projects/wicked-loom` is at **0.1.0 (compose only)** — it ships `resolve`/`doctor`/`compose`. The `gate` and `flow` surfaces are Plan B (conduct), landing as **0.2.0**. Resolution: Task 1 (`resolve`) works against 0.1.0; Tasks 2–3 (`gate`/`flow`) require 0.2.0. The plan pins `^0.2.0` and the end-to-end smoke (Task 6 Step 2) is SKIPPED-with-note if 0.2.0 is not yet published — the injected-runner contract tests prove parity without it. Execution Handoff states conduct must be published first.
+
+3. **§3.1 flow-def `hitl` is per-phase, but the catalog's `hitl` is archetype-level.** The catalog gives one `hitl` string per archetype (e.g. `migrate` → `hard:cutover-gate`) and names hard-gate phases only in `phase_manager._HARD_GATE_PHASES`. Resolution (the compiler's translation rule): every phase defaults to `hitl: "none"`; the archetype's discipline is attached to its gate phase — the hard-gate phase from `_HARD_GATE_PHASES` when present, else the last phase — verbatim. The compiler imports `_HARD_GATE_PHASES` from `phase_manager` so the two engines agree by construction (asserted by Task 3's parity contract).
+
+4. **Which phase carries the `gate`?** The catalog lists `produces` at the archetype level, not per phase. Resolution: the gate phase (above) carries `gate: "produces:<first-produces-id>"`; gateless archetypes (`hitl` ∈ {none, continuous}: triage, explore) get `gate: null` everywhere. This matches Plan B's flow-def semantics (`null` → advance freely; `produces:<id>` → re-derive that contract).
+
+5. **Does the `flow` cutover replace `phase_manager`'s storage?** No — that would be a high-risk storage migration, and §7 contracts (deletes) are the *next* phase. Resolution: the `flow` cutover is a **read-only parity mirror** — `approve_phase` cross-checks loom's park-at-hard-gate decision against `_HARD_GATE_PHASES` and emits `wicked.loom.parity_mismatch` on disagreement, but the in-process guard stays authoritative. This surfaces drift in production before the contract phase moves storage onto `loom flow`.
+
+6. **How is the gate fail-closed posture preserved across the shim?** Both paths fail closed. The loom `gate` returns `gate: "unavailable"` when the vault is unresolvable behind it → mapped to `available: False` → `gate_satisfied` returns the unavailable verdict. If loom *itself* is unreachable in `auto` mode, the head falls through to the in-process `cross_check`, which fails closed on a missing vault exactly as today. A loom error never invents a PASS (I2), proven by `test_gate_fails_closed_when_loom_errors_and_vault_absent`.
+
+7. **`vault_available()` must not be corrupted by loom's npx fallback.** `vault_available()` calls `resolve_vault(allow_npx=False)` to detect a *concrete* install. Loom's `resolve` would report the npx fallback as resolvable. Resolution: the loom head in `resolve_vault` is guarded by `allow_npx` — the concrete-install probe stays in-process, preserving the exact "installed" signal setup and bootstrap rely on.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-06-08-wicked-loom-cutover.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks. REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`. Note the Task 3 ↔ Task 5 dependency: Task 3's two parity subtests go green only after Task 5 ships the compiler — keep Task 3 open and re-run its full file at the end of Task 5.
+2. **Inline Execution** — execute in this session with checkpoints. REQUIRED SUB-SKILL: `superpowers:executing-plans`.
+
+Notes for the executor:
+- Execution happens in **wicked-garden** (`~/Projects/wicked-garden`), editing existing files. The in-process runtime code is **left in place behind the shim** — do NOT delete it; that is the contract phase.
+- **Prerequisite for Tasks 2–3:** `wicked-loom@0.2.0` (the conduct surface — `gate`, `flow`) must be published and reachable via `npx wicked-loom`. Plan B (`docs/plans/2026-06-08-wicked-loom-conduct.md`) is its deliverable. Task 1 (`resolve`) works against the already-shipped 0.1.0. The contract tests are hermetic (loom subprocess injected) and prove parity without a published loom; only the Task 6 end-to-end smoke needs the real CLI.
+- Garden imports nothing from loom's Python — it shells `npx wicked-loom` via `scripts/_loom.py`. Loom stays a sibling primitive.
+- Rollback during transition is a single env var: `WICKED_LOOM_CUTOVER=off` runs every surface in-process. No code revert needed.
+- The CONTRACT phase (deleting the `→ loom` rows in spec §6, re-measuring footprint, absorbing #843) is the **next** plan — run it only after this cutover is proven in production.
+
+**Which approach?**

--- a/docs/plans/2026-06-08-wicked-loom-expand-compose.md
+++ b/docs/plans/2026-06-08-wicked-loom-expand-compose.md
@@ -1,0 +1,843 @@
+# wicked-loom — Expand Phase, Plan A (compose skeleton) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the `wicked-loom` standalone package with its `compose` surface — peer manifest, the runtime resolution ladder, version-check, and install orchestration — publishable as `wicked-loom@0.1.0` and runnable as `npx wicked-loom`, with garden untouched.
+
+**Architecture:** An **npm package** whose `bin` is a thin Node shim (`bin/loom.mjs`) that execs `python3` on a bundled Python module (`python/loom/`). The Python core holds all logic (CLI dispatch + compose). This matches garden's existing `npx wicked-*` consumption + resolution ladder while reusing garden's Python resolver code. **Compose only** — gate/flow/conduct is Plan B (do not build it here; YAGNI).
+
+**Tech Stack:** Python 3.9+ (stdlib only — no third-party deps, mirroring garden's hook discipline), `pytest` for tests, a ~30-line Node ESM shim, `npm` packaging.
+
+**Decisions locked for this plan (override in review):**
+- Distribution: npm package + Node bin shim → bundled Python. (Alt: pip/pipx.)
+- Scope: compose surface only — `loom resolve`, `loom doctor`, `loom compose install`. Conduct = Plan B.
+- Target repo dir for execution: `~/Projects/wicked-loom` (a NEW git repo, sibling to wicked-garden). Adjust paths if you place it elsewhere.
+
+**Source material to port (read these in wicked-garden before Task 3+):**
+- `scripts/_integration_resolver.py`, `scripts/_capability_resolver.py` — the resolution ladder + kill-switch.
+- `scripts/qe/vault_gate.py` (the `_resolve_vault` portion only) — the `WICKED_VAULT_BIN → config → PATH → node_modules → npx` ladder, verbatim pattern.
+- `docs/required-peers.md` + `.claude-plugin/plugin.json` — the peer set, version pins (`testing ^0.3`, `vault ^0.3`, `brain ^0.14`, `bus ^2.0`) and install commands.
+
+**Bulletproof standards:** R1–R6 (no dead code, no bare panics, no magic values, no swallowed errors, no unbounded ops, no god functions) and T1–T6 (determinism, no sleep-based sync, isolation, single-assertion focus, descriptive names, provenance). The resolution ladder must be deterministic and fully mockable — never hit the network or real `npx` in a unit test.
+
+---
+
+## File Structure
+
+```
+wicked-loom/
+├── package.json                 # npm metadata + bin: { "loom": "bin/loom.mjs" }
+├── bin/loom.mjs                 # Node ESM shim → spawns python3 on python/loom
+├── python/loom/
+│   ├── __init__.py              # version constant
+│   ├── __main__.py              # `python3 -m loom` entry → cli.main(argv)
+│   ├── cli.py                   # arg dispatch: resolve | doctor | compose
+│   ├── manifest.py              # Peer dataclass + PEERS registry (the peer set)
+│   ├── resolve.py               # the runtime resolution ladder + kill-switch
+│   └── compose.py               # version-check + install orchestration
+├── tests/
+│   ├── test_manifest.py
+│   ├── test_resolve.py
+│   ├── test_compose.py
+│   └── test_cli.py
+├── .gitignore
+└── README.md
+```
+
+Responsibilities: `manifest` = *what the peers are* (data). `resolve` = *find a peer's runnable command* (the ladder). `compose` = *check versions + install* (actions, built on resolve+manifest). `cli` = *argument dispatch only* (no logic). `bin/loom.mjs` = *launch python3* (no logic). One responsibility per file; `cli` and the shim stay logic-free so the Python modules are unit-testable without a process boundary.
+
+---
+
+## Task 1: Repo + package skeleton
+
+**Files:**
+- Create: `~/Projects/wicked-loom/package.json`
+- Create: `~/Projects/wicked-loom/.gitignore`
+- Create: `~/Projects/wicked-loom/python/loom/__init__.py`
+
+- [ ] **Step 1: Init the repo**
+
+```bash
+mkdir -p ~/Projects/wicked-loom/python/loom ~/Projects/wicked-loom/bin ~/Projects/wicked-loom/tests
+cd ~/Projects/wicked-loom && git init
+```
+
+- [ ] **Step 2: Write `package.json`**
+
+```json
+{
+  "name": "wicked-loom",
+  "version": "0.1.0",
+  "description": "Local-first orchestration runtime for agent ecosystems: resolves, version-checks, and installs the wicked-* peer set (compose). Conduct (gate/flow) ships separately.",
+  "bin": { "loom": "bin/loom.mjs" },
+  "files": ["bin/", "python/", "README.md"],
+  "type": "module",
+  "engines": { "node": ">=18" },
+  "license": "MIT",
+  "repository": "https://github.com/mikeparcewski/wicked-loom",
+  "keywords": ["orchestration", "agents", "local-first", "compose", "wicked"]
+}
+```
+
+- [ ] **Step 3: Write `.gitignore`**
+
+```
+__pycache__/
+*.pyc
+node_modules/
+.pytest_cache/
+```
+
+- [ ] **Step 4: Write `python/loom/__init__.py`**
+
+```python
+"""wicked-loom — orchestration runtime (compose surface)."""
+
+__version__ = "0.1.0"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add package.json .gitignore python/loom/__init__.py
+git commit -m "chore: wicked-loom package skeleton"
+```
+
+---
+
+## Task 2: Node bin shim (launch python3)
+
+**Files:**
+- Create: `~/Projects/wicked-loom/bin/loom.mjs`
+- Test: `~/Projects/wicked-loom/tests/test_cli.py` (the shim is smoke-tested via the CLI task; here we only assert it exists + is wired)
+
+- [ ] **Step 1: Write the shim**
+
+```javascript
+#!/usr/bin/env node
+// Thin launcher: find python3 and exec `python3 -m loom <args>` with python/ on PYTHONPATH.
+// All logic lives in the Python module; this file only bridges npx → python3.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pyRoot = join(here, "..", "python");
+
+function findPython() {
+  for (const cand of ["python3", "python", "py"]) {
+    const r = spawnSync(cand, ["--version"], { stdio: "ignore" });
+    if (r.status === 0) return cand;
+  }
+  return null;
+}
+
+const python = findPython();
+if (!python) {
+  console.error("[wicked-loom] python3 is required but was not found on PATH.");
+  process.exit(127);
+}
+
+const env = { ...process.env, PYTHONPATH: pyRoot + (process.env.PYTHONPATH ? `:${process.env.PYTHONPATH}` : "") };
+const res = spawnSync(python, ["-m", "loom", ...process.argv.slice(2)], { stdio: "inherit", env });
+process.exit(res.status === null ? 1 : res.status);
+```
+
+- [ ] **Step 2: Make it executable + smoke it (will fail until `__main__` exists)**
+
+Run: `chmod +x ~/Projects/wicked-loom/bin/loom.mjs && node ~/Projects/wicked-loom/bin/loom.mjs --help`
+Expected: a Python error (`No module named loom.__main__`) — proves the shim finds python3 and dispatches. (Green after Task 6.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add bin/loom.mjs
+git commit -m "feat: node bin shim launches bundled python"
+```
+
+---
+
+## Task 3: Peer manifest
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/manifest.py`
+- Test: `~/Projects/wicked-loom/tests/test_manifest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from loom import manifest
+
+
+def test_known_peers_present():
+    assert set(manifest.PEERS) == {"vault", "testing", "brain", "bus"}
+
+
+def test_each_peer_has_required_fields():
+    for name, peer in manifest.PEERS.items():
+        assert peer.name == name
+        assert peer.npm_package.startswith("wicked-")
+        assert peer.env_var.startswith("WICKED_") and peer.env_var.endswith("_BIN")
+        assert peer.version_pin  # non-empty
+        assert isinstance(peer.install_cmd, list) and peer.install_cmd
+        assert isinstance(peer.probe_cmd, list) and peer.probe_cmd
+
+
+def test_vault_pins_match_garden():
+    assert manifest.PEERS["vault"].version_pin == "0.3"
+    assert manifest.PEERS["vault"].env_var == "WICKED_VAULT_BIN"
+
+
+def test_get_unknown_peer_returns_none():
+    assert manifest.get("nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_manifest.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.manifest'`
+
+- [ ] **Step 3: Write `manifest.py`**
+
+```python
+"""manifest.py — the wicked-* peer set: what each peer is and how to reach it.
+
+Source of truth ported from wicked-garden docs/required-peers.md + plugin.json.
+Version pins are the MAJOR.MINOR floor (the `^x.y` in plugin.json), compared by
+compose.py. Install commands are headless (npm/npx) — the `/plugin install`
+path is CC-UX sugar, not the only route.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Peer:
+    name: str
+    npm_package: str
+    env_var: str           # runtime override env var, e.g. WICKED_VAULT_BIN
+    version_pin: str        # MAJOR.MINOR floor, e.g. "0.3"
+    install_cmd: list[str]  # headless install command
+    probe_cmd: list[str]    # command to print the installed version
+
+
+PEERS: dict[str, Peer] = {
+    "vault": Peer(
+        name="vault",
+        npm_package="wicked-vault",
+        env_var="WICKED_VAULT_BIN",
+        version_pin="0.3",
+        install_cmd=["npx", "wicked-vault-install"],
+        probe_cmd=["wicked-vault", "--version"],
+    ),
+    "testing": Peer(
+        name="testing",
+        npm_package="wicked-testing",
+        env_var="WICKED_TESTING_BIN",
+        version_pin="0.3",
+        install_cmd=["npx", "wicked-testing", "install"],
+        probe_cmd=["wicked-testing", "--version"],
+    ),
+    "brain": Peer(
+        name="brain",
+        npm_package="wicked-brain",
+        env_var="WICKED_BRAIN_BIN",
+        version_pin="0.14",
+        install_cmd=["npm", "install", "-g", "wicked-brain@latest"],
+        probe_cmd=["wicked-brain-server", "--version"],
+    ),
+    "bus": Peer(
+        name="bus",
+        npm_package="wicked-bus",
+        env_var="WICKED_BUS_BIN",
+        version_pin="2.0",
+        install_cmd=["npm", "install", "-g", "wicked-bus@latest"],
+        probe_cmd=["wicked-bus", "--version"],
+    ),
+}
+
+
+def get(name: str) -> "Peer | None":
+    """Return the Peer for ``name`` or None if unknown."""
+    return PEERS.get(name)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_manifest.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/manifest.py tests/test_manifest.py
+git commit -m "feat: peer manifest (vault/testing/brain/bus)"
+```
+
+---
+
+## Task 4: Resolution ladder
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/resolve.py`
+- Test: `~/Projects/wicked-loom/tests/test_resolve.py`
+
+The ladder, ported from `vault_gate.py`: `WICKED_<PEER>_BIN` env → `PATH` (shutil.which) → `npx <package>` fallback. Empty env var (`WICKED_VAULT_BIN=""`) is the **kill-switch** → returns None. (Garden also checks a config file + node_modules; omitted in 0.1 as YAGNI — add when a consumer needs them.)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import shutil
+from unittest.mock import patch
+
+from loom import resolve
+
+
+def test_env_var_override_wins(monkeypatch):
+    monkeypatch.setenv("WICKED_VAULT_BIN", "/opt/custom/vault")
+    assert resolve.resolve("vault") == ["/opt/custom/vault"]
+
+
+def test_empty_env_var_is_killswitch(monkeypatch):
+    monkeypatch.setenv("WICKED_VAULT_BIN", "")
+    assert resolve.resolve("vault") is None
+
+
+def test_path_lookup_when_no_env(monkeypatch):
+    monkeypatch.delenv("WICKED_VAULT_BIN", raising=False)
+    with patch.object(shutil, "which", return_value="/usr/local/bin/wicked-vault"):
+        assert resolve.resolve("vault") == ["/usr/local/bin/wicked-vault"]
+
+
+def test_npx_fallback_when_not_on_path(monkeypatch):
+    monkeypatch.delenv("WICKED_VAULT_BIN", raising=False)
+    with patch.object(shutil, "which", return_value=None):
+        assert resolve.resolve("vault") == ["npx", "wicked-vault"]
+
+
+def test_unknown_peer_returns_none():
+    assert resolve.resolve("nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_resolve.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.resolve'`
+
+- [ ] **Step 3: Write `resolve.py`**
+
+```python
+"""resolve.py — the runtime resolution ladder for a peer's runnable command.
+
+Ladder (highest priority first):
+  1. WICKED_<PEER>_BIN env var — explicit override. Empty string is a
+     deliberate kill-switch (returns None, resolution short-circuits cleanly).
+  2. PATH — shutil.which(<npm_package>).
+  3. npx fallback — ["npx", "<npm_package>"].
+
+Returns a command as a list[str] (argv-ready) or None when unresolvable /
+killed / unknown peer. Pure + deterministic: no process is spawned here.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from loom import manifest
+
+
+def resolve(peer_name: str) -> "list[str] | None":
+    peer = manifest.get(peer_name)
+    if peer is None:
+        return None
+
+    if peer.env_var in os.environ:
+        override = os.environ[peer.env_var].strip()
+        if override == "":
+            return None  # kill-switch
+        return [override]
+
+    on_path = shutil.which(peer.npm_package)
+    if on_path:
+        return [on_path]
+
+    return ["npx", peer.npm_package]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_resolve.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/resolve.py tests/test_resolve.py
+git commit -m "feat: peer resolution ladder + kill-switch"
+```
+
+---
+
+## Task 5: Version-check + install orchestration
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/compose.py`
+- Test: `~/Projects/wicked-loom/tests/test_compose.py`
+
+`check_peer` resolves the peer, runs its `probe_cmd`, parses a semver-ish version, and compares MAJOR.MINOR against the pin. `install_peer` runs the headless `install_cmd`. Both return structured dicts; neither raises (R4 — surface errors as data). A subprocess runner is injected so tests never spawn real processes (T1/T3).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+from loom import compose
+
+
+def _runner(stdout="", code=0):
+    def run(cmd, timeout=None):
+        return compose.RunResult(returncode=code, stdout=stdout, stderr="")
+    return run
+
+
+def test_check_peer_satisfied_when_version_meets_pin():
+    with patch.object(compose, "resolve", return_value=["wicked-vault"]):
+        r = compose.check_peer("vault", run=_runner(stdout="wicked-vault 0.3.2\n"))
+    assert r["status"] == "ok"
+    assert r["installed"] == "0.3.2"
+    assert r["pin"] == "0.3"
+
+
+def test_check_peer_below_pin_is_drift():
+    with patch.object(compose, "resolve", return_value=["wicked-vault"]):
+        r = compose.check_peer("vault", run=_runner(stdout="0.2.9"))
+    assert r["status"] == "drift"
+
+
+def test_check_peer_unresolvable_is_missing():
+    with patch.object(compose, "resolve", return_value=None):
+        r = compose.check_peer("vault", run=_runner())
+    assert r["status"] == "missing"
+
+
+def test_check_peer_probe_failure_is_error():
+    with patch.object(compose, "resolve", return_value=["wicked-vault"]):
+        r = compose.check_peer("vault", run=_runner(code=1))
+    assert r["status"] == "error"
+
+
+def test_install_peer_runs_install_cmd_and_reports():
+    calls = []
+
+    def run(cmd, timeout=None):
+        calls.append(cmd)
+        return compose.RunResult(returncode=0, stdout="ok", stderr="")
+
+    r = compose.install_peer("vault", run=run)
+    assert calls == [["npx", "wicked-vault-install"]]
+    assert r["status"] == "installed"
+
+
+def test_install_unknown_peer_is_error():
+    r = compose.install_peer("nope", run=_runner())
+    assert r["status"] == "error"
+
+
+def test_check_all_returns_one_row_per_peer():
+    with patch.object(compose, "resolve", return_value=["x"]):
+        rows = compose.check_all(run=_runner(stdout="9.9.9"))
+    assert {row["peer"] for row in rows} == {"vault", "testing", "brain", "bus"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_compose.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.compose'`
+
+- [ ] **Step 3: Write `compose.py`**
+
+```python
+"""compose.py — version-check + install orchestration over the peer set.
+
+check_peer:  resolve → probe → parse version → compare MAJOR.MINOR to the pin.
+install_peer: run the peer's headless install command.
+check_all:   one check_peer row per known peer.
+
+Subprocess execution is injected (the ``run`` parameter) so callers (and tests)
+control side effects. Nothing here raises — failures are returned as status
+rows ("ok" | "drift" | "missing" | "error" | "installed" | "install-failed").
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Callable
+
+from loom import manifest
+from loom.resolve import resolve
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+@dataclass
+class RunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+Runner = Callable[..., RunResult]
+
+
+def _default_run(cmd: list[str], timeout: int = 30) -> RunResult:
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return RunResult(returncode=p.returncode, stdout=p.stdout, stderr=p.stderr)
+
+
+def _parse_version(text: str) -> "str | None":
+    m = _VERSION_RE.search(text or "")
+    if not m:
+        return None
+    major, minor, patch = m.group(1), m.group(2), m.group(3) or "0"
+    return f"{major}.{minor}.{patch}"
+
+
+def _meets_pin(installed: str, pin: str) -> bool:
+    iv = _parse_version(installed)
+    pv = _parse_version(pin) or pin
+    if iv is None:
+        return False
+    ip = [int(x) for x in iv.split(".")]
+    pp = [int(x) for x in (_parse_version(pin) or "0.0.0").split(".")]
+    # Compare MAJOR.MINOR floor.
+    return (ip[0], ip[1]) >= (pp[0], pp[1])
+
+
+def check_peer(name: str, run: Runner = _default_run) -> dict:
+    peer = manifest.get(name)
+    if peer is None:
+        return {"peer": name, "status": "error", "detail": "unknown peer"}
+
+    cmd = resolve(name)
+    if cmd is None:
+        return {"peer": name, "status": "missing", "pin": peer.version_pin}
+
+    try:
+        result = run(cmd[:1] + peer.probe_cmd[1:] if cmd[0] == peer.probe_cmd[0]
+                     else cmd + peer.probe_cmd[1:])
+    except Exception as e:  # noqa: BLE001 — surface as data, never crash (R4)
+        return {"peer": name, "status": "error", "detail": str(e), "pin": peer.version_pin}
+
+    if result.returncode != 0:
+        return {"peer": name, "status": "error", "detail": result.stderr.strip(),
+                "pin": peer.version_pin}
+
+    installed = _parse_version(result.stdout)
+    if installed is None:
+        return {"peer": name, "status": "error", "detail": "unparseable version",
+                "pin": peer.version_pin}
+
+    status = "ok" if _meets_pin(installed, peer.version_pin) else "drift"
+    return {"peer": name, "status": status, "installed": installed, "pin": peer.version_pin}
+
+
+def install_peer(name: str, run: Runner = _default_run) -> dict:
+    peer = manifest.get(name)
+    if peer is None:
+        return {"peer": name, "status": "error", "detail": "unknown peer"}
+    try:
+        result = run(peer.install_cmd, timeout=300)
+    except Exception as e:  # noqa: BLE001
+        return {"peer": name, "status": "install-failed", "detail": str(e)}
+    if result.returncode != 0:
+        return {"peer": name, "status": "install-failed", "detail": result.stderr.strip()}
+    return {"peer": name, "status": "installed"}
+
+
+def check_all(run: Runner = _default_run) -> list[dict]:
+    return [check_peer(name, run=run) for name in manifest.PEERS]
+```
+
+> Note for the implementer: the `check_peer` `run(...)` argument constructs the probe command from the resolved command + the probe's trailing args. Keep it simple — if `resolve` returned `["npx", "wicked-vault"]`, the probe is `["npx", "wicked-vault", "--version"]`; if it returned `["/usr/local/bin/wicked-vault"]`, the probe is `["/usr/local/bin/wicked-vault", "--version"]`. The expression above does exactly that; if it reads awkwardly, refactor to an explicit `_probe_command(cmd, peer)` helper with its own test — but keep behavior identical.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_compose.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/compose.py tests/test_compose.py
+git commit -m "feat: compose version-check + install orchestration"
+```
+
+---
+
+## Task 6: CLI dispatch + `__main__`
+
+**Files:**
+- Create: `~/Projects/wicked-loom/python/loom/cli.py`
+- Create: `~/Projects/wicked-loom/python/loom/__main__.py`
+- Test: `~/Projects/wicked-loom/tests/test_cli.py`
+
+`cli.main(argv)` dispatches `resolve <peer>`, `doctor`, `compose install [--peer X]` and prints JSON to stdout, returning an exit code. Logic stays in resolve/compose; cli only parses args + formats output (R6 — no god function).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import io
+import json
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from loom import cli
+
+
+def _run(argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        code = cli.main(argv)
+    return code, buf.getvalue()
+
+
+def test_resolve_prints_command():
+    with patch("loom.cli.resolve", return_value=["npx", "wicked-vault"]):
+        code, out = _run(["resolve", "vault"])
+    assert code == 0
+    assert json.loads(out)["command"] == ["npx", "wicked-vault"]
+
+
+def test_resolve_unresolvable_exits_nonzero():
+    with patch("loom.cli.resolve", return_value=None):
+        code, out = _run(["resolve", "vault"])
+    assert code == 1
+    assert json.loads(out)["command"] is None
+
+
+def test_doctor_prints_all_rows():
+    rows = [{"peer": "vault", "status": "ok"}]
+    with patch("loom.cli.check_all", return_value=rows):
+        code, out = _run(["doctor"])
+    assert code == 0
+    assert json.loads(out)["peers"] == rows
+
+
+def test_doctor_exits_nonzero_on_missing_peer():
+    rows = [{"peer": "vault", "status": "missing"}]
+    with patch("loom.cli.check_all", return_value=rows):
+        code, _ = _run(["doctor"])
+    assert code == 1
+
+
+def test_compose_install_targets_one_peer():
+    with patch("loom.cli.install_peer", return_value={"peer": "vault", "status": "installed"}) as m:
+        code, out = _run(["compose", "install", "--peer", "vault"])
+    assert code == 0
+    m.assert_called_once_with("vault")
+    assert json.loads(out)["results"][0]["status"] == "installed"
+
+
+def test_unknown_command_exits_two():
+    code, _ = _run(["frobnicate"])
+    assert code == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_cli.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'loom.cli'`
+
+- [ ] **Step 3: Write `cli.py`**
+
+```python
+"""cli.py — argument dispatch + JSON output for the compose surface.
+
+Commands:
+  loom resolve <peer>              -> {"peer","command"}            exit 0/1
+  loom doctor                      -> {"peers":[check rows]}        exit 0/1
+  loom compose install [--peer X]  -> {"results":[install rows]}    exit 0/1
+
+No business logic lives here — only parsing + formatting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from loom import manifest
+from loom.compose import check_all, install_peer
+from loom.resolve import resolve
+
+
+def _emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+
+
+def _cmd_resolve(args: list[str]) -> int:
+    if not args:
+        _emit({"error": "usage: loom resolve <peer>"})
+        return 2
+    cmd = resolve(args[0])
+    _emit({"peer": args[0], "command": cmd})
+    return 0 if cmd is not None else 1
+
+
+def _cmd_doctor(_args: list[str]) -> int:
+    rows = check_all()
+    _emit({"peers": rows})
+    return 0 if all(r.get("status") == "ok" for r in rows) else 1
+
+
+def _cmd_compose(args: list[str]) -> int:
+    if not args or args[0] != "install":
+        _emit({"error": "usage: loom compose install [--peer <name>]"})
+        return 2
+    target = None
+    if "--peer" in args:
+        i = args.index("--peer")
+        if i + 1 < len(args):
+            target = args[i + 1]
+    names = [target] if target else list(manifest.PEERS)
+    results = [install_peer(n) for n in names]
+    _emit({"results": results})
+    return 0 if all(r.get("status") == "installed" for r in results) else 1
+
+
+_DISPATCH = {"resolve": _cmd_resolve, "doctor": _cmd_doctor, "compose": _cmd_compose}
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] in ("-h", "--help"):
+        _emit({"commands": list(_DISPATCH)})
+        return 0
+    handler = _DISPATCH.get(argv[0])
+    if handler is None:
+        _emit({"error": f"unknown command: {argv[0]}", "commands": list(_DISPATCH)})
+        return 2
+    return handler(argv[1:])
+```
+
+- [ ] **Step 4: Write `__main__.py`**
+
+```python
+"""`python3 -m loom` entry point."""
+
+import sys
+
+from loom.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest tests/test_cli.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 6: Smoke the full path through the Node shim**
+
+Run: `cd ~/Projects/wicked-loom && node bin/loom.mjs doctor`
+Expected: a JSON line `{"peers": [...]}` with one row per peer (statuses depend on what's installed locally; the point is the shim → python3 → cli path works end-to-end).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add python/loom/cli.py python/loom/__main__.py tests/test_cli.py
+git commit -m "feat: compose CLI (resolve/doctor/compose install) + __main__"
+```
+
+---
+
+## Task 7: README + full suite + publish-readiness
+
+**Files:**
+- Create: `~/Projects/wicked-loom/README.md`
+
+- [ ] **Step 1: Write `README.md`**
+
+```markdown
+# wicked-loom
+
+Local-first orchestration runtime for agent ecosystems. **0.1 ships the
+`compose` surface** — it resolves, version-checks, and installs the `wicked-*`
+peer set. Conduct (gate/flow) ships separately.
+
+## Use
+
+    npx wicked-loom doctor                      # check every peer
+    npx wicked-loom resolve vault               # print vault's runnable command
+    npx wicked-loom compose install --peer bus  # install one peer
+
+Requires `python3` on PATH (the npm package launches a bundled Python core).
+
+## Resolution ladder
+
+For each peer: `WICKED_<PEER>_BIN` env (empty = kill-switch) → `PATH` →
+`npx <package>`.
+
+## Peers
+
+vault · testing · brain · bus — pins mirror wicked-garden's `required-peers`.
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `cd ~/Projects/wicked-loom && PYTHONPATH=python python3 -m pytest -v`
+Expected: PASS — 22 tests (4 manifest + 5 resolve + 7 compose + 6 cli).
+
+- [ ] **Step 3: Dry-run the npm package contents**
+
+Run: `cd ~/Projects/wicked-loom && npm pack --dry-run`
+Expected: the tarball lists `bin/`, `python/`, `README.md`, `package.json` — and NOT `tests/` or `__pycache__/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Projects/wicked-loom
+git add README.md
+git commit -m "docs: README + publish-readiness"
+```
+
+- [ ] **Step 5: STOP — publish is a human-gated outward action**
+
+Do **not** run `npm publish` autonomously. Report to the operator that `wicked-loom@0.1.0` is publish-ready (suite green, `npm pack` clean) and let them publish + create the GitHub repo. Garden integration (the resolve cutover) is a later plan.
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan A scope = compose):**
+- COMPOSE: declare (manifest, Task 3) · resolve ladder + kill-switch (Task 4) · version-check + install (Task 5) · CLI surface `resolve`/`doctor`/`compose install` (Task 6). ✓ matches spec §4.1 / §4.3.
+- D5 (npm + python via subprocess): package.json bin → Node shim → python3 (Tasks 1–2, 6). ✓
+- Standalone-usable by a non-garden consumer (success criterion #1): `npx wicked-loom doctor` works with zero garden present. ✓
+- **Deferred (correctly out of scope for Plan A):** conduct/gate/flow/park (§4.2), bus event contract (§4.3 #2/#3), the archetype→flow seam (§3.1), garden cutover (§7 step 2). These belong to Plan B + the cutover plan. No gap — intentional decomposition.
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; the one prose note (Task 5 probe-command construction) shows the exact expression + the refactor option with identical behavior. ✓
+
+**Type consistency:** `Peer` fields (`name`, `npm_package`, `env_var`, `version_pin`, `install_cmd`, `probe_cmd`) are used identically in manifest/resolve/compose/cli. `resolve()` returns `list[str] | None` everywhere. `RunResult(returncode, stdout, stderr)` consistent across compose + tests. `check_peer`/`install_peer`/`check_all` signatures match their cli call sites. Status vocabulary (`ok`/`drift`/`missing`/`error`/`installed`/`install-failed`) consistent. ✓
+
+---
+
+## Execution Handoff
+
+Plan complete. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks.
+2. **Inline Execution** — execute in this session with checkpoints.
+
+Note: execution happens in a **new repo** (`~/Projects/wicked-loom`), not in wicked-garden.

--- a/docs/specs/2026-06-08-wicked-loom-extraction.md
+++ b/docs/specs/2026-06-08-wicked-loom-extraction.md
@@ -1,0 +1,223 @@
+# North-Star Spec — `wicked-loom`: extracting the orchestration runtime
+
+- **Date:** 2026-06-08
+- **Status:** Design (approved shape; pending written-spec review → implementation plan)
+- **Author:** brainstormed with Mike Parcewski
+- **Topic:** Reshape wicked-garden from a heavy library into a thin orchestrator by extracting its runtime/wiring into a new standalone peer, `wicked-loom`.
+- **Related:** ETHOS.md, docs/required-peers.md, issues #887 #843 #878 #842
+
+---
+
+## 1. Context & motivation
+
+`wicked-garden` is published at **v12.2.0** on a marketplace with real users. It has grown heavy: **~127k lines** across **71 skills · 93 commands · 55 agents · 131 Python scripts**. A large share of that weight is not domain expertise or archetype intelligence — it is *runtime plumbing*: peer detection/install/resolution, bus wiring, gate execution, and phase-loop mechanics. That plumbing was even formalized once as a `daemon/` (typed bus subscribers + projector + council, #592/#624) and then **deliberately deleted in v11** (commit `d205fc3`, "daemon cleanup") for being too heavy in-tree. The plumbing keeps wanting to exist, and keeps not belonging in garden.
+
+Meanwhile the `wicked-*` ecosystem already decomposes cleanly by concern, each concern a standalone primitive:
+
+| Primitive | Concern |
+|---|---|
+| `wicked-bus` | messaging substrate (how components talk) |
+| `wicked-brain` | memory / knowledge |
+| `wicked-vault` | evidence / verification (re-derive, never trust a claim) |
+| `wicked-testing` | QE execution (plan → run → judge) |
+| `wicked-understanding` | per-repo knowledge + **verifier spec** |
+
+`wicked-garden` uniquely owns three things none of the primitives provide: the **archetype engine** (classify work-shape, steer phases), the **domain catalog** (skills + agents), and the **compiler** (stamp a self-contained gate into any repo). Everything else garden does today is runtime that *should be a primitive too* — and isn't. That missing primitive is `wicked-loom`.
+
+**Thesis:** garden should *drive* a runtime, not *be* one. Extract the runtime into `wicked-loom`; garden becomes "archetype engine + domain catalog + compiler, running on loom."
+
+---
+
+## 2. Decisions (locked)
+
+These were settled during brainstorming and are the spine of this spec.
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **North star = Level 1.** Garden keeps the archetype engine, domain catalog, and compiler. Extract concerns *gate/phase + autonomy substrate* and *peer-wiring/adapters* into one standalone. | L1 is destination *and* first increment — biggest clarity win, smallest blast radius, and it names the missing component precisely. L2 (unbundle the domain catalog) and L3 (gut the archetype engine) are explicitly **out of scope** — L3 would erase garden's identity. |
+| D2 | **One new primitive, not two.** `wicked-loom`, containing a `compose` module and a `conduct` module. | Honors the "a missing component" (singular) framing and YAGNI — do not spec a separate `compose` primitive until a *second* consumer needs it. |
+| D3 | **Hybrid autonomy, synchronous-core-first.** The in-session synchronous runtime is the L1 deliverable. Headless/daemon is **spec'd now, built later**, with the park-at-hard-gate contract baked into the interface from day one. | The deleted daemon shows headless was too heavy as a default; garden's HITL discipline (hard gates require a human) collides with unattended autonomy unless bounded. Baking the contract in now prevents a later repaint. |
+| D4 | **Hybrid wiring.** Bus-as-spine for coordination/audit/knowledge/parks (async); direct synchronous resolution for re-derivation gates. **An event never satisfies a gate.** | Vault re-derivation must be blocking + in-line — a gate cannot return "pass" off a stale event. The bus carries everything that *isn't* a gate verdict. |
+| D5 | **Language-neutral standalone, Python impl, CLI + (deferred) daemon surface, consumed by garden via subprocess.** | Reuses nearly all existing Python code (daemon, `qe/`, resolvers) while making loom a true sibling primitive any stack can shell to — identical to how garden already consumes `npx wicked-vault`. Keeps garden's plugin packaging decoupled from loom's Python env. |
+| D6 | **Name: `wicked-loom`.** | A loom is the frame that wires threads together into cloth — the literal metaphor for "only wiring them together." |
+
+---
+
+## 3. Target architecture
+
+```
+                       ┌───────────────────────────────────────────┐
+ prompt ─────────────► │            wicked-garden (plugin)          │
+                       │  • archetype engine (classify + steer)     │   KEEPS
+                       │  • domain catalog (71 skills / 55 agents)  │
+                       │  • compiler (emit stamped gate into repos) │
+                       │  compiles archetype → FLOW DEFINITION;     │
+                       │  shells to loom for compose / gate / flow  │
+                       └───────────────┬───────────────────────────┘
+                          subprocess (CLI, sync)  +  bus events (async)
+                                       ▼
+                       ┌───────────────────────────────────────────┐
+                       │        wicked-loom  (NEW standalone)       │   TAKES
+                       │  COMPOSE: declare → install → version →    │
+                       │           resolve (the WICKED_*_BIN ladder)│
+                       │  CONDUCT: run any FLOW DEFINITION —        │
+                       │           phase-loop · gate exec · park-   │
+                       │           at-hard-gate · bus-consumer+proj │
+                       └──┬──────────┬──────────┬──────────┬─────────┘
+            direct/sync ──┘          │          │          └── bus/async
+                       ▼             ▼          ▼             ▼
+                  wicked-vault  wicked-testing  wicked-brain  wicked-bus
+                  (re-derive)   (QE exec)       (knowledge)   (spine)
+                              (+ wicked-understanding — verifier spec, optional/fail-soft)
+```
+
+### 3.1 The load-bearing abstraction: loom is archetype-agnostic
+
+Garden does **not** hand loom an archetype name. Garden's archetype engine compiles a catalog entry into a generic, declarative **flow definition**:
+
+```jsonc
+// flow definition — garden produces it, loom executes it
+{
+  "flow_id": "…",
+  "phases": [
+    { "name": "plan",      "gate": null,                       "produces": [...] },
+    { "name": "implement", "gate": null,                       "produces": [...] },
+    { "name": "test",      "gate": "produces:test-report",     "hitl": "discrete:review" },
+    { "name": "review",    "gate": "produces:verdict",         "hitl": "hard:final-verdict" }
+  ],
+  "peers_required": ["vault", "testing"],
+  "verifier_spec_ref": "…optional wicked-understanding verify.json…"
+}
+```
+
+Loom knows nothing about "build" vs "migrate" vs "incident." It runs *any* flow definition: advance phase → if the phase has a gate, execute it (sync vault re-derive) → if the gate is `hard:*`, park and emit `needs-human` → else continue. This is the seam that makes loom a genuine reusable primitive (any agent system can author flow definitions) rather than "garden's engine in a sidecar repo." Garden remains the archetype-to-flow compiler; loom is the generic flow runtime.
+
+### 3.2 Responsibility split
+
+| Concern | Owner | Notes |
+|---|---|---|
+| Archetype catalog, detector, steering hook, playbooks | **garden** | `archetypes_v11.py`, `prompt_submit.py`, `commands/archetype/`, `skills/archetype/refs/`, `archetypes.json` |
+| Domain catalog (skills/agents) | **garden** | unchanged |
+| Compiler (stamped-gate emitter) | **garden** | stays; see §7 synergy |
+| Archetype → flow-definition compilation | **garden** | new thin layer; the handoff contract to loom |
+| Peer install + version-check + resolution (compose) | **loom** | cross-cutting; not archetype-specific |
+| Gate execution (vault re-derive) | **loom** | the honest-evidence engine |
+| Flow/phase mechanics + state + park-at-gate | **loom** | generic flow runtime |
+| Bus consumer + projector (headless) | **loom** | resurrected daemon, deferred-on by default |
+
+---
+
+## 4. `wicked-loom` component spec
+
+One standalone, two modules, three surfaces.
+
+### 4.1 COMPOSE module
+Owns the peer lifecycle. Salvaged from garden's `bootstrap.py` (peer portion), `_integration_resolver.py`, `_capability_resolver.py`, `_capability_registry.py`, and `required-peers` logic.
+
+- **Declare** — a peer manifest (peer name, npm package, pinned `^x.y`, resolution env var, optional/required).
+- **Install** — orchestrate installs across mechanisms. **All four current peers are on npm**, so install runs headless via `npm`/`npx` (`npx wicked-testing install`, `npx wicked-vault-install`, `npm i wicked-brain@0.14`, `npm i wicked-bus@2`). The Claude Code `/plugin install` path is UX sugar, *not* the only route — loom never depends on a live CC session to install.
+- **Version-check** — verify resolved versions satisfy the pins; report drift.
+- **Resolve** — own the runtime resolution ladder (`WICKED_<PEER>_BIN` → config → `PATH` → `node_modules/.bin` → `npx`), including the `WICKED_VAULT_BIN=""` kill-switch.
+
+### 4.2 CONDUCT module
+Runs flow definitions. Salvaged from `qe/vault_gate.py`, `crew/phase_manager.py`, and the deleted `daemon/`.
+
+- **Run a flow** — advance through declared phases; persist phase state.
+- **Execute a gate** — *synchronous, in-line* vault re-derivation: re-hash recorded evidence + re-run the verifier via `cross-check`. Missing vault → `gate: "unavailable"`, **fail-closed**, never a vacuous pass. Hard gates additionally require an independent attestation (`--with-attestations`). If a `verifier_spec_ref` is present, read it to know *what* to re-derive; if absent/stale, fall back to generic detection (fail-soft on the *spec*, never on the *gate*).
+- **Park at hard gate** — on `hard:mitigate / cutover / final-verdict`, stop the flow and emit `loom:flow:needs-human`; do not self-approve. (Contract present from day one even though headless execution is deferred.)
+- **Project** — materialize flow/phase/evidence state from bus events to disk (headless, deferred).
+
+### 4.3 Surfaces
+1. **CLI** (the L1 deliverable; garden shells to it):
+   - `loom compose install [--peer X] [--check]` · `loom resolve <peer>` · `loom doctor`
+   - `loom gate <produces> [--verifier-spec path] [--with-attestations]`
+   - `loom flow run <flow-def.json>` · `loom flow status <flow-id>` · `loom flow resume <flow-id>`
+2. **Bus-consumer / daemon** (deferred per D3): headless mode that reacts to bus events, runs soft-gated flows unattended, parks at hard gates.
+3. **Event contract** (stable, on `wicked-bus`): `loom:flow:started|phase-advanced|gate-passed|gate-failed|needs-human|completed`, `loom:compose:installed|drift-detected`.
+
+---
+
+## 5. Wiring contract & invariants
+
+- **I1 — Gates are synchronous and direct.** `loom gate` re-derives every call. **An event never satisfies a gate.**
+- **I2 — Fail-closed.** Missing vault → `unavailable`, never pass. A claimed-but-false "tests pass" is rejected.
+- **I3 — Fail-soft on the verifier spec only.** Absent/stale `wicked-understanding` verifier spec → generic detection, never a blocked or vacuous gate.
+- **I4 — Bus is the spine for everything that is not a gate verdict:** phase transitions, evidence-recorded notices, brain knowledge writes, audit, and `needs-human` parks.
+- **I5 — Autonomy never overrides a hard gate.** Headless flows park + emit at `hard:*`.
+- **I6 — Loom is archetype-agnostic.** It executes flow definitions; it does not know archetype names.
+
+---
+
+## 6. Extraction inventory (file-level, grounded)
+
+`→ loom` = moves; `STAY` = remains in garden; `PARTIAL` = split.
+
+| File | Lines | Disposition |
+|---|---:|---|
+| `hooks/scripts/bootstrap.py` | 1711 | **PARTIAL** — peer detect/install/resolve → loom compose; session-bootstrap (state init, archetype priming, brain orientation) STAYS |
+| `scripts/_integration_resolver.py` | 321 | → loom (compose) |
+| `scripts/_capability_resolver.py` | 322 | → loom (compose) |
+| `scripts/_capability_registry.py` | 226 | → loom (compose) |
+| `scripts/qe/vault_gate.py` | 348 | → loom (conduct/gate) |
+| `scripts/crew/phase_manager.py` | 614 | → loom (conduct/state) |
+| `scripts/_bus.py` | 973 | **PARTIAL** — consumer/projector role → loom; thin fire-and-forget emit (`_bus_emit.py`, 43) STAYS so any garden component can emit |
+| `scripts/_event_store.py` / `_event_log_reader.py` / `_event_schema.py` | 397 / 154 / 305 | → loom (conduct/projector) — confirm during expand phase |
+| `scripts/_wicked_testing_probe.py` / `_wicked_testing_tier1.py` | 277 / 88 | → loom (compose/resolution) |
+| `scripts/_brain_port.py` | 65 | → loom (compose/resolution) |
+| `scripts/crew/archetypes_v11.py` | 348 | **STAY** — archetype engine (garden identity) |
+| `hooks/scripts/prompt_submit.py` | 1126 | **STAY** — classification entry (archetype engine) |
+| `scripts/crew/scope_delta.py` | 264 | **STAY** — HITL scope heuristic feeds flow-definition compilation |
+| `scripts/compiler/**` | 2312 | **STAY** — see §7 synergy |
+
+Exact partial boundaries (esp. `bootstrap.py`, `_bus.py`, the `_event_*` trio) are confirmed empirically during the **expand** phase, not asserted here.
+
+---
+
+## 7. Migration plan — strangler (expand → cutover → contract)
+
+Garden is published with users; this is a migration, not a rewrite. Each step is independently verifiable via vault.
+
+1. **Expand.** Stand up the `wicked-loom` repo. *Copy* (don't move) compose + conduct code; ship the CLI; publish to npm with a `^0.1` pin. Garden is byte-for-byte unchanged and keeps working. Loom is usable standalone by other consumers immediately.
+2. **Cutover (strangler).** Garden's `scripts/` shims start shelling to `loom` instead of running in-process, **one surface at a time**: `resolve` → `gate` → `flow`. Each cutover ships behind the existing fail-soft posture (if loom unresolvable, the old in-process path or graceful degradation still applies during transition). Add `wicked-loom` as a **5th peer** in `docs/required-peers.md` (required at install, resilient at runtime — same stance as the other four). Introduce the archetype → flow-definition compiler in garden.
+3. **Contract.** Delete the now-dead in-garden runtime code (the `→ loom` rows above). Re-measure garden's footprint; slim whatever genuinely remains (this absorbs #843).
+
+**Backward compat:** during expand+cutover, no user-visible behavior change. The contract phase is a major version bump for garden (v13) with a migration note: "wicked-loom is now a required peer; `/wicked-garden:setup` installs it."
+
+---
+
+## 8. The four open issues, re-triaged against the north star
+
+| Issue | Disposition |
+|---|---|
+| **#887** consume wicked-understanding | **Absorbed into loom.** Understanding's `verify.json` is the `verifier_spec_ref` that `loom gate` reads to know *what* to re-derive. Optional/fail-soft peer (I3), exactly as the author proposed. Resolve by speccing it into loom, not as a standalone garden change. Open sub-item: confirm the `verify.json` schema loom's gate consumes (tracked in §9). |
+| **#843** slim `commands/*` | **Largely dissolved** by the contract phase — much weight is runtime plumbing that leaves. Re-measure after contract; slim the genuine remainder. |
+| **#878** cwd-leak PreToolUse hook | **Tactical, do now.** Independent of the rethink — worktree-safety bug. Not blocked by loom. |
+| **#842** SessionEnd dogfood (v9.2.15) | **Stale** (we're at v12.2). Verify-or-close; do not carry v9 dogfooding forward. |
+
+---
+
+## 9. Open questions / deferred
+
+- **D-headless:** the daemon/bus-consumer execution mode is spec'd (§4.2/§4.3) but **not built** in L1. The contract (park-at-hard-gate, event names) is fixed now to avoid a repaint.
+- **Compiler↔loom synergy:** `loom gate` and the compiler's stamped gate are the same logic at different lifetimes (live runtime vs. stamped file). L1 leaves the compiler as-is (self-contained, resolves vault directly via npx). A later increment *may* have the compiler emit a thin shim over loom — flagged, not scoped.
+- **compose-as-its-own-primitive:** deferred per D2 (YAGNI). Revisit only if a non-garden consumer needs the composer.
+- **`verify.json` schema:** the structured sidecar wicked-understanding would emit (issue #887, rec #2) needs its shape confirmed against what `loom gate` consumes. Coordinate cross-repo before building.
+- **CLI verb naming:** `compose`/`gate`/`flow` are provisional.
+
+---
+
+## 10. Error handling & testing posture
+
+- **Error handling:** all peer interaction is fail-soft *except gates* (fail-closed, I2). Loom unresolvable → garden degrades gracefully during transition; a gate with no vault returns `unavailable`. The `WICKED_VAULT_BIN=""` kill-switch and the loom resolution ladder are preserved verbatim.
+- **Testing:** loom ships with its own suite (compose resolution ladder, gate fail-closed behavior, flow phase advance + park-at-hard-gate). Garden adds **contract tests** asserting each cutover shim produces identical results to the in-process path it replaces (the strangler's safety net). The emitted-compiler-gate AST test (stdlib-only, imports nothing from the garden) is unaffected.
+
+---
+
+## 11. Success criteria for L1
+
+1. `wicked-loom` exists as a standalone npm-published primitive with a working CLI, usable by a non-garden consumer.
+2. Garden shells to loom for `resolve`, `gate`, and `flow`; the in-process runtime code is deleted.
+3. No regression: every archetype's gate behavior is identical pre/post cutover (proven by contract tests + vault re-derivation, not asserted).
+4. Garden's footprint drops measurably (target: the `→ loom` rows above leave; #843 re-measured).
+5. The honest-evidence invariants (§5) hold unchanged — done is still re-derived, never claimed.
+6. Loom is archetype-agnostic: it runs a hand-authored flow definition with zero garden knowledge.


### PR DESCRIPTION
North-star architecture spec: reshape wicked-garden from a heavy library into a **thin orchestrator** by extracting its runtime/wiring into a new standalone peer, **`wicked-loom`**. Garden keeps the archetype engine, domain catalog, and compiler — and runs *on top of* loom.

## Decisions captured (locked during brainstorm)
- **D1** north star = Level 1: extract concern *gate/phase + autonomy substrate* and *peer-wiring*; keep archetype engine + domain catalog + compiler.
- **D2** one new primitive (`compose` + `conduct` modules), not two.
- **D3** hybrid autonomy, synchronous-core-first; headless daemon spec'd-but-deferred with park-at-hard-gate baked in.
- **D4** hybrid wiring: bus-as-spine for coordination/audit/knowledge; direct synchronous resolution for re-derivation gates. An event never satisfies a gate.
- **D5** language-neutral standalone, Python impl, CLI + (deferred) daemon, consumed by garden via subprocess.
- **D6** name: `wicked-loom`.

## Highlights
- The **archetype-agnostic flow-definition seam** (garden compiles archetype → flow def; loom executes any flow def) — the abstraction that makes loom a real reusable primitive.
- Honest-evidence invariants **I1–I6** preserved (fail-closed gates; fail-soft only on the verifier spec).
- Grounded **file-level extraction inventory** + the **strangler migration** (expand → cutover → contract). The `daemon/` conduct code is recoverable from pre-#871 history (~8600 LOC).
- **Four-issue re-triage**: #887 absorbed (verifier_spec_ref), #843 downstream of compose extraction, #878 (PR #888), #842 tuning.

Spec doc only — no code. The **expand-phase implementation plan** follows (separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
