### PR TITLE
fix(qe): prove.py --with-attestations actually enforces independent attestation (v12.7.0 was vacuous)

### DIFF
--- a/commands/prove.md
+++ b/commands/prove.md
@@ -28,3 +28,10 @@ Instructions:
   means the backend is down and the gate failed closed.
 - Only report the work as done when `satisfied: true`. On `REJECT`, the claim is
   false — fix it, don't narrate around it.
+
+**Hard gates (incident/migrate/review): `--with-attestations`.** Add it and the
+gate stays `REJECT` (`UNATTESTED`) until an INDEPENDENT evaluator — not the agent
+that did the work — runs `wicked-vault attest <artifact-id> --opinion pass`. The
+doer's own evidence cannot satisfy a hard gate; that's the point. Find the
+artifact with `wicked-vault list --scope <scope> --phase <phase>`. A `reject`
+attestation flips the gate to `REJECT` even if the evidence re-derives.

--- a/scripts/qe/prove.py
+++ b/scripts/qe/prove.py
@@ -87,10 +87,19 @@ def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
 
     # init (idempotent — ignore "already initialized"), declare, record --run.
     _vault(prefix, pd, "init")
-    contract = {"required_evidence": [{
+    claim_spec = {
         "claim_id": claim, "kind": "test-run",
         "verifier": verifier_spec, "required": True,
-    }]}
+    }
+    if with_attestations:
+        # Hard gate (incident/migrate/review): the doer's own evidence cannot
+        # satisfy it. Opt the contract into the vault's attestation enforcement
+        # (`require_attestation`) so the gate REJECTs as UNATTESTED until an
+        # INDEPENDENT evaluator records `wicked-vault attest` (evaluator !=
+        # creator). Without this flag the contract is integrity-only and the
+        # gate would pass on the doer's evidence alone — a vacuous hard gate.
+        claim_spec["require_attestation"] = True
+    contract = {"required_evidence": [claim_spec]}
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
         fh.write(json.dumps(contract))
         spec_path = fh.name
@@ -126,8 +135,11 @@ def main() -> int:
     p.add_argument("--phase", default="verify")
     p.add_argument("--project-dir", default=".")
     p.add_argument("--with-attestations", action="store_true",
-                   help="require an independent attestation (hard gates: "
-                        "incident/migrate/review)")
+                   help="hard gate (incident/migrate/review): require an "
+                        "INDEPENDENT attestation. The gate stays REJECT "
+                        "(UNATTESTED) until someone other than the doer runs "
+                        "`wicked-vault attest <artifact> --opinion pass` — the "
+                        "doer's own evidence cannot satisfy it")
     a = p.parse_args()
     verdict = prove(a.claim, a.by, verifier=a.verifier, scope=a.scope,
                     phase=a.phase, project_dir=a.project_dir,

--- a/skills/archetype/refs/incident.md
+++ b/skills/archetype/refs/incident.md
@@ -115,7 +115,7 @@ confirming the bleeding stopped. Don't skip to followup before resolve.
 `mitigate` is a **hard gate** — confirm the bleeding stopped before
 moving past it, and don't self-grade the mitigation. Check the gate WITH
 judgment:
-`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase incident --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase incident --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase incident --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase incident --with-attestations` **`--with-attestations`** keeps this gate `UNATTESTED`/`REJECT` until an INDEPENDENT evaluator (not the doer) runs `wicked-vault attest <artifact-id> --opinion pass` — find it via `wicked-vault list --scope <scope> --phase incident`. The doer's own evidence cannot satisfy a hard gate.
 (exit 0 = satisfied). This re-runs the symptom check (the mitigation pin)
 and requires an **independent attestation** — an evaluator who is *not*
 the responder confirms the mitigation holds and the RCA is adequate,

--- a/skills/archetype/refs/migrate.md
+++ b/skills/archetype/refs/migrate.md
@@ -104,7 +104,7 @@ tested, backfill complete, dual-read working).
    - Monitoring + alerts updated to surface new shape's anomalies.
 2. **Gate before any switch** — don't self-assert the checklist. Run the
    produces-gate WITH judgment:
-   `scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+   `scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations` **`--with-attestations`** keeps this gate `UNATTESTED`/`REJECT` until an INDEPENDENT evaluator (not the doer) runs `wicked-vault attest <artifact-id> --opinion pass` — find it via `wicked-vault list --scope <scope> --phase migrate`. The doer's own evidence cannot satisfy a hard gate.
    (exit 0 = satisfied). This re-derives the rollback drill and the
    shape-change post-condition over the declared contract, and requires
    the independent attestation (evaluator ≠ migrator, via
@@ -129,7 +129,7 @@ tested, backfill complete, dual-read working).
 
 Cutover may only proceed when the produces-gate is satisfied — check it,
 don't self-assert it:
-`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase migrate --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase migrate --with-attestations` **`--with-attestations`** keeps this gate `UNATTESTED`/`REJECT` until an INDEPENDENT evaluator (not the doer) runs `wicked-vault attest <artifact-id> --opinion pass` — find it via `wicked-vault list --scope <scope> --phase migrate`. The doer's own evidence cannot satisfy a hard gate.
 (exit 0 = satisfied). This is a re-derived PASS over the declared contract
 plus the independent attestation; a missing vault is `gate: "unavailable"`
 / `satisfied: false`, never a claim-only pass.

--- a/skills/archetype/refs/review.md
+++ b/skills/archetype/refs/review.md
@@ -117,7 +117,7 @@ banned (banned-reviewer enforcement applies — `auto-approve-*`,
 
 Review is done when the produces-gate is satisfied. Check the gate —
 don't self-assert it:
-`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase review --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase review --with-attestations`
+`scripts/qe/prove.py <claim> --by "<command>" --scope <scope> --phase review --with-attestations` (frictionless, single claim — re-derive, don't assert) — or the full multi-claim contract via `scripts/qe/vault_gate.py gate <project_dir> --scope <scope> --phase review --with-attestations` **`--with-attestations`** keeps this gate `UNATTESTED`/`REJECT` until an INDEPENDENT evaluator (not the doer) runs `wicked-vault attest <artifact-id> --opinion pass` — find it via `wicked-vault list --scope <scope> --phase review`. The doer's own evidence cannot satisfy a hard gate.
 (exit 0 = satisfied). This is a re-derived PASS over the declared
 contract. `--with-attestations` makes the gate require a passing
 independent `opinion_attestation` recorded via the

--- a/tests/qe/test_prove.py
+++ b/tests/qe/test_prove.py
@@ -122,6 +122,42 @@ class ProveEndToEndTests(unittest.TestCase):
         self.assertEqual(out["overall"], "REJECT")
         self.assertEqual(proc.returncode, 1)
 
+    def test_with_attestations_rejects_until_independent_attestation(self):
+        # The fix for the v12.7.0 false guarantee: --with-attestations must set
+        # require_attestation on the contract so a hard gate CANNOT be satisfied
+        # by the doer's own evidence — it stays REJECT (UNATTESTED) until an
+        # independent evaluator attests. A mock test cannot catch this (it was
+        # green while the gate vacuously passed); only the real round-trip can.
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env.update(WICKED_VAULT_BIN=_VAULT, WICKED_LOOM_BIN=_LOOM,
+                   WICKED_LOOM_CUTOVER="on")
+        # doer-only run → REJECT / UNATTESTED
+        proc = subprocess.run(
+            [sys.executable, str(_PROVE_CLI), "tests-pass", "--by", "true",
+             "--scope", "s", "--phase", "migrate", "--with-attestations",
+             "--project-dir", str(self.proj)],
+            capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=120)
+        out = json.loads(proc.stdout)
+        self.assertFalse(out["satisfied"])
+        self.assertEqual(out["overall"], "REJECT")
+        self.assertEqual(out["claims"][0]["result"], "UNATTESTED")
+        self.assertEqual(proc.returncode, 1)
+
+        # independent evaluator attests PASS → gate flips to PASS
+        listing = subprocess.run(["node", _VAULT, "list", "--scope", "s",
+                                  "--phase", "migrate"], cwd=str(self.proj),
+                                 capture_output=True, text=True, timeout=60)
+        aid = json.loads(listing.stdout)[0]["id"]
+        subprocess.run(["node", _VAULT, "attest", aid, "--opinion", "pass",
+                        "--evaluator", "independent-reviewer", "--rationale", "ok"],
+                       cwd=str(self.proj), capture_output=True, text=True, timeout=60)
+        gate = subprocess.run(
+            [sys.executable, str(_REPO / "scripts" / "qe" / "vault_gate.py"),
+             "gate", str(self.proj), "--scope", "s", "--phase", "migrate",
+             "--with-attestations"],
+            capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=120)
+        self.assertTrue(json.loads(gate.stdout)["satisfied"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why
Found by **re-deriving my own just-shipped claim** — running `prove.py` for each gating phase (the exact discipline the plugin exists to enforce). v12.7.0 claimed `prove.py --with-attestations` made the verb "universal across hard gates." It didn't: the hard gate **PASSED on the doer's own evidence with no independent attestation**, and even ignored a recorded `reject`. The plugin's flagship safety guarantee — "hard gates require an independent attestation" (CLAUDE.md) — was **theater** on the prove path.

## Root cause
`prove.py --with-attestations` forwarded the flag to the gate but never set `require_attestation` on its synthesized contract. wicked-vault enforces attestations **only** when the contract opts in (`require_attestation: true`) — verified directly:

| contract `require_attestation` | attestation state | gate |
|---|---|---|
| (unset, the old prove behavior) | none | **PASS** ← the bug |
| true | none | REJECT (`UNATTESTED`) |
| true | independent `reject` | REJECT |
| true | independent `pass` | PASS |

The vault is correct; the garden simply never opted in.

## Fix
- `prove.py` sets `require_attestation: true` when `--with-attestations`, so a hard gate stays **REJECT (`UNATTESTED`) until an INDEPENDENT evaluator** runs `wicked-vault attest <artifact> --opinion pass` — the doer cannot self-satisfy a hard gate.
- New E2E test pins the full round-trip (doer-only → `UNATTESTED`; independent `pass` → `PASS`). A mock test **cannot** catch this — the old mock forwarding test stayed green while the gate vacuously passed.
- `commands/prove.md` + the incident/migrate/review playbooks document the independent-attestation requirement and how to record it.

## Verification
- **544 passed**; validation **PASS (0/0)**.
- Merge gated by `prove.py` re-deriving the full suite (PASS).

This is the kind of finding the goal was about: a guarantee that *looked* like value but wasn't enforced — now made real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
