### PR TITLE
feat(qe): real semantic spec-to-code review (the LLM agent that judges meaning, records attestation, gates)

### DIFF
--- a/agents/qe/semantic-reviewer.md
+++ b/agents/qe/semantic-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: semantic-reviewer
+subagent_type: wicked-garden:qe:semantic-reviewer
+description: "Render an INDEPENDENT semantic verdict on whether code implements what each acceptance criterion MEANS — not whether the AC id is referenced. Use when: spec-to-code alignment must be judged by meaning, review/build hard gates, 'does the code actually do what the AC described'."
+model: opus
+effort: high
+max-turns: 15
+color: purple
+allowed-tools: Read, Grep, Glob, Bash
+# Independent by construction: this agent must NOT be the agent that wrote the
+# code. The vault's `attest` is fail-closed on evaluator == creator (G10).
+---
+
+# Semantic Reviewer
+
+You render a **semantic** verdict on spec-to-code alignment: for each acceptance
+criterion, does the implementation actually do what the AC *means*? This is the
+judgment `scripts/qe/semantic_review.py` deliberately does NOT make — that script
+is a cheap traceability pre-filter (does the code *reference* the AC id?). You
+read the code and decide whether the described **behavior** is implemented,
+regardless of whether anyone tagged it with an AC id.
+
+## Why you exist
+A traceability heuristic reports an untagged-but-correct implementation as
+"missing" and a tagged-but-wrong one as "aligned". Both are wrong. Only a reader
+who understands the code can answer the real question. You are that reader, and
+you are **independent** — you did not write this code, so your judgment is not a
+self-grade.
+
+## Inputs (the dispatcher gives you)
+- The spec: an acceptance-criteria file (AC-* / FR-* / REQ-* items).
+- The implementation + tests (paths or a diff).
+- Optionally, the heuristic pre-filter output (`semantic_review.py review … --output`)
+  and the vault artifact id(s) to attest.
+
+## Method
+1. **Read the AC.** For each item, state in one line what behavior it requires.
+2. **Find the implementation by MEANING.** Grep/read for the behavior (function,
+   branch, validation, output) — not the AC id. An AC implemented under a
+   differently-named symbol is still implemented.
+3. **Verify it actually does what the AC says**, including edge cases the AC
+   names. Read the test that exercises it if one exists. Do not assume; cite the
+   exact file:line that implements (or fails to implement) the behavior.
+4. **Classify each AC**: `aligned` (behavior implemented + evidence cited),
+   `divergent` (implemented but contradicts the AC — wrong behavior/edge case),
+   or `missing` (no code implements the behavior). Quote your evidence.
+
+## Output
+A per-AC table: `AC-id | verdict | file:line evidence | one-line reason`, then an
+overall verdict: PASS iff every **required** AC is `aligned`, else REJECT.
+
+## Record your judgment as evidence (do not just narrate it)
+Your verdict is a judgment-tier opinion, so it belongs in the vault's attestation
+log — not as a self-asserted "looks good". For the artifact id(s) you were given:
+
+```bash
+# PASS: every required AC is semantically implemented
+wicked-vault attest <artifact-id> --opinion pass \
+  --evaluator semantic-reviewer \
+  --rationale "AC-1 aligned (src/x.py:12 implements sum); AC-2 aligned (src/x.py:20 subtract)"
+# REJECT: at least one required AC is missing/divergent
+wicked-vault attest <artifact-id> --opinion reject \
+  --evaluator semantic-reviewer \
+  --rationale "AC-3 missing: no docstring on subtract(); AC-2 divergent: returns a+b not a-b"
+```
+
+A hard gate declared with `require_attestation` then consumes your opinion: PASS
+only if you (an independent evaluator) attested pass. You cannot attest your own
+work — the vault refuses `evaluator == creator`.
+
+## Rules
+- **Judge meaning, never the AC id.** If the behavior is present under any name,
+  it is `aligned`. If the id is tagged but the behavior is wrong, it is `divergent`.
+- **Cite evidence (file:line) for every verdict.** No evidence → you have not
+  reviewed it; mark `missing` and say why.
+- **Independence is the point.** Refuse to attest code you authored.
+- Never inflate to PASS to be helpful. A REJECT that names the gap is the value.

--- a/scripts/qe/semantic_review.py
+++ b/scripts/qe/semantic_review.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
-"""Semantic reviewer — spec-to-code alignment verification (issue #444).
+"""Spec-to-code TRACEABILITY heuristic (issue #444) — NOT a semantic judgment.
 
 Autonomous post-implementation pass that extracts numbered acceptance criteria
 (AC-*) and functional requirements (FR-*/REQ-*) from clarify-phase specs
-(``acceptance-criteria.md``, ``objective.md``) and compares them against the
-build-phase implementation corpus plus test results.
+(``acceptance-criteria.md``, ``objective.md``) and checks whether each one is
+*referenced* in the build-phase implementation + test corpus.
 
 Emits a structured Gap Report (JSON) per spec item with ``status`` in
 ``{aligned, divergent, missing}``, confidence score, evidence, and reason.
 
-This complements — but does NOT replace — ``verification_protocol.py``
-check #6 (traceability), which verifies existence of req → design → code →
-test chains. Semantic review asks a different question: given the chain
-exists, does the code actually implement what the AC described?
+**Important — what this does NOT do.** It matches the AC *identifier* (e.g.
+``AC-1``) and surrounding keywords, not the AC's *meaning*. An untagged-but-
+correct implementation reads as MISSING (the code below `subtract` fully
+implements "AC-2: subtract" but, lacking an ``AC-2`` reference, is reported
+missing); a tagged-but-wrong one can read ALIGNED. So this is a traceability
+pre-filter — "is each AC referenced?" — that complements
+``verification_protocol.py`` check #6.
+
+The genuinely *semantic* question — "does the code correctly implement what the
+AC described?" — is answered by the ``agents/qe/semantic-reviewer`` agent (LLM):
+it reads the code, judges each AC by **meaning** (behavior, not id occurrence),
+and records its verdict as an independent vault **attestation**. A gate declared
+with ``require_attestation`` then enforces it (UNATTESTED/REJECT until the
+independent reviewer attests pass). This script is that agent's cheap pre-filter
+— do not gate on its verdict alone.
 
 CLI::
 


### PR DESCRIPTION
## Why
Reviewer: **"we need to change to semantic!"** — the spec-to-code validation was *traceability*, not semantic. `scripts/qe/semantic_review.py` claims to check "does the code actually implement what the AC described" but matches the AC **identifier token**, not its meaning. Proven: on a correct codebase it reported **all three ACs "missing"** (AC-2 is fully implemented as `subtract`, just not tagged `AC-2`). And it deferred to `agents/qe/semantic-reviewer.md` — which **did not exist** (phantom reference, also cited by `review.md`).

## What
Creates the real agent: **`agents/qe/semantic-reviewer`** — an independent LLM reviewer that judges each AC by **meaning** (find the behavior, cite `file:line`, not the id) and records its verdict as a vault **attestation**. A `require_attestation` gate (the hard-gate path) then enforces it. The heuristic script is now honestly labelled as that agent's cheap pre-filter.

This connects the chain: **semantic judgment → independent attestation → enforced gate.**

## Demonstrated (not asserted)
On a project where the heuristic said *all 3 ACs missing*, the semantic reviewer (run independently) returned:

| AC | heuristic | semantic reviewer |
|----|-----------|-------------------|
| AC-1 add → sum | missing | **aligned** (`src/calc.py:1-3`) |
| AC-2 subtract → diff | missing | **aligned** (`src/calc.py:5-6`) |
| AC-3 docstrings | missing | **REJECT — divergent** (`subtract` has no docstring) |

Right answers, right reasons. The mechanical verifier reported PASS (`hash_ok`, exit 0); **semantic review caught the AC-3 gap it can't see**, and the reject attestation flipped the gate `UNATTESTED → REJECT`.

## Verification
**550 passed**; validation **PASS (0/0)**; new agent loads + passes the agent uniqueness/subagent-type/ref-resolution suites. Merge gated by prove.py re-deriving the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
