### PR TITLE
fix: gate CLI _loom import — produces-gate now re-derives via its documented commands (v12.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "AI-Native SDLC plugin; requires wicked-testing (npm) for QE behavior.",
-      "version": "12.5.0"
+      "version": "12.5.1"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "description": "AI-Native SDLC organized around 9 work-shape archetypes (triage, explore, specify, decide, ship, review, incident, build, migrate). Each archetype owns its own phase shape, produces contract, HITL discipline, and cost band \u2014 there is no universal pipeline. The UserPromptSubmit hook auto-classifies prompts into archetypes and emits steering directives. Each archetype has a slim playbook (skills/archetype/refs/), a slash command (commands/archetype/), and detection signals declared in .claude-plugin/archetypes.json. Steering, not blocking. Gating archetypes re-derive their produces through wicked-vault (required, fail-closed) instead of trusting a self-asserted 'done', and the compiler (/wicked-garden:compile) emits a self-contained, vault-backed build gate into any repo. Requires five sibling peers verified at setup \u2014 wicked-testing, wicked-vault, wicked-brain, wicked-bus, wicked-loom \u2014 required at install but resilient to a transient runtime outage. Coexists with domain skills + agents (engineering, platform, data, product, jam, search, agentic, persona, delivery).",
   "wicked_testing_version": "^0.3.0",
   "wicked_vault_version": "^0.3.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [12.5.1] - 2026-06-09
+
+### Bug Fixes
+- fix: vault_gate CLI imports _loom (gate was failing closed via its own documented commands) (d0ce3eb)
+
 ## [12.5.0] - 2026-06-09
 
 ### Features

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -51,8 +51,16 @@ _DEFAULT_TIMEOUT = 120
 # (contract phase: the in-process re-derivation + npx ladder were removed).
 # When the loom shim is absent the shimmed surfaces are unavailable and the
 # gate fails closed — there is no in-process fallback.
+# ``_loom`` is a sibling module in scripts/. When this runs as a CLI
+# (`python3 scripts/qe/vault_gate.py …`, incl. via _python.sh) only scripts/qe
+# is on sys.path, so add scripts/ — otherwise the import fails, the loom shim
+# is None, and EVERY gate silently fails closed ("unavailable") even with loom
+# + vault installed. Module-level imports (hooks, conftest) already have
+# scripts/ on the path; this makes the CLI path behave the same. phase_manager
+# does the same insert. (Regression introduced by the loom cutover, #891.)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 try:
-    import _loom  # scripts/ is on sys.path for hook + CLI invocations
+    import _loom
 except ImportError:  # pragma: no cover — loom shim absent => surfaces unavailable
     _loom = None  # type: ignore
 
@@ -327,6 +335,11 @@ if __name__ == "__main__":
             "resolvable": prefix is not None,
             "installed": vault_available(),  # concrete install (not npx)
             "argv_prefix": prefix,
+            # Honesty signal: did the loom shim import succeed? If False, the
+            # gate fails closed regardless of whether loom/vault are installed
+            # (the CLI sys.path bug). Lets callers/tests distinguish "loom shim
+            # broken" from "vault genuinely absent".
+            "loom_shim_loaded": _loom is not None,
         }))
         sys.exit(0)
 

--- a/tests/qe/test_vault_gate.py
+++ b/tests/qe/test_vault_gate.py
@@ -247,5 +247,37 @@ class VaultBackedGateTests(unittest.TestCase):
         self.assertEqual(len(cc["claims"]), 1)
 
 
+class CliInvocationTests(unittest.TestCase):
+    """The gate must work when run as a CLI, not only imported as a module.
+
+    Regression (loom cutover, #891): this scripts/qe/ module imports its
+    sibling ``_loom`` from scripts/. Invoked as a CLI (``python3
+    scripts/qe/vault_gate.py …``, incl. via _python.sh) only scripts/qe is on
+    sys.path, so the import failed, ``_loom`` became None, and EVERY gate
+    silently failed closed ("unavailable") even with loom + vault installed.
+    Module-level tests run with scripts/ already on sys.path (conftest), so
+    they cannot catch this — only a subprocess invocation can. The fix inserts
+    scripts/ onto sys.path before importing _loom; this test pins it.
+    """
+
+    def test_cli_resolve_imports_loom_shim(self):
+        repo = Path(__file__).resolve().parents[2]
+        script = repo / "scripts" / "qe" / "vault_gate.py"
+        # Strip PYTHONPATH so the subprocess sees the same sys.path the real
+        # CLI/_python.sh invocation does (only the script's own dir, scripts/qe).
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        proc = subprocess.run(
+            [sys.executable, str(script), "resolve"],
+            capture_output=True, text=True, cwd=str(repo), env=env, timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        out = json.loads(proc.stdout)
+        self.assertTrue(
+            out.get("loom_shim_loaded"),
+            "vault_gate CLI failed to import the _loom shim — the gate would "
+            "fail closed regardless of whether loom/vault are installed",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Follow-up to #896 (v12.5.0). A skeptical re-verification — exercising the gate through its **actual production CLI** rather than as an imported module — surfaced that the produces-gate **never re-derived in production**: it always returned `gate: unavailable` / fail-closed, even with loom + vault installed.

## Root cause

The loom cutover added `import _loom` (a `scripts/` sibling) to `scripts/qe/vault_gate.py`, relying on *"scripts/ is on sys.path"*. That holds for **module** imports (hooks, `conftest.py`) but **not** when the file runs as a **CLI**: `python3 scripts/qe/vault_gate.py …` (including via `_python.sh`) puts only `scripts/qe` on `sys.path`, so `import _loom` failed, `_loom` became `None`, and every gate silently failed closed.

This is the exact command the archetype playbooks (build/decide/migrate/ship/specify) instruct agents to run:
```
scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase <phase>
scripts/qe/vault_gate.py resolve   # reported resolvable:false while installed:true
```
So the plugin's central claim — *"evidence is re-derived, not asserted"* — did not hold via its own documented surface. The test suite missed it because `conftest.py` puts `scripts/` on `sys.path`; only a subprocess invocation reproduces the real CLI condition. (`phase_manager.py` already did the `sys.path` insert; `vault_gate.py` didn't.)

## Fix
- Insert `scripts/` onto `sys.path` before `import _loom` (mirrors `phase_manager.py`).
- Add a `loom_shim_loaded` honesty signal to `resolve` output.
- Add `CliInvocationTests` — a subprocess/CLI-level regression test that **fails without the fix** (verified).

## Verification (via the real `_python.sh` CLI, from a different cwd than the project)
```
resolve                → resolvable:true, installed:true, loom_shim_loaded:true
gate (passing evidence)→ satisfied:true,  re_derived:true,  overall:PASS
gate (false 'done')    → satisfied:false, re_derived:true,  overall:REJECT   ← the headline claim
gate (CUTOVER=off)     → satisfied:false, re_derived:false, gate:unavailable ← fail-closed
```
Full suite: **520 passed** (new CLI guard included). Patch release **12.5.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
