### PR TITLE
release: v12.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "12.2.0"
+      "version": "12.3.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.2.0",
+  "version": "12.3.0",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires five sibling peers verified at setup \u2014 wicked-testing, wicked-vault, wicked-brain, wicked-bus, wicked-loom \u2014 required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [12.3.0] - 2026-06-08
+
+### Features
+- feat: wicked-loom contract — loom is the sole gate/resolve path (delete in-process re-derivation) (#891) (7e4492a)
+- feat: wicked-loom cutover — garden shells to loom resolve/gate/flow (additive, flag-gated) (#890) (ae928a7)
+- feat(#878): worktree cwd-leak guard on Bash PreToolUse (#888) (859d2a0)
+
+### Documentation
+- docs: wicked-loom north-star spec (extract the orchestration runtime) (#889) (16c3e70)
+
 ## [12.2.0] - 2026-06-01
 
 ### Features


### PR DESCRIPTION
Version bump to 12.3.0 — loom cutover + contract + worktree guard. CHANGELOG + plugin.json + marketplace.json. (Suites green: garden 502, loom 73; structural checks pass; merged PRs #888-891 CI-green.)