### PR TITLE
feat: wire real security scanners + make archetype steering actionable

### DIFF
--- a/commands/platform/security.md
+++ b/commands/platform/security.md
@@ -1,5 +1,5 @@
 ---
-description: Security review and vulnerability assessment
+description: Security review and vulnerability assessment (real scanners, then triage)
 argument-hint: "<path, PR, or 'full' for comprehensive scan> [--scenarios]"
 phase_relevance: ["build", "review", "operate"]
 archetype_relevance: ["*"]
@@ -7,17 +7,32 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:platform:security
 
-Security review with OWASP coverage, secrets detection, and dependency assessment. Use for ad hoc vulnerability scans on code, PRs, or full repos. NOT for compliance evidence collection (use platform:audit) or IaC posture (use platform:infra).
+Run the real security scanners, then triage their actual output. Use for ad hoc vulnerability scans on code, PRs, or full repos. NOT for compliance evidence collection (use platform:audit) or IaC posture (use platform:infra).
 
-## 1. Dispatch
+This command does NOT grep-guess. It detects which scanners are installed, runs the ones that exist, and feeds their findings to triage. A missing scanner is reported and skipped — the command never fails because a tool is absent.
 
+## 1. Detect + run scanners
+
+Set `TARGET="$ARGUMENTS"` (a path; default `.` if empty, or the PR's changed files when given a PR number). Then run, gracefully skipping any absent tool:
+
+```bash
+SC=$(command -v semgrep || true); GL=$(command -v gitleaks || true); NPM=$(command -v npm || true)
+TMP="${TMPDIR:-/tmp}"
+# Secrets — gitleaks. NOTE: exit 1 means "leaks found", NOT a tool error; ignore exit code, read the JSON.
+[ -n "$GL" ] && gitleaks detect --no-banner --redact -f json --report-path "$TMP/gitleaks.json" >/dev/null 2>&1; echo "gitleaks: ${GL:-ABSENT}"
+# SAST — semgrep auto ruleset (carries CWE/OWASP/severity per finding).
+[ -n "$SC" ] && semgrep --config auto --json "$TARGET" > "$TMP/semgrep.json" 2>/dev/null; echo "semgrep: ${SC:-ABSENT}"
+# Dependencies — npm audit, only where a package.json exists.
+[ -n "$NPM" ] && [ -f "$TARGET/package.json" ] && (cd "$TARGET" && npm audit --json > "$TMP/npm-audit.json" 2>/dev/null); echo "npm: ${NPM:-ABSENT}"
 ```
-Task(subagent_type="wicked-garden:platform:security-engineer",
-     prompt="""Security review.
 
-Scope: $ARGUMENTS  (path | PR number | 'full')
-Flags: pass --scenarios through if present (emit wicked-scenarios blocks per CRITICAL/HIGH finding).
+Read whichever report files exist (paths printed `ABSENT` were skipped — say so in the report, don't treat it as a failure):
+- `$TMP/gitleaks.json` — JSON array; each: `RuleID`, `Description`, `File`, `StartLine`, `Match`/`Secret` (redacted), `Entropy`, `Commit`. Scans full git **history** by default, so many hits are old/example secrets in docs — triage accordingly.
+- `$TMP/semgrep.json` — `{results:[{check_id, path, start.line, extra:{severity (ERROR|WARNING|INFO), message, metadata:{cwe, owasp}}}], errors[]}`.
+- `$TMP/npm-audit.json` — `{vulnerabilities:{<pkg>:{severity, via, range}}, metadata.vulnerabilities:{critical,high,...}}`.
 
-Run OWASP Top 10 + secrets + injection + auth + dependency-vuln + misconfig assessment.
-Return risk level, findings by severity with file:line, OWASP matrix, prioritized fixes.""")
-```
+## 2. Triage the real findings
+
+Read `${CLAUDE_PLUGIN_ROOT}/agents/platform/security-engineer.md` for the triage rubric (your reference, NOT a thing to re-derive): the CWE table, severity bands, OWASP matrix, output format, `--scenarios` behaviour, and bus emit.
+
+Your job is to triage actual scanner output, not guess: dedupe, drop false positives (e.g. example secrets in `*.md`/scenarios, test fixtures), keep semgrep's own `cwe`/`owasp`/`severity` (don't reinvent them), and rank true findings CRITICAL→LOW with `file:line`. If `--scenarios` is set, emit a wicked-scenarios block per surviving CRITICAL/HIGH. Report risk level, the severity-ranked findings table, the OWASP matrix, prioritized fixes, and which scanners were ABSENT/skipped.

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -180,6 +180,71 @@ def _has_ambiguity_signals(prompt: str) -> bool:
     return any(sig in lower for sig in _JAM_AMBIGUITY_SIGNALS)
 
 
+# Archetypes whose playbook ends in a produces-gate that re-derives through
+# wicked-loom. For these, steering is only actionable if it names the exact
+# `prove.py` one-liner the agent should reach for at the gate phase. Keyed by
+# archetype -> (claim, gate-phase, hard-gate?). Hard gates (incident/migrate/
+# review) require an INDEPENDENT attestation, so they carry --with-attestations.
+# Archetypes absent from this map (explore, triage) have no produces-gate, so
+# no prove hint is emitted for them (silence is correct).
+_PROVE_GATE = {
+    "build":    ("tests-pass",       "review",               False),
+    "specify":  ("criteria-met",     "validate",             False),
+    "decide":   ("adr-recorded",     "record",               False),
+    "ship":     ("rollout-healthy",  "soak",                 False),
+    "review":   ("review-verdict",   "remediate-or-accept",  True),
+    "incident": ("incident-resolved", "resolve",             True),
+    "migrate":  ("rollback-proven",  "cutover",              True),
+}
+
+
+def _prove_hint_for(archetype: str) -> str | None:
+    """Return the concrete `prove:` one-liner for an archetype's produces-gate,
+    or None when the archetype has no gate. Tells the agent exactly how to
+    re-derive (not assert) the produce at the gate phase. Fail-open: any
+    unexpected input yields None rather than raising.
+
+    The verify command is a placeholder (`<verify cmd>`) the agent fills in —
+    e.g. the project's test command for build, a `cat <artifact>` + --verifier
+    for doc-shaped produces. Hard gates append --with-attestations so the gate
+    stays REJECT until an independent evaluator attests.
+    """
+    spec = _PROVE_GATE.get(archetype)
+    if not spec:
+        return None
+    claim, phase, hard = spec
+    line = (
+        f"prove: scripts/qe/prove.py {claim} --by \"<verify cmd>\" "
+        f"--scope {archetype} --phase {phase}"
+    )
+    if hard:
+        line += " --with-attestations"
+    return line
+
+
+def _with_prove_hints(directive: str, archetypes: list[str]) -> str:
+    """Append prove-hint line(s) to a directive for any gated archetypes.
+
+    Dedupes, preserves catalog order, and is a no-op when none of the
+    archetypes have a produces-gate. Fail-open on any error (returns the
+    original directive unchanged)."""
+    try:
+        hints = []
+        seen = set()
+        for a in archetypes:
+            if a in seen:
+                continue
+            seen.add(a)
+            h = _prove_hint_for(a)
+            if h:
+                hints.append(h)
+        if not hints:
+            return directive
+        return directive + "\n" + "\n".join(hints)
+    except Exception:
+        return directive
+
+
 def _build_archetype_directive(prompt: str, intent: str, state=None) -> str | None:
     """v11 — emit a slim work-shape archetype steering directive.
 
@@ -213,16 +278,18 @@ def _build_archetype_directive(prompt: str, intent: str, state=None) -> str | No
         if len(real) == 1 and float(real[0].get("score", 0)) >= 0.7:
             n = real[0]["name"]
             s = float(real[0]["score"])
-            return f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"llm\" />"
+            base = f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"llm\" />"
+            return _with_prove_hints(base, [n])
         shape_lines = [
             f"  - {a['name']} ({float(a.get('score', 0)):.2f})"
             for a in real[:3]
         ]
-        return (
+        base = (
             "<wg archetypes classified=\"llm\">\n"
             + "\n".join(shape_lines)
             + "\n</wg>"
         )
+        return _with_prove_hints(base, [a["name"] for a in real[:3]])
 
     # Tier 2: regex fallback
     try:
@@ -259,14 +326,16 @@ def _build_archetype_directive(prompt: str, intent: str, state=None) -> str | No
     high = [(n, s, e) for (n, s, e) in real if s >= HIGH_CONFIDENCE]
     if len(high) == 1 and len(real) == 1:
         n, s, _ = high[0]
-        return f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"regex\" />"
+        base = f"<wg archetype=\"{n}\" score=\"{s:.2f}\" classified=\"regex\" />"
+        return _with_prove_hints(base, [n])
 
     shape_lines = [f"  - {n} ({s:.2f})" for (n, s, _) in real[:3]]
-    return (
+    base = (
         "<wg archetypes classified=\"regex\">\n"
         + "\n".join(shape_lines)
         + "\n</wg>"
     )
+    return _with_prove_hints(base, [n for (n, _s, _e) in real[:3]])
 
 
 def _suggest_jam(prompt: str, state) -> str | None:

--- a/tests/crew/test_archetypes_v11.py
+++ b/tests/crew/test_archetypes_v11.py
@@ -17,7 +17,12 @@ if _SCRIPTS not in sys.path:
 if _CREW not in sys.path:
     sys.path.append(_CREW)
 
+_HOOKS = str(_REPO_ROOT / "hooks" / "scripts")
+if _HOOKS not in sys.path:
+    sys.path.append(_HOOKS)
+
 import archetypes_v11 as av  # noqa: E402
+import prompt_submit as ps  # noqa: E402
 
 
 class TestCatalogShape(unittest.TestCase):
@@ -247,6 +252,68 @@ class TestCLI(unittest.TestCase):
         payload = json.loads(result.stdout)
         names = set(payload.get("archetypes", {}).keys())
         self.assertEqual(names, TestCatalogShape.EXPECTED_NAMES)
+
+
+class TestArchetypeProveHints(unittest.TestCase):
+    """The steering directive must be *actionable* — for archetypes with a
+    produces-gate it surfaces the exact `prove.py` one-liner the agent should
+    re-derive through, not just a bare <wg archetype/> tag (Issue: actionable
+    steering)."""
+
+    def test_build_directive_includes_prove_hint(self):
+        # "add a CSV export" routes to the build archetype; whether the regex
+        # emits the single <wg archetype/> tag or the multi-archetype shape
+        # card, the build produces-gate prove hint must be appended.
+        directive = ps._build_archetype_directive("add a CSV export", "feature")
+        self.assertIsNotNone(directive)
+        self.assertIn("build", directive)
+        self.assertIn("prove: scripts/qe/prove.py tests-pass", directive)
+        self.assertIn("--scope build", directive)
+        self.assertIn("--phase review", directive)
+
+    def test_build_single_high_confidence_directive_includes_prove_hint(self):
+        # A more explicit build prompt scores high enough for the single tag.
+        directive = ps._build_archetype_directive("add a CSV export feature", "feature")
+        self.assertIn("<wg archetype=\"build\"", directive)
+        self.assertIn("prove: scripts/qe/prove.py tests-pass", directive)
+
+    def test_build_prove_hint_is_soft_gate(self):
+        # build is a discrete (soft) gate — no independent attestation.
+        directive = ps._build_archetype_directive("implement a search box", "feature")
+        self.assertIn("prove:", directive)
+        self.assertNotIn("--with-attestations", directive)
+
+    def test_hard_gate_archetypes_carry_attestations(self):
+        for name in ("review", "incident", "migrate"):
+            hint = ps._prove_hint_for(name)
+            self.assertIsNotNone(hint, f"{name} should have a prove hint")
+            self.assertIn("--with-attestations", hint,
+                          f"{name} is a hard gate and must require attestations")
+
+    def test_soft_gate_archetypes_omit_attestations(self):
+        for name in ("build", "specify", "decide", "ship"):
+            hint = ps._prove_hint_for(name)
+            self.assertIsNotNone(hint)
+            self.assertNotIn("--with-attestations", hint)
+
+    def test_non_gated_archetypes_have_no_prove_hint(self):
+        # explore / triage have no produces-gate — silence is correct.
+        self.assertIsNone(ps._prove_hint_for("explore"))
+        self.assertIsNone(ps._prove_hint_for("triage"))
+
+    def test_prove_hint_phase_matches_catalog_terminal_phase(self):
+        # The gate phase named in each hint must be a real phase of that
+        # archetype in the catalog (so the agent isn't told a fictional phase).
+        catalog = av.load_catalog()["archetypes"]
+        for name, (_claim, phase, _hard) in ps._PROVE_GATE.items():
+            self.assertIn(name, catalog)
+            self.assertIn(phase, catalog[name]["phases"],
+                          f"{name} gate phase '{phase}' not in catalog phases")
+
+    def test_directive_unchanged_for_non_gated_when_no_hint(self):
+        # _with_prove_hints is a no-op when no archetype is gated.
+        base = "<wg archetype=\"explore\" score=\"0.80\" classified=\"regex\" />"
+        self.assertEqual(ps._with_prove_hints(base, ["explore"]), base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two 'make-better-use' wins from the redundancy review. **(1) platform:security** now drives installed `gitleaks`+`semgrep` (+npm audit where present) and triages REAL scanner output, instead of greping while the scanners sat unused (it even ran pip-audit, which isn't installed). Graceful skip when absent; gitleaks-exits-1-on-findings handled. **(2) archetype steering** is now actionable: `_build_archetype_directive` appends the exact `prove.py` one-liner per produces-gate phase (with --with-attestations for hard gates incident/migrate/review), turning a passive reminder into the enforcement arm of 'evidence is re-derived, not asserted.' Slim, fail-open, stdlib. New TestArchetypeProveHints. Suite green; validator PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)