### PR TITLE
fix: repair 9 confirmed-broken wicked-garden command surfaces

### DIFF
--- a/agents/agentic/safety-reviewer.md
+++ b/agents/agentic/safety-reviewer.md
@@ -71,20 +71,41 @@ Before manual analysis, leverage available tools:
 
 ### 1. Analyze System with Issue Taxonomy
 
-Use the taxonomy script to identify safety issues:
+`issue_taxonomy.py` does NOT scan a codebase directly — it categorizes
+*pre-computed* findings. Run the upstream scripts first, then feed their
+JSON in. The pipeline is: `analyze_agents.py` (detect agents) →
+`pattern_scorer.py` (score patterns into findings, including `safety`-category
+ones) → `issue_taxonomy.py` (build the report).
 
 ```bash
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/agentic/issue_taxonomy.py" \
-  --path /path/to/codebase \
-  --category safety \
-  --output safety-report.json
+PY="${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh"
+AGENTIC="${CLAUDE_PLUGIN_ROOT}/scripts/agentic"
+
+# 1. Detect agents in the target codebase (prints agents JSON to stdout)
+sh "$PY" "$AGENTIC/analyze_agents.py" --path /path/to/codebase > agents.json
+
+# 2. Score patterns into findings (requires --agents; prints findings JSON)
+sh "$PY" "$AGENTIC/pattern_scorer.py" --agents agents.json > findings.json
+
+# 3. Build the taxonomy report (requires --findings; --agents/--framework optional)
+sh "$PY" "$AGENTIC/issue_taxonomy.py" \
+  --findings findings.json \
+  --agents agents.json \
+  --format json > report.json
 ```
 
-Output includes:
-- Categorized safety issues (guardrails, validation, PII, injection)
-- Severity levels (CRITICAL, HIGH, MEDIUM, LOW)
-- Evidence and location
-- Remediation suggestions
+`issue_taxonomy.py` flags (verified against its argparse):
+- `--findings PATH` (required) — findings JSON from `pattern_scorer.py`
+- `--agents PATH` (optional) — agents JSON from `analyze_agents.py`. **Supply
+  this**: with no agents detected, the maturity verdict is *Indeterminate*
+  (level 0), not a false 5/5 clean bill.
+- `--framework PATH` (optional) — framework JSON from `detect_framework.py`
+- `--format {markdown,json,both}` (default `markdown`)
+
+For a safety-only view, filter the report's findings to the `safety` category
+(it is a property of each finding — there is no `--category` flag). The report
+includes severity levels (CRITICAL, HIGH, MEDIUM, LOW), evidence, locations,
+and remediation suggestions.
 
 ### 2. Prompt Injection Assessment
 

--- a/commands/engineering/new-generator.md
+++ b/commands/engineering/new-generator.md
@@ -217,7 +217,7 @@ from generators import {language}_generator
 
 Execute:
 ```bash
-cd ~/Projects/wicked-garden/plugins/wicked-patch/scripts
+cd "${CLAUDE_PLUGIN_ROOT}/scripts/engineering/patch"
 python3 tests/test_conformance.py
 ```
 

--- a/commands/engineering/plan.md
+++ b/commands/engineering/plan.md
@@ -132,7 +132,7 @@ After presenting the plan, ask:
 
 > Ready to proceed with implementation, or would you like to adjust the approach?
 
-If approved, the plan can be executed using `/wicked-garden:crew:execute` or manual implementation.
+If approved, the plan can be executed using `/wicked-garden:archetype:build` or manual implementation.
 
 ## Example
 

--- a/commands/platform/plugin-health.md
+++ b/commands/platform/plugin-health.md
@@ -8,7 +8,7 @@ phase_relevance: ["build", "review", "operate"]
 archetype_relevance: ["*"]
 ---
 
-# /wicked-garden:platform:health
+# /wicked-garden:platform:plugin-health
 
 Run health probes to validate ecosystem integrity.
 

--- a/commands/product/acceptance.md
+++ b/commands/product/acceptance.md
@@ -127,7 +127,6 @@ Format the agent's output into the standard acceptance criteria structure.
 Automatically:
 - **Native tasks**: AC stored via TaskCreate/TaskUpdate with `metadata={event_type:"task", chain_id:"{project}.clarify", source_agent:"requirements-analyst", phase:"clarify", initiative:"{req_id}"}` for traceability
 - **qe**: AC available for test scenario generation
-- **Event**: Emits `[product:acceptance:defined:success]`
 
 ## Example
 
@@ -159,7 +158,6 @@ AC8: Given login attempt, When check, Then password encrypted
 
 Stored on active task (initiative: US-001)
 Ready for QE test scenario generation
-Event emitted: [product:acceptance:defined:success]
 ```
 
 ### 4. Optional: Generate Wicked-Scenarios Format

--- a/commands/product/align.md
+++ b/commands/product/align.md
@@ -138,7 +138,6 @@ Format the agent's output into the standard alignment analysis structure.
 Automatically:
 - **Native tasks**: Documents alignment status via TaskCreate/TaskUpdate with `metadata.event_type="task"`
 - **wicked-brain:memory**: Stores stakeholder patterns for future reference
-- **Event**: Emits `[product:alignment:achieved:success]` or `[product:concern:raised:warning]`
 
 ## Example
 
@@ -180,7 +179,6 @@ Next Steps:
 3. Document OAuth roadmap for v2
 
 Stored on active task (initiative: alignment-001)
-Events emitted: [product:concern:raised:warning]
 ```
 
 ## Facilitation Tips

--- a/commands/product/elicit.md
+++ b/commands/product/elicit.md
@@ -132,7 +132,6 @@ Format the agent's output into the standard elicitation report structure.
 Automatically updates:
 - **Native tasks**: Stores requirements via TaskUpdate description appends on the active clarify task
 - **wicked-brain:memory**: Stores requirements patterns for future reference
-- **Event**: Emits `[product:requirements:elicited:success]`
 
 ## Example
 
@@ -159,5 +158,4 @@ Open Questions:
 2. Social login support (Google, GitHub)?
 
 Stored on active task: task-001
-Event emitted: [product:requirements:elicited:success]
 ```

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -684,6 +684,115 @@ def _bus_reset_stats() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Tail — read-only recent-event view (no cursor, no subscriber side effects)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_bus_db_path() -> Optional[str]:
+    """Return the wicked-bus event-store DB path via ``status --json``.
+
+    Uses the same binary resolver as every other call in this module so the
+    path stays correct regardless of how wicked-bus was installed. Returns
+    None when the bus is unavailable or the status payload lacks ``db_path``.
+    Never raises.
+    """
+    if not _check_available():
+        return None
+    try:
+        result = subprocess.run(
+            _build_cmd("status", "--json"),
+            capture_output=True, text=True,
+            timeout=_EMIT_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+    except Exception:
+        _invalidate_cache()
+        return None
+    db_path = data.get("db_path")
+    return db_path if isinstance(db_path, str) and db_path else None
+
+
+def tail_events(limit: int = 10) -> List[Dict[str, Any]]:
+    """Return the most recent ``limit`` bus events, newest first. Read-only.
+
+    This is a *display* helper (e.g. ``/wicked-garden:smaht:state``). It does
+    NOT register a subscriber, advance a cursor, or mutate the bus in any way:
+    the wicked-bus ``replay`` command resets a cursor rather than returning
+    rows, and ``list`` returns subscribers, so neither yields event rows
+    synchronously. Instead we resolve the event-store path via ``status``
+    (through the shared binary resolver) and read the ``events`` table in
+    read-only mode.
+
+    Each returned dict carries the canonical bus columns plus a ``data`` alias
+    for the parsed ``payload`` (consumers index ``event.get("data", {})``).
+
+    Fail-open: any error — bus absent, unreadable DB, malformed rows — returns
+    ``[]``. Never raises.
+
+    Args:
+        limit: Max number of recent events to return (clamped to >= 0).
+    """
+    if limit <= 0:
+        return []
+
+    db_path = _resolve_bus_db_path()
+    if not db_path or not os.path.exists(db_path):
+        return []
+
+    import sqlite3  # stdlib; imported lazily so the module loads without it
+
+    events: List[Dict[str, Any]] = []
+    conn = None
+    try:
+        # Read-only URI connection — never creates or writes the DB.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT event_id, event_type, domain, subdomain, payload, "
+            "metadata, emitted_at "
+            "FROM events ORDER BY event_id DESC LIMIT ?",
+            (int(limit),),
+        ).fetchall()
+    except Exception:
+        return []  # fail open — bus DB unreadable or schema mismatch
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    for row in rows:
+        try:
+            payload_raw = row["payload"]
+            payload = json.loads(payload_raw) if payload_raw else {}
+            if not isinstance(payload, dict):
+                payload = {"value": payload}
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        try:
+            meta_raw = row["metadata"]
+            metadata = json.loads(meta_raw) if meta_raw else {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
+        events.append({
+            "event_id": row["event_id"],
+            "event_type": row["event_type"],
+            "domain": row["domain"],
+            "subdomain": row["subdomain"],
+            "payload": payload,
+            "data": payload,  # alias — consumers read event.get("data", {})
+            "metadata": metadata,
+            "emitted_at": row["emitted_at"],
+        })
+    return events
+
+
+# ---------------------------------------------------------------------------
 # Poll — on-invoke consumption
 # ---------------------------------------------------------------------------
 

--- a/scripts/agentic/issue_taxonomy.py
+++ b/scripts/agentic/issue_taxonomy.py
@@ -202,7 +202,32 @@ def render_markdown(taxonomy: dict) -> str:
 
 
 def _assess_maturity(findings: list, agents: list) -> dict:
-    """Assess maturity level based on findings."""
+    """Assess maturity level based on findings.
+
+    Guards against a false clean bill of health: if NO agents were detected,
+    the analysis had nothing to evaluate, so an empty findings list does NOT
+    mean "Optimized". Returning level 5 in that case would hand a dangerous
+    5/5 verdict to a codebase the scanner couldn't actually read. Instead we
+    return an *indeterminate* verdict (level 0) so callers surface "couldn't
+    assess" rather than "perfect".
+    """
+    # No agents detected → nothing was analyzed → indeterminate, NOT 5/5.
+    if not agents:
+        return {
+            "level": 0,
+            "name": "Indeterminate",
+            "description": (
+                "No agents were detected, so maturity could not be assessed. "
+                "An empty findings list here means the scanner found nothing to "
+                "evaluate — not that the system is mature. Re-run with agent "
+                "detection (analyze_agents.py → --agents) to get a real verdict."
+            ),
+            "next_level_actions": [
+                "Confirm this is an agentic codebase and that agent detection ran",
+                "Provide --agents (analyze_agents.py output) so maturity can be scored",
+            ],
+        }
+
     severities = [f["severity"] for f in findings]
     categories = [f["category"] for f in findings]
 

--- a/scripts/platform/observability/assert_contracts.py
+++ b/scripts/platform/observability/assert_contracts.py
@@ -27,14 +27,15 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Resolve _domain_store from the parent scripts/ directory
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# Resolve _domain_store from the scripts/ directory.
+# This file lives at scripts/platform/observability/, so scripts/ is parents[2].
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from _domain_store import DomainStore
 
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
-PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent  # scripts/observability/ → scripts/ → wicked-garden/
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent.parent  # scripts/platform/observability/ → scripts/ → repo root
 SCHEMAS_DIR = PLUGIN_ROOT / "schemas"
 PLUGINS_ROOT = PLUGIN_ROOT.parent  # …/plugins/
 TIMEOUT_SECONDS = 10

--- a/scripts/platform/observability/health_probe.py
+++ b/scripts/platform/observability/health_probe.py
@@ -27,11 +27,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Resolve _domain_store from the parent scripts/ directory
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# Resolve _domain_store from the scripts/ directory.
+# This file lives at scripts/platform/observability/, so scripts/ is parents[2].
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from _domain_store import DomainStore
 
 _sm = DomainStore("wicked-observability")
+
+# Repo root (the wicked-garden plugin itself). This file lives at
+# scripts/platform/observability/, so the repo root is parents[3].
+PLUGIN_ROOT = Path(__file__).resolve().parents[3]
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -774,8 +779,14 @@ def _rel_from(path: Path, base: Path) -> str:
 # Plugins directory discovery
 # ---------------------------------------------------------------------------
 
-def find_plugins_dir(start: Path) -> Path:
-    """Walk up from start to find a 'plugins/' directory in the monorepo root."""
+def find_plugins_dir(start: Path) -> Path | None:
+    """Walk up from start to find a 'plugins/' directory in the monorepo root.
+
+    Returns None when no ``plugins/`` directory exists anywhere up the tree.
+    The single-plugin layout (this repo *is* the plugin — no ``plugins/``
+    monorepo wrapper) is handled by the caller, which treats PLUGIN_ROOT as
+    the lone plugin rather than iterating a non-existent ``plugins/`` dir.
+    """
     candidate = start
     for _ in range(10):
         plugins = candidate / "plugins"
@@ -785,8 +796,7 @@ def find_plugins_dir(start: Path) -> Path:
         if parent == candidate:
             break
         candidate = parent
-    # Fallback: relative to script location (scripts/ → wicked-observability/ → plugins/)
-    return Path(__file__).resolve().parent.parent.parent
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -829,30 +839,46 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    # Resolve plugins directory
+    # Resolve plugins directory. When --plugins-dir is omitted we walk up
+    # looking for a 'plugins/' monorepo wrapper; if none exists this repo IS
+    # the single plugin, so we fall back to PLUGIN_ROOT.
     if args.plugins_dir:
         plugins_dir = Path(args.plugins_dir).resolve()
     else:
         plugins_dir = find_plugins_dir(Path.cwd())
 
-    if not plugins_dir.is_dir():
-        print(f"ERROR: plugins directory not found: {plugins_dir}", file=sys.stderr)
-        return 2
-
-    # Determine which plugins to probe
-    if args.plugin:
-        plugin_root = plugins_dir / args.plugin
-        if not plugin_root.is_dir():
+    if plugins_dir is None:
+        # Single-plugin layout: the repo root is the lone plugin. Its parent
+        # acts as the synthetic "plugins/" dir so --plugin <name> still works.
+        single_plugin_root = PLUGIN_ROOT
+        plugins_dir = PLUGIN_ROOT.parent
+        if args.plugin and args.plugin != single_plugin_root.name:
             print(
-                f"ERROR: plugin '{args.plugin}' not found in {plugins_dir}",
+                f"ERROR: plugin '{args.plugin}' not found (single-plugin repo "
+                f"is '{single_plugin_root.name}')",
                 file=sys.stderr,
             )
             return 2
-        plugin_roots = [plugin_root]
+        plugin_roots = [single_plugin_root]
     else:
-        plugin_roots = sorted(
-            p for p in plugins_dir.iterdir() if p.is_dir() and p.name.startswith("wicked-")
-        )
+        if not plugins_dir.is_dir():
+            print(f"ERROR: plugins directory not found: {plugins_dir}", file=sys.stderr)
+            return 2
+
+        # Determine which plugins to probe
+        if args.plugin:
+            plugin_root = plugins_dir / args.plugin
+            if not plugin_root.is_dir():
+                print(
+                    f"ERROR: plugin '{args.plugin}' not found in {plugins_dir}",
+                    file=sys.stderr,
+                )
+                return 2
+            plugin_roots = [plugin_root]
+        else:
+            plugin_roots = sorted(
+                p for p in plugins_dir.iterdir() if p.is_dir() and p.name.startswith("wicked-")
+            )
 
     # Run probes
     all_violations: list[dict[str, Any]] = []

--- a/scripts/smaht/propose_skills.py
+++ b/scripts/smaht/propose_skills.py
@@ -117,13 +117,15 @@ _DOMAIN_KEYWORDS: dict[str, tuple[str, ...]] = {
 def project_slug(cwd: Path | None = None) -> str:
     """Return the Claude Code project slug for ``cwd`` (default: real cwd).
 
-    Claude Code encodes project paths by replacing path separators with ``-``
-    and prefixing with ``-``. Cross-platform: uses ``Path.as_posix()`` so
-    Windows ``\\`` separators and drive letters (``C:``) are normalized before
+    Claude Code encodes project paths by replacing path separators *and dots*
+    with ``-`` and prefixing with ``-``. Cross-platform: uses ``Path.as_posix()``
+    so Windows ``\\`` separators and drive letters (``C:``) are normalized before
     the substitution.
 
     Example (POSIX): ``/home/alice/Projects/wicked-garden`` →
     ``-home-alice-Projects-wicked-garden``.
+    Example (dotted user): ``/Users/first.last/Projects/wg`` →
+    ``-Users-first-last-Projects-wg`` (the ``.`` becomes ``-``).
     Example (Windows): ``C:\\Users\\x\\Projects\\wg`` → ``-C-Users-x-Projects-wg``.
     """
     base = (cwd or Path.cwd()).expanduser().resolve()
@@ -131,7 +133,9 @@ def project_slug(cwd: Path | None = None) -> str:
     # Strip the Windows drive colon (e.g. ``C:`` → ``C``) so the slug stays
     # filesystem-safe under Claude Code's project-dir naming convention.
     posix = posix.replace(":", "")
-    return "-" + posix.strip("/").replace("/", "-")
+    # Claude Code replaces dots with ``-`` too, so a dotted username
+    # (``first.last``) maps to the real ~/.claude/projects/ directory.
+    return "-" + posix.strip("/").replace("/", "-").replace(".", "-")
 
 
 def resolve_claude_config_dir() -> Path:


### PR DESCRIPTION
## Summary

Repairs **9 independently-confirmed broken command surfaces** across the observability, smaht, engineering, product, and agentic domains. Each root cause was reproduced before editing; each fix was re-verified after. Full suite stays green (**533 passed, 17 skipped** — unchanged from baseline).

No forbidden files touched (`commands/search/blast-radius.md`, `scripts/_codegraph.py`, `scripts/codegraph/**`, `docs/adr/**` are owned by another stream).

## Fixes + verification

**1. `scripts/platform/observability/assert_contracts.py` — ImportError + wrong schema dir**
The `_domain_store` import inserted `parents[1]` (=`scripts/platform`) on `sys.path`; the module lives at `scripts/` (`parents[2]`). Also `PLUGIN_ROOT` resolved to `scripts/`, so `SCHEMAS_DIR` pointed at the nonexistent `scripts/schemas/`. Fixed the import to `parents[2]` and added one more `.parent` to `PLUGIN_ROOT` so it points at the repo root.
*Verified:* `python3 scripts/platform/observability/assert_contracts.py --json` no longer raises `ModuleNotFoundError` and now discovers + validates all 3 repo-root schemas (`assert_contracts.json`, `health_probe.json`, `plugin_status.json`).

**2. `scripts/platform/observability/health_probe.py` — ImportError + 0 plugins checked**
Same `parents[1]`→`parents[2]` import fix. `find_plugins_dir` returned a bogus fallback path when no `plugins/` dir exists, so `main()` iterated nothing → `plugins_checked=0`. Now `find_plugins_dir` returns `None` for the single-plugin layout and `main()` treats the repo root (`PLUGIN_ROOT`) as the lone plugin.
*Verified:* runs cleanly and reports `plugins_checked: 1` (was 0).

**3. `commands/platform/plugin-health.md` — H1 collision**
H1 was `# /wicked-garden:platform:health`, colliding with `health.md`. Renamed to `# /wicked-garden:platform:plugin-health`.
*Verified:* `grep -c '^# /wicked-garden:platform:health$' commands/platform/*.md` == 1 (only `health.md` now).

**4. `scripts/smaht/propose_skills.py` — dotted-username slug mismatch**
`project_slug()` replaced `/` and `:` but not `.`, so a user path like `/Users/first.last/...` produced `-Users-first.last-...` which never matched the real `~/.claude/projects/` dir (Claude Code replaces dots with `-`). Added `.replace(".", "-")`.
*Verified:* `project_slug('/Users/michael.parcewski/Projects/wicked-garden')` → `-Users-michael-parcewski-Projects-wicked-garden`, which matches a real entry under `~/.claude/projects/`.

**5. `scripts/_bus.py` — missing `tail_events`**
`commands/smaht/state.md:60` does `from _bus import tail_events`, but no such function existed. Added a read-only `tail_events(limit=10)`. The `wicked-bus replay` command *resets a cursor* (returns no event rows) and `list` returns subscribers, so neither yields events synchronously — `tail_events` instead resolves the event-store DB path via `status --json` (through the existing `_resolve_binary`/`_build_cmd` helpers) and reads the `events` table in `mode=ro`. Returns event dicts (with a `data` alias for the parsed payload), fail-open `[]`, no subscriber side effects.
*Verified:* `python3 -c "import sys;sys.path.insert(0,'scripts');from _bus import tail_events;print(type(tail_events(limit=3)))"` → `<class 'list'>`; returns 3 real event dicts; `limit=0` → `[]`; subscriber count unchanged (no registration).

**6. `commands/engineering/plan.md` — dangling command ref**
`/wicked-garden:crew:execute` (does not exist) → `/wicked-garden:archetype:build`.
*Verified:* `commands/crew/` contains only `archive.md`; `commands/archetype/build.md` exists.

**7. `commands/engineering/new-generator.md` — dead path**
`cd ~/Projects/wicked-garden/plugins/wicked-patch/scripts` (dead `plugins/` layout) → `cd "${CLAUDE_PLUGIN_ROOT}/scripts/engineering/patch"`.
*Verified:* `scripts/engineering/patch/tests/test_conformance.py` exists.

**8. `commands/product/{elicit,acceptance,align}.md` — false event claims**
Removed the "Event emitted: `[product:*:success]`" claims (both the Integration bullet and the Example output line in each file). Nothing emits these events.
*Verified:* `grep` over `scripts/`/`hooks/` finds no emit points for `product:requirements:elicited` / `product:acceptance:defined` / `product:alignment:achieved` / `product:concern:raised`; no claim lines remain in the three files.

**9. `scripts/agentic/issue_taxonomy.py` + `agents/agentic/safety-reviewer.md` — false clean bill + wrong flags**
`_assess_maturity` returned **5/5 "Optimized"** when `findings==[]` regardless of whether any agents were detected — a dangerous false clean bill for a codebase the scanner couldn't read. Now returns an **Indeterminate** verdict (level 0) when `agent_count==0`. (`render_markdown` and the summary block handle level 0 without error.) Separately, `safety-reviewer.md` documented nonexistent flags (`--path`, `--category`, `--output`); corrected to the real argparse contract (`--findings` required, `--agents`/`--framework`/`--format` optional) plus the real upstream pipeline (`analyze_agents.py` → `pattern_scorer.py` → `issue_taxonomy.py`), and noted that `safety` is a per-finding category to filter on, not a CLI flag.
*Verified:* unit checks — no-agents → level 0/Indeterminate; agents+clean → level 5; `categorize()`+`render_markdown()` don't crash on level 0. Upstream flag names cross-checked against each script's argparse.

## Deferred follow-up

Fix #9 deliberately scopes only the false-5/5 maturity verdict and the doc correction. The **larger framework-aware node extraction** for the agentic taxonomy (richer agent/graph extraction so the maturity model has real structural signal beyond findings + agent count) is **not** attempted here and should be tracked as a separate piece of work.

## Test evidence

```
python3 -m pytest tests/ -q
533 passed, 17 skipped
```
Identical to the pre-change baseline; targeted module tests (116, incl. observability/contract probes) also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
