### PR TITLE
test(e2e): real-surface E2E harness (gate/bootstrap/routing/resilience) + CI wiring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,11 +19,25 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Setup Node
+        # Needed so the E2E gate/resilience tests (tests/e2e/) can resolve the
+        # wicked-loom / wicked-vault peers and RUN rather than skip.
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install pytest
         # Stdlib-only project; only pytest is needed for the test suite.
         run: pip install pytest
 
-      - name: Run v11 test suite
+      - name: Install wicked peers for E2E (best-effort)
+        # The E2E gate/resilience tests skip cleanly when these are absent, so a
+        # registry hiccup must not fail the build — but when present, the gate is
+        # exercised through its REAL CLI surface (the path that hid two
+        # loom-cutover regressions module-level tests could not see).
+        run: npm i -g wicked-vault wicked-loom wicked-testing || echo "peer install failed — E2E gate tests will skip"
+
+      - name: Run v11 test suite (incl. tests/e2e/ — real-surface gate + resilience)
         run: python -m pytest tests/ -q
 
       - name: Run wicked-patch generator conformance tests

--- a/tests/e2e/_helpers.py
+++ b/tests/e2e/_helpers.py
@@ -1,0 +1,41 @@
+"""Shared helpers for the E2E harness.
+
+The key lesson these helpers encode: E2E tests must NOT assume the developer's
+configured/onboarded machine. A fresh CI checkout has no
+``~/.something-wicked/wicked-garden/config.json``, so prompt_submit's setup gate
+hard-blocks (exit 2) — correct behavior, but it means a test asserting exit 0
+fails in CI while passing locally. These helpers give each test an isolated,
+explicitly-(un)configured HOME so it behaves identically everywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+
+def configured_home() -> tempfile.TemporaryDirectory:
+    """A temp dir usable as $HOME with a minimal setup_complete config, so the
+    prompt_submit setup gate proceeds (exit 0) rather than hard-blocking. Caller
+    keeps the returned TemporaryDirectory alive for the subprocess lifetime and
+    passes ``{"HOME": tmp.name}`` in the subprocess env."""
+    tmp = tempfile.TemporaryDirectory()
+    cfg = Path(tmp.name) / ".something-wicked" / "wicked-garden"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "config.json").write_text(
+        json.dumps({"setup_complete": True, "storage_mode": "local"}),
+        encoding="utf-8")
+    return tmp
+
+
+def unconfigured_home() -> tempfile.TemporaryDirectory:
+    """A temp dir usable as $HOME with NO config — exercises the setup gate's
+    hard-block (exit 2)."""
+    return tempfile.TemporaryDirectory()
+
+
+def has_python_traceback(stderr: str) -> bool:
+    """True if stderr contains an uncaught Python traceback — the crash
+    signature a fail-open / controlled-exit hook must never produce."""
+    return "Traceback (most recent call last)" in (stderr or "")

--- a/tests/e2e/test_e2e_bootstrap_routing.py
+++ b/tests/e2e/test_e2e_bootstrap_routing.py
@@ -29,6 +29,9 @@ _DETECT = _REPO / "scripts" / "crew" / "archetypes_v11.py"
 sys.path.insert(0, str(_REPO / "tests" / "calibration"))
 from corpus import CORPUS  # noqa: E402
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _helpers import configured_home, unconfigured_home, has_python_traceback  # noqa: E402
+
 _ENV = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(_REPO)}
 
 
@@ -96,30 +99,55 @@ class RoutingRecallEndToEndTests(unittest.TestCase):
 
 
 class HookSmokeEndToEndTests(unittest.TestCase):
-    """prompt_submit must never crash and always emit valid JSON (fail-open)."""
+    """prompt_submit must never CRASH (no uncaught traceback) and must always
+    produce a controlled outcome — regardless of prompt or whether the project
+    is configured. Uses an isolated, explicitly-configured HOME so it behaves
+    identically in CI and on a developer machine (the assumption that broke the
+    first version of this test)."""
 
-    def test_prompt_submit_fails_open_for_varied_prompts(self):
-        prompts = [
-            "add a CSV export button to the dashboard",
-            "the prod API is down with 500s",
-            "",                       # empty
-            "yes",                    # continuation token
-            "rm -rf /; drop table",   # adversarial-ish, must not crash
-        ]
-        for p in prompts:
-            payload = json.dumps({"hook_event_name": "UserPromptSubmit",
-                                  "prompt": p, "cwd": str(_REPO),
-                                  "session_id": "e2e-smoke"})
-            proc = subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
-                                  input=payload, capture_output=True, text=True,
-                                  env=_ENV, cwd=str(_REPO), timeout=30)
-            # fail-open: returncode 0 (or 2 only if the setup gate hard-blocks,
-            # which it must not here since the project is configured).
-            self.assertIn(proc.returncode, (0,), f"prompt={p!r} stderr={proc.stderr}")
-            # every line of stdout that is non-empty must be valid JSON
-            for line in proc.stdout.splitlines():
-                if line.strip():
-                    json.loads(line)
+    def _run(self, prompt: str, home_dir: str) -> subprocess.CompletedProcess:
+        payload = json.dumps({"hook_event_name": "UserPromptSubmit",
+                              "prompt": prompt, "cwd": str(_REPO),
+                              "session_id": "e2e-smoke"})
+        env = {**_ENV, "HOME": home_dir}
+        return subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
+                              input=payload, capture_output=True, text=True,
+                              env=env, cwd=str(_REPO), timeout=30)
+
+    def test_configured_project_proceeds_without_crash(self):
+        home = configured_home()
+        try:
+            for p in ["add a CSV export button to the dashboard",
+                      "the prod API is down with 500s",
+                      "", "yes", "rm -rf /; drop table"]:
+                proc = self._run(p, home.name)
+                self.assertFalse(has_python_traceback(proc.stderr),
+                                 f"prompt={p!r} crashed: {proc.stderr}")
+                # configured → setup gate passes → controlled exit 0
+                self.assertEqual(proc.returncode, 0,
+                                 f"prompt={p!r} rc={proc.returncode} err={proc.stderr}")
+                for line in proc.stdout.splitlines():
+                    if line.strip():
+                        json.loads(line)  # valid JSON or raises
+        finally:
+            home.cleanup()
+
+    def test_unconfigured_project_setup_gate_blocks_and_cannot_be_bypassed(self):
+        # The contract that broke the first version of this test: an
+        # unconfigured project HARD-BLOCKS (exit 2) — setup cannot be bypassed,
+        # even by a continuation token. That is correct, controlled behavior
+        # (not a crash), and it must hold deterministically.
+        home = unconfigured_home()
+        try:
+            for p in ["implement a feature", "yes"]:
+                proc = self._run(p, home.name)
+                self.assertFalse(has_python_traceback(proc.stderr),
+                                 f"prompt={p!r} crashed: {proc.stderr}")
+                self.assertEqual(proc.returncode, 2,
+                                 f"setup gate must hard-block unconfigured; "
+                                 f"prompt={p!r} rc={proc.returncode}")
+        finally:
+            home.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_e2e_bootstrap_routing.py
+++ b/tests/e2e/test_e2e_bootstrap_routing.py
@@ -1,0 +1,126 @@
+"""E2E — SessionStart bootstrap + prompt routing through the REAL hook surfaces.
+
+- Bootstrap: invoked as a subprocess via invoke.py (the way Claude Code calls
+  it). Asserts it returns valid JSON (fail-open contract), reports the required
+  peers, and emits NO 'Unknown capability' warnings (the capability-registry
+  regression we fixed).
+- Routing: the detector driven through its real CLI (`archetypes_v11.py detect`)
+  over the labeled calibration corpus → per-archetype recall outcome. This is
+  the subprocess-surface complement to tests/calibration (which calls the
+  function in-process).
+- Hook smoke: prompt_submit must never crash and must always emit valid JSON
+  (fail-open), regardless of prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_INVOKE = _REPO / "hooks" / "scripts" / "invoke.py"
+_DETECT = _REPO / "scripts" / "crew" / "archetypes_v11.py"
+
+# Reuse the labeled corpus the calibration suite uses.
+sys.path.insert(0, str(_REPO / "tests" / "calibration"))
+from corpus import CORPUS  # noqa: E402
+
+_ENV = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(_REPO)}
+
+
+class BootstrapEndToEndTests(unittest.TestCase):
+    def _run_bootstrap(self):
+        payload = json.dumps({"hook_event_name": "SessionStart",
+                              "cwd": str(_REPO), "session_id": "e2e-boot"})
+        return subprocess.run([sys.executable, str(_INVOKE), "bootstrap"],
+                              input=payload, capture_output=True, text=True,
+                              env=_ENV, cwd=str(_REPO), timeout=30)
+
+    def test_bootstrap_returns_valid_json_and_does_not_crash(self):
+        proc = self._run_bootstrap()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # fail-open contract: stdout is a single JSON object
+        json.loads(proc.stdout)
+
+    def test_bootstrap_emits_no_unknown_capability_warnings(self):
+        # The capability-registry regression printed these to stderr on every
+        # session start. The fix (registering apm/tracing/logging/telemetry)
+        # must keep them at zero.
+        proc = self._run_bootstrap()
+        self.assertNotIn("Unknown capability", proc.stderr,
+                         f"capability warnings leaked: {proc.stderr}")
+
+    def test_bootstrap_reports_required_peers(self):
+        proc = self._run_bootstrap()
+        ctx = (json.loads(proc.stdout).get("hookSpecificOutput") or {}).get(
+            "additionalContext", "")
+        # The readiness/briefing context should reference the evidence backend.
+        self.assertTrue(ctx, "bootstrap emitted no additionalContext")
+
+
+class RoutingRecallEndToEndTests(unittest.TestCase):
+    """Drive the detector CLI over the corpus; assert per-archetype recall."""
+
+    def _detect(self, prompt: str) -> set[str]:
+        proc = subprocess.run(
+            [sys.executable, str(_DETECT), "detect", "--prompt", prompt],
+            capture_output=True, text=True, env=_ENV, cwd=str(_REPO), timeout=30)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        data = json.loads(proc.stdout)
+        return {m["archetype"] for m in data.get("matches", [])}
+
+    def test_corpus_recall_through_cli_meets_threshold(self):
+        # The full-corpus recall bar is held fast by tests/calibration (in
+        # process). Here we prove the CLI *surface* routes correctly with a
+        # representative sample — the first corpus entry per primary archetype
+        # — keeping the subprocess cost to ~one call per archetype.
+        sample = {}
+        for entry in CORPUS:
+            sample.setdefault(entry["primary"], entry)
+        hits, misses = 0, []
+        for primary, entry in sample.items():
+            got = self._detect(entry["prompt"])
+            if primary in got:
+                hits += 1
+            else:
+                misses.append((entry["prompt"], primary, sorted(got)))
+        recall = hits / max(1, len(sample))
+        self.assertGreaterEqual(
+            recall, 0.85,
+            f"CLI routing recall {recall:.2f} < 0.85 over {len(sample)} "
+            f"archetypes; misses={misses}")
+
+
+class HookSmokeEndToEndTests(unittest.TestCase):
+    """prompt_submit must never crash and always emit valid JSON (fail-open)."""
+
+    def test_prompt_submit_fails_open_for_varied_prompts(self):
+        prompts = [
+            "add a CSV export button to the dashboard",
+            "the prod API is down with 500s",
+            "",                       # empty
+            "yes",                    # continuation token
+            "rm -rf /; drop table",   # adversarial-ish, must not crash
+        ]
+        for p in prompts:
+            payload = json.dumps({"hook_event_name": "UserPromptSubmit",
+                                  "prompt": p, "cwd": str(_REPO),
+                                  "session_id": "e2e-smoke"})
+            proc = subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
+                                  input=payload, capture_output=True, text=True,
+                                  env=_ENV, cwd=str(_REPO), timeout=30)
+            # fail-open: returncode 0 (or 2 only if the setup gate hard-blocks,
+            # which it must not here since the project is configured).
+            self.assertIn(proc.returncode, (0,), f"prompt={p!r} stderr={proc.stderr}")
+            # every line of stdout that is non-empty must be valid JSON
+            for line in proc.stdout.splitlines():
+                if line.strip():
+                    json.loads(line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_e2e_gate_cli.py
+++ b/tests/e2e/test_e2e_gate_cli.py
@@ -1,0 +1,156 @@
+"""E2E — the produces-gate exercised through its REAL production CLI surface.
+
+This is the test that would have caught both loom-cutover regressions:
+  1. the cwd regression (gate re-derived against the process cwd, not the
+     project) — #891; and
+  2. the `_loom` CLI-import regression (gate failed closed because scripts/
+     wasn't on sys.path when invoked as a CLI).
+
+Both were invisible to module-level tests (which run with scripts/ already on
+sys.path via conftest). The only way to catch them is to invoke the gate the
+way production does: ``python3 scripts/qe/vault_gate.py gate <dir> …`` as a
+subprocess, from a DIFFERENT cwd than the project, with PYTHONPATH stripped.
+
+Outcomes asserted (positive + negative pairing — the plugin's own doctrine):
+  - genuinely-passing evidence   → satisfied:true,  re_derived:true,  PASS
+  - claimed-but-false 'done'     → satisfied:false, re_derived:true,  REJECT
+  - backend disabled (cutover)   → satisfied:false, re_derived:false, unavailable
+
+Skips (does not fake-pass) when node / wicked-loom / wicked-vault are not
+resolvable — the same hermetic posture the rest of the suite uses. CI installs
+the peers (see .github/workflows/test.yml) so this RUNS rather than skips.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GATE_CLI = _REPO_ROOT / "scripts" / "qe" / "vault_gate.py"
+_CONTRACT = json.dumps({
+    "required_evidence": [{
+        "claim_id": "tests-pass", "kind": "test-run",
+        "verifier": {"kind": "exit_code_eq", "params": {"code": 0}},
+        "required": True,
+    }]
+})
+
+
+def _locate(env_var: str, *sibling_parts: str) -> str | None:
+    if shutil.which("node") is None:
+        return None
+    env = os.environ.get(env_var)
+    if env and Path(env).exists():
+        return env
+    onpath = shutil.which(sibling_parts[-1].replace(".mjs", "")) if sibling_parts else None
+    if onpath:
+        return onpath
+    sib = _REPO_ROOT.parent.joinpath(*sibling_parts)
+    return str(sib) if sib.exists() else None
+
+
+_VAULT = _locate("WICKED_VAULT_BIN", "wicked-vault", "bin", "wicked-vault.mjs")
+_LOOM = _locate("WICKED_LOOM_BIN", "wicked-loom", "bin", "loom.mjs") or shutil.which("wicked-loom")
+
+
+@unittest.skipIf(_VAULT is None or _LOOM is None,
+                 "needs runnable wicked-vault + wicked-loom (sibling checkout, "
+                 "PATH, or WICKED_*_BIN) — E2E gate is an integration test")
+class GateCliEndToEndTests(unittest.TestCase):
+    """Drive the gate the way the archetype playbooks tell agents to."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.proj = Path(self._tmp.name)
+        env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+        subprocess.run(["git", "init", "-q"], cwd=self.proj, check=True)
+        subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"],
+                       cwd=self.proj, env=env, check=True)
+        self._vault("init")
+        (self.proj / "c.json").write_text(_CONTRACT, encoding="utf-8")
+        self._vault("declare-contract", "--scope", "demo", "--phase", "build",
+                    "--spec", str(self.proj / "c.json"))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _vault(self, *args: str):
+        subprocess.run(["node", _VAULT, *args], cwd=self.proj,
+                       capture_output=True, text=True, timeout=60, check=False)
+
+    def _record(self, source: str):
+        self._vault("record", "--scope", "demo", "--phase", "build",
+                    "--claim", "tests-pass", "--kind", "test-run", "--source", source,
+                    "--criteria", "tests pass", "--verifier", "exit_code_eq:0", "--run")
+
+    def _gate(self, *extra_env_pairs) -> dict:
+        # The crux: invoke the gate CLI from the REPO ROOT (not the project),
+        # with PYTHONPATH stripped, so we exercise the real sys.path the
+        # production CLI sees. project_dir is passed as an arg.
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env["WICKED_VAULT_BIN"] = _VAULT
+        env["WICKED_LOOM_BIN"] = _LOOM
+        for k, v in extra_env_pairs:
+            env[k] = v
+        proc = subprocess.run(
+            [sys.executable, str(_GATE_CLI), "gate", str(self.proj),
+             "--scope", "demo", "--phase", "build"],
+            cwd=str(_REPO_ROOT), env=env, capture_output=True, text=True, timeout=120,
+        )
+        self.assertTrue(proc.stdout.strip(), f"no stdout; stderr={proc.stderr}")
+        return json.loads(proc.stdout)
+
+    def test_genuinely_passing_evidence_gates_PASS(self):
+        self._record("true")
+        out = self._gate(("WICKED_LOOM_CUTOVER", "on"))
+        self.assertTrue(out["re_derived"], out)
+        self.assertTrue(out["satisfied"], out)
+        self.assertEqual(out["overall"], "PASS", out)
+
+    def test_claimed_but_false_done_is_REJECTED(self):
+        # The headline claim: 'done' cannot be self-asserted into truth.
+        self._record("false")
+        out = self._gate(("WICKED_LOOM_CUTOVER", "on"))
+        self.assertTrue(out["re_derived"], out)
+        self.assertFalse(out["satisfied"], out)
+        self.assertEqual(out["overall"], "REJECT", out)
+
+    def test_backend_disabled_fails_closed(self):
+        # Kill-switch: gate is unavailable, never a vacuous PASS.
+        self._record("true")
+        out = self._gate(("WICKED_LOOM_CUTOVER", "off"))
+        self.assertFalse(out["satisfied"], out)
+        self.assertFalse(out["re_derived"], out)
+        self.assertEqual(out["gate"], "unavailable", out)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node required for the CLI shim probe")
+class GateCliShimLoadTests(unittest.TestCase):
+    """`resolve` via the CLI must import the _loom shim regardless of cwd /
+    PYTHONPATH. Without scripts/ on sys.path the import fails and every gate
+    silently fails closed — the #891 CLI-import regression. This runs even
+    when loom/vault are absent (it checks the import, not resolution)."""
+
+    def test_cli_resolve_loads_loom_shim(self):
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        proc = subprocess.run(
+            [sys.executable, str(_GATE_CLI), "resolve"],
+            cwd=str(_REPO_ROOT), env=env, capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        out = json.loads(proc.stdout)
+        self.assertTrue(out.get("loom_shim_loaded"),
+                        "CLI failed to import _loom — gate would fail closed "
+                        "regardless of whether loom/vault are installed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_resilience_peer_down.py
+++ b/tests/e2e/test_resilience_peer_down.py
@@ -1,0 +1,112 @@
+"""E2E Tier C — resilience / chaos. Down each peer and assert the plugin
+degrades correctly: the GATE fails CLOSED (never a vacuous PASS), and the
+HOOKS fail OPEN (never block the session). The two invariants must not be
+confused — a closed gate protects correctness; an open hook protects the user.
+
+These are the claims behind "five required peers, resilient to a transient
+runtime outage": an outage degrades, it does not crash.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_GATE_CLI = _REPO / "scripts" / "qe" / "vault_gate.py"
+_INVOKE = _REPO / "hooks" / "scripts" / "invoke.py"
+_ENV = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(_REPO)}
+
+
+def _clean_env(**overrides) -> dict:
+    env = {k: v for k, v in _ENV.items() if k != "PYTHONPATH"}
+    env.update(overrides)
+    return env
+
+
+class GateFailsClosedTests(unittest.TestCase):
+    """The gate must NEVER report satisfied when its backend is gone."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.proj = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _gate(self, env) -> dict:
+        proc = subprocess.run(
+            [sys.executable, str(_GATE_CLI), "gate", str(self.proj),
+             "--scope", "demo", "--phase", "build"],
+            cwd=str(_REPO), env=env, capture_output=True, text=True, timeout=60)
+        self.assertTrue(proc.stdout.strip(), proc.stderr)
+        # exit code must be non-zero (gate not satisfied)
+        self.assertNotEqual(proc.returncode, 0, "fail-closed must exit non-zero")
+        return json.loads(proc.stdout)
+
+    def test_loom_cutover_off_fails_closed(self):
+        out = self._gate(_clean_env(WICKED_LOOM_CUTOVER="off"))
+        self.assertFalse(out["satisfied"])
+        self.assertEqual(out["gate"], "unavailable")
+
+    def test_vault_killswitch_fails_closed(self):
+        # Empty WICKED_VAULT_BIN is the documented vault kill-switch.
+        out = self._gate(_clean_env(WICKED_VAULT_BIN="", WICKED_LOOM_CUTOVER="auto"))
+        self.assertFalse(out["satisfied"])
+        self.assertEqual(out["gate"], "unavailable")
+
+    def test_loom_pointed_at_missing_binary_fails_closed(self):
+        out = self._gate(_clean_env(WICKED_LOOM_BIN="/nonexistent/loom",
+                                    WICKED_LOOM_CUTOVER="on"))
+        self.assertFalse(out["satisfied"])
+        # never a vacuous PASS — satisfied is false regardless of the label
+        self.assertNotEqual(out.get("overall"), "PASS")
+
+
+class HooksFailOpenTests(unittest.TestCase):
+    """Hooks must never block the session when a peer is down."""
+
+    def _bootstrap(self, env) -> subprocess.CompletedProcess:
+        payload = json.dumps({"hook_event_name": "SessionStart",
+                              "cwd": str(_REPO), "session_id": "e2e-chaos"})
+        return subprocess.run([sys.executable, str(_INVOKE), "bootstrap"],
+                              input=payload, capture_output=True, text=True,
+                              env=env, cwd=str(_REPO), timeout=30)
+
+    def test_bootstrap_fails_open_with_brain_down(self):
+        # Brain unreachable: point the brain port somewhere dead. Bootstrap must
+        # still return 0 with valid JSON (it only warns, never blocks).
+        env = _clean_env(WICKED_BRAIN_PORT="59999")
+        proc = self._bootstrap(env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        json.loads(proc.stdout)
+
+    def test_bootstrap_fails_open_with_all_backends_killswitched(self):
+        env = _clean_env(WICKED_LOOM_CUTOVER="off", WICKED_VAULT_BIN="",
+                         WICKED_BRAIN_PORT="59999")
+        proc = self._bootstrap(env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        json.loads(proc.stdout)
+
+    def test_prompt_submit_fails_open_with_backends_down(self):
+        env = _clean_env(WICKED_LOOM_CUTOVER="off", WICKED_VAULT_BIN="",
+                         WICKED_BRAIN_PORT="59999")
+        payload = json.dumps({"hook_event_name": "UserPromptSubmit",
+                              "prompt": "implement a feature",
+                              "cwd": str(_REPO), "session_id": "e2e-chaos"})
+        proc = subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
+                              input=payload, capture_output=True, text=True,
+                              env=env, cwd=str(_REPO), timeout=30)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for line in proc.stdout.splitlines():
+            if line.strip():
+                json.loads(line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_resilience_peer_down.py
+++ b/tests/e2e/test_resilience_peer_down.py
@@ -22,6 +22,9 @@ _GATE_CLI = _REPO / "scripts" / "qe" / "vault_gate.py"
 _INVOKE = _REPO / "hooks" / "scripts" / "invoke.py"
 _ENV = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(_REPO)}
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _helpers import configured_home, has_python_traceback  # noqa: E402
+
 
 def _clean_env(**overrides) -> dict:
     env = {k: v for k, v in _ENV.items() if k != "PYTHONPATH"}
@@ -94,18 +97,29 @@ class HooksFailOpenTests(unittest.TestCase):
         json.loads(proc.stdout)
 
     def test_prompt_submit_fails_open_with_backends_down(self):
-        env = _clean_env(WICKED_LOOM_CUTOVER="off", WICKED_VAULT_BIN="",
-                         WICKED_BRAIN_PORT="59999")
-        payload = json.dumps({"hook_event_name": "UserPromptSubmit",
-                              "prompt": "implement a feature",
-                              "cwd": str(_REPO), "session_id": "e2e-chaos"})
-        proc = subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
-                              input=payload, capture_output=True, text=True,
-                              env=env, cwd=str(_REPO), timeout=30)
-        self.assertEqual(proc.returncode, 0, proc.stderr)
-        for line in proc.stdout.splitlines():
-            if line.strip():
-                json.loads(line)
+        # Configured HOME so the hook proceeds PAST the setup gate and actually
+        # exercises the backend-down path (in a fresh/unconfigured env the setup
+        # gate blocks first — correct, but it wouldn't test resilience). All
+        # evidence backends are killswitched + brain unreachable: the hook must
+        # still produce a controlled exit and never crash.
+        home = configured_home()
+        try:
+            env = _clean_env(WICKED_LOOM_CUTOVER="off", WICKED_VAULT_BIN="",
+                             WICKED_BRAIN_PORT="59999", HOME=home.name)
+            payload = json.dumps({"hook_event_name": "UserPromptSubmit",
+                                  "prompt": "implement a feature",
+                                  "cwd": str(_REPO), "session_id": "e2e-chaos"})
+            proc = subprocess.run([sys.executable, str(_INVOKE), "prompt_submit"],
+                                  input=payload, capture_output=True, text=True,
+                                  env=env, cwd=str(_REPO), timeout=30)
+            self.assertFalse(has_python_traceback(proc.stderr),
+                             f"hook crashed under peer-down: {proc.stderr}")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            for line in proc.stdout.splitlines():
+                if line.strip():
+                    json.loads(line)
+        finally:
+            home.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Two loom-cutover regressions (gate cwd #891, gate CLI `_loom` import) shipped behind a **green unit suite** because every test imports modules in-process (with `scripts/` already on `sys.path` via `conftest`) — the production CLI/hook surfaces were never exercised. This adds a realistic, **real-surface** test harness so that blind spot is permanently closed, and wires it into CI.

## Principle
The plugin is deterministic machinery (hooks, detector, gate, phase_manager, compiler) wrapped around a nondeterministic agent. So: **drive the published surface, assert the observable artifact** — never in-process mocks, never grade LLM prose.

## What's here (Tiers A + C — deterministic, repeatable, CI-gated)
`tests/e2e/` — 15 tests, positive+negative paired:

- **Gate CLI** (`test_e2e_gate_cli.py`) — invokes `vault_gate.py gate` as a subprocess from the repo root against a project elsewhere, `PYTHONPATH` stripped (the exact path that hid both regressions): genuinely-passing→`PASS`, false "done"→`REJECT`, backend-off→`unavailable`, plus a `loom_shim_loaded` CLI-import guard.
- **Bootstrap + routing** (`test_e2e_bootstrap_routing.py`) — bootstrap via `invoke.py` (valid JSON, peers reported, **0 capability warnings**); detector routing recall ≥ 0.85 through its real CLI; `prompt_submit` fail-open smoke across varied/adversarial prompts.
- **Resilience** (`test_resilience_peer_down.py`) — gate **fails CLOSED** under every kill-switch (loom off / vault killswitch / missing binary); hooks **fail OPEN** under peer-down (brain unreachable, all backends killswitched). The two invariants that back "five peers, resilient to a transient outage."

Compiler is already covered by `tests/compiler` (`EmittedGateIntegrationTests` + killswitch + AST self-containment), so it's referenced, not duplicated.

## CI
Adds `setup-node` + best-effort peer install so the gate/resilience E2E **run** in CI (skip gracefully if the registry hiccups). Local: **535 passed** (520 + 15).

## Tier B (live LLM-in-the-loop) — demonstrated, recorded here for the record
A live executor agent drove the `build` archetype on a sandbox repo (init vault → declare contract → record evidence by running the real test → gate). Outcome:
```
green tests   → satisfied:true,  re_derived:true,  PASS
inject a bug  → satisfied:false, re_derived:true,  REJECT (claim FAIL exit_code=1)
```
i.e. the headline claim — a false "done" is rejected by re-derivation — holds with a real agent driving the documented flow. (Live runs are inherently non-repeatable, so they're not in the CI suite; the deterministic Tier-A gate test encodes the same PASS/REJECT mechanically.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
