### PR TITLE
feat(qe): prove.py validates outputs (regex/not_contains/jq_pred), final and interim

### DIFF
--- a/commands/prove.md
+++ b/commands/prove.md
@@ -23,6 +23,16 @@ Instructions:
     <claim> --by "<command>" [--verifier exit_code_eq:0] [--project-dir <dir>]
   ```
   e.g. `prove.py tests-pass --by "pytest -q"` · `prove.py build-clean --by "npm run build"`
+- **Validate the OUTPUT, not just an exit code.** `--verifier` re-runs against the
+  command's output: `regex_match:<re>` / `not_contains:<re>` scan stdout;
+  `jq_pred:<expr>` evaluates a predicate over the command's JSON stdout;
+  `commit_exists:<sha>` checks a git commit. This works on **final and interim**
+  artifacts — prove an intermediate produce the moment it exists, not only at the end:
+  ```
+  prove.py adr-has-decision --by "cat decision.md" --verifier "regex_match:## Decision" --kind doc
+  prove.py config-no-secrets --by "cat app.yaml"   --verifier "not_contains:(?i)password" --kind doc
+  prove.py enough-options    --by "cat options.json" --verifier "jq_pred:.options | length >= 2" --kind doc
+  ```
 - Read the JSON verdict: `satisfied` is the truth; `re_derived: true` means it
   was recomputed from frozen evidence (not your claim); `gate: "unavailable"`
   means the backend is down and the gate failed closed.

--- a/scripts/qe/prove.py
+++ b/scripts/qe/prove.py
@@ -42,19 +42,31 @@ except ImportError:  # pragma: no cover
     vault_gate = None  # type: ignore
 
 
+# Mirror wicked-vault's parseVerifier so prove can validate the OUTPUT, not
+# just an exit code: regex_match / not_contains run against the command's
+# stdout; jq_pred evaluates a predicate over JSON stdout; commit_exists checks
+# a git SHA. This is what lets prove validate produced artifacts (an ADR has a
+# Decision section, a config contains no TODO, a decision JSON has >=2 options),
+# final or interim — not merely "a command exited 0".
 _VERIFIERS = {
-    # name:arg  ->  vault verifier spec
-    "exit_code_eq": lambda arg: {"kind": "exit_code_eq", "params": {"code": int(arg)}},
+    "exit_code_eq": lambda arg: {"kind": "exit_code_eq", "params": {"code": int(arg or "0")}},
+    "regex_match": lambda arg: {"kind": "regex_match", "params": {"pattern": arg}},
+    "not_contains": lambda arg: {"kind": "not_contains", "params": {"pattern": arg}},
+    "commit_exists": lambda arg: {"kind": "commit_exists", "params": {"sha": arg}},
+    "jq_pred": lambda arg: {"kind": "jq_pred", "params": {"expr": arg}},
 }
 
 
 def _parse_verifier(spec: str) -> dict:
-    """`exit_code_eq:0` -> {kind, params}. Defaults to exit_code_eq:0."""
-    name, _, arg = spec.partition(":")
+    """`exit_code_eq:0` / `regex_match:## Decision` / `jq_pred:.options>=2` ->
+    {kind, params}. Defaults to exit_code_eq:0."""
+    name, sep, arg = spec.partition(":")
     builder = _VERIFIERS.get(name)
     if builder is None:
         raise ValueError(f"unsupported verifier '{name}'; known: {sorted(_VERIFIERS)}")
-    return builder(arg or "0")
+    if name != "exit_code_eq" and not (sep and arg):
+        raise ValueError(f"verifier '{name}' requires an argument, e.g. {name}:<value>")
+    return builder(arg)
 
 
 def _vault(prefix: list[str], project_dir: Path, *args: str) -> subprocess.CompletedProcess:
@@ -64,7 +76,8 @@ def _vault(prefix: list[str], project_dir: Path, *args: str) -> subprocess.Compl
 
 def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
           scope: str = "prove", phase: str = "verify",
-          project_dir: str = ".", with_attestations: bool = False) -> dict:
+          project_dir: str = ".", with_attestations: bool = False,
+          kind: str = "check") -> dict:
     """Re-derive a single claim end to end; return the gate verdict dict.
 
     ``with_attestations`` forwards to the gate's hard-gate requirement (the
@@ -79,6 +92,15 @@ def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
         return {"satisfied": False, "gate": "unavailable", "re_derived": False,
                 "error": ("evidence backend (wicked-loom/wicked-vault) not "
                           "resolvable — fails closed, never a vacuous pass")}
+    # jq_pred ergonomics: prove always records via --run, so the payload is the
+    # capture envelope {command, exit_code, stdout, ...}. An agent means "query
+    # my command's JSON OUTPUT", not the envelope — so target stdout-as-JSON.
+    # Rewrite `jq_pred:<expr>` -> evaluate <expr> over fromjson(.stdout), unless
+    # the expr already navigates the envelope (mentions .stdout). regex_match /
+    # not_contains already scan the captured text, so they need no rewrite.
+    if verifier.startswith("jq_pred:") and ".stdout" not in verifier:
+        expr = verifier[len("jq_pred:"):]
+        verifier = f"jq_pred:.stdout | fromjson | ({expr})"
     try:
         verifier_spec = _parse_verifier(verifier)
     except ValueError as e:
@@ -88,7 +110,7 @@ def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
     # init (idempotent — ignore "already initialized"), declare, record --run.
     _vault(prefix, pd, "init")
     claim_spec = {
-        "claim_id": claim, "kind": "test-run",
+        "claim_id": claim, "kind": kind,
         "verifier": verifier_spec, "required": True,
     }
     if with_attestations:
@@ -107,7 +129,7 @@ def prove(claim: str, command: str, *, verifier: str = "exit_code_eq:0",
         _vault(prefix, pd, "declare-contract", "--scope", scope, "--phase", phase,
                "--spec", spec_path)
         _vault(prefix, pd, "record", "--scope", scope, "--phase", phase,
-               "--claim", claim, "--kind", "test-run", "--source", command,
+               "--claim", claim, "--kind", kind, "--source", command,
                "--criteria", f"{claim}: `{command}` satisfies {verifier}",
                "--verifier", verifier, "--run")
     finally:
@@ -130,7 +152,9 @@ def main() -> int:
                         "runs in --project-dir, so prefer absolute paths or a "
                         "command valid from there")
     p.add_argument("--verifier", default="exit_code_eq:0",
-                   help="verifier spec (default: exit_code_eq:0)")
+                   help="verifier spec: exit_code_eq:0 | regex_match:<re> | not_contains:<re> | jq_pred:<expr> | commit_exists:<sha>. The regex/not_contains/jq_pred kinds validate the command's OUTPUT, not just its exit code.")
+    p.add_argument("--kind", default="check",
+                   help="evidence kind label (e.g. test-run, doc, output)")
     p.add_argument("--scope", default="prove")
     p.add_argument("--phase", default="verify")
     p.add_argument("--project-dir", default=".")
@@ -143,7 +167,7 @@ def main() -> int:
     a = p.parse_args()
     verdict = prove(a.claim, a.by, verifier=a.verifier, scope=a.scope,
                     phase=a.phase, project_dir=a.project_dir,
-                    with_attestations=a.with_attestations)
+                    with_attestations=a.with_attestations, kind=a.kind)
     print(json.dumps(verdict, indent=2))
     if verdict.get("satisfied"):
         return 0

--- a/tests/qe/test_prove.py
+++ b/tests/qe/test_prove.py
@@ -46,6 +46,18 @@ class VerifierParsingTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             pv._parse_verifier("magic:1")
 
+    def test_output_verifiers_parse(self):
+        self.assertEqual(pv._parse_verifier("regex_match:## Decision"),
+                         {"kind": "regex_match", "params": {"pattern": "## Decision"}})
+        self.assertEqual(pv._parse_verifier("not_contains:TODO"),
+                         {"kind": "not_contains", "params": {"pattern": "TODO"}})
+        self.assertEqual(pv._parse_verifier("jq_pred:.a>=2"),
+                         {"kind": "jq_pred", "params": {"expr": ".a>=2"}})
+
+    def test_content_verifier_requires_argument(self):
+        with self.assertRaises(ValueError):
+            pv._parse_verifier("regex_match")  # no pattern
+
 
 class AttestationForwardingTests(unittest.TestCase):
     """--with-attestations must reach the gate (hard gates require an
@@ -157,6 +169,42 @@ class ProveEndToEndTests(unittest.TestCase):
              "--with-attestations"],
             capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=120)
         self.assertTrue(json.loads(gate.stdout)["satisfied"])
+
+    # --- OUTPUT validation (not just exit codes): the capability the gate
+    #     needs to be useful for produced artifacts, final or interim. ---
+    def _prove_out(self, claim, command, verifier, phase):
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env.update(WICKED_VAULT_BIN=_VAULT, WICKED_LOOM_BIN=_LOOM,
+                   WICKED_LOOM_CUTOVER="on")
+        proc = subprocess.run(
+            [sys.executable, str(_PROVE_CLI), claim, "--by", command,
+             "--verifier", verifier, "--kind", "doc", "--scope", "s",
+             "--phase", phase, "--project-dir", str(self.proj)],
+            capture_output=True, text=True, env=env, cwd=str(_REPO), timeout=120)
+        return json.loads(proc.stdout)["overall"]
+
+    def test_regex_match_validates_output_content(self):
+        (self.proj / "adr.md").write_text("## Decision\nUse PG.\n", encoding="utf-8")
+        self.assertEqual(self._prove_out("has-decision", "cat adr.md",
+                                         "regex_match:## Decision", "p1"), "PASS")
+        self.assertEqual(self._prove_out("has-rollback", "cat adr.md",
+                                         "regex_match:## Rollback", "p2"), "REJECT")
+
+    def test_not_contains_validates_absence(self):
+        (self.proj / "f.txt").write_text("clean line\n", encoding="utf-8")
+        self.assertEqual(self._prove_out("no-todo", "cat f.txt",
+                                         "not_contains:TODO", "p3"), "PASS")
+        (self.proj / "g.txt").write_text("x  # TODO\n", encoding="utf-8")
+        self.assertEqual(self._prove_out("no-todo2", "cat g.txt",
+                                         "not_contains:TODO", "p4"), "REJECT")
+
+    def test_jq_pred_validates_structured_output(self):
+        (self.proj / "d.json").write_text('{"options":3}\n', encoding="utf-8")
+        # natural expr (prove targets the command's JSON stdout automatically)
+        self.assertEqual(self._prove_out("enough", "cat d.json",
+                                         "jq_pred:.options >= 2", "p5"), "PASS")
+        self.assertEqual(self._prove_out("too-few", "cat d.json",
+                                         "jq_pred:.options >= 9", "p6"), "REJECT")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Reviewer push: *"Are we validating for outputs (final and interim) as well as friction? You need to be able to use these."* The honest answer was **no** — prove.py only supported `exit_code_eq`, so it could prove "a command exited 0" but not validate the **output** an archetype produces (does the ADR have a Decision section? does the config contain a secret? does the decision JSON have ≥2 options?). A gate that only checks exit codes says nothing about output quality.

## What
prove.py now mirrors the vault's full verifier set, so the one-line verb validates **outputs**:
- `regex_match:<re>` / `not_contains:<re>` — scan the command's stdout (content present / absent)
- `jq_pred:<expr>` — predicate over the command's JSON stdout (auto-targets stdout: prove records via `--run`, whose payload is the capture envelope, so natural exprs like `.options >= 2` work)
- `commit_exists:<sha>` — a git commit exists
- `--kind` so evidence is labelled honestly (doc/output vs test-run)

Works on **final and interim** artifacts — prove an intermediate produce the moment it exists.

## Use it (not just build it)
This PR's merge was gated on **two dimensions** via prove.py:
1. exit-code: full suite passes →  `PASS`
2. output-content: `prove.py --help` actually exposes `regex_match` (`regex_match:regex_match` over the help output) → `PASS (matched /regex_match/)`

## Verification
New unit + E2E tests pin **pass AND fail** for each verifier (regex present/absent, not_contains clean/dirty, jq_pred natural-expr true/false). **549 passed**; validation **PASS (0/0)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
