### PR TITLE
feat(codegraph): command→agent + capability→tool injected extractors + wire blast-radius/lineage

### DIFF
--- a/commands/search/blast-radius.md
+++ b/commands/search/blast-radius.md
@@ -22,22 +22,45 @@ Analyze what would be affected if you changed a symbol. Shows both what this sym
 
 ## Instructions
 
-1. **Search via brain** for reference discovery:
+1. **Query the codegraph graph** for static + injected dependents (the authoritative layer — covers what grep can't see):
    ```bash
-   curl -s -X POST http://localhost:4242/api \
+   # Static refs (imports/calls/instantiations) resolved by the engine:
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" 2>/dev/null  # shim is library-only; run the CLI:
+   codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json
+
+   # INJECTED relationships grep + the static graph miss (bus producer→consumer,
+   # command→agent dispatch, agent→capability) — read straight from the graph DB:
+   python3 - "$SYMBOL" <<'PY'
+   import sqlite3, sys, pathlib
+   sym = sys.argv[1]
+   db = pathlib.Path(".codegraph/codegraph.db")
+   if not db.exists():
+       print("no index — run `codegraph index` first"); raise SystemExit
+   c = sqlite3.connect(str(db))
+   # dependents reaching this symbol's file via any injected edge
+   rows = c.execute(
+     "SELECT source, target, provenance, metadata FROM edges "
+     "WHERE provenance LIKE 'injected:%' AND (source LIKE ? OR target LIKE ?)",
+     (f"%{sym}%", f"%{sym}%")).fetchall()
+   for r in rows: print(r)
+   c.close()
+   PY
+   ```
+   `codegraph impact` gives static dependents; the `injected:%` query adds bus/dispatch/capability edges (materialized by `scripts/codegraph/inject_edges.py`, `inject_dispatch_edges.py`, `inject_capability_edges.py`). Union both — a complete blast radius needs the injected layer, since a command that *dispatches* an agent or a consumer that *subscribes* to an event has no literal reference for grep to find.
+
+2. **Cross-reference via brain** (semantic neighbors the graph may not name):
+   ```bash
+   curl -s -X POST http://localhost:4243/api \
      -H "Content-Type: application/json" \
      -d '{"action":"search","params":{"query":"<symbol>","limit":30}}'
    ```
-   Use matching chunks as the starting set for blast radius analysis.
+   Use matching chunks to corroborate the dependent set.
 
-2. **Expand with native tools**: Use Grep to find transitive dependencies at the requested depth. For each direct reference found, search for its callers/importers to build the dependency graph.
+3. **If neither graph nor brain is available**: Use Grep and Glob to trace literal references only — and flag that injected relationships (bus/dispatch/capability) will be MISSING from the result. Suggest `codegraph index` + the inject extractors, or `wicked-brain:ingest`, for a complete picture.
 
-3. **If brain is unavailable**: Use Grep and Glob exclusively to trace the dependency chain.
-   Suggest: `wicked-brain:ingest` for richer graph-based analysis.
-
-3. Report the impact assessment:
+4. Report the impact assessment:
    - **Dependencies** (outgoing): What this symbol uses/imports
-   - **Dependents** (incoming): What uses this symbol (direct and transitive)
+   - **Dependents** (incoming): What uses this symbol — static (from `codegraph impact`) AND injected (from the `injected:%` edges)
    - Total blast radius count
    - Files affected
 
@@ -56,6 +79,6 @@ Analyze what would be affected if you changed a symbol. Shows both what this sym
 
 ## Notes
 
-- Requires indexing first with `/wicked-garden:search:index`
+- **Requires a codegraph index**: run `codegraph index` (writes `.codegraph/codegraph.db`), then materialize the injected edges (`scripts/codegraph/inject_edges.py`, `inject_dispatch_edges.py`, `inject_capability_edges.py`) so the `injected:%` query returns bus/dispatch/capability dependents. Without an index, the graph steps no-op and you fall back to grep (literal refs only).
 - Deeper depth = more complete but slower analysis
 - For data lineage tracing (UI → DB), use `/wicked-garden:search:lineage` instead

--- a/commands/search/lineage.md
+++ b/commands/search/lineage.md
@@ -25,7 +25,7 @@ Trace data lineage paths through the codebase. Follow data flow from UI fields t
 
 1. **Search brain for the symbol** to find its location and references:
    ```bash
-   curl -s -X POST http://localhost:4242/api \
+   curl -s -X POST http://localhost:4243/api \
      -H "Content-Type: application/json" \
      -d '{"action":"search","params":{"query":"<symbol>","limit":20}}'
    ```
@@ -35,13 +35,22 @@ Trace data lineage paths through the codebase. Follow data flow from UI fields t
    ```
    If no results at all, suggest: `wicked-brain:ingest` to index the codebase first.
 
-2. **Trace data flow** using Grep to follow the symbol through layers:
+2. **Query the codegraph graph for reference flow** (when a `.codegraph/codegraph.db` index exists). The graph gives both static reference edges and the *injected* edges grep can't see (bus producer→consumer, command→agent dispatch, agent→capability) — useful when the data/reference path crosses a string-keyed link rather than a literal call:
+   ```bash
+   codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json
+   # injected reference flow (string-keyed links static analysis misses):
+   sqlite3 .codegraph/codegraph.db \
+     "SELECT source, target, provenance FROM edges WHERE provenance LIKE 'injected:%' AND (source LIKE '%<symbol>%' OR target LIKE '%<symbol>%');"
+   ```
+   No index → skip this step (run `codegraph index` first for graph-backed lineage); fall back to Grep below.
+
+3. **Trace data flow** using Grep to follow the symbol through layers:
    - Search for imports/requires of the file containing the symbol
    - Search for function calls that pass the symbol as an argument
    - Search for assignments, mappings, and transformations of the symbol
    - Follow the chain through controller → service → repository → database layers
 
-3. Report the lineage paths found:
+4. Report the lineage paths found:
    - Show each path with steps from source to sink
    - Include file locations at each step
    - Note any gaps in the lineage chain

--- a/scripts/codegraph/inject_capability_edges.py
+++ b/scripts/codegraph/inject_capability_edges.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""inject_capability_edges.py — materialize agent→capability edges into the
+codegraph symbol graph.
+
+A wicked-garden agent declares the runtime capabilities it needs through a
+``tool-capabilities:`` frontmatter list (e.g. ``security-scanning``,
+``version-control``). Each capability is defined in ``scripts/_capability_registry.py``
+(``CAPABILITY_REGISTRY``), which maps it to the concrete tools that satisfy it
+(MCP servers / CLI binaries, probed at runtime). The link from an agent to the
+capability it depends on is a *string in YAML* keyed against a Python registry —
+there is no symbol reference from the agent's markdown into the registry module,
+so neither grep nor a static call-graph can connect them.
+
+This reads each agent's ``tool-capabilities`` list + the registry, and for every
+capability that IS defined in the registry, INSERTs:
+  - a synthetic node ``capability:<name>`` (kind ``capability``), and
+  - an edge ``file:<agent.md>`` → ``capability:<name>`` with
+    ``provenance='injected:capability'``,
+
+so blast-radius/impact traversals over the capability node surface every agent
+that depends on it (change/remove a capability or its backing tool → the agents
+that declare it are in the blast radius). Capabilities NOT present in the registry
+are skipped — the extractor never fabricates a node for an undefined capability.
+
+Stdlib-only. Idempotent (re-run replaces injected edges + the synthetic nodes it
+owns). Read-the-registry, not the LLM — deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+_REPO = Path(__file__).resolve().parents[2]
+_AGENTS_DIR = _REPO / "agents"
+_INJECTED_PROVENANCE = "injected:capability"
+_CAPABILITY_NODE_KIND = "capability"
+
+# scripts/ on sys.path so we can read the registry (the source of truth for which
+# capability names are real). Mirrors the test harness's path insertion.
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _registry_capabilities() -> Set[str]:
+    """The set of capability names defined in CAPABILITY_REGISTRY.
+
+    Imported lazily so a missing/!importable registry degrades to 'no known
+    capabilities' (every cap skipped) rather than raising."""
+    try:
+        from _capability_registry import CAPABILITY_REGISTRY  # noqa: WPS433
+    except Exception:  # noqa: BLE001 — registry absence must not crash the extractor
+        return set()
+    return set(CAPABILITY_REGISTRY.keys())
+
+
+def _frontmatter(text: str) -> str:
+    """Return the YAML frontmatter block (between the leading --- fences), or ''."""
+    if not text.startswith("---"):
+        return ""
+    end = text.find("\n---", 3)
+    return text[3:end] if end > 0 else ""
+
+
+def _declared_capabilities(fm: str) -> List[str]:
+    """Capability names from a ``tool-capabilities:`` block list in frontmatter.
+
+    Matches the block-list shape used across agents:
+        tool-capabilities:
+          - security-scanning
+          - version-control
+    """
+    block = re.search(
+        r"(?m)^tool-capabilities:\s*\n((?:[ \t]+-[ \t]*[a-z0-9_-]+[ \t]*\n?)+)", fm
+    )
+    if not block:
+        return []
+    return re.findall(r"-[ \t]*([a-z0-9_-]+)", block.group(1))
+
+
+def _agent_capabilities() -> List[Tuple[str, str]]:
+    """[(agent_relpath, capability_name), ...] for caps that exist in the registry.
+
+    Deterministic ordering; one entry per (agent, distinct declared cap)."""
+    known = _registry_capabilities()
+    out: List[Tuple[str, str]] = []
+    for md in sorted(_AGENTS_DIR.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        caps = _declared_capabilities(_frontmatter(text))
+        if not caps:
+            continue
+        agent_rel = md.relative_to(_REPO).as_posix()
+        seen: Set[str] = set()
+        for cap in caps:
+            if cap in seen or cap not in known:  # skip dupes + caps absent from registry
+                continue
+            seen.add(cap)
+            out.append((agent_rel, cap))
+    return out
+
+
+def _file_node_id(conn: sqlite3.Connection, relpath: str) -> str | None:
+    """codegraph file node ids are 'file:<relpath>'. Confirm it exists."""
+    nid = f"file:{relpath}"
+    row = conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone()
+    return nid if row else None
+
+
+def _ensure_capability_node(conn: sqlite3.Connection, cap: str) -> str:
+    """Create (idempotently) the synthetic ``capability:<name>`` node, return its id."""
+    nid = f"capability:{cap}"
+    conn.execute(
+        "INSERT OR IGNORE INTO nodes (id, kind, name, file_path) VALUES (?, ?, ?, ?)",
+        (nid, _CAPABILITY_NODE_KIND, cap, None),
+    )
+    return nid
+
+
+def inject(db_path: Path) -> Dict[str, int]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # idempotent: clear prior injected capability edges, then the synthetic
+        # capability nodes this extractor owns (no other edge should reference them).
+        conn.execute("DELETE FROM edges WHERE provenance = ?", (_INJECTED_PROVENANCE,))
+        conn.execute("DELETE FROM nodes WHERE kind = ?", (_CAPABILITY_NODE_KIND,))
+        pairs = _agent_capabilities()
+        added, skipped = 0, 0
+        caps_created: Set[str] = set()
+        for agent_rel, cap in pairs:
+            src = _file_node_id(conn, agent_rel)
+            if src is None:  # agent file not indexed in this graph — skip
+                skipped += 1
+                continue
+            tgt = _ensure_capability_node(conn, cap)
+            caps_created.add(cap)
+            conn.execute(
+                "INSERT INTO edges (source, target, kind, metadata, provenance) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (src, tgt, "references",
+                 json.dumps({"injected": "capability", "capability": cap}),
+                 _INJECTED_PROVENANCE),
+            )
+            added += 1
+        conn.commit()
+        return {"edges_added": added, "skipped": skipped,
+                "capabilities": len(caps_created), "pairs": len(pairs)}
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    db = Path(sys.argv[1]) if len(sys.argv) > 1 else _REPO / ".codegraph" / "codegraph.db"
+    if not db.exists():
+        print(json.dumps({"error": f"codegraph db not found at {db}; run `codegraph index` first"}))
+        return 1
+    print(json.dumps(inject(db), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codegraph/inject_dispatch_edges.py
+++ b/scripts/codegraph/inject_dispatch_edges.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""inject_dispatch_edges.py — materialize command→agent DISPATCH edges into the
+codegraph symbol graph.
+
+A wicked-garden slash command dispatches work to a subagent by naming it through
+``Task(subagent_type="wicked-garden:<domain>:<agent>")`` (and, where present, a
+``subagent_type:`` frontmatter key). That ``subagent_type`` is a *string handle*
+resolved by the Claude Code runtime — the command file never references the
+agent's file or any symbol it defines. So neither grep ("who calls this agent?")
+nor a static call-graph can link a command to the agent it drives: the dispatch
+is invisible as a call.
+
+This reads the command markdown, extracts each ``subagent_type`` handle, resolves
+``wicked-garden:<domain>:<name>`` to ``agents/<domain>/<name>.md`` by the project's
+naming convention (CLAUDE.md: ``wicked-garden:{domain}:{agent-name}`` ↔
+``agents/{domain}/{agent-name}.md``), and INSERTs an edge
+``file:<command.md>`` → ``file:<agent.md>`` with ``provenance='injected:dispatch'``
+so blast-radius/impact traversals surface the command as a dependent of the agent
+(change the agent → the commands that dispatch it are in the blast radius).
+
+The same ``wicked-garden:X:Y`` shape also appears for *cross-references to other
+commands/skills* (e.g. ``Load skill wicked-garden:agentic:agentic-patterns``).
+Those resolve to no ``agents/...`` file, so the target node is absent and the edge
+is skipped — only real command→agent dispatches are materialized.
+
+Stdlib-only. Idempotent (re-run replaces injected edges). Read-the-registry
+(here: the command/agent files on disk), not the LLM — deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+_REPO = Path(__file__).resolve().parents[2]
+_COMMANDS_DIR = _REPO / "commands"
+_AGENTS_DIR = _REPO / "agents"
+_INJECTED_PROVENANCE = "injected:dispatch"
+
+# subagent_type referenced as a Task(...) kwarg (subagent_type="..."/'...') OR as a
+# YAML frontmatter key (subagent_type: ...). Capture the wicked-garden:domain:name handle.
+_DISPATCH_RE = re.compile(
+    r"""subagent_type\s*[:=]\s*["']?(wicked-garden:[a-z0-9_-]+:[a-z0-9_-]+)["']?"""
+)
+
+
+def _agent_relpath_for(handle: str) -> str | None:
+    """Resolve a ``wicked-garden:<domain>:<name>`` handle to ``agents/<domain>/<name>.md``.
+
+    Returns the repo-relative posix path iff that agent file exists on disk;
+    None otherwise (the handle names a command/skill, not an agent)."""
+    parts = handle.split(":")
+    if len(parts) != 3:
+        return None
+    _, domain, name = parts
+    if not domain or not name:
+        return None
+    candidate = _AGENTS_DIR / domain / f"{name}.md"
+    if candidate.exists():
+        return candidate.relative_to(_REPO).as_posix()
+    return None
+
+
+def _dispatches() -> List[Tuple[str, str, str]]:
+    """[(command_relpath, agent_relpath, handle), ...].
+
+    One entry per (command, distinct subagent_type handle) where the handle
+    resolves to an existing agent file. Deterministic ordering."""
+    out: List[Tuple[str, str, str]] = []
+    for md in sorted(_COMMANDS_DIR.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        cmd_rel = md.relative_to(_REPO).as_posix()
+        seen: Set[str] = set()
+        for handle in _DISPATCH_RE.findall(text):
+            if handle in seen:
+                continue
+            seen.add(handle)
+            agent_rel = _agent_relpath_for(handle)
+            if agent_rel is None:
+                continue
+            out.append((cmd_rel, agent_rel, handle))
+    return out
+
+
+def _file_node_id(conn: sqlite3.Connection, relpath: str) -> str | None:
+    """codegraph file node ids are 'file:<relpath>'. Confirm it exists."""
+    nid = f"file:{relpath}"
+    row = conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone()
+    return nid if row else None
+
+
+def inject(db_path: Path) -> Dict[str, int]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # idempotent: clear prior injected dispatch edges
+        conn.execute("DELETE FROM edges WHERE provenance = ?", (_INJECTED_PROVENANCE,))
+        dispatches = _dispatches()
+        added, skipped = 0, 0
+        for cmd_rel, agent_rel, handle in dispatches:
+            src = _file_node_id(conn, cmd_rel)
+            tgt = _file_node_id(conn, agent_rel)
+            if src is None or tgt is None:
+                skipped += 1
+                continue
+            conn.execute(
+                "INSERT INTO edges (source, target, kind, metadata, provenance) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (src, tgt, "references",
+                 json.dumps({"injected": "dispatch", "subagent_type": handle}),
+                 _INJECTED_PROVENANCE),
+            )
+            added += 1
+        conn.commit()
+        return {"edges_added": added, "skipped": skipped, "dispatches": len(dispatches)}
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    db = Path(sys.argv[1]) if len(sys.argv) > 1 else _REPO / ".codegraph" / "codegraph.db"
+    if not db.exists():
+        print(json.dumps({"error": f"codegraph db not found at {db}; run `codegraph index` first"}))
+        return 1
+    print(json.dumps(inject(db), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/codegraph/test_codegraph.py
+++ b/tests/codegraph/test_codegraph.py
@@ -23,6 +23,8 @@ for _p in (_REPO / "scripts", _REPO / "scripts" / "codegraph"):
         sys.path.insert(0, str(_p))
 
 import _codegraph as cg  # noqa: E402
+import inject_capability_edges as ice  # noqa: E402
+import inject_dispatch_edges as idis  # noqa: E402
 import inject_edges as ie  # noqa: E402
 
 
@@ -134,6 +136,179 @@ class InjectEdgesTests(unittest.TestCase):
                 "SELECT count(*) FROM edges WHERE provenance='injected:bus'").fetchone()[0]
             conn.close()
             self.assertEqual(total, n2)
+
+
+class InjectDispatchEdgesTests(unittest.TestCase):
+    """command→agent dispatch edges (provenance='injected:dispatch').
+
+    A command names its subagent through a `subagent_type` string handle; the
+    command file never references the agent's file or any symbol — so grep/static
+    call-graphs can't link them. The extractor resolves the handle to the agent
+    file and materializes the edge."""
+
+    def test_dispatches_resolve_handles_to_existing_agent_files(self):
+        dispatches = idis._dispatches()
+        self.assertTrue(dispatches, "no command→agent dispatches resolved from commands/")
+        cmd_rel, agent_rel, handle = dispatches[0]
+        self.assertTrue(cmd_rel.startswith("commands/") and cmd_rel.endswith(".md"))
+        self.assertTrue(agent_rel.startswith("agents/") and agent_rel.endswith(".md"))
+        self.assertTrue(handle.startswith("wicked-garden:"))
+        self.assertTrue((_REPO / agent_rel).exists(), "resolved agent file must exist")
+
+    def test_handle_resolution_skips_non_agent_references(self):
+        # A `wicked-garden:<domain>:<name>` handle that names a command/skill (not an
+        # agent) resolves to no agents/... file → None (so its edge is never created).
+        self.assertIsNone(idis._agent_relpath_for("wicked-garden:search:lineage"))
+        # A real agent handle resolves to its file.
+        self.assertEqual(
+            idis._agent_relpath_for("wicked-garden:platform:auditor"),
+            "agents/platform/auditor.md",
+        )
+
+    def test_injects_command_to_agent_edge(self):
+        dispatches = idis._dispatches()
+        if not dispatches:
+            self.skipTest("no resolvable command→agent dispatch")
+        cmd_rel, agent_rel, handle = dispatches[0]
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [cmd_rel, agent_rel])
+            stats = idis.inject(Path(dbp))
+            self.assertGreaterEqual(stats["edges_added"], 1)
+            conn = sqlite3.connect(dbp)
+            row = conn.execute(
+                "SELECT source, target, provenance FROM edges "
+                "WHERE provenance='injected:dispatch'"
+            ).fetchone()
+            conn.close()
+            self.assertIsNotNone(row, "no injected:dispatch edge created")
+            self.assertEqual(row[0], f"file:{cmd_rel}")
+            self.assertEqual(row[1], f"file:{agent_rel}")
+
+    def test_skips_when_agent_node_absent(self):
+        # The dispatch is real, but the agent file is NOT a node in this graph
+        # (only the command is). The edge must be skipped, not fabricated — this is
+        # the "grep can't link them" guard: no node, no edge.
+        dispatches = idis._dispatches()
+        if not dispatches:
+            self.skipTest("no resolvable command→agent dispatch")
+        cmd_rel, _agent_rel, _handle = dispatches[0]
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [cmd_rel])  # command node only
+            stats = idis.inject(Path(dbp))
+            self.assertEqual(stats["edges_added"], 0)
+            self.assertGreaterEqual(stats["skipped"], 1)
+
+    def test_inject_is_idempotent(self):
+        dispatches = idis._dispatches()
+        rels = {c for c, _, _ in dispatches} | {a for _, a, _ in dispatches}
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, sorted(rels))
+            n1 = idis.inject(Path(dbp))["edges_added"]
+            n2 = idis.inject(Path(dbp))["edges_added"]
+            self.assertEqual(n1, n2)  # re-run replaces, does not duplicate
+            conn = sqlite3.connect(dbp)
+            total = conn.execute(
+                "SELECT count(*) FROM edges WHERE provenance='injected:dispatch'"
+            ).fetchone()[0]
+            conn.close()
+            self.assertEqual(total, n2)
+
+
+class InjectCapabilityEdgesTests(unittest.TestCase):
+    """agent→capability edges (provenance='injected:capability').
+
+    An agent declares the capabilities it needs via `tool-capabilities:`; each is
+    defined in CAPABILITY_REGISTRY. The agent markdown never references the registry
+    module — the link is a YAML string keyed against a Python dict. The extractor
+    materializes a synthetic `capability:<name>` node + the agent→capability edge."""
+
+    def test_declared_capabilities_subset_of_registry(self):
+        pairs = ice._agent_capabilities()
+        self.assertTrue(pairs, "no agent→capability pairs resolved from agents/")
+        known = ice._registry_capabilities()
+        self.assertTrue(known, "CAPABILITY_REGISTRY did not import")
+        for _agent, cap in pairs:
+            # Only registry-defined capabilities are emitted (no fabrication).
+            self.assertIn(cap, known)
+
+    def test_skips_capability_absent_from_registry(self):
+        # A `tool-capabilities` block listing an unknown cap yields no pair — the
+        # extractor never fabricates a node for a capability the registry doesn't define.
+        fm = "name: x\ntool-capabilities:\n  - security-scanning\n  - totally-made-up-cap\n"
+        known = ice._registry_capabilities()
+        declared = ice._declared_capabilities(fm)
+        self.assertIn("totally-made-up-cap", declared)  # parsed...
+        self.assertNotIn("totally-made-up-cap", known)  # ...but not in the registry
+
+    def test_injects_agent_to_capability_edge_and_node(self):
+        pairs = ice._agent_capabilities()
+        if not pairs:
+            self.skipTest("no resolvable agent→capability pair")
+        agent_rel, cap = pairs[0]
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [agent_rel])
+            stats = ice.inject(Path(dbp))
+            self.assertGreaterEqual(stats["edges_added"], 1)
+            conn = sqlite3.connect(dbp)
+            edge = conn.execute(
+                "SELECT source, target, provenance FROM edges "
+                "WHERE provenance='injected:capability'"
+            ).fetchone()
+            node = conn.execute(
+                "SELECT id, kind FROM nodes WHERE id = ?", (f"capability:{cap}",)
+            ).fetchone()
+            conn.close()
+            self.assertIsNotNone(edge, "no injected:capability edge created")
+            self.assertEqual(edge[0], f"file:{agent_rel}")
+            self.assertEqual(edge[1], f"capability:{cap}")
+            self.assertIsNotNone(node, "synthetic capability node not created")
+            self.assertEqual(node[1], "capability")
+
+    def test_skips_when_agent_node_absent(self):
+        # Agent declares a real registry capability, but the agent file is not a
+        # node in this graph → no edge, no synthetic node fabricated.
+        pairs = ice._agent_capabilities()
+        if not pairs:
+            self.skipTest("no resolvable agent→capability pair")
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [])  # no nodes at all
+            stats = ice.inject(Path(dbp))
+            self.assertEqual(stats["edges_added"], 0)
+            conn = sqlite3.connect(dbp)
+            cnodes = conn.execute(
+                "SELECT count(*) FROM nodes WHERE kind='capability'"
+            ).fetchone()[0]
+            conn.close()
+            self.assertEqual(cnodes, 0)
+
+    def test_inject_is_idempotent(self):
+        pairs = ice._agent_capabilities()
+        rels = sorted({a for a, _ in pairs})
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, rels)
+            n1 = ice.inject(Path(dbp))["edges_added"]
+            n2 = ice.inject(Path(dbp))["edges_added"]
+            self.assertEqual(n1, n2)  # re-run replaces edges, does not duplicate
+            conn = sqlite3.connect(dbp)
+            edges = conn.execute(
+                "SELECT count(*) FROM edges WHERE provenance='injected:capability'"
+            ).fetchone()[0]
+            cnodes = conn.execute(
+                "SELECT count(*) FROM nodes WHERE kind='capability'"
+            ).fetchone()[0]
+            distinct_caps = conn.execute(
+                "SELECT count(DISTINCT target) FROM edges "
+                "WHERE provenance='injected:capability'"
+            ).fetchone()[0]
+            conn.close()
+            self.assertEqual(edges, n2)
+            self.assertEqual(cnodes, distinct_caps)  # one node per referenced cap, no dupes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Advances ADR 0001. Two new injected-edge extractors (same deterministic registry-read pattern as the bus extractor): **inject_dispatch_edges.py** (command→agent via `subagent_type` — 52 edges; resolves `wicked-garden:domain:name`→`agents/domain/name.md`, skips non-agent handles) and **inject_capability_edges.py** (agent→tool via `tool-capabilities`+`_capability_registry` — 16 edges/10 cap nodes). Wires `search:blast-radius` + `lineage` to query the graph (static `codegraph impact` + injected `provenance LIKE 'injected:%'` edges) and fixes the brain port 4242→4243 (was silently failing). **Proof:** grep finds 0 links between `commands/agentic/audit.md` and `agents/agentic/safety-reviewer.md`, yet the extractor materializes that dispatch edge. 19 codegraph tests; suite 559 green; validation PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)