### PR TITLE
feat(codegraph): adopt codegraph engine + injected-edge extractor (ADR 0001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ _meta/
 # wicked-garden compiler: transient probe transcripts (regenerable)
 scripts/compiler/phase0/evidence/
 scripts/compiler/**/__pycache__/
+
+# codegraph local index (per-machine, do not commit)
+.codegraph/

--- a/docs/adr/0001-code-relationship-graph-engine.md
+++ b/docs/adr/0001-code-relationship-graph-engine.md
@@ -1,0 +1,116 @@
+# ADR 0001 — Code-relationship graph: adopt codegraph as the engine, add injected-edge extractors
+
+- **Status:** Accepted (prototype validated)
+- **Date:** 2026-06-09
+- **Context owners:** wicked-garden
+
+## Context
+
+Three features need a real code-relationship graph, and none works today:
+
+- **`search:blast-radius`** — "what breaks if I change X" — currently runs a brain
+  search (hardcoded to the wrong port, 4242; the brain is on 4243) + `grep`. It is
+  effectively grep-with-extra-steps.
+- **`search:lineage`** — data flow — same shape.
+- **wicked-patch** (`engineering:rename`/`add-field`/`remove`) — deterministic
+  multi-file refactor — requires a symbol `--db` that **nothing in the ecosystem
+  produces**, so the whole family is dead-on-arrival.
+
+The decisive requirement is **injected relationships**: this plugin's load-bearing
+edges are wired by a shared *string* through a registry, never by a literal symbol
+reference, so neither `grep` nor a static call-graph can see them:
+
+| Injected edge (grep-/static-invisible) | Wired by (deterministically extractable) |
+|---|---|
+| event producer → consumer | `emit_event("wicked.x")` + `_bus_consumers.json` `event_filter` |
+| command/Task → agent | `subagent_type:` frontmatter |
+| agent → tool | `tool-capabilities` + `_capability_registry` |
+| hook event → script | `hooks.json` |
+| archetype → playbook/gate | `archetypes.json` + `refs/` |
+
+## Decision
+
+**Adopt [codegraph](https://github.com/colbymchenry/codegraph) (`@colbymchenry/codegraph`, MIT,
+TypeScript/web-tree-sitter) as the static code-graph engine, consumed as a
+runtime-resolved peer** (the same model as wicked-loom/vault/testing/bus), and
+**add wicked-garden-specific injected-edge extractors on top.** Do not build a
+graph engine from scratch — re-implementing multi-language tree-sitter resolution
+to codegraph's fidelity is months of work it already does.
+
+### Why codegraph (vs roam-code, vs build)
+Both codegraph and [roam-code](https://github.com/Cranot/roam-code) (Apache-2.0,
+Python) are credible "adopt-as-engine" candidates. codegraph wins for us on two
+decisive axes:
+
+1. **Architecture fit** — it ships a CLI + MCP server + a plain SQLite contract and
+   is npm/node, exactly how we already consume our peers (a `_codegraph.py` shim
+   mirrors `_loom.py`). roam-code is a Python library — a different integration shape.
+2. **Patch precision** — codegraph is **column-precise** (`file:line:col` on nodes
+   *and* reference sites) with real import/alias/workspace/re-export/JVM-FQN
+   resolution and confidence/provenance per edge. roam-code is line-granular +
+   heuristic name resolution (false-positive risk) — riskier to refactor against.
+
+**Borrow, don't adopt, from roam-code:** its Code-Graph Attestation (re-derive
+Merkle/edge digests from the live DB, fail-closed) is a genuine twin of our vault
+gate, operating on a layer the vault doesn't cover; and its `oracle_*` deterministic
+fact tools are clean gate inputs. We keep it at arm's length because it is a
+*competing change-governance framework* (constitution/permits/leases) that overlaps
+wicked-garden's entire premise — we want a code-graph *component*, not to outsource
+our governance.
+
+## Validation (prototype, this ADR)
+
+Run on this repo, Node 26:
+
+- `codegraph index` → **4,179 nodes / 7,733 edges** across 196 Python files in ~1s;
+  plain SQLite at `.codegraph/codegraph.db` (auto-gitignored). `codegraph impact <symbol>`
+  (blast-radius) and `query`/`callers` work out of the box.
+- `scripts/codegraph/inject_edges.py` (the first injected-edge extractor) reads
+  `_bus_consumers.json` + emit sites and materializes producer→consumer edges:
+  `file:scripts/_bus.py --[wicked.persona.contributed]--> file:scripts/jam/_bus_consumers.py`.
+  codegraph's static graph had **0** such edges; `grep` finds **no** link between
+  producer and consumer (they share only the event string). Blast-radius now
+  traverses them.
+- Bonus finding: a consumer in `_bus_consumers.json` (`crew:auto-advance`) points at
+  `scripts/crew/_bus_consumers.py`, which **does not exist** — a stale registry entry
+  the graph build surfaced.
+
+## Architecture
+
+```
+codegraph (static: symbols + imports/calls/refs, column-precise, SQLite)
+        +  injected-edge extractors (deterministic, per wiring mechanism)
+             bus emit↔_bus_consumers.json   [prototype: scripts/codegraph/inject_edges.py]
+             command→agent (subagent_type)  [next]
+             agent→tool (capabilities)       [next]
+        +  data-flow lineage layer           [build: neither engine provides general lineage]
+        =  the relationship graph
+        →  consumers: blast-radius, lineage, wicked-patch (--db)
+```
+
+- **Peer shim** `scripts/_codegraph.py` — resolves + runs the codegraph CLI/MCP
+  exactly like `_loom.py` does for loom (env `WICKED_CODEGRAPH_BIN` → config → PATH →
+  npx). Pin Node ≥ 22.5 (codegraph uses `node:sqlite`); we run 26.
+- **Injected edges** carry their semantics in the edge `metadata` (codegraph's
+  node/edge `kind` are closed unions; `references` + `provenance='injected:<mechanism>'`
+  is the no-fork convention). Coverage caveat: if a wired file isn't a codegraph
+  node, the extractor skips it (and that itself flags stale wiring, as above).
+
+## Consequences
+
+- blast-radius/lineage flip from **redundant** (grep+broken) → **genuinely
+  differentiated** (they answer injected-relationship questions grep cannot).
+- wicked-patch flips from **broken** (no `--db`) → **working** (consumes the
+  codegraph SQLite as its symbol DB).
+- **Risk:** codegraph bus-factor = 1. Mitigated by MIT license + the SQLite schema
+  being a stable, self-describing contract we can read even if upstream stalls.
+- **Lock-in:** low — we depend on a documented SQLite shape, not an opaque service.
+
+## Roadmap
+
+1. ✅ Prototype: peer shim + bus injected-edge extractor + blast-radius proof (this ADR).
+2. command→agent and agent→tool extractors (same pattern as the bus extractor).
+3. Rewire `search:blast-radius`/`lineage` to query the graph (and fix the 4242→4243 port).
+4. Wire wicked-patch to consume the codegraph SQLite as its `--db` (revives the patch family).
+5. Build the data-flow lineage layer on top.
+6. Evaluate borrowing roam-code's Code-Graph Attestation as a complement to the vault gate.

--- a/scripts/_codegraph.py
+++ b/scripts/_codegraph.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""_codegraph.py — resolve + run the codegraph CLI, peer-neutral.
+
+The garden's runtime shim for the adopted static code-graph engine
+(``@colbymchenry/codegraph``, MIT). Mirrors ``_loom.py``/``vault_gate.resolve_vault``:
+the garden NEVER imports codegraph's TypeScript; it shells the published CLI
+exactly as it shells wicked-loom/wicked-vault. See docs/adr/0001-code-relationship-graph-engine.md.
+
+This module owns:
+  1. resolve_codegraph() — the resolution ladder: WICKED_CODEGRAPH_BIN env
+     (empty = kill-switch) -> config tool_preferences.codegraph -> PATH ->
+     node_modules/.bin -> ``npx @colbymchenry/codegraph``.
+  2. run_json() — run a codegraph subcommand with --json, return
+     {exit_code, json, stdout, stderr, error}. Never raises (R4 — surface as data).
+  3. db_path() — the SQLite graph location for a project (<project>/.codegraph/codegraph.db),
+     which injected-edge extractors + blast-radius/lineage/patch read directly.
+
+Stdlib-only. Cross-platform (argv lists, shutil.which, no shell).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess  # noqa: S404 — argv lists only, shell=False
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
+_DEFAULT_TIMEOUT = 300
+_PACKAGE = "@colbymchenry/codegraph"
+_ENV_BIN = "WICKED_CODEGRAPH_BIN"
+
+
+def _argv_for(target: str) -> List[str]:
+    """A .mjs/.js path is a script -> invoke via node; else run directly."""
+    if target.endswith((".mjs", ".js")):
+        return ["node", target]
+    return [target]
+
+
+def _read_config_preference(key: str) -> Optional[str]:
+    try:
+        if not _CONFIG_PATH.exists():
+            return None
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = data.get("tool_preferences")
+        if isinstance(prefs, dict):
+            value = prefs.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def resolve_codegraph(*, allow_npx: bool = True,
+                      project_dir: Optional[Path] = None) -> Optional[List[str]]:
+    """Return the argv prefix that invokes codegraph, or None.
+
+    ``WICKED_CODEGRAPH_BIN=""`` (set-but-empty) is the deliberate kill-switch -> None.
+    With ``allow_npx=False`` the npx last-resort is skipped (the "is a concrete
+    install present?" probe used by setup/bootstrap)."""
+    if _ENV_BIN in os.environ:
+        env = os.environ[_ENV_BIN].strip()
+        return _argv_for(env) if env else None  # empty == kill-switch
+
+    pref = _read_config_preference("codegraph")
+    if pref:
+        return _argv_for(pref)
+
+    found = shutil.which("codegraph")
+    if found:
+        return [found]
+
+    base = Path(project_dir) if project_dir else Path.cwd()
+    local = base / "node_modules" / ".bin" / "codegraph"
+    if local.exists():
+        return [str(local)]
+
+    if allow_npx and shutil.which("npx"):
+        return ["npx", "-y", _PACKAGE]
+
+    return None
+
+
+def codegraph_available(project_dir: Optional[Path] = None) -> bool:
+    """True iff a CONCRETE codegraph install resolves (not the npx last-resort)."""
+    return resolve_codegraph(allow_npx=False, project_dir=project_dir) is not None
+
+
+def db_path(project_dir: Optional[Path] = None) -> Path:
+    base = Path(project_dir) if project_dir else Path.cwd()
+    return base / ".codegraph" / "codegraph.db"
+
+
+def _default_run(prefix: List[str], args: List[str], timeout: int,
+                 cwd: Optional[str] = None) -> Dict[str, Any]:
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            prefix + args, capture_output=True, text=True, timeout=timeout, cwd=cwd,
+        )
+        return {"exit_code": proc.returncode, "stdout": proc.stdout,
+                "stderr": proc.stderr, "error": None}
+    except FileNotFoundError:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": "codegraph executable not found"}
+    except subprocess.TimeoutExpired:
+        return {"exit_code": None, "stdout": "", "stderr": "",
+                "error": f"codegraph call exceeded {timeout}s"}
+
+
+def run_json(args: List[str], *, timeout: int = _DEFAULT_TIMEOUT,
+             project_dir: Optional[Path] = None, _run=None) -> Dict[str, Any]:
+    """Run ``codegraph <args> --json``; return {exit_code, json, stdout, stderr, error}.
+    Never raises (R4). json is parsed stdout or None (unresolvable/non-JSON/timeout).
+    The codegraph subprocess runs in project_dir (its graph is per-project)."""
+    prefix = resolve_codegraph(project_dir=project_dir)
+    if prefix is None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": "codegraph not resolvable"}
+    cwd = str(project_dir) if project_dir is not None else None
+    if _run is not None:
+        run = _run(prefix, args, timeout)
+    else:
+        run = _default_run(prefix, args, timeout, cwd=cwd)
+    if run["error"] is not None:
+        return {"exit_code": None, "json": None, "stdout": "", "stderr": "",
+                "error": run["error"]}
+    try:
+        parsed = json.loads(run["stdout"]) if (run["stdout"] or "").strip() else {}
+    except json.JSONDecodeError:
+        return {"exit_code": run["exit_code"], "json": None,
+                "stdout": run["stdout"], "stderr": run["stderr"],
+                "error": "codegraph returned non-JSON output"}
+    return {"exit_code": run["exit_code"], "json": parsed,
+            "stdout": run["stdout"], "stderr": run["stderr"], "error": None}
+
+
+__all__ = ["resolve_codegraph", "codegraph_available", "db_path", "run_json"]

--- a/scripts/codegraph/inject_edges.py
+++ b/scripts/codegraph/inject_edges.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""inject_edges.py — materialize wicked-garden's INJECTED relationships into the
+codegraph symbol graph.
+
+codegraph (the adopted static engine) resolves literal references — imports,
+calls, instantiations. But this plugin's load-bearing relationships are
+*injected*: wired by a shared string through a registry, never by a literal
+symbol reference, so neither grep nor a static call-graph can see them:
+
+  - **bus**: a producer ``emit_event("wicked.gate.decided")`` and a consumer that
+    subscribes to ``wicked.gate.decided`` in ``_bus_consumers.json`` never
+    reference each other — the event string is the only link.
+  - (next: command→agent via ``subagent_type``; agent→tool via tool-capabilities.)
+
+This reads codegraph's SQLite graph + the plugin's wiring registries, computes
+the producer→consumer edges, and INSERTs them with ``provenance='injected:bus'``
+so blast-radius/impact traversals (which walk incoming edges) surface the
+consumer as a dependent of the producer. The codegraph engine + this extractor
+together are the relationship graph blast-radius/lineage/patch consume.
+
+Stdlib-only. Idempotent (re-run replaces injected edges). Read-the-registry, not
+the LLM — deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+_REPO = Path(__file__).resolve().parents[2]
+_CONSUMERS = _REPO / "scripts" / "_bus_consumers.json"
+_EVENT_RE = re.compile(r"""["']((?:wicked|wg)\.[a-z0-9_]+(?:\.[a-z0-9_]+)+)["']""")
+_INJECTED_PROVENANCE = "injected:bus"
+
+
+def _consumers() -> List[Tuple[str, str]]:
+    """[(event_filter, consumer_module_relpath), ...] from the registry."""
+    if not _CONSUMERS.exists():
+        return []
+    data = json.loads(_CONSUMERS.read_text(encoding="utf-8"))
+    out = []
+    for c in data.get("consumers", []):
+        ev, mod = c.get("event_filter"), c.get("module")
+        if ev and mod:
+            out.append((ev, mod))
+    return out
+
+
+def _producers_for(events: Set[str]) -> Dict[str, Set[str]]:
+    """event -> {producer file relpaths}. A producer is any .py under scripts/
+    that uses the literal event string and is NOT the consumer-registry plumbing
+    (so the edge is producer→consumer, not registry→itself)."""
+    by_event: Dict[str, Set[str]] = {e: set() for e in events}
+    for py in (_REPO / "scripts").rglob("*.py"):
+        if "__pycache__" in py.parts or py.name.endswith("_bus_consumers.py"):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        rel = py.relative_to(_REPO).as_posix()
+        for ev in _EVENT_RE.findall(text):
+            if ev in by_event:
+                by_event[ev].add(rel)
+    return by_event
+
+
+def _file_node_id(conn: sqlite3.Connection, relpath: str) -> str | None:
+    """codegraph file node ids are 'file:<relpath>'. Confirm it exists."""
+    nid = f"file:{relpath}"
+    row = conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone()
+    return nid if row else None
+
+
+def inject(db_path: Path) -> Dict[str, int]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # idempotent: clear prior injected bus edges
+        conn.execute("DELETE FROM edges WHERE provenance = ?", (_INJECTED_PROVENANCE,))
+        consumers = _consumers()
+        events = {ev for ev, _ in consumers}
+        producers = _producers_for(events)
+        added, skipped = 0, 0
+        for ev, consumer_mod in consumers:
+            tgt = _file_node_id(conn, consumer_mod)
+            if tgt is None:
+                skipped += 1
+                continue
+            for prod in sorted(producers.get(ev, set())):
+                if prod == consumer_mod:
+                    continue
+                src = _file_node_id(conn, prod)
+                if src is None:
+                    skipped += 1
+                    continue
+                conn.execute(
+                    "INSERT INTO edges (source, target, kind, metadata, provenance) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (src, tgt, "references",
+                     json.dumps({"injected": "bus", "event": ev}),
+                     _INJECTED_PROVENANCE),
+                )
+                added += 1
+        conn.commit()
+        return {"edges_added": added, "skipped": skipped, "consumers": len(consumers)}
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    db = Path(sys.argv[1]) if len(sys.argv) > 1 else _REPO / ".codegraph" / "codegraph.db"
+    if not db.exists():
+        print(json.dumps({"error": f"codegraph db not found at {db}; run `codegraph index` first"}))
+        return 1
+    print(json.dumps(inject(db), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/codegraph/test_codegraph.py
+++ b/tests/codegraph/test_codegraph.py
@@ -1,0 +1,140 @@
+"""Tests for the codegraph peer shim + the injected-edge extractor.
+
+The shim (`_codegraph.resolve_codegraph`) mirrors `_loom.resolve_loom`: env →
+config → PATH → node_modules → npx, with an empty `WICKED_CODEGRAPH_BIN` as the
+kill-switch. The extractor (`scripts/codegraph/inject_edges.py`) materializes the
+bus producer→consumer edges grep + the static graph miss; we test it against a
+temp SQLite shaped like codegraph's, so it needs neither codegraph nor peers.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO = Path(__file__).resolve().parents[2]
+for _p in (_REPO / "scripts", _REPO / "scripts" / "codegraph"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _codegraph as cg  # noqa: E402
+import inject_edges as ie  # noqa: E402
+
+
+class ResolverTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("WICKED_CODEGRAPH_BIN")
+        os.environ.pop("WICKED_CODEGRAPH_BIN", None)
+
+    def tearDown(self):
+        os.environ.pop("WICKED_CODEGRAPH_BIN", None)
+        if self._saved is not None:
+            os.environ["WICKED_CODEGRAPH_BIN"] = self._saved
+
+    def test_env_override_wins(self):
+        os.environ["WICKED_CODEGRAPH_BIN"] = "/opt/custom/codegraph"
+        self.assertEqual(cg.resolve_codegraph(), ["/opt/custom/codegraph"])
+
+    def test_empty_env_is_killswitch(self):
+        os.environ["WICKED_CODEGRAPH_BIN"] = ""
+        self.assertIsNone(cg.resolve_codegraph())
+
+    def test_mjs_override_invoked_via_node(self):
+        os.environ["WICKED_CODEGRAPH_BIN"] = "/some/codegraph.mjs"
+        self.assertEqual(cg.resolve_codegraph(), ["node", "/some/codegraph.mjs"])
+
+    def test_npx_fallback_when_not_on_path(self):
+        import shutil
+        with patch.object(shutil, "which",
+                          side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertEqual(cg.resolve_codegraph(),
+                             ["npx", "-y", "@colbymchenry/codegraph"])
+
+    def test_available_excludes_npx(self):
+        import shutil
+        with patch.object(shutil, "which",
+                          side_effect=lambda b: "/usr/bin/npx" if b == "npx" else None):
+            self.assertFalse(cg.codegraph_available())
+
+    def test_db_path(self):
+        self.assertEqual(cg.db_path(Path("/x")), Path("/x/.codegraph/codegraph.db"))
+
+
+def _codegraph_shaped_db(path: str, file_relpaths):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, file_path TEXT)")
+    conn.execute("CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, "
+                 "target TEXT, kind TEXT, metadata TEXT, line INT, col INT, provenance TEXT)")
+    for rel in file_relpaths:
+        conn.execute("INSERT INTO nodes (id, kind, name, file_path) VALUES (?,?,?,?)",
+                     (f"file:{rel}", "file", rel, rel))
+    conn.commit()
+    conn.close()
+
+
+class InjectEdgesTests(unittest.TestCase):
+    def test_consumers_parsed_from_registry(self):
+        consumers = ie._consumers()
+        self.assertTrue(consumers, "no bus consumers parsed from _bus_consumers.json")
+        ev, mod = consumers[0]
+        self.assertTrue(ev.startswith("wicked.") or ev.startswith("wg."))
+        self.assertTrue(mod.endswith(".py"))
+
+    def test_injects_producer_to_consumer_edge(self):
+        # Use a real (event, consumer-module) from the registry and a real producer
+        # that references that event string, both present as file nodes in the db.
+        consumers = ie._consumers()
+        events = {e for e, _ in consumers}
+        producers = ie._producers_for(events)
+        # pick an event that has both a producer and a consumer module that exists
+        chosen = None
+        for ev, mod in consumers:
+            prods = {p for p in producers.get(ev, set()) if (_REPO / mod).exists()
+                     and (_REPO / p).exists()}
+            if prods and (_REPO / mod).exists():
+                chosen = (ev, mod, sorted(prods)[0])
+                break
+        if chosen is None:
+            self.skipTest("no event with both a real producer file and an existing consumer module")
+        ev, mod, prod = chosen
+
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [mod, prod])
+            stats = ie.inject(Path(dbp))
+            self.assertGreaterEqual(stats["edges_added"], 1)
+            conn = sqlite3.connect(dbp)
+            row = conn.execute(
+                "SELECT source, target, provenance FROM edges WHERE provenance='injected:bus'"
+            ).fetchone()
+            conn.close()
+            self.assertIsNotNone(row, "no injected:bus edge created")
+            self.assertEqual(row[0], f"file:{prod}")
+            self.assertEqual(row[1], f"file:{mod}")
+
+    def test_inject_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            # nodes for every consumer module + every producer, so edges are created
+            consumers = ie._consumers()
+            events = {e for e, _ in consumers}
+            producers = ie._producers_for(events)
+            rels = {m for _, m in consumers} | {p for s in producers.values() for p in s}
+            _codegraph_shaped_db(dbp, sorted(rels))
+            n1 = ie.inject(Path(dbp))["edges_added"]
+            n2 = ie.inject(Path(dbp))["edges_added"]
+            self.assertEqual(n1, n2)  # re-run replaces, does not duplicate
+            conn = sqlite3.connect(dbp)
+            total = conn.execute(
+                "SELECT count(*) FROM edges WHERE provenance='injected:bus'").fetchone()[0]
+            conn.close()
+            self.assertEqual(total, n2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ADR 0001 decision + validated prototype. Adopt codegraph (MIT, tree-sitter, column-precise, SQLite, peer-shaped) as the static code-graph engine; add wicked-garden injected-edge extractors on top — the edges (bus producer→consumer, command→agent, capability→tool) grep + static call-graphs can't see. **Validated on this repo:** codegraph indexes 4179 nodes/7733 edges in ~1s; `scripts/_codegraph.py` is the peer shim (mirrors _loom.py); `scripts/codegraph/inject_edges.py` materializes producer→consumer bus edges the static graph had **0** of and grep can't link (bonus: surfaced a stale consumer-registry entry). 9 tests; .codegraph/ gitignored. Roadmap: command→agent + capability→tool extractors, rewire blast-radius/lineage to query the graph (+port 4242→4243 fix), wire wicked-patch to consume the SQLite as its --db, build lineage. Borrow (not adopt) roam-code's attestation idea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)