### PR TITLE
feat(qe): prove.py universal (--with-attestations) + wire into all 7 gating playbooks

### DIFF
--- a/scripts/qe/prove.py
+++ b/scripts/qe/prove.py
@@ -64,8 +64,12 @@ def _vault(prefix: list[str], project_dir: Path, *args: str) -> subprocess.Compl
 
 def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
           scope: str = "prove", phase: str = "verify",
-          project_dir: str = ".") -> dict:
-    """Re-derive a single claim end to end; return the gate verdict dict."""
+          project_dir: str = ".", with_attestations: bool = False) -> dict:
+    """Re-derive a single claim end to end; return the gate verdict dict.
+
+    ``with_attestations`` forwards to the gate's hard-gate requirement (the
+    evaluator must not be the agent that did the work) — use it for
+    incident/migrate/review gates."""
     if vault_gate is None:
         return {"satisfied": False, "gate": "unavailable", "re_derived": False,
                 "error": "vault_gate import failed"}
@@ -104,7 +108,8 @@ def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
             pass
 
     # The verdict is RE-DERIVED by the gate, not taken from the record above.
-    return vault_gate.gate_satisfied(pd, scope, phase)
+    return vault_gate.gate_satisfied(pd, scope, phase,
+                                     with_attestations=with_attestations)
 
 
 def main() -> int:
@@ -120,9 +125,13 @@ def main() -> int:
     p.add_argument("--scope", default="prove")
     p.add_argument("--phase", default="verify")
     p.add_argument("--project-dir", default=".")
+    p.add_argument("--with-attestations", action="store_true",
+                   help="require an independent attestation (hard gates: "
+                        "incident/migrate/review)")
     a = p.parse_args()
     verdict = prove(a.claim, a.by, verifier=a.verifier, scope=a.scope,
-                    phase=a.phase, project_dir=a.project_dir)
+                    phase=a.phase, project_dir=a.project_dir,
+                    with_attestations=a.with_attestations)
     print(json.dumps(verdict, indent=2))
     if verdict.get("satisfied"):
         return 0

--- a/skills/archetype/refs/decide.md
+++ b/skills/archetype/refs/decide.md
@@ -97,7 +97,7 @@ not part of this discrete gate.)
 
 Decide is done when the produces-gate is satisfied AND the chosen option
 is named. Check the gate — don't self-assert it:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase decide`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase decide` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase decide`
 (exit 0 = satisfied). This is a re-derived PASS over the declared
 contract — the ADR was re-hashed and its structure verifier re-run. A
 REJECT means the recorded ADR doesn't clear its contract (a missing

--- a/skills/archetype/refs/incident.md
+++ b/skills/archetype/refs/incident.md
@@ -115,7 +115,7 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
 `mitigate` is a **hard gate** — confirm the bleeding stopped before
 moving past it, and don't self-grade the mitigation. Check the gate WITH
 judgment:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase incident --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase incident --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase incident --with-attestations`
 (exit 0 = satisfied). This re-runs the symptom check (the mitigation pin)
 and requires an **independent attestation** — an evaluator who is *not*
 the responder confirms the mitigation holds and the RCA is adequate,

--- a/skills/archetype/refs/migrate.md
+++ b/skills/archetype/refs/migrate.md
@@ -104,7 +104,7 @@ tested, backfill complete, dual-read working).
    - Monitoring + alerts updated to surface new shape's anomalies.
 2. **Gate before any switch** — don't self-assert the checklist. Run the
    produces-gate WITH judgment:
-   `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+   `scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
    (exit 0 = satisfied). This re-derives the rollback drill and the
    shape-change post-condition over the declared contract, and requires
    the independent attestation (evaluator ≠ migrator, via
@@ -129,7 +129,7 @@ tested, backfill complete, dual-read working).
 
 Cutover may only proceed when the produces-gate is satisfied — check it,
 don't self-assert it:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
 (exit 0 = satisfied). This is a re-derived PASS over the declared contract
 plus the independent attestation; a missing vault is `gate: "unavailable"`
 / `satisfied: false`, never a claim-only pass.

--- a/skills/archetype/refs/review.md
+++ b/skills/archetype/refs/review.md
@@ -117,7 +117,7 @@ banned (banned-reviewer enforcement applies — `auto-approve-*`,
 
 Review is done when the produces-gate is satisfied. Check the gate —
 don't self-assert it:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase review --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase review --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase review --with-attestations`
 (exit 0 = satisfied). This is a re-derived PASS over the declared
 contract. `--with-attestations` makes the gate require a passing
 independent `opinion_attestation` recorded via the

--- a/skills/archetype/refs/ship.md
+++ b/skills/archetype/refs/ship.md
@@ -95,7 +95,7 @@ always available.** Don't bypass the gate; widen the criteria.
 
 Each ramp step advances only when the produces-gate is satisfied — check
 it, don't self-assert it:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase ship`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase ship` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase ship`
 (exit 0 = satisfied). This is a re-derived APPROVE over the declared
 contract, re-run at **every** ramp step against the fresh captured
 snapshot. A REJECT means the recorded SLO snapshot doesn't clear its

--- a/skills/archetype/refs/specify.md
+++ b/skills/archetype/refs/specify.md
@@ -82,7 +82,7 @@ proceed past validate without explicit user agreement on the AC set.
 
 Specify is done when the user has signed off on the AC list AND the
 produces-gate is satisfied. Check the gate — don't self-assert it:
-`scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase specify`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase specify` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase specify`
 (exit 0 = satisfied). This is a re-derived PASS over the declared
 contract: the AC artifact is re-hashed and its structural verifier
 re-run. A REJECT means the recorded ACs don't clear the testability bar —

--- a/tests/qe/test_prove.py
+++ b/tests/qe/test_prove.py
@@ -47,6 +47,25 @@ class VerifierParsingTests(unittest.TestCase):
             pv._parse_verifier("magic:1")
 
 
+class AttestationForwardingTests(unittest.TestCase):
+    """--with-attestations must reach the gate (hard gates require an
+    independent attestation). Mocked — no peers, deterministic."""
+
+    def test_with_attestations_forwarded_to_gate(self):
+        import unittest.mock as mock
+        captured = {}
+
+        def fake_gate(pd, scope, phase, with_attestations=False):
+            captured["wa"] = with_attestations
+            return {"satisfied": True, "re_derived": True, "overall": "PASS"}
+
+        with mock.patch.object(pv.vault_gate, "resolve_vault", return_value=["echo"]), \
+             mock.patch.object(pv, "_vault", lambda *a, **k: None), \
+             mock.patch.object(pv.vault_gate, "gate_satisfied", fake_gate):
+            pv.prove("c", "true", with_attestations=True)
+        self.assertTrue(captured.get("wa"), "with_attestations not forwarded to gate")
+
+
 class FailClosedTests(unittest.TestCase):
     """No peers needed: with the loom cutover disabled the backend is
     unresolvable, so prove must fail closed — never a vacuous pass."""


### PR DESCRIPTION
## Why
Follow-up to #899 (prove.py). The verb was single-claim and wired into only `build.md` — so the kernel was reflexive in 1 of 7 gating archetypes, and couldn't cover the hard gates (incident/migrate/review) which require an independent attestation. That's where re-derivation matters *most*. This completes it.

## What
- `prove.py --with-attestations` — forwards to `gate_satisfied`, so the verb is **universal** across discrete *and* hard gates. Test locks the forwarding (mocked, no peers).
- All **7 gating playbooks** (build was #899; this adds decide/specify/ship + incident/migrate/review) now recommend `prove.py` first (frictionless, single-claim, re-derive) and the full multi-claim `vault_gate.py gate` second. So an agent following any gating archetype reaches for the one-line re-derivation verb instead of the 5-step ritual it would otherwise skip.

## Verification
- **543 passed**; structural validation **PASS (0/0)**.
- This PR's merge was gated by `prove.py` re-deriving the full suite (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
