### PR TITLE
feat(patch): revive wicked-patch via codegraph (adapter builds its --db)

### DIFF
--- a/scripts/engineering/patch/codegraph_db.py
+++ b/scripts/engineering/patch/codegraph_db.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""codegraph_db.py — adapt codegraph's SQLite into the symbol-graph DB wicked-patch
+expects (the `--db`).
+
+This is the payoff of ADR 0001: codegraph builds a column-precise, multi-language
+symbol+edge graph; wicked-patch needs a `--db` with a `symbols` table + reference
+tables for cross-file refactor (rename/add-field/remove). Nothing produced that
+`--db` before, so the patch family was dead-on-arrival. This translates
+codegraph's `nodes`/`edges` into the schema `PropagationEngine` + `_resolve_symbol_id`
+read, reviving the family without changing patch's engine.
+
+Mapping (codegraph → patch):
+  nodes(id,name,kind,file_path,start_line,end_line,metadata)
+      -> symbols(id,name,type,file_path,line_start,line_end,metadata,layer)
+  edges(source,target,kind):
+      kind='references' -> symbol_refs(source_id,target_id,ref_type) + refs
+      kind='calls'      -> symbol_calls(symbol_id,target_id)         + refs
+      kind='imports'    -> symbol_imports(symbol_id,target_id)       + refs
+      (all)             -> refs(source_id,target_id,ref_type,confidence)
+  + metadata(key,value) with indexed_at (safety.py freshness check)
+
+Stdlib-only. Deterministic. Rebuilds the patch DB from scratch each run.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict
+
+# codegraph edge kind -> (patch reference table, columns)
+_EDGE_TABLE = {
+    "references": ("symbol_refs", ("source_id", "target_id", "ref_type")),
+    "calls": ("symbol_calls", ("symbol_id", "target_id")),
+    "imports": ("symbol_imports", ("symbol_id", "target_id")),
+}
+
+
+def build_patch_db(codegraph_db: Path, out_db: Path) -> Dict[str, int]:
+    """Translate a codegraph SQLite into a patch-compatible symbol-graph DB.
+    Returns counts. Rebuilds out_db from scratch (idempotent)."""
+    if not Path(codegraph_db).exists():
+        raise FileNotFoundError(f"codegraph db not found: {codegraph_db}; run `codegraph index` first")
+    src = sqlite3.connect(f"file:{codegraph_db}?mode=ro", uri=True)
+    src.row_factory = sqlite3.Row
+    if Path(out_db).exists():
+        Path(out_db).unlink()
+    dst = sqlite3.connect(str(out_db))
+    try:
+        dst.executescript(
+            """
+            CREATE TABLE symbols (
+              id TEXT PRIMARY KEY, name TEXT, type TEXT, file_path TEXT,
+              line_start INTEGER, line_end INTEGER, metadata TEXT, layer TEXT
+            );
+            CREATE TABLE refs (source_id TEXT, target_id TEXT, ref_type TEXT, confidence REAL);
+            CREATE TABLE symbol_refs (source_id TEXT, target_id TEXT, ref_type TEXT);
+            CREATE TABLE symbol_calls (symbol_id TEXT, target_id TEXT);
+            CREATE TABLE symbol_imports (symbol_id TEXT, target_id TEXT);
+            CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+            CREATE INDEX idx_symbols_name ON symbols(name);
+            CREATE INDEX idx_symbols_file ON symbols(file_path);
+            CREATE INDEX idx_refs_target ON refs(target_id);
+            """
+        )
+        counts = {"symbols": 0, "refs": 0, "symbol_refs": 0, "symbol_calls": 0, "symbol_imports": 0}
+        # codegraph nodes carry no `metadata` column. PropagationEngine does
+        # json.loads(metadata) so it MUST be a JSON object (or NULL -> "{}").
+        # Pack the useful codegraph fields (signature) as JSON. layer has no
+        # codegraph equivalent -> NULL.
+        for r in src.execute(
+            "SELECT id, name, kind, file_path, start_line, end_line, signature FROM nodes"
+        ):
+            meta = json.dumps({"signature": r["signature"]}) if r["signature"] else None
+            dst.execute(
+                "INSERT OR IGNORE INTO symbols (id,name,type,file_path,line_start,line_end,metadata,layer)"
+                " VALUES (?,?,?,?,?,?,?,?)",
+                (r["id"], r["name"], r["kind"], r["file_path"],
+                 r["start_line"], r["end_line"], meta, None),
+            )
+            counts["symbols"] += 1
+        for e in src.execute("SELECT source, target, kind FROM edges"):
+            s, t, k = e["source"], e["target"], e["kind"]
+            dst.execute("INSERT INTO refs (source_id,target_id,ref_type,confidence) VALUES (?,?,?,?)",
+                        (s, t, k, 1.0))
+            counts["refs"] += 1
+            spec = _EDGE_TABLE.get(k)
+            if spec:
+                table, cols = spec
+                dst.execute(f"INSERT INTO {table} ({','.join(cols)}) VALUES ({','.join('?' * len(cols))})",
+                            (s, t, k) if len(cols) == 3 else (s, t))
+                counts[table] += 1
+        dst.execute("INSERT INTO metadata (key,value) VALUES ('indexed_at', ?)",
+                    (datetime.now(timezone.utc).isoformat(),))
+        dst.execute("INSERT INTO metadata (key,value) VALUES ('source', 'codegraph')")
+        dst.commit()
+        return counts
+    finally:
+        src.close()
+        dst.close()
+
+
+def main() -> int:
+    import argparse
+    p = argparse.ArgumentParser(description="Build a wicked-patch --db from codegraph's SQLite.")
+    p.add_argument("--codegraph-db", default=".codegraph/codegraph.db")
+    p.add_argument("--out", default=".wicked/patch-symbols.db")
+    a = p.parse_args()
+    out = Path(a.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        counts = build_patch_db(Path(a.codegraph_db), out)
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    import json
+    print(json.dumps({"out": str(out), **counts}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/engineering/patch/tests/test_codegraph_db.py
+++ b/scripts/engineering/patch/tests/test_codegraph_db.py
@@ -1,0 +1,92 @@
+"""Tests for codegraph_db — the adapter that revives wicked-patch by translating
+codegraph's SQLite into the symbol-graph schema patch's --db expects.
+
+Built against a temp codegraph-shaped DB (no codegraph/peers needed), asserting
+the patch-side schema (symbols + refs/symbol_calls/symbol_imports + metadata) is
+populated and that metadata is valid JSON (PropagationEngine json.loads it).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parents[1]
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import codegraph_db as cgdb  # noqa: E402
+
+
+def _codegraph_shaped_db(path: str):
+    c = sqlite3.connect(path)
+    c.executescript(
+        """
+        CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+          file_path TEXT, language TEXT, start_line INT, end_line INT, start_column INT,
+          end_column INT, docstring TEXT, signature TEXT);
+        CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, target TEXT,
+          kind TEXT, metadata TEXT, line INT, col INT, provenance TEXT);
+        """
+    )
+    c.execute("INSERT INTO nodes (id,kind,name,file_path,start_line,end_line,signature) "
+              "VALUES ('function:a','function','add','src/calc.py',1,2,'def add(a, b)')")
+    c.execute("INSERT INTO nodes (id,kind,name,file_path,start_line,end_line,signature) "
+              "VALUES ('function:b','function','main','src/app.py',5,9,NULL)")
+    c.execute("INSERT INTO edges (source,target,kind) VALUES ('function:b','function:a','calls')")
+    c.execute("INSERT INTO edges (source,target,kind) VALUES ('function:b','function:a','references')")
+    c.execute("INSERT INTO edges (source,target,kind) VALUES ('function:b','import:x','imports')")
+    c.commit()
+    c.close()
+
+
+class CodegraphDbAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cg = str(Path(self._tmp.name) / "codegraph.db")
+        self.out = str(Path(self._tmp.name) / "patch-symbols.db")
+        _codegraph_shaped_db(self.cg)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_translates_nodes_and_edges(self):
+        counts = cgdb.build_patch_db(Path(self.cg), Path(self.out))
+        self.assertEqual(counts["symbols"], 2)
+        self.assertEqual(counts["symbol_calls"], 1)
+        self.assertEqual(counts["symbol_refs"], 1)
+        self.assertEqual(counts["symbol_imports"], 1)
+        self.assertEqual(counts["refs"], 3)
+
+    def test_symbols_schema_matches_patch_expectations(self):
+        cgdb.build_patch_db(Path(self.cg), Path(self.out))
+        c = sqlite3.connect(self.out)
+        cols = {r[1] for r in c.execute("pragma table_info(symbols)")}
+        self.assertTrue({"id", "name", "type", "file_path", "line_start", "line_end",
+                         "metadata", "layer"} <= cols)
+        # _resolve_symbol_id does: SELECT id FROM symbols WHERE id LIKE ?
+        row = c.execute("SELECT id FROM symbols WHERE id LIKE ? LIMIT 1", ("function:a",)).fetchone()
+        self.assertIsNotNone(row)
+        c.close()
+
+    def test_metadata_is_valid_json(self):
+        # PropagationEngine does json.loads(metadata or "{}") — a raw signature
+        # string would crash it. Confirm it's JSON (or NULL).
+        cgdb.build_patch_db(Path(self.cg), Path(self.out))
+        c = sqlite3.connect(self.out)
+        for (meta,) in c.execute("SELECT metadata FROM symbols"):
+            json.loads(meta or "{}")  # must not raise
+        c.close()
+
+    def test_idempotent_rebuild(self):
+        a = cgdb.build_patch_db(Path(self.cg), Path(self.out))
+        b = cgdb.build_patch_db(Path(self.cg), Path(self.out))  # rebuilds from scratch
+        self.assertEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ADR 0001 payoff. The patch family (rename/add-field/remove) was dead — it needs a `--db` symbol graph nothing produced. `scripts/engineering/patch/codegraph_db.py` translates codegraph's `nodes`/`edges` → patch's expected schema (symbols + refs/symbol_calls/symbol_imports + metadata). **Proven:** built a --db from this repo's codegraph index (4179 symbols, 2984 calls), then `patch --db <db> plan <symbol>` produced a risk-assessed propagation plan (exit 0) — previously a hard error. Caught 2 real schema mismatches by running it (no `metadata` col → use signature; metadata must be JSON). 4 adapter tests + 12 conformance green. Doesn't change patch's engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)