### PR TITLE
feat(qe): prove.py — frictionless re-derivation verb (make the gate something agents actually use)

### DIFF
--- a/commands/prove.md
+++ b/commands/prove.md
@@ -1,0 +1,30 @@
+---
+description: Prove a claim by re-deriving it (run + gate) instead of asserting "done"
+phase_relevance: ["build", "review", "operate"]
+archetype_relevance: ["*"]
+---
+
+# /wicked-garden:prove
+
+The one-line re-derivation verb. Before you tell the user something is "done"
+/ "tests pass" / "the build is clean", **prove it** — don't assert it. This
+runs the command, freezes its real exit code as wicked-vault evidence, and gates
+by re-running the verifier. Exit 0 only on a re-derived PASS; fail-closed (exit
+3) when the loom/vault backend is unresolvable — never a vacuous pass.
+
+It collapses the gate ritual (vault init → declare-contract → record --run →
+gate) into one call, so the gate is something you reach for by reflex.
+
+Instructions:
+- Run it inline (the `--by` command executes in `--project-dir`, default `.`):
+  ```bash
+  sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+    "${CLAUDE_PLUGIN_ROOT}/scripts/qe/prove.py" \
+    <claim> --by "<command>" [--verifier exit_code_eq:0] [--project-dir <dir>]
+  ```
+  e.g. `prove.py tests-pass --by "pytest -q"` · `prove.py build-clean --by "npm run build"`
+- Read the JSON verdict: `satisfied` is the truth; `re_derived: true` means it
+  was recomputed from frozen evidence (not your claim); `gate: "unavailable"`
+  means the backend is down and the gate failed closed.
+- Only report the work as done when `satisfied: true`. On `REJECT`, the claim is
+  false — fix it, don't narrate around it.

--- a/scripts/qe/prove.py
+++ b/scripts/qe/prove.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""prove.py — the one-line re-derivation verb.
+
+The produces-gate is the plugin's most valuable feature for an agent: it stops
+"done" from being self-asserted. But using it is a ~5-step ritual (vault init →
+author a contract.json → declare-contract → record --run → gate). That friction
+is exactly why an agent skips it and just *claims* the work is done — turning
+the gate into ceremony that exists but isn't used.
+
+This collapses the ritual into one verb an agent reaches for by reflex:
+
+    prove.py tests-pass --by "pytest -q"
+    prove.py build-clean --by "npm run build" --verifier exit_code_eq:0
+
+It re-derives, never asserts: it RUNS <command>, freezes the real exit code as
+vault evidence, then gates by re-running the verifier against that frozen
+evidence. Exit 0 iff the gate PASSES (re-derived). When the loom/vault backend
+is unresolvable it FAILS CLOSED (exit 3, gate: "unavailable") — never a vacuous
+pass. Reuses scripts/qe/vault_gate.py (resolve + gate_satisfied) and the vault
+CLI; it invents no new gating logic.
+
+Stdlib-only. Cross-platform (argv lists, shell=False).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # noqa: S404 — argv lists only, shell=False
+import sys
+import tempfile
+from pathlib import Path
+
+# Importing the sibling gate module must work whether this runs as a CLI
+# (`python3 scripts/qe/prove.py …` → only scripts/qe on sys.path) or imported.
+# Add scripts/ for vault_gate's own sibling import (_loom). This is the same
+# CLI-import discipline a subdir script that imports a top-level sibling needs.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+try:
+    import vault_gate  # scripts/qe sibling
+except ImportError:  # pragma: no cover
+    vault_gate = None  # type: ignore
+
+
+_VERIFIERS = {
+    # name:arg  ->  vault verifier spec
+    "exit_code_eq": lambda arg: {"kind": "exit_code_eq", "params": {"code": int(arg)}},
+}
+
+
+def _parse_verifier(spec: str) -> dict:
+    """`exit_code_eq:0` -> {kind, params}. Defaults to exit_code_eq:0."""
+    name, _, arg = spec.partition(":")
+    builder = _VERIFIERS.get(name)
+    if builder is None:
+        raise ValueError(f"unsupported verifier '{name}'; known: {sorted(_VERIFIERS)}")
+    return builder(arg or "0")
+
+
+def _vault(prefix: list[str], project_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(prefix + list(args), cwd=str(project_dir),
+                          capture_output=True, text=True, timeout=300)
+
+
+def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
+          scope: str = "prove", phase: str = "verify",
+          project_dir: str = ".") -> dict:
+    """Re-derive a single claim end to end; return the gate verdict dict."""
+    if vault_gate is None:
+        return {"satisfied": False, "gate": "unavailable", "re_derived": False,
+                "error": "vault_gate import failed"}
+    pd = Path(project_dir).resolve()
+    prefix = vault_gate.resolve_vault(project_dir=pd)  # loom-resolved vault argv
+    if prefix is None:
+        return {"satisfied": False, "gate": "unavailable", "re_derived": False,
+                "error": ("evidence backend (wicked-loom/wicked-vault) not "
+                          "resolvable — fails closed, never a vacuous pass")}
+    try:
+        verifier_spec = _parse_verifier(verifier)
+    except ValueError as e:
+        return {"satisfied": False, "gate": "error", "re_derived": False,
+                "error": str(e)}
+
+    # init (idempotent — ignore "already initialized"), declare, record --run.
+    _vault(prefix, pd, "init")
+    contract = {"required_evidence": [{
+        "claim_id": claim, "kind": "test-run",
+        "verifier": verifier_spec, "required": True,
+    }]}
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        fh.write(json.dumps(contract))
+        spec_path = fh.name
+    try:
+        _vault(prefix, pd, "declare-contract", "--scope", scope, "--phase", phase,
+               "--spec", spec_path)
+        _vault(prefix, pd, "record", "--scope", scope, "--phase", phase,
+               "--claim", claim, "--kind", "test-run", "--source", command,
+               "--criteria", f"{claim}: `{command}` satisfies {verifier}",
+               "--verifier", verifier, "--run")
+    finally:
+        try:
+            Path(spec_path).unlink()
+        except OSError:
+            pass
+
+    # The verdict is RE-DERIVED by the gate, not taken from the record above.
+    return vault_gate.gate_satisfied(pd, scope, phase)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Prove a claim by re-deriving it (run + gate), not asserting it.")
+    p.add_argument("claim", help="claim id, e.g. tests-pass")
+    p.add_argument("--by", required=True, metavar="COMMAND",
+                   help="the command whose real exit code is the evidence; it "
+                        "runs in --project-dir, so prefer absolute paths or a "
+                        "command valid from there")
+    p.add_argument("--verifier", default="exit_code_eq:0",
+                   help="verifier spec (default: exit_code_eq:0)")
+    p.add_argument("--scope", default="prove")
+    p.add_argument("--phase", default="verify")
+    p.add_argument("--project-dir", default=".")
+    a = p.parse_args()
+    verdict = prove(a.claim, a.by, verifier=a.verifier, scope=a.scope,
+                    phase=a.phase, project_dir=a.project_dir)
+    print(json.dumps(verdict, indent=2))
+    if verdict.get("satisfied"):
+        return 0
+    # distinguish fail-closed (backend gone) from a real REJECT
+    return 3 if verdict.get("gate") == "unavailable" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/archetype/refs/build.md
+++ b/skills/archetype/refs/build.md
@@ -101,9 +101,17 @@ through PR review, council, or the `review` archetype if rigor warrants.
 ## When to stop
 
 Build is done when the produces-gate is satisfied AND the PR is merged.
-Check the gate — don't self-assert it:
+Check the gate — don't self-assert it.
+
+**Frictionless (recommended for a single decisive claim):** skip the
+init/declare/record/gate ritual and re-derive in one call —
+`scripts/qe/prove.py tests-pass --by "<your test command>" --scope <scope> --phase build`
+(exit 0 = re-derived PASS; exit 1 = REJECT; exit 3 = backend down / fail-closed).
+Run it before you tell anyone the build is done.
+
+**Full contract (multi-claim):** declare a contract then
 `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase build`
-(exit 0 = satisfied). This is a re-derived PASS over the declared
+(exit 0 = satisfied). Either way it is a re-derived PASS over the declared
 contract. A REJECT means the recorded evidence does not clear its
 contract — fix the work, not the claim. An `unavailable` verdict means
 the required vault isn't installed — run `/wicked-garden:setup`. If the

--- a/tests/qe/test_prove.py
+++ b/tests/qe/test_prove.py
@@ -1,0 +1,108 @@
+"""Tests for prove.py — the one-line re-derivation verb.
+
+Unit layer (no peers): verifier parsing + fail-closed when the backend is
+disabled (deterministic). Integration layer (skip when node/loom/vault are
+absent): real PASS / REJECT through the actual CLI, proving the verb re-derives
+rather than asserts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+for _p in (_REPO / "scripts", _REPO / "scripts" / "qe"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import prove as pv  # noqa: E402
+
+_PROVE_CLI = _REPO / "scripts" / "qe" / "prove.py"
+_VAULT = os.environ.get("WICKED_VAULT_BIN")
+if not _VAULT:
+    sib = _REPO.parent / "wicked-vault" / "bin" / "wicked-vault.mjs"
+    _VAULT = str(sib) if sib.exists() else None
+_LOOM = os.environ.get("WICKED_LOOM_BIN") or shutil.which("wicked-loom")
+_PEERS = shutil.which("node") and _VAULT and _LOOM
+
+
+class VerifierParsingTests(unittest.TestCase):
+    def test_exit_code_eq_parses(self):
+        self.assertEqual(pv._parse_verifier("exit_code_eq:0"),
+                         {"kind": "exit_code_eq", "params": {"code": 0}})
+
+    def test_defaults_to_zero(self):
+        self.assertEqual(pv._parse_verifier("exit_code_eq"),
+                         {"kind": "exit_code_eq", "params": {"code": 0}})
+
+    def test_unknown_verifier_raises(self):
+        with self.assertRaises(ValueError):
+            pv._parse_verifier("magic:1")
+
+
+class FailClosedTests(unittest.TestCase):
+    """No peers needed: with the loom cutover disabled the backend is
+    unresolvable, so prove must fail closed — never a vacuous pass."""
+
+    def test_backend_disabled_fails_closed(self):
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env["WICKED_LOOM_CUTOVER"] = "off"
+        with tempfile.TemporaryDirectory() as d:
+            proc = subprocess.run(
+                [sys.executable, str(_PROVE_CLI), "tests-pass", "--by", "true",
+                 "--project-dir", d],
+                capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=60)
+            out = json.loads(proc.stdout)
+            self.assertFalse(out["satisfied"])
+            self.assertEqual(out["gate"], "unavailable")
+            self.assertEqual(proc.returncode, 3, "fail-closed must use exit 3")
+
+
+@unittest.skipIf(not _PEERS, "needs node + wicked-loom + wicked-vault")
+class ProveEndToEndTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.proj = Path(self._tmp.name)
+        env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+        subprocess.run(["git", "init", "-q"], cwd=self.proj, check=True)
+        subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "i"],
+                       cwd=self.proj, env=env, check=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _prove(self, command: str):
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env.update(WICKED_VAULT_BIN=_VAULT, WICKED_LOOM_BIN=_LOOM,
+                   WICKED_LOOM_CUTOVER="on")
+        proc = subprocess.run(
+            [sys.executable, str(_PROVE_CLI), "tests-pass", "--by", command,
+             "--project-dir", str(self.proj)],
+            capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=120)
+        return proc, json.loads(proc.stdout)
+
+    def test_true_command_proves_PASS(self):
+        proc, out = self._prove("true")
+        self.assertTrue(out["satisfied"])
+        self.assertTrue(out["re_derived"])
+        self.assertEqual(out["overall"], "PASS")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_false_command_is_REJECTED(self):
+        proc, out = self._prove("false")
+        self.assertFalse(out["satisfied"])
+        self.assertTrue(out["re_derived"])
+        self.assertEqual(out["overall"], "REJECT")
+        self.assertEqual(proc.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The produces-gate ("re-derive, don't assert") is the plugin's most valuable feature **for an agent** — it stops false "done." But using it is a ~5-step ritual (vault `init` → author `contract.json` → `declare-contract` → `record --run` → `gate`). That friction is exactly why an agent skips it and just *claims* the work is done — turning the gate into ceremony that exists but isn't used. This is the difference between a forcing function an agent reaches for and "another plugin that does stuff."

## What
`scripts/qe/prove.py` — the one-line re-derivation verb:
```
prove.py tests-pass --by "pytest -q"
prove.py build-clean --by "npm run build" --verifier exit_code_eq:0
```
It RUNS the command, freezes the real exit code as wicked-vault evidence, and **re-derives** by re-running the verifier. Exit codes: `0` = re-derived PASS · `1` = REJECT · `3` = fail-closed (backend down — never a vacuous pass). It reuses `vault_gate` (resolve + `gate_satisfied`) and the vault CLI — **invents no new gating logic**, just collapses the ritual.

- `commands/prove.md` — slim slash-command surface (`/wicked-garden:prove`).
- `build.md` "When to stop" now recommends `prove.py` as the frictionless path so an agent re-derives instead of self-asserting.
- `tests/qe/test_prove.py` — verifier parsing, fail-closed (no peers), and real PASS/REJECT through the CLI (skips when peers absent).

## Dogfood (evidence, not assertion)
- `prove.py` proves its **own** test suite: `satisfied:true, re_derived:true, PASS, hash_ok:true`.
- This PR's **merge was gated by `prove.py`** re-deriving the full 542-test suite (exit 0), not by me asserting it.
- Local: **542 passed**; structural validation **PASS (0/0)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
