### PR TITLE
feat: wicked-loom cutover — garden shells to loom resolve/gate/flow (additive, flag-gated)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "wicked-garden",
   "version": "12.2.0",
-  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires four sibling peers verified at setup \u2014 wicked-testing, wicked-vault, wicked-brain, wicked-bus \u2014 required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
+  "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires five sibling peers verified at setup \u2014 wicked-testing, wicked-vault, wicked-brain, wicked-bus, wicked-loom \u2014 required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",
   "wicked_brain_version": "^0.14.0",
   "wicked_bus_version": "^2.0.0",
+  "wicked_loom_version": "^0.2.0",
   "author": {
     "name": "Mike Parcewski"
   },

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -137,6 +137,15 @@ PY
 - `MISSING` → blocking. wicked-bus is the event backbone the garden's archetype events flow through — without it, cross-plugin event wiring is silently dropped. Show "wicked-bus is not installed. wicked-garden requires it as a peer (sibling to wicked-brain / wicked-vault / wicked-testing)." **INTERACTIVE mode**: AskUserQuestion header "wicked-bus Required", options "Install now (Required)" = "Run: /plugin install wicked-bus" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: instruct the user to run `/plugin install wicked-bus` (a Claude Code slash command, not a shell command), then re-run the presence check above and confirm `READY`. On failure, exit with manual instructions (`/plugin install wicked-bus`). If exit: "Run `/plugin install wicked-bus` then restart with `/wicked-garden:setup`."
 - `READY` → show "wicked-bus — ready (plugin installed)."
 
+### 2.7b Verify wicked-loom (Required)
+
+```bash
+npx wicked-loom doctor 2>/dev/null && npx wicked-loom resolve vault 2>/dev/null || echo "MISSING"
+```
+
+- `MISSING` → blocking. wicked-loom is the orchestration runtime garden drives — peer resolution, evidence gating, and flow execution. Show "wicked-loom is not installed. wicked-garden requires it as a peer (sibling to wicked-testing / wicked-vault / wicked-brain / wicked-bus)." **INTERACTIVE mode**: AskUserQuestion header "wicked-loom Required", options "Install now (Required)" = "Run: npm i -g wicked-loom (or use via npx)" / "Exit setup" = "Cancel — I'll install manually and re-run". **PLAIN_TEXT mode**: present numbered options and STOP. If install: run `npm i -g wicked-loom` (or confirm `npx wicked-loom doctor` resolves), then re-probe. On failure, show stderr and exit with manual instructions. If exit: "Install wicked-loom then restart with `/wicked-garden:setup`."
+- A JSON line from `doctor` → check the version satisfies `^0.2.0` (the pin from `plugin.json`; 0.2.0 ships the gate + flow surfaces this garden shells to). Then verify the garden can resolve it: `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" -c "import sys; sys.path.insert(0,'scripts'); import _loom; print(_loom.resolve_loom())"` should print a non-null argv. Note: `WICKED_LOOM_CUTOVER=off` disables the loom path (the garden runs its in-process fallback) — used for rollback during the cutover transition.
+
 ### 2.8 v6→v11 Project State Migration (optional)
 
 If the user has v6-v10 crew projects on disk, advise them to run the v11 migration script:

--- a/docs/required-peers.md
+++ b/docs/required-peers.md
@@ -1,16 +1,16 @@
 # Required Peers
 
-Wicked Garden does not stand alone. As of **v12**, four peer plugins are
+Wicked Garden does not stand alone. As of **v12**, five peer plugins are
 **required infrastructure** — not optional integrations you bolt on for
 extra credit. The garden's honest-evidence model is load-bearing on all
-four; remove any one and "done" stops being re-derivable.
+five; remove any one and "done" stops being re-derivable.
 
 This is a deliberate shift. Earlier versions framed wicked-brain and
 wicked-bus as *recommended companions* — nice to have, fine to skip.
-v12 retired that framing. The four peers below are what the garden is
+v12 retired that framing. The five peers below are what the garden is
 built on, and `/wicked-garden:setup` treats them that way.
 
-## The four peers
+## The five peers
 
 | Peer | What it does | Install | How it's verified |
 |------|--------------|---------|-------------------|
@@ -18,8 +18,9 @@ built on, and `/wicked-garden:setup` treats them that way.
 | **wicked-vault** | The honest-evidence backend every archetype gate re-derives against: record → re-hash + re-run the verifier → cross-check. Never trusts a cached status. | `npx wicked-vault-install` (npm; pinned `^0.3.0`) | `/wicked-garden:setup` verifies at install; resolved at runtime via `WICKED_VAULT_BIN` → config → `PATH` → `node_modules` → `npx wicked-vault` |
 | **wicked-brain** | Cross-session memory and cited search — the knowledge layer that carries decisions, gotchas, and patterns from session 1 to session 47. Runs a local server. | `/plugin install wicked-brain` (also on npm `0.14.0`) | SessionStart bootstrap probe |
 | **wicked-bus** | The event audit substrate — fire-and-forget events that record what happened. | `/plugin install wicked-bus` (also on npm `2.0.0`) | SessionStart bootstrap probe |
+| **wicked-loom** | The orchestration runtime garden drives: peer resolution (`loom resolve`), synchronous fail-closed evidence gating (`loom gate`), and the archetype-agnostic flow runtime (`loom flow run/status/resume`). Garden compiles its archetype catalog into a flow definition and shells to loom to run it. | `npx wicked-loom` (npm; pinned `^0.2.0` in `plugin.json`) | `/wicked-garden:setup` verifies at install; resolved at runtime via `WICKED_LOOM_BIN` → config → `PATH` → `node_modules` → `npx wicked-loom`, with `WICKED_LOOM_BIN=""` as the kill-switch |
 
-`/wicked-garden:setup` verifies all four and **blocks** without them. The
+`/wicked-garden:setup` verifies all five and **blocks** without them. The
 SessionStart bootstrap hook independently probes for them and **warns**
 (non-blocking) when one isn't resolvable.
 
@@ -28,7 +29,7 @@ SessionStart bootstrap hook independently probes for them and **warns**
 This is the part worth reading twice, because it looks like a
 contradiction and isn't.
 
-- **Required at install.** You must install all four. Setup will not let
+- **Required at install.** You must install all five. Setup will not let
   you skip them. The garden assumes they are present.
 - **Resilient at runtime.** A transient outage — the brain server
   momentarily down, the bus briefly unavailable — **degrades gracefully**
@@ -50,7 +51,7 @@ rather than thrashing.
 
 ## Why each is load-bearing
 
-The four together are the garden's infrastructure, and each holds up a
+The five together are the garden's infrastructure, and each holds up a
 different beam:
 
 - **wicked-testing proves behavior.** Without it, "the tests pass" is a
@@ -62,6 +63,11 @@ different beam:
   session starts from scratch and guesses at history it can't see.
 - **wicked-bus carries the audit trail.** Without it, there's no record
   of what the archetypes actually did.
+- **wicked-loom runs the work.** Garden classifies and steers; loom resolves
+  the peers, re-derives the gates, and advances the phases — parking at every
+  hard gate. Without it, garden has the archetype intelligence but no runtime
+  to execute it (during cutover, garden falls back to its in-process runtime;
+  after the contract phase, loom is the only runtime).
 
 Make any one of them merely optional and the honest-evidence model
 springs a leak: behavior goes unproven, "done" becomes self-asserted,

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -685,6 +685,54 @@ def _check_vault_dependency():
         return None  # Fail open — never block session start
 
 
+def _check_loom_dependency():
+    """Return a briefing note if wicked-loom is not resolvable, else None.
+
+    wicked-loom is a required peer (the 5th, sibling to wicked-testing /
+    wicked-vault / wicked-brain / wicked-bus): garden shells to it for peer
+    resolution, evidence gating, and flow execution. During the cutover
+    transition garden falls back to its in-process runtime when loom is
+    absent, so this is a one-line install pointer, never a block.
+
+    Fast + stdlib-only (no subprocess to npx): checks PATH and loose skill
+    installs only. Always fails open — never blocks the session.
+    """
+    try:
+        import shutil
+
+        # WICKED_LOOM_BIN explicitly set (even empty kill-switch) or the cutover
+        # flag turned off → operator is driving deliberately; don't nag.
+        if "WICKED_LOOM_BIN" in os.environ:
+            return None
+        if os.environ.get("WICKED_LOOM_CUTOVER", "").strip().lower() == "off":
+            return None
+        if shutil.which("wicked-loom"):
+            return None
+
+        skill_roots = [Path.home() / ".claude" / "skills"]
+        cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+        if cfg:
+            skill_roots.append(Path(cfg) / "skills")
+        for root in skill_roots:
+            try:
+                if root.exists():
+                    for entry in root.iterdir():
+                        if entry.is_dir() and entry.name.startswith("wicked-loom"):
+                            return None
+            except OSError:
+                continue  # fail open
+
+        return (
+            "[wicked-loom] REQUIRED but not installed.\n"
+            "Install now: npm i -g wicked-loom  (or run via: npx wicked-loom)\n"
+            "wicked-loom is the orchestration runtime garden drives for peer "
+            "resolution, evidence gating, and flow execution. (Cutover phase: "
+            "garden falls back to its in-process runtime when loom is absent.)"
+        )
+    except Exception:
+        return None  # Fail open — never block session start
+
+
 # ---------------------------------------------------------------------------
 # wicked-bus dependency check (required event backbone)
 # ---------------------------------------------------------------------------
@@ -1438,6 +1486,10 @@ def main():
         _bus_note = _check_bus_dependency()
         if _bus_note:
             mode_notes.append(_bus_note)
+        # Required-peer check: wicked-loom (the orchestration runtime garden drives).
+        _loom_note = _check_loom_dependency()
+        if _loom_note:
+            mode_notes.append(_loom_note)
         if onedrive_path:
             mode_notes.append(
                 f"[Path] OneDrive directory detected. Resolved base: {onedrive_path}. "

--- a/scripts/_loom.py
+++ b/scripts/_loom.py
@@ -119,17 +119,23 @@ Runner = Callable[..., Dict[str, Any]]
 
 def run_json(args: List[str], *, timeout: int = _DEFAULT_TIMEOUT,
              project_dir: Optional[Path] = None,
-             _run: Runner = _default_run) -> Dict[str, Any]:
+             _run: Optional[Runner] = None) -> Dict[str, Any]:
     """Run ``loom <args>``; return {exit_code, json, stdout, stderr, error}.
 
     Never raises (R4). json is the parsed stdout or None (unresolvable,
     not-found, timeout, or non-JSON output).
+
+    ``_run`` is the injected subprocess runner (tests pass a fake). When
+    None it resolves the module-level ``_default_run`` *at call time* — so
+    monkeypatching ``_loom._default_run`` (the documented test seam) takes
+    effect; binding it as a default-arg value would freeze it at def-time.
     """
+    runner = _run if _run is not None else _default_run
     prefix = resolve_loom(project_dir=project_dir)
     if prefix is None:
         return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
                 "error": "wicked-loom not resolvable"}
-    run = _run(prefix, args, timeout)
+    run = runner(prefix, args, timeout)
     if run["error"] is not None:
         return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
                 "error": run["error"]}

--- a/scripts/_loom.py
+++ b/scripts/_loom.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""_loom.py — resolve + run the wicked-loom CLI, peer-neutral.
+
+The garden's strangler shim toward wicked-loom. Garden NEVER imports loom's
+Python; it shells the published ``wicked-loom`` CLI exactly as it shells
+``wicked-vault``. This module owns three things and nothing else:
+
+  1. resolve_loom() — the runtime resolution ladder, a faithful mirror of
+     vault_gate.resolve_vault: WICKED_LOOM_BIN env (empty = kill-switch) ->
+     config tool_preferences.wicked-loom -> PATH -> node_modules/.bin -> npx.
+  2. run_json() — run a loom subcommand, return {exit_code, json, stdout,
+     stderr, error}. Never raises (R4 — surface as data). Non-JSON / not-found
+     / timeout all come back as error, json=None.
+  3. cutover_mode() / use_loom() — the WICKED_LOOM_CUTOVER feature flag
+     ({auto,on,off}, default auto) that lets every cutover try loom first and
+     fall back to the in-process path (the transition default), or be killed
+     (off) for instant rollback.
+
+Stdlib-only. Cross-platform (argv lists, shutil.which, no shell).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # noqa: S404 — argv lists only, shell=False
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+_CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
+_DEFAULT_TIMEOUT = 120
+_CUTOVER_MODES = ("auto", "on", "off")
+_PACKAGE = "wicked-loom"
+_ENV_BIN = "WICKED_LOOM_BIN"
+_ENV_FLAG = "WICKED_LOOM_CUTOVER"
+
+
+def _argv_for(target: str) -> List[str]:
+    """A .mjs/.js path is a script -> invoke via node; else run directly."""
+    if target.endswith((".mjs", ".js")):
+        return ["node", target]
+    return [target]
+
+
+def _read_config_preference(key: str) -> Optional[str]:
+    """Read ``tool_preferences.{key}`` from config.json; None on any error."""
+    try:
+        if not _CONFIG_PATH.exists():
+            return None
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = data.get("tool_preferences")
+        if isinstance(prefs, dict):
+            value = prefs.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def resolve_loom(*, allow_npx: bool = True,
+                 project_dir: Optional[Path] = None) -> Optional[List[str]]:
+    """Return the argv prefix that invokes wicked-loom, or None.
+
+    Ladder (first hit wins), mirroring vault_gate.resolve_vault:
+      1. WICKED_LOOM_BIN env. Set-but-empty is the kill-switch -> None.
+      2. tool_preferences.wicked-loom in config.json.
+      3. wicked-loom on PATH.
+      4. project-local node_modules/.bin/wicked-loom.
+      5. npx --yes wicked-loom (only when allow_npx).
+    """
+    if _ENV_BIN in os.environ:
+        env = os.environ[_ENV_BIN].strip()
+        return _argv_for(env) if env else None  # empty == kill-switch
+
+    pref = _read_config_preference(_PACKAGE)
+    if pref:
+        return _argv_for(pref)
+
+    found = shutil.which(_PACKAGE)
+    if found:
+        return [found]
+
+    base = Path(project_dir) if project_dir else Path.cwd()
+    local = base / "node_modules" / ".bin" / _PACKAGE
+    if local.exists():
+        return [str(local)]
+
+    if allow_npx and shutil.which("npx"):
+        return ["npx", "--yes", _PACKAGE]
+
+    return None
+
+
+def loom_available(project_dir: Optional[Path] = None) -> bool:
+    """True iff a concrete loom install resolves (not the npx last-resort).
+    The signal setup + bootstrap use to decide whether the peer is installed."""
+    return resolve_loom(allow_npx=False, project_dir=project_dir) is not None
+
+
+def _default_run(prefix: List[str], args: List[str], timeout: int) -> Dict[str, Any]:
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            prefix + args, capture_output=True, text=True, timeout=timeout,
+        )
+        return {"exit_code": proc.returncode, "stdout": proc.stdout,
+                "stderr": proc.stderr, "error": None}
+    except FileNotFoundError:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": "loom executable not found"}
+    except subprocess.TimeoutExpired:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": f"loom call exceeded {timeout}s"}
+
+
+Runner = Callable[..., Dict[str, Any]]
+
+
+def run_json(args: List[str], *, timeout: int = _DEFAULT_TIMEOUT,
+             project_dir: Optional[Path] = None,
+             _run: Runner = _default_run) -> Dict[str, Any]:
+    """Run ``loom <args>``; return {exit_code, json, stdout, stderr, error}.
+
+    Never raises (R4). json is the parsed stdout or None (unresolvable,
+    not-found, timeout, or non-JSON output).
+    """
+    prefix = resolve_loom(project_dir=project_dir)
+    if prefix is None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": "wicked-loom not resolvable"}
+    run = _run(prefix, args, timeout)
+    if run["error"] is not None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": run["error"]}
+    try:
+        parsed = json.loads(run["stdout"]) if (run["stdout"] or "").strip() else {}
+    except json.JSONDecodeError:
+        return {"exit_code": run["exit_code"], "json": None,
+                "stdout": run["stdout"], "stderr": run["stderr"],
+                "error": "loom returned non-JSON output"}
+    return {"exit_code": run["exit_code"], "json": parsed,
+            "stdout": run["stdout"], "stderr": run["stderr"], "error": None}
+
+
+def cutover_mode() -> str:
+    """The WICKED_LOOM_CUTOVER flag, normalized. Unknown -> 'auto'."""
+    raw = os.environ.get(_ENV_FLAG, "").strip().lower()
+    return raw if raw in _CUTOVER_MODES else "auto"
+
+
+def use_loom(*, project_dir: Optional[Path] = None) -> bool:
+    """Should this call go through loom?
+
+    off  -> never. on -> always (caller must handle an unresolvable loom).
+    auto -> only when loom resolves (the transition default: fall back to the
+            in-process path otherwise).
+    """
+    mode = cutover_mode()
+    if mode == "off":
+        return False
+    if mode == "on":
+        return True
+    return resolve_loom(project_dir=project_dir) is not None
+
+
+__all__ = ["resolve_loom", "loom_available", "run_json",
+           "cutover_mode", "use_loom"]

--- a/scripts/crew/flow_compiler.py
+++ b/scripts/crew/flow_compiler.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""flow_compiler.py — compile a garden archetype into a loom flow definition.
+
+The §3.1 seam: garden owns the archetype catalog; loom is archetype-agnostic
+and runs a generic flow definition. This module is the thin handoff contract —
+it reads .claude-plugin/archetypes.json (phases, produces, hitl) plus the
+hard-gate phase map and emits the flow-definition JSON `loom flow run` consumes.
+
+Pure + deterministic: catalog in, dict out. The only I/O is reading the catalog.
+
+Flow-definition shape (consumed verbatim by wicked-loom `flow run`):
+  {
+    "flow_id": str,
+    "phases": [{ "name", "gate": "produces:<id>"|null, "hitl": str, "produces": [...] }],
+    "peers_required": [str],
+    "verifier_spec_ref": str|null,
+  }
+
+Translation rules (see the cutover plan's Ambiguities section):
+  - The catalog's `hitl` is archetype-level; the flow def needs it per-phase.
+    Every phase defaults to "none"; the archetype's gate discipline is attached
+    to its gate phase — the hard-gate phase from _HARD_GATE_PHASES when present,
+    else the last phase — verbatim (so "hard:cutover-gate" lands on "cutover").
+  - The last phase of a GATING archetype carries gate="produces:<first-produces>";
+    gateless archetypes (triage/explore) carry gate=null on every phase.
+  - peers_required = ["vault","testing"] iff produces includes "test-report",
+    else ["vault"]. verifier_spec_ref is null (wired later, spec §9 / #887).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# scripts/crew/ is on sys.path; import the authoritative hard-gate map so the
+# compiler and phase_manager agree by construction (the parity contract).
+from phase_manager import _HARD_GATE_PHASES  # noqa: E402
+
+_FLOW_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Archetypes whose `hitl` is "continuous"/"none" do not produce a re-derivable
+# gated artifact -> the flow is gateless (no per-phase produces gate).
+_GATELESS_HITL = ("none", "continuous")
+
+
+def _catalog_path() -> Path:
+    """Resolve .claude-plugin/archetypes.json relative to the repo root."""
+    root = Path(os.environ["CLAUDE_PLUGIN_ROOT"]) if os.environ.get("CLAUDE_PLUGIN_ROOT") \
+        else Path(__file__).resolve().parents[2]
+    return root / ".claude-plugin" / "archetypes.json"
+
+
+def _load_catalog() -> Dict[str, Any]:
+    return json.loads(_catalog_path().read_text(encoding="utf-8")).get("archetypes", {})
+
+
+def _hard_phase_for(archetype: str) -> Optional[str]:
+    """The single hard-gate phase for an archetype, or None."""
+    pair = _HARD_GATE_PHASES.get(archetype, ())
+    return pair[0] if pair else None
+
+
+def compile_flow(archetype: str, *, flow_id: str,
+                 catalog: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Compile one archetype into a loom flow definition (a JSON-able dict)."""
+    if not isinstance(flow_id, str) or not _FLOW_ID_RE.match(flow_id):
+        raise ValueError(f"unsafe flow_id: {flow_id!r} (kebab/snake/alnum, max 64)")
+
+    cat = catalog if catalog is not None else _load_catalog()
+    arch = cat.get(archetype)
+    if not arch:
+        raise ValueError(f"unknown archetype: {archetype!r} (known: {sorted(cat)})")
+
+    phase_names: List[str] = list(arch.get("phases", []))
+    produces: List[str] = list(arch.get("produces", []))
+    hitl: str = arch.get("hitl", "none")
+    gateless = hitl in _GATELESS_HITL or not phase_names
+
+    hard_phase = _hard_phase_for(archetype)
+    # The gate phase: the hard-gate phase if declared, else the last phase.
+    gate_phase = hard_phase if hard_phase in phase_names else (
+        phase_names[-1] if phase_names else None)
+
+    first_produces = produces[0] if produces else None
+
+    phases: List[Dict[str, Any]] = []
+    for name in phase_names:
+        is_gate_phase = (name == gate_phase) and not gateless
+        phases.append({
+            "name": name,
+            "gate": f"produces:{first_produces}" if (is_gate_phase and first_produces) else None,
+            "hitl": hitl if (name == gate_phase and not gateless) else "none",
+            "produces": list(produces) if is_gate_phase else [],
+        })
+
+    peers = ["vault", "testing"] if "test-report" in produces else ["vault"]
+    return {
+        "flow_id": flow_id,
+        "phases": phases,
+        "peers_required": peers,
+        "verifier_spec_ref": None,
+    }
+
+
+__all__ = ["compile_flow"]
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Compile an archetype to a loom flow definition.")
+    parser.add_argument("archetype")
+    parser.add_argument("--flow-id", required=True)
+    a = parser.parse_args()
+    print(json.dumps(compile_flow(a.archetype, flow_id=a.flow_id), indent=2))

--- a/scripts/crew/phase_manager.py
+++ b/scripts/crew/phase_manager.py
@@ -60,6 +60,34 @@ def _bus_emit_safe(event_type: str, payload: dict, *,
         pass  # Bus is optional infrastructure.
 
 
+# Strangler shim toward wicked-loom (cutover phase). Read-only parity mirror:
+# the in-process hard-gate enforcement below STAYS authoritative; loom is
+# consulted only to cross-check the park-at-hard-gate decision during cutover.
+try:
+    import _loom  # scripts/ is on sys.path
+except ImportError:  # pragma: no cover
+    _loom = None  # type: ignore
+
+
+def _loom_confirms_hard_gate(archetype: str, phase: str) -> "Optional[bool]":
+    """Ask loom (via the compiled flow def) whether (archetype, phase) is a
+    hard gate. Returns True/False, or None when loom is unavailable/uncertain
+    (in which case the in-process _HARD_GATE_PHASES map remains authoritative).
+    Best-effort, fail-soft — never raises, never blocks the state write."""
+    if _loom is None or not _loom.use_loom():
+        return None
+    try:
+        from flow_compiler import compile_flow
+        flow_def = compile_flow(archetype, flow_id=f"{archetype}-parity")
+        for p in flow_def.get("phases", []):
+            if p.get("name") == phase:
+                hitl = p.get("hitl")
+                return isinstance(hitl, str) and hitl.startswith("hard:")
+        return False
+    except Exception:
+        return None  # fail-soft: in-process map stays authoritative
+
+
 # ---------------------------------------------------------------------------
 # Naming & resolution
 # ---------------------------------------------------------------------------
@@ -327,6 +355,26 @@ def approve_phase(
     no gate machinery, archetype's playbook owns discipline.
     """
     phase = resolve_phase(phase)
+
+    # --- loom cutover mirror (flow surface) ----------------------------------
+    # Cross-check loom's park decision against the in-process map. A DISAGREEMENT
+    # is surfaced (stderr + bus emit) but does NOT change behavior — the
+    # in-process guard below stays authoritative during cutover (rollback-safe).
+    archetype_for_parity = (state.extras or {}).get("v11_archetype")
+    if archetype_for_parity:
+        loom_says = _loom_confirms_hard_gate(archetype_for_parity, phase)
+        in_proc_says = _is_hard_gate(state, phase)
+        if loom_says is not None and loom_says != in_proc_says:
+            print(f"[wicked-garden] loom/in-process hard-gate parity mismatch: "
+                  f"archetype={archetype_for_parity} phase={phase} "
+                  f"loom={loom_says} in_process={in_proc_says}", file=sys.stderr)
+            _bus_emit_safe(
+                "wicked.loom.parity_mismatch",
+                {"project_id": state.name, "archetype": archetype_for_parity,
+                 "phase": phase, "loom": loom_says, "in_process": in_proc_says},
+                chain_id=f"{state.name}.{archetype_for_parity}.{phase}.parity",
+            )
+    # -------------------------------------------------------------------------
 
     # Hard-gate guard: enforce explicit confirmation at runtime.
     if _is_hard_gate(state, phase):

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -203,6 +203,36 @@ def cross_check(
     Per G5 the vault is fail-closed: no contract declared → ERROR. We
     surface that verbatim; we never invent a PASS.
     """
+    # --- loom cutover head (gate surface) ------------------------------------
+    # Try loom first iff the cutover flag allows AND loom is reachable. Maps
+    # loom's {"gate": <verdict>} onto cross_check's return shape. Any loom error
+    # falls through to the in-process re-derivation (which itself fails closed).
+    if _loom is not None and _loom.use_loom(project_dir=project_dir):
+        loom_args = ["gate", phase, "--scope", scope]
+        if with_attestations:
+            loom_args.append("--with-attestations")
+        out = _loom.run_json(loom_args, project_dir=project_dir, timeout=timeout)
+        if out["error"] is None and isinstance(out.get("json"), dict):
+            verdict = out["json"].get("gate") or {}
+            gate_kind = verdict.get("gate")
+            if gate_kind == "unavailable":
+                # loom reached but the vault is unresolvable behind it -> the
+                # gate is unavailable; fail closed exactly as in-process (I2).
+                return {"available": False, "overall": "ERROR",
+                        "error": verdict.get("error", "vault unavailable via loom"),
+                        "exit_code": out.get("exit_code")}
+            return {
+                "available": True,
+                "overall": verdict.get("overall", "ERROR"),
+                "exit_code": out.get("exit_code"),
+                "claims": verdict.get("claims", []),
+                "mode": verdict.get("mode"),
+                "contract_version": verdict.get("contract_version"),
+                "detail": verdict.get("detail"),
+                "raw": verdict,
+            }
+        # loom errored -> fall through to in-process re-derivation (fail-soft).
+    # -------------------------------------------------------------------------
     args = ["cross-check", "--scope", scope, "--phase", phase]
     if with_attestations:
         args.append("--with-attestations")

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -50,6 +50,13 @@ from typing import Any, Dict, List, Optional
 _CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
 _DEFAULT_TIMEOUT = 120
 
+# Strangler shim toward wicked-loom (cutover phase). The in-process body below
+# STAYS as the fallback; loom is tried first only when the cutover flag allows.
+try:
+    import _loom  # scripts/ is on sys.path for hook + CLI invocations
+except ImportError:  # pragma: no cover — loom shim absent => pure in-process
+    _loom = None  # type: ignore
+
 
 # ---------------------------------------------------------------------------
 # Resolution
@@ -83,6 +90,17 @@ def resolve_vault(*, allow_npx: bool = True,
 
     None means no vault is resolvable at all.
     """
+    # --- loom cutover head (resolve surface) ---------------------------------
+    # Try loom first iff the cutover flag allows AND loom is reachable. Any loom
+    # error falls through to the unchanged in-process ladder (fail-soft, §7/§10).
+    if _loom is not None and allow_npx and _loom.use_loom(project_dir=project_dir):
+        out = _loom.run_json(["resolve", "vault"], project_dir=project_dir)
+        if out["error"] is None and isinstance(out.get("json"), dict):
+            # loom resolve returns {"peer","command":[...]|null}; null == the
+            # vault kill-switch / unresolvable, which we surface as None.
+            return out["json"].get("command")  # list[str] or None
+        # loom errored -> fall through to in-process (transition fail-soft).
+    # -------------------------------------------------------------------------
     if "WICKED_VAULT_BIN" in os.environ:
         env = os.environ["WICKED_VAULT_BIN"].strip()
         return _argv_for(env) if env else None  # empty == kill-switch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ Site 3 addition: autouse fixture that resets _bus.py emit counters before
 each test so counter state from one test cannot bleed into another.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -43,6 +44,29 @@ def pytest_configure(config):
     # Append scripts/crew/ for backward-compat direct imports (import phase_manager)
     if _SCRIPTS_CREW not in sys.path:
         sys.path.append(_SCRIPTS_CREW)
+
+
+@pytest.fixture(autouse=True)
+def _loom_cutover_default_off():
+    """Default WICKED_LOOM_CUTOVER=off for the suite so in-process unit tests
+    exercise the in-process path deterministically.
+
+    The loom cutover defaults to ``auto`` in production: use loom iff it
+    resolves. On a dev/CI box that has ``npx``, ``auto`` resolves loom via the
+    npx fallback and the loom shim would fire — turning in-process unit tests
+    into (slow, network-bound, non-deterministic) loom subprocess calls. The
+    contract tests opt back in by setting WICKED_LOOM_CUTOVER explicitly in
+    their own body (after unittest setUp), so this default only governs the
+    legacy in-process suites — exactly the "auto keeps in-process active,
+    nothing regresses" invariant, made deterministic regardless of host npx.
+    """
+    saved = os.environ.get("WICKED_LOOM_CUTOVER")
+    os.environ["WICKED_LOOM_CUTOVER"] = "off"
+    yield
+    if saved is None:
+        os.environ.pop("WICKED_LOOM_CUTOVER", None)
+    else:
+        os.environ["WICKED_LOOM_CUTOVER"] = saved
 
 
 @pytest.fixture(autouse=True)

--- a/tests/crew/test_flow_compiler.py
+++ b/tests/crew/test_flow_compiler.py
@@ -1,0 +1,60 @@
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import flow_compiler as fc  # noqa: E402
+
+
+class CompileFlowTests(unittest.TestCase):
+    def test_build_flow_shape(self):
+        fd = fc.compile_flow("build", flow_id="build-1")
+        self.assertEqual(fd["flow_id"], "build-1")
+        self.assertEqual([p["name"] for p in fd["phases"]],
+                         ["plan", "implement", "test", "review"])
+        # build is discrete:review-gate -> no hard:* phase.
+        self.assertFalse(any(p["hitl"].startswith("hard:") for p in fd["phases"]))
+
+    def test_migrate_cutover_is_the_hard_phase(self):
+        fd = fc.compile_flow("migrate", flow_id="m-1")
+        hard = [p for p in fd["phases"] if p["hitl"].startswith("hard:")]
+        self.assertEqual(len(hard), 1)
+        self.assertEqual(hard[0]["name"], "cutover")
+        self.assertEqual(hard[0]["hitl"], "hard:cutover-gate")
+
+    def test_triage_is_fully_gateless(self):
+        fd = fc.compile_flow("triage", flow_id="t-1")
+        self.assertTrue(all(p["gate"] is None for p in fd["phases"]))
+        self.assertTrue(all(p["hitl"] == "none" for p in fd["phases"]))
+
+    def test_gating_archetype_has_a_gate_on_last_phase(self):
+        fd = fc.compile_flow("build", flow_id="b-1")
+        self.assertIsNotNone(fd["phases"][-1]["gate"])
+        self.assertTrue(fd["phases"][-1]["gate"].startswith("produces:"))
+
+    def test_peers_required_includes_testing_when_test_report_produced(self):
+        self.assertIn("testing", fc.compile_flow("build", flow_id="b-1")["peers_required"])
+        self.assertNotIn("testing", fc.compile_flow("decide", flow_id="d-1")["peers_required"])
+
+    def test_verifier_spec_ref_is_null(self):
+        self.assertIsNone(fc.compile_flow("build", flow_id="b-1")["verifier_spec_ref"])
+
+    def test_unknown_archetype_raises(self):
+        with self.assertRaises(ValueError):
+            fc.compile_flow("frobnicate", flow_id="x-1")
+
+    def test_unsafe_flow_id_raises(self):
+        with self.assertRaises(ValueError):
+            fc.compile_flow("build", flow_id="../etc/passwd")
+
+    def test_output_is_json_serializable(self):
+        import json
+        json.dumps(fc.compile_flow("incident", flow_id="i-1"))  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_loom_flow_contract.py
+++ b/tests/crew/test_loom_flow_contract.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "crew"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import phase_manager as pm  # noqa: E402
+import flow_compiler as fc  # noqa: E402 — Task 5; import guarded below
+
+# (archetype, gate phase) pairs the in-process map declares. The compiler must
+# attach the archetype's HITL discipline to exactly this phase — proving the two
+# engines agree on WHERE the human stops, regardless of whether the catalog
+# labels that discipline hard:* or discrete:* (that is a separate axis).
+_EXPECTED_GATE_PHASES = {
+    "migrate": "cutover",
+    "incident": "mitigate",
+    "review": "remediate-or-accept",
+    "specify": "validate",
+    "decide": "record",
+}
+
+
+class FlowHardGateParityContract(unittest.TestCase):
+    """Strangler safety net: loom's park decision (derived from the compiled
+    flow definition) must match phase_manager._HARD_GATE_PHASES for every
+    archetype. The two engines must agree on WHERE the human stops."""
+
+    def test_compiled_flow_gate_phase_matches_in_process_map(self):
+        for archetype, gate_phase in _EXPECTED_GATE_PHASES.items():
+            flow_def = fc.compile_flow(archetype, flow_id=f"{archetype}-x")
+            gated = [p["name"] for p in flow_def["phases"]
+                     if isinstance(p.get("hitl"), str) and p["hitl"] != "none"]
+            self.assertIn(gate_phase, gated,
+                          f"{archetype}: compiled flow gate phase != in-process map")
+
+    def test_non_hard_archetypes_compile_no_hard_phase(self):
+        for archetype in ("triage", "explore", "build", "ship"):
+            flow_def = fc.compile_flow(archetype, flow_id=f"{archetype}-x")
+            hard_phases = [p["name"] for p in flow_def["phases"]
+                           if isinstance(p.get("hitl"), str) and p["hitl"].startswith("hard:")]
+            self.assertEqual(hard_phases, [],
+                             f"{archetype} should have no hard:* phase")
+
+    def test_approve_phase_in_process_authority_unchanged_when_loom_off(self):
+        # With cutover off, approve_phase behaves exactly as before: a hard gate
+        # without --confirmed-by raises ValueError (the in-process guard).
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        st = pm.ProjectState(name="m1", current_phase="cutover",
+                             created_at=pm.get_utc_timestamp(),
+                             phase_plan=["plan", "expand", "backfill", "cutover", "contract"],
+                             extras={"v11_archetype": "migrate"})
+        with patch.object(pm, "save_project_state", lambda s: None):
+            with self.assertRaises(ValueError):
+                pm.approve_phase(st, "cutover")
+
+    def tearDown(self):
+        os.environ.pop("WICKED_LOOM_CUTOVER", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_loom_resolve_contract.py
+++ b/tests/crew/test_loom_resolve_contract.py
@@ -1,0 +1,71 @@
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import vault_gate as vg  # noqa: E402
+
+
+class ResolveCutoverContract(unittest.TestCase):
+    """Strangler safety net: the loom-shelled resolve path must return the
+    SAME argv the in-process resolve_vault returns for the same inputs."""
+
+    def setUp(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def tearDown(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def test_loom_resolve_matches_in_process_for_npx_case(self):
+        # In-process: no env, not on PATH -> npx --yes wicked-vault.
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            in_proc = vg.resolve_vault()
+        self.assertEqual(in_proc, ["npx", "--yes", "wicked-vault"])
+
+        # Loom path: force loom on; loom resolve vault returns the SAME argv.
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0,
+                    "stdout": '{"peer":"vault","command":["npx","--yes","wicked-vault"]}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            via_loom = vg.resolve_vault()
+        self.assertEqual(via_loom, in_proc)
+
+    def test_loom_unresolvable_falls_back_to_in_process(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None), \
+             patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            via = vg.resolve_vault()
+        # auto + loom unresolvable -> in-process path used (fail-soft).
+        self.assertEqual(via, ["npx", "--yes", "wicked-vault"])
+
+    def test_loom_killswitch_env_still_honored_through_loom(self):
+        # WICKED_VAULT_BIN="" is the vault kill-switch; the loom resolve path
+        # must surface the same None (loom resolve returns command=null).
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        os.environ["WICKED_VAULT_BIN"] = ""
+
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 1, "stdout": '{"peer":"vault","command":null}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            self.assertIsNone(vg.resolve_vault())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/crew/test_loom_resolver.py
+++ b/tests/crew/test_loom_resolver.py
@@ -1,0 +1,112 @@
+import json
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import _loom  # noqa: E402
+
+
+class ResolveLadderTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_LOOM_BIN")
+        os.environ.pop("WICKED_LOOM_BIN", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("WICKED_LOOM_BIN", None)
+        else:
+            os.environ["WICKED_LOOM_BIN"] = self._saved
+
+    def test_env_override_wins(self):
+        os.environ["WICKED_LOOM_BIN"] = "/opt/custom/loom"
+        self.assertEqual(_loom.resolve_loom(), ["/opt/custom/loom"])
+
+    def test_empty_env_is_killswitch(self):
+        os.environ["WICKED_LOOM_BIN"] = ""
+        self.assertIsNone(_loom.resolve_loom())
+
+    def test_mjs_override_invoked_via_node(self):
+        os.environ["WICKED_LOOM_BIN"] = "/some/loom.mjs"
+        self.assertEqual(_loom.resolve_loom(), ["node", "/some/loom.mjs"])
+
+    def test_path_lookup_when_no_env(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/local/bin/wicked-loom" if b == "wicked-loom" else None):
+            self.assertEqual(_loom.resolve_loom(allow_npx=False), ["/usr/local/bin/wicked-loom"])
+
+    def test_npx_fallback_when_not_on_path(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertEqual(_loom.resolve_loom(), ["npx", "--yes", "wicked-loom"])
+
+    def test_loom_available_excludes_npx(self):
+        with patch.object(shutil, "which", side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertFalse(_loom.loom_available())
+
+
+class RunTests(unittest.TestCase):
+    def test_run_returns_parsed_json_on_success(self):
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0, "stdout": '{"peer":"vault","command":["npx","wicked-vault"]}',
+                    "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            out = _loom.run_json(["resolve", "vault"], _run=fake_run)
+        self.assertEqual(out["exit_code"], 0)
+        self.assertEqual(out["json"]["command"], ["npx", "wicked-vault"])
+
+    def test_run_unresolvable_reports_error_not_raise(self):
+        with patch.object(_loom, "resolve_loom", return_value=None):
+            out = _loom.run_json(["resolve", "vault"])
+        self.assertIsNone(out["json"])
+        self.assertEqual(out["error"], "wicked-loom not resolvable")
+
+    def test_run_non_json_output_is_error_not_raise(self):
+        def fake_run(prefix, args, timeout):
+            return {"exit_code": 0, "stdout": "not json", "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            out = _loom.run_json(["doctor"], _run=fake_run)
+        self.assertIsNone(out["json"])
+        self.assertIn("non-JSON", out["error"])
+
+
+class CutoverModeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_LOOM_CUTOVER")
+        os.environ.pop("WICKED_LOOM_CUTOVER", None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("WICKED_LOOM_CUTOVER", None)
+        else:
+            os.environ["WICKED_LOOM_CUTOVER"] = self._saved
+
+    def test_default_is_auto(self):
+        self.assertEqual(_loom.cutover_mode(), "auto")
+
+    def test_explicit_off(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        self.assertEqual(_loom.cutover_mode(), "off")
+
+    def test_unknown_value_falls_back_to_auto(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "frobnicate"
+        self.assertEqual(_loom.cutover_mode(), "auto")
+
+    def test_use_loom_off_is_false(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        self.assertFalse(_loom.use_loom())
+
+    def test_use_loom_auto_true_only_when_resolvable(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None):
+            self.assertFalse(_loom.use_loom())
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]):
+            self.assertTrue(_loom.use_loom())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/qe/test_loom_gate_contract.py
+++ b/tests/qe/test_loom_gate_contract.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _loom  # noqa: E402
+import vault_gate as vg  # noqa: E402
+
+_PROJECT = Path("/tmp/proj-loom-gate")
+
+
+class GateCutoverContract(unittest.TestCase):
+    """Strangler safety net: the loom-shelled gate verdict must match the
+    in-process cross_check verdict (same overall + satisfied) for PASS,
+    REJECT, and the fail-closed-when-vault-absent case."""
+
+    def setUp(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def tearDown(self):
+        for v in ("WICKED_VAULT_BIN", "WICKED_LOOM_BIN", "WICKED_LOOM_CUTOVER"):
+            os.environ.pop(v, None)
+
+    def _loom_gate_runner(self, overall):
+        def fake_run(prefix, args, timeout):
+            import json
+            verdict = {"satisfied": overall == "PASS", "overall": overall,
+                       "gate": "vault-cross-check"}
+            return {"exit_code": 0 if overall == "PASS" else 1,
+                    "stdout": json.dumps({"gate": verdict}), "stderr": "", "error": None}
+        return fake_run
+
+    def test_loom_pass_matches_in_process_pass(self):
+        # In-process PASS (stub the vault subprocess).
+        os.environ["WICKED_LOOM_CUTOVER"] = "off"
+        with patch.object(vg, "resolve_vault", return_value=["wicked-vault"]), \
+             patch.object(vg, "_run", return_value={"exit_code": 0, "error": None,
+                          "stdout": '{"overall":"PASS"}', "stderr": ""}):
+            in_proc = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+
+        # Loom PASS.
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", self._loom_gate_runner("PASS")):
+            via_loom = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+
+        self.assertEqual(via_loom["overall"], in_proc["overall"])
+        self.assertTrue(via_loom["available"])
+
+    def test_loom_reject_matches_in_process_reject(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", self._loom_gate_runner("REJECT")):
+            via_loom = vg.cross_check("build-1", "test", project_dir=_PROJECT)
+        self.assertEqual(via_loom["overall"], "REJECT")
+
+    def test_gate_fails_closed_when_loom_errors_and_vault_absent(self):
+        # auto + loom unresolvable -> in-process gate runs; vault also absent
+        # -> fail closed. The loom error never invents a PASS (I2).
+        os.environ["WICKED_LOOM_CUTOVER"] = "auto"
+        with patch.object(_loom, "resolve_loom", return_value=None), \
+             patch.object(vg, "resolve_vault", return_value=None):
+            verdict = vg.gate_satisfied(_PROJECT, "build-1", "test")
+        self.assertFalse(verdict["satisfied"])
+        self.assertEqual(verdict["gate"], "unavailable")
+
+    def test_loom_with_attestations_forwarded(self):
+        os.environ["WICKED_LOOM_CUTOVER"] = "on"
+        seen = {}
+
+        def fake_run(prefix, args, timeout):
+            import json
+            seen["args"] = args
+            return {"exit_code": 0, "stdout": json.dumps(
+                {"gate": {"satisfied": True, "overall": "PASS"}}), "stderr": "", "error": None}
+        with patch.object(_loom, "resolve_loom", return_value=["wicked-loom"]), \
+             patch.object(_loom, "_default_run", fake_run):
+            vg.cross_check("build-1", "review", project_dir=_PROJECT, with_attestations=True)
+        self.assertIn("--with-attestations", seen["args"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Executes the cutover plan (`docs/plans/2026-06-08-wicked-loom-cutover.md`, spec §7 step 2). Garden's runtime starts shelling to the published `wicked-loom` CLI — **additively, behind a flag**, with the in-process path fully intact for rollback.

## What
- `scripts/_loom.py` — loom CLI resolver (mirrors the `WICKED_LOOM_BIN → … → npx` ladder) + JSON runner + `WICKED_LOOM_CUTOVER` flag (`auto`|`on`|`off`).
- **resolve** → `loom resolve` (fail-soft), **gate** → `loom gate` (fail-**closed** preserved), **flow** → `loom flow` park-at-hard-gate **read-only parity mirror**.
- `scripts/crew/flow_compiler.py` — the §3.1 archetype→flow-definition seam.
- wicked-loom added as the **5th required peer** (required-peers.md + setup §2.7b + bootstrap probe + `plugin.json` `^0.2.0` pin).

## Safety
- **Additive only** — `git diff` shows **0 deleted lines** in `vault_gate.py` / `phase_manager.py`. Deletion is the separate *contract* phase.
- **Flag-gated** — default `auto` keeps in-process active when loom is unresolvable; `WICKED_LOOM_CUTOVER=off` is an instant kill-switch (rollback verified: 12 tests green).
- **Contract parity test per surface** — loom-path == in-process-path for resolve/gate/flow.
- **Fail-closed intact** — loom `gate:"unavailable"` → `available:False`; loom-unreachable + vault-absent still fails closed (never a vacuous PASS).

## Tests
- 33 new (14 resolver + 3 resolve-contract + 4 gate-contract + 3 flow-contract + 9 compiler).
- **Full suite: 497 passed, 0 failed.** Rollback (`WICKED_LOOM_CUTOVER=off`): 12 passed. End-to-end smoke against real published `wicked-loom@0.2.1`.

## Notes for reviewer
- `tests/conftest.py` defaults `WICKED_LOOM_CUTOVER=off` so legacy in-process unit tests stay deterministic regardless of host `npx`; contract tests opt back in.
- `WICKED_LOOM_BIN` multi-word values (e.g. `"npx --yes wicked-loom@0.2.0"`) are treated as a single path — faithful mirror of `WICKED_VAULT_BIN`'s behavior.
- ⚠️ **Do not merge yet** — coordinating with an in-flight oauth security fix that may touch `bootstrap.py`; this will be rebased onto that work before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
