### PR TITLE
cleanup(data+delivery): collapse 7 rubric-wrappers → inline skill-refs

### DIFF
--- a/commands/data/analyze.md
+++ b/commands/data/analyze.md
@@ -1,25 +1,18 @@
 ---
 description: Start interactive data analysis session for CSV/Excel files
 argument-hint: "<file-path> [--focus <type>] [--context <file>] [--refresh] [--scenarios]"
-phase_relevance: ["design", "build"]
+phase_relevance: ["clarify", "design", "build"]
 archetype_relevance: ["*"]
 ---
 
 # /wicked-garden:data:analyze
 
-Interactive analysis on a CSV/Excel/data file. Routes by `--focus` to the right specialist (stats, quality, warehouse, ml). Use this for one-off data exploration on a file. NOT for profiling/validation/quality reports across a known schema (use `data:data`) or pipeline-level review (use `data:pipeline`).
+Interactive analysis on a CSV/Excel/data file. Use for one-off data exploration.
+NOT for schema-level checks (use `data:data`) or pipeline review (use `data:pipeline`).
 
-## 1. Arg parse + profile
+## Run it inline (no dispatch)
 
-Extract `file-path`, `--focus` (stats|quality|warehouse|ml, default stats), `--context`, `--refresh`, `--scenarios`. Read first rows of the file to capture column names/types/nulls/sample.
-
-## 2. Dispatch by focus (one of)
-
-Common preamble: `File: {file-path}  Context: {context or none}  Profile: {columns/types/nulls/sample}  Scenarios: {--scenarios true/false}`. Each agent runs its standard rubric + emits wicked-scenarios api/perf blocks if `--scenarios`.
-
-```
-Task(subagent_type="wicked-garden:data:data-analyst",   prompt="<preamble>")  # --focus stats (default)
-Task(subagent_type="wicked-garden:data:data-engineer",  prompt="<preamble>")  # --focus quality
-Task(subagent_type="wicked-garden:data:data-architect", prompt="<preamble>")  # --focus warehouse
-Task(subagent_type="wicked-garden:data:ml-engineer",    prompt="<preamble>")  # --focus ml
-```
+1. Parse `<file-path>`, `--focus` (stats|quality|warehouse|ml, default `stats`), `--context`, `--refresh`, `--scenarios`.
+2. Read first rows of the file to capture column names / types / nulls / sample.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/data/refs/analyze.md")` — the EDA rubric, quality/warehouse/ml modes, insight pattern, and output format.
+4. Apply the rubric directly for the chosen `--focus` mode and emit the analysis.

--- a/commands/data/data.md
+++ b/commands/data/data.md
@@ -10,15 +10,12 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:data:data
 
-Core data engineering ops: `profile`, `validate`, `quality`. Use this for schema-level checks. NOT for interactive exploration (use `data:analyze`) or ML pipeline review (use `data:ml`).
+Core data engineering ops: `profile`, `validate`, `quality`. NOT for interactive exploration
+(use `data:analyze`) or ML pipeline review (use `data:ml`).
 
-## 1. Arg parse + read
+## Run it inline (no dispatch)
 
-Extract `subcommand` (profile|validate|quality) and its args (`<path>`, `--schema` for validate). Read the data file head/tail + capture columns/types/nulls.
-
-## 2. Dispatch
-
-```
-Task(subagent_type="wicked-garden:data:data-engineer",
-     prompt="""Run data {subcommand} on {path}. Schema: {schema-path or n/a}. Profile: {columns/types/nulls/sample}. Apply your standard rubric for the requested subcommand and return structured markdown with tables and prioritized findings.""")
-```
+1. Parse `subcommand` (profile|validate|quality) and its args (`<path>`, `--schema` for validate).
+2. Read the data file head/tail to capture columns / types / nulls / sample.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/data/refs/data.md")` — the profile, validate, and quality rubrics with output formats.
+4. Apply the rubric for the requested subcommand and emit structured markdown with tables and prioritized findings.

--- a/commands/data/ml.md
+++ b/commands/data/ml.md
@@ -7,15 +7,12 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:data:ml
 
-ML model `review` and training-`pipeline` design. Use this for model-side work. NOT for ETL pipeline design (use `data:pipeline`) or data profiling (use `data:data`).
+ML model `review` and training-`pipeline` design. NOT for ETL pipeline design
+(use `data:pipeline`) or data profiling (use `data:data`).
 
-## 1. Arg parse + gather
+## Run it inline (no dispatch)
 
-Extract `subcommand` (review|pipeline) and args (`<path>` for review, `--type <classification|regression|ranking>` for pipeline). For review, read model files at `<path>`.
-
-## 2. Dispatch
-
-```
-Task(subagent_type="wicked-garden:data:ml-engineer",
-     prompt="""Run ML {subcommand}. Path: {path or n/a}. Task type: {type or n/a}. For review: cover leakage, evaluation, features, imbalance, production readiness, P1/P2/P3, model card. For pipeline: cover problem setup, data/feature stages, model arch, evaluation, tuning, deployment, monitoring. Return structured markdown.""")
-```
+1. Parse `subcommand` (review|pipeline) and args (`<path>` for review, `--type` for pipeline).
+2. For `review`, read model files at `<path>`.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/data/refs/ml.md")` — the model review checklist, pipeline design template, deployment readiness checklist, and MLOps standards.
+4. Apply the rubric for the requested subcommand and emit structured markdown.

--- a/commands/data/pipeline.md
+++ b/commands/data/pipeline.md
@@ -7,15 +7,11 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:data:pipeline
 
-Data pipeline `design` and `review`. Use this for ETL/streaming pipeline architecture. NOT for ML training pipelines (use `data:ml`) or one-off file analysis (use `data:analyze`).
+Data pipeline `design` and `review`. NOT for ML training pipelines (use `data:ml`)
+or one-off file analysis (use `data:analyze`).
 
-## 1. Arg parse + gather
+## Run it inline (no dispatch)
 
-Extract `subcommand` (design|review) and args. For review, read pipeline files at `<path>`. For design, capture `--source`, `--target`, `--frequency`.
-
-## 2. Dispatch
-
-```
-Task(subagent_type="wicked-garden:data:data-engineer",
-     prompt="""Run pipeline {subcommand}. Path: {path or n/a}. Source/Target/Frequency: {src or n/a} / {tgt or n/a} / {freq or n/a}. For review: code quality, idempotency, monitoring, validation, silent-loss, P1/P2/P3 with code fixes. For design: architecture pattern, orchestrator, stage flow, quality gates, monitoring, costs, risks. Return structured markdown.""")
-```
+1. Parse `subcommand` (design|review) and args. For `review`, read pipeline files at `<path>`. For `design`, capture `--source`, `--target`, `--frequency`.
+2. `Read("${CLAUDE_PLUGIN_ROOT}/skills/data/refs/pipeline.md")` — the design checklist, review rubric with P1/P2/P3 findings, and engineering standards.
+3. Apply the rubric for the requested subcommand and emit structured markdown.

--- a/commands/delivery/experiment.md
+++ b/commands/delivery/experiment.md
@@ -7,44 +7,12 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:delivery:experiment
 
-Design experiments with proper hypothesis formulation, metric selection, sample size calculation, and instrumentation planning.
+Design experiments with proper hypothesis formulation, metric selection, sample
+size calculation, and instrumentation planning.
 
-## Instructions
+## Run it inline (no dispatch)
 
-### 1. Parse Arguments
-
-Extract the experiment description from arguments. If no description provided, ask for one.
-
-### 2. Gather Context
-
-Read any referenced files (feature specs, analytics configs, baseline metrics) from the current directory.
-
-### 3. Dispatch to Experiment Designer
-
-```
-Task(
-  subagent_type="wicked-garden:delivery:experiment-designer",
-  prompt="""
-  {user description}
-
-  Working directory: {cwd}
-  {File contents if referenced}
-
-  Provide a comprehensive experiment design covering:
-  1. Hypothesis formulation: "[Action] will [effect] [metric] by [amount] because [reason]"
-  2. Metrics hierarchy: primary (ONE), secondary, guardrail
-  3. Sample size calculation with stated assumptions (significance, power)
-  4. Duration estimate based on traffic
-  5. Control and treatment variant definitions
-  6. Instrumentation plan (events, properties, tracking code)
-  7. Success criteria and decision framework
-  8. Risks and mitigations
-
-  Return structured markdown suitable for stakeholder review.
-  """
-)
-```
-
-### 4. Present Results
-
-Display the agent's experiment design document.
+1. Parse the experiment `<description>` from arguments. If none provided, ask for one.
+2. Read any referenced files (feature specs, analytics configs, baseline metrics) from the current directory.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/delivery/refs/experiment.md")` — hypothesis format, metrics hierarchy, sample-size rules, variant design, instrumentation plan, bus event, and output format.
+4. Apply the rubric directly and emit the experiment design document.

--- a/commands/delivery/report.md
+++ b/commands/delivery/report.md
@@ -12,60 +12,14 @@ Generate multi-perspective stakeholder reports from project data.
 ## Arguments
 
 - `file`: Input file (outcome.md, project brief, or crew phase data)
-- `--personas <list>`: Comma-separated perspectives to include (default: all)
+- `--personas <list>`: Comma-separated perspectives (default: all three default personas)
   - Options: `delivery`, `engineering`, `product`, `qe`, `architecture`, `devsecops`
-- `--all`: Include all available perspectives
+- `--all`: Include all six perspectives
 - `--output <dir>`: Write report to directory (default: stdout)
 
-## Instructions
+## Run it inline (no dispatch)
 
-### 1. Parse Arguments
-
-Extract `file`, `--personas`, `--all`, and `--output` from the provided arguments.
-If no file provided, use current crew project context.
-
-### 2. Gather Project Context
-
-Read the input file or collect context from the active crew project:
-```bash
-# If crew project active
-sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" status
-```
-
-### 3. Delegate to Stakeholder Reporter
-
-```
-Task(
-  subagent_type="wicked-garden:delivery:stakeholder-reporter",
-  prompt="Generate a multi-perspective stakeholder report.
-
-Input: {file_contents_or_project_context}
-
-Personas to cover: {personas_list or 'all six: Delivery, Engineering, Product, QE, Architecture, DevSecOps'}
-
-For each persona, produce a focused section addressing what that stakeholder cares most about:
-- **Delivery**: Progress, blockers, timeline, risk status
-- **Engineering**: Technical debt, architecture decisions, code quality signals
-- **Product**: Feature completeness, scope changes, user story coverage
-- **QE**: Test coverage, quality gate results, known defects
-- **Architecture**: Design decisions, trade-offs, technical risks
-- **DevSecOps**: Security findings, deployment readiness, compliance status
-
-Format as a single cohesive stakeholder report with a 3-bullet executive summary at the top.
-
-Output directory: {output_dir or 'stdout'}"
-)
-```
-
-## Examples
-
-```bash
-# Report from outcome file
-/wicked-garden:delivery:report outcome.md
-
-# Engineering and QE perspectives only
-/wicked-garden:delivery:report outcome.md --personas engineering,qe
-
-# All perspectives, save to reports/
-/wicked-garden:delivery:report outcome.md --all --output reports/
-```
+1. Parse `file`, `--personas`, `--all`, and `--output` from arguments. If no file, collect context from the active crew project via `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" status`.
+2. Read the input file or active project context.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/delivery/refs/report.md")` — six persona lenses, base metrics, persona section template, cross-synthesis, executive summary, and output format rules.
+4. Apply the rubric directly, filter to requested personas, and emit the stakeholder report.

--- a/commands/delivery/rollout.md
+++ b/commands/delivery/rollout.md
@@ -7,44 +7,12 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:delivery:rollout
 
-Plan safe, staged feature rollouts with risk assessment, canary deployment stages, monitoring, and rollback criteria.
+Plan safe, staged feature rollouts with risk assessment, canary deployment
+stages, monitoring, and rollback criteria.
 
-## Instructions
+## Run it inline (no dispatch)
 
-### 1. Parse Arguments
-
-Extract the rollout description from arguments. If no description provided, ask for one.
-
-### 2. Gather Context
-
-Read any referenced files (feature descriptions, baseline metrics, deployment configs) from the current directory.
-
-### 3. Dispatch to Rollout Manager
-
-```
-Task(
-  subagent_type="wicked-garden:delivery:rollout-manager",
-  prompt="""
-  {user description}
-
-  Working directory: {cwd}
-  {File contents if referenced}
-
-  Provide a comprehensive rollout plan covering:
-  1. Risk assessment: user impact, revenue impact, system criticality, reversibility
-  2. Rollout strategy recommendation (canary, blue-green, ring-based)
-  3. Staged rollout plan with traffic percentages, durations, and success criteria
-  4. Success criteria with specific measurable thresholds
-  5. Automatic rollback triggers (error rate, latency, revenue thresholds)
-  6. Monitoring plan (dashboards, alerts with WARNING/CRITICAL levels)
-  7. Communication plan (stakeholder matrix, templates)
-  8. Rollback procedure (step-by-step)
-
-  Return structured markdown suitable for team sign-off.
-  """
-)
-```
-
-### 4. Present Results
-
-Display the agent's rollout plan document.
+1. Parse the rollout `<description>` from arguments. If none provided, ask for one.
+2. Read any referenced files (feature descriptions, baseline metrics, deployment configs) from the current directory.
+3. `Read("${CLAUDE_PLUGIN_ROOT}/skills/delivery/refs/rollout.md")` — risk assessment matrix, strategy-by-risk table, stage definition template, alert thresholds, bus event, and output format.
+4. Apply the rubric directly and emit the rollout plan document.

--- a/skills/data/refs/analyze.md
+++ b/skills/data/refs/analyze.md
@@ -1,0 +1,123 @@
+# Data Analysis Rubric
+
+Apply this inline. Route by `--focus` to the right analysis mode. File has been
+pre-profiled (columns / types / nulls / sample rows) by the caller.
+
+## EDA output format (default / --focus stats)
+
+```markdown
+## Data Analysis Report
+
+**Dataset**: {name}
+**Analysis Date**: {date}
+
+### Executive Summary
+{2-3 key takeaways}
+
+### Quick Stats
+- **Rows**: {count}  **Columns**: {count}  **Date Range**: {start–end}
+
+### Initial Findings
+1. {Observable pattern or anomaly}
+2. {Interesting correlation or trend}
+
+### Visualization Recommendations
+- {Chart type}: {What it shows}
+
+### Next Steps / Questions Raised
+- {Follow-up analyses or data needs}
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## Statistical analysis patterns
+
+**Distributions**: MIN / Q1 / MEDIAN / Q3 / MAX; histogram or box-plot.
+**Categorical**: frequency + percentage breakdown; bar chart.
+**Time series**: DATE_TRUNC day/week aggregation; line chart.
+**Correlations**: CORR(a, b) spot-check.
+**Cohort/RFM**: group by signup month; recency/frequency/monetary.
+
+## Insight pattern
+
+- **Observation**: What the data shows (fact).
+- **Insight**: Why it matters (interpretation).
+- **Action**: What to do (recommendation).
+- **Confidence**: HIGH | MEDIUM | LOW (state sample size + caveats).
+
+## --focus quality (data-quality mode)
+
+| Dimension | Check |
+|-----------|-------|
+| Completeness | Null rates per column |
+| Uniqueness | Duplicate detection |
+| Validity | Type conformance + constraints |
+| Consistency | Cross-field validation |
+| Timeliness | Freshness metrics |
+
+```markdown
+## Data Quality Report
+
+**Dataset**: {name}  **Rows**: {count}  **Columns**: {count}
+
+### Quality Metrics
+| Dimension | Score | Issues |
+|-----------|-------|--------|
+| Completeness | {%} | {null columns} |
+| Uniqueness  | {%} | {duplicate rate} |
+| Validity    | {%} | {constraint violations} |
+
+### Critical Issues
+- {Issue with severity and impact}
+
+### Recommendations
+1. {Prioritized action items}
+```
+
+## --focus warehouse (warehouse/lakehouse mode)
+
+Evaluate dimensional model fit: Star vs Snowflake vs Data Vault vs Wide Table.
+Cover partitioning / clustering / materialization strategy and cost plan.
+
+```markdown
+## Warehouse Analysis: {domain}
+
+### Approach
+Pattern: {Star|Snowflake|Data Vault|Wide Table}
+Justification: {why}
+
+### Schema
+#### Fact: {fact_table}
+| Column | Type | Description | Source |
+
+#### Dimension: {dim_table}
+| Column | Type | SCD Type | Description |
+
+### Performance
+- Partitioning: {strategy}   Clustering: {columns}   Materialization: {views vs tables}
+
+### Cost Plan
+{Storage tier, compute, optimization levers}
+```
+
+## --focus ml (ML-readiness mode)
+
+Assess training data quality for ML: leakage, imbalance, feature distributions,
+label quality. See refs/ml.md for full ML pipeline rubric.
+
+## Scenarios block (--scenarios)
+
+When `--scenarios` is set, append:
+```yaml
+scenarios:
+  api:
+    - name: "{dataset}_baseline"
+      given: "data file at {path}"
+      when: "analyze --focus {focus}"
+      then: "key finding X observed"
+  perf:
+    - name: "{dataset}_large_file"
+      given: "file with {N} rows"
+      when: "profiling runs"
+      then: "completes within threshold"
+```

--- a/skills/data/refs/data.md
+++ b/skills/data/refs/data.md
@@ -1,0 +1,95 @@
+# Data Engineering Rubric — profile / validate / quality
+
+Apply this inline for schema-level checks. Caller has pre-read the data file
+head/tail and captured columns / types / nulls.
+
+## profile
+
+Emit a structured profile with shape, per-column stats, and prioritized findings.
+
+```markdown
+## Data Profile: {name}
+
+**Rows**: {count}  **Columns**: {count}  **File**: {path}
+
+### Column Summary
+| Column | Type | Null% | Unique | Min | Max | Sample |
+|--------|------|-------|--------|-----|-----|--------|
+
+### Key Observations
+1. {High null-rate columns}
+2. {Type anomalies or mixed types}
+3. {Skew / outlier signals}
+
+### Recommendations
+1. {Prioritized action — e.g. handle nulls in col X}
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## validate
+
+Compare actual data against the provided schema. Report breaking vs non-breaking drift.
+
+```markdown
+## Schema Validation: {name}
+
+**Schema**: {schema-path}  **Data**: {data-path}
+
+### Result: {PASS|FAIL}
+
+### Breaking Issues (must fix)
+| Column | Expected | Actual | Impact |
+|--------|----------|--------|--------|
+
+### Warnings (non-breaking)
+| Column | Note |
+|--------|------|
+
+### Recommendations
+1. {Fix breaking issues first}
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+Schema design principles to apply:
+- Explicit types (avoid variant unless necessary).
+- Clear nullability contracts.
+- Consistent naming conventions.
+- Version schemas explicitly.
+- Document breaking vs non-breaking changes.
+
+## quality
+
+Five-dimension quality assessment: Completeness, Uniqueness, Validity, Consistency, Timeliness.
+
+```markdown
+## Data Quality Report
+
+**Dataset**: {name}  **Rows**: {count}  **Columns**: {count}
+
+### Quality Metrics
+| Dimension    | Score | Issues |
+|--------------|-------|--------|
+| Completeness | {%}   | {null columns} |
+| Uniqueness   | {%}   | {duplicate rate} |
+| Validity     | {%}   | {constraint violations} |
+| Consistency  | {%}   | {cross-field failures} |
+| Timeliness   | {age} | {freshness status} |
+
+### Critical Issues
+- {Issue with severity and impact}
+
+### Recommendations
+1. {Prioritized action items}
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## General engineering checklist
+
+- [ ] Schema-first: define schemas before processing.
+- [ ] Fail fast: validate early, fail loudly.
+- [ ] Idempotent: pipelines rerunnable without side effects.
+- [ ] Observable: emit metrics + logs at every stage.
+- [ ] Tested: data quality tests are non-negotiable.

--- a/skills/data/refs/ml.md
+++ b/skills/data/refs/ml.md
@@ -1,0 +1,118 @@
+# ML Engineering Rubric — review / pipeline
+
+Apply this inline. Caller has pre-gathered model files (for review) or
+captured task-type (for pipeline design).
+
+## review
+
+```markdown
+## ML Engineering Assessment
+
+**Model**: {name}
+**Type**: {classification|regression|ranking|other}
+**Status**: {Development|Staging|Production}
+
+### Summary
+{2-3 sentence overview}
+
+### Architecture Review
+- **Problem Type**: {clear definition}
+- **Model Type**: {algorithm/architecture}
+- **Justification**: {why this approach}
+- **Alternatives Considered**: {other options}
+
+### Data & Features
+- **Training Size**: {rows}
+- **Feature Count**: {count}
+- **Quality**: {assessment}
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| No data leakage (target in features) | {pass/fail} | |
+| Label quality | {pass/fail} | |
+| Class imbalance handled | {pass/fail} | |
+| Missing values handled | {pass/fail} | |
+| Categorical encoding defined | {pass/fail} | |
+| Feature importance tracked | {pass/fail} | |
+
+### Evaluation Strategy
+- **Metrics**: {precision, recall, RMSE, etc.}
+- **Validation**: {holdout / k-fold / time-based}
+- **Success Criteria**: {minimum acceptable performance}
+
+### Deployment Readiness
+- [ ] Inference latency acceptable
+- [ ] Model size appropriate for deployment target
+- [ ] Feature pipeline reproducible in production
+- [ ] Graceful fallback if model fails
+- [ ] A/B testing framework ready
+- [ ] Monitoring and logging instrumented
+- [ ] Rollback plan documented
+
+### Recommendations
+| Priority | Recommendation | Impact | Effort |
+|----------|----------------|--------|--------|
+| P1 | {critical item} | HIGH | {S/M/L} |
+
+**Recommendation**: {APPROVE|CONDITIONAL|NEEDS REWORK}
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## pipeline (training pipeline design)
+
+Problem setup → data/feature stages → model arch → evaluation → tuning → deployment → monitoring.
+
+```markdown
+## Training Pipeline: {model_name}
+
+### Problem Statement
+- **Type**: {Classification|Regression|Ranking|Other}
+- **Target**: {what is being predicted}
+- **Business Metric**: {how success is measured}
+- **Baseline**: {minimum viable baseline established?}
+
+### Data Flow
+1. **Source**: {where data comes from}
+2. **Sampling**: {train/val/test split strategy — e.g. 70/15/15}
+3. **Features**: {transformation pipeline, feature store integration}
+4. **Training**: {model training config, hyperparameter search}
+5. **Validation**: {holdout / cross-validation approach}
+6. **Registry**: {versioning scheme, metadata, promotion criteria}
+
+### Configuration (sample)
+```yaml
+data:
+  source: {path}
+  train_split: 0.7  val_split: 0.15  test_split: 0.15
+features:
+  categorical: [col1, col2]
+  numerical: [col3, col4]
+  target: label
+model:
+  type: {algorithm}
+  key_params: {}
+evaluation:
+  metric: {f1_score|rmse|ndcg}
+  threshold: {value}
+```
+
+### Monitoring Plan
+- **Drift detection**: {feature/target drift strategy}
+- **Performance tracking**: {metrics logged}
+- **Retraining trigger**: {when to retrain}
+
+### MLOps Principles
+- **Reproducible**: version data, code, and models.
+- **Monitored**: track performance continuously.
+- **Automated**: CI/CD for ML pipelines.
+- **Tested**: unit tests for features, integration tests for pipeline.
+- **Documented**: model cards for transparency.
+```
+
+## Common pitfalls
+
+- Training on future data (leakage).
+- Overfitting to validation set.
+- Ignoring class imbalance.
+- Not testing inference performance.
+- Deploying without monitoring.

--- a/skills/data/refs/pipeline.md
+++ b/skills/data/refs/pipeline.md
@@ -1,0 +1,92 @@
+# Data Pipeline Rubric — design / review
+
+Apply this inline for ETL/streaming pipeline architecture.
+Caller has pre-captured source / target / frequency (for design) or read pipeline
+files at `<path>` (for review).
+
+## design
+
+Cover architecture pattern, orchestrator, stage flow, quality gates, monitoring, costs, risks.
+
+```markdown
+## Pipeline Design: {name}
+
+### Architecture
+- **Pattern**: {Batch|Streaming|Hybrid}
+- **Orchestration**: {Airflow|Dagster|Prefect|Other}
+- **Storage**: {Data Lake|Warehouse|Lakehouse}
+
+### Data Flow
+1. **Source**: {description — type, API/DB/file, credentials approach}
+2. **Extract**: {method and frequency}
+3. **Transform**: {key transformations}
+4. **Load**: {destination and format}
+
+### Quality Gates
+- **Source validation**: {checks before processing}
+- **Transform validation**: {checks mid-pipeline}
+- **Load validation**: {row counts, key checks post-load}
+
+### Performance
+- **Expected volume**: {records/day}
+- **Processing time estimate**: {duration}
+- **Cost estimate**: {$/month}
+
+### Risk Assessment
+| Level | Risk | Mitigation |
+|-------|------|------------|
+| HIGH  | {critical risk} | {mitigation} |
+| MED   | {moderate risk} | {mitigation} |
+
+### Design Checklist
+- [ ] Data sources identified and accessible
+- [ ] Schema evolution strategy defined
+- [ ] Error handling and retry logic designed
+- [ ] Idempotency and reprocessing supported
+- [ ] Monitoring and alerting plan
+- [ ] Data quality checks embedded
+- [ ] Cost estimation completed
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## review
+
+Cover code quality, idempotency, monitoring, validation, silent-loss risk.
+Emit P1/P2/P3 findings with code fixes.
+
+```markdown
+## Pipeline Review: {path}
+
+**Architecture**: {summary — pattern, orchestrator, storage}
+**Quality Score**: {score}/100
+
+### Findings
+| Priority | Finding | Impact | Effort | Fix |
+|----------|---------|--------|--------|-----|
+| P1 | {critical} | HIGH | {S/M/L} | {code snippet} |
+| P2 | {moderate} | MED  | {S/M/L} | {code snippet} |
+| P3 | {minor}    | LOW  | {S/M/L} | {note} |
+
+### Review Checklist
+- [ ] Error handling: failures managed and surfaced
+- [ ] Schema versioned and enforced
+- [ ] Monitoring: what metrics are tracked
+- [ ] Testing: data quality tests present
+- [ ] Idempotent: safe to reprocess without duplication
+- [ ] Silent-loss risk: no data drops without alert
+- [ ] Documentation: pipeline well-documented
+
+### Recommendations
+1. {Action with rationale and expected outcome}
+
+**Confidence**: {HIGH|MEDIUM|LOW}
+```
+
+## Engineering standards (apply to both)
+
+- **Schema-first**: always define schemas before processing.
+- **Fail fast**: validate early, fail loudly.
+- **Idempotent**: pipelines rerunnable.
+- **Observable**: emit metrics + logs at every stage.
+- **Tested**: data quality tests are non-negotiable.

--- a/skills/delivery/refs/experiment.md
+++ b/skills/delivery/refs/experiment.md
@@ -1,0 +1,108 @@
+# Experiment Design Rubric
+
+Apply this inline. Design statistically rigorous A/B test experiments with proper
+hypothesis formulation, metric selection, sample size calculation, and instrumentation.
+
+## Hypothesis formulation
+
+**Good format**: `"[Action] will [increase/decrease] [Metric] by [Amount] because [Reason]"`
+
+Examples:
+- "Blue CTA will increase clicks by 10% because it provides better contrast"
+- "Auto-save will reduce abandonment by 15% because users fear losing progress"
+
+Bad: "Users will like the new design" (not measurable), "Feature X is better" (no direction).
+
+## Metrics hierarchy
+
+1. **Primary** — the ONE metric that determines success (e.g. conversion rate).
+2. **Secondary** — supporting metrics to understand impact (time-to-convert, cart value).
+3. **Guardrail** — metrics that must NOT degrade (page load time, error rate).
+
+## Sample size rules of thumb
+
+| Minimum Detectable Effect | Samples per variant |
+|--------------------------|---------------------|
+| 5% | ~3,200 |
+| 10% | ~800 |
+| 20% | ~200 |
+
+Standard parameters: significance α = 0.05, power 1−β = 0.80, confidence 95%.
+Adjust for multiple variants (Bonferroni correction) and sequential testing.
+
+## Variant design
+
+- **Control**: current experience.
+- **Treatment(s)**: new experience(s) — limit to 2–3 variants total.
+- One clear change per variant; variants mutually exclusive.
+
+## Instrumentation plan
+
+```
+experiment_viewed    {variant, user_id, timestamp}
+primary_metric_achieved  {variant, user_id, value}
+secondary_metric_achieved {variant, user_id, value}
+```
+
+Implementation: feature flag for assignment, analytics events for metrics, logging for debug.
+
+## Success criteria
+
+- Statistical: p < 0.05, 95% confidence, 80% power.
+- Business: minimum effect worth shipping + maximum acceptable risk.
+
+## Bus event (emit after experiment concludes)
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" \
+  wicked.experiment.concluded \
+  '{"winner":"variant_a","significance":0.95,"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`winner`: one of `variant_a`, `variant_b`, `inconclusive`. `significance`: float in [0.0, 1.0].
+Payload: Tier 1 + Tier 2 only — no customer-cohort details, no per-user data.
+
+## Output format
+
+```markdown
+## Experiment Design
+
+**Hypothesis**: {clear hypothesis}
+
+### Metrics
+- **Primary**: {metric} — {definition}
+- **Secondary**: {metrics}
+- **Guardrail**: {metrics}
+
+### Variants
+- **Control**: {description}
+- **Treatment**: {description}
+
+### Sample Size
+- Per variant: {n}  Total: {total}  Duration: {duration} at {traffic_rate}%
+
+### Statistical Parameters
+- Significance: 0.05  Confidence: 95%  Power: 80%  MDE: {mde}%
+
+### Instrumentation Plan
+{Feature flags, analytics events, logging}
+
+### Success Criteria
+{What makes this experiment a success}
+
+### Risks
+{Potential issues and mitigations}
+
+### Next Steps
+1. Set up feature flag
+2. Implement instrumentation
+3. Run in staging
+4. Launch to {x}% traffic
+```
+
+## Common pitfalls
+
+- Multiple testing without correction.
+- Peeking at results early (inflates Type I error).
+- Changing metrics mid-experiment.
+- Confounding variables (seasonality, concurrent launches).

--- a/skills/delivery/refs/report.md
+++ b/skills/delivery/refs/report.md
@@ -1,0 +1,111 @@
+# Stakeholder Report Rubric
+
+Apply this inline. Generate multi-perspective delivery reports from project data.
+
+## Data ingestion
+
+Accept from:
+- **CSV/export files**: map columns to id, title, status, priority, assignee, labels, dates.
+- **Active tasks**: read native tasks under `${CLAUDE_CONFIG_DIR}/tasks/{session_id}/`; filter by `metadata.event_type=="task"`.
+- **Crew project**: `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/crew/phase_manager.py" status`.
+- **Verbal description**: extract tasks, statuses, blockers from prose.
+
+## Base metrics to compute
+
+- **Total items**: count of all tasks.
+- **Status breakdown**: Done / In Progress / Blocked / Todo.
+- **Completion rate**: Done / Total.
+- **Priority distribution**: P0/P1/P2/P3 counts.
+- **Aging**: items not updated in threshold period.
+- **Blocker count**: items in blocked status.
+
+## Six persona lenses
+
+### Default (always generated)
+
+**Delivery Lead**: Sprint velocity + completion rate, blockers + escalation triggers,
+timeline risk + scope status, dependency health, action items for unblocking.
+
+**Engineering Lead**: Technical complexity + debt, team capacity + workload,
+implementation risks, code quality signals, resource allocation recommendations.
+
+**Product Lead**: Feature delivery progress, user value + impact, backlog health +
+prioritization, stakeholder alignment, go-to-market readiness.
+
+### Extended (with --all flag)
+
+**QE Lead**: Defect density + trends, test coverage gaps, quality risks by feature area,
+regression signals, testing capacity.
+
+**Architecture Lead**: System impact of changes, technical decision tracking,
+integration point risks, scalability concerns, debt-to-feature ratio.
+
+**DevSecOps Lead**: Security items, CI/CD pipeline health, operational readiness,
+compliance concerns, infrastructure stability.
+
+## Persona section template
+
+```markdown
+### {Persona Name} Perspective
+
+**Summary**: {1-2 sentence assessment}
+**Risk Level**: {GREEN|YELLOW|RED}
+
+**Key Findings**:
+1. {finding relevant to this persona}
+2. {finding relevant to this persona}
+
+**Metrics**:
+| Metric | Value | Assessment |
+|--------|-------|------------|
+| {relevant metric} | {value} | {interpretation} |
+
+**Recommendations**:
+1. {actionable recommendation with ticket reference}
+```
+
+## Cross-persona synthesis
+
+After individual sections:
+- **Consensus risks**: issues flagged by 2+ personas.
+- **Conflicting priorities**: where personas disagree.
+- **Blind spots**: issues no persona flagged but data suggests.
+
+## Executive summary
+
+```markdown
+## Executive Summary
+
+**Sprint/Project**: {name}  **Status**: {ON TRACK|AT RISK|CRITICAL}  **Date**: {date}
+
+### Key Metrics
+| Metric | Value | Status |
+|--------|-------|--------|
+| Completion | {%}% ({done}/{total}) | {status} |
+| Blocked    | {n} items | {status} |
+| Velocity   | {value} | {trend} |
+
+### Critical Items
+1. {most important finding}
+
+### Decisions Needed
+- {decision needed from leadership}
+
+### Recommendations
+1. {top recommendation}
+```
+
+## Output formats
+
+- **Default**: all three default personas inline.
+- **--all**: include six personas.
+- **--personas {list}**: specific personas only.
+- **--output {dir}**: write per-persona files to directory.
+
+## Quality standards
+
+- **Perspective-appropriate**: each persona sees what matters to them.
+- **Data-backed**: every finding references specific items.
+- **Actionable**: recommendations are specific with ticket references.
+- **Honest**: status reflects reality, not optimism.
+- **Concise**: one page per persona max.

--- a/skills/delivery/refs/rollout.md
+++ b/skills/delivery/refs/rollout.md
@@ -1,0 +1,102 @@
+# Rollout Plan Rubric
+
+Apply this inline. Plan safe, staged feature rollouts with risk assessment, canary
+deployment stages, monitoring, and rollback criteria.
+
+## Risk assessment
+
+| Factor | LOW | MEDIUM | HIGH |
+|--------|-----|--------|------|
+| User impact | <1% users | <25% users | >50% users |
+| Revenue impact | none | indirect | direct |
+| System criticality | nice-to-have | important | mission-critical |
+| Reversibility | instant flag-off | minutes | hours/manual |
+
+## Rollout strategy by risk
+
+| Risk | Strategy | Timeline |
+|------|----------|----------|
+| LOW | Big bang | 0% → 100% immediately |
+| MEDIUM | Progressive | 0% → 10% → 50% → 100% over 2 weeks |
+| HIGH | Canary | 0% → 1% → 5% → 10% → 25% → 50% → 100% over 4–6 weeks |
+
+## Stage definition template
+
+```
+Stage N:
+  Traffic: {percentage}%
+  Duration: {time — minimum 24h}
+  Success criteria: {metrics with thresholds}
+  Rollback criteria: {automatic trigger conditions}
+```
+
+## Alert thresholds
+
+- **WARNING**: 1.5x baseline on error rate or latency.
+- **CRITICAL**: 2x baseline OR 5% error rate.
+
+**Automatic rollback triggers**: error rate >2x baseline, latency >50% slower,
+critical user-reported bugs.
+**Manual rollback criteria**: revenue impact, security vulnerability, regulatory issue.
+
+## Communication plan
+
+| Audience | Content | Timing |
+|----------|---------|--------|
+| Engineering | Technical details, rollback plan | T-2 days |
+| Product | Timeline, success criteria | T-2 days |
+| Support | User-facing changes, FAQs | T-1 day |
+| Leadership | Risk assessment, go/no-go | T-0 |
+
+## Bus event (emit after go/no-go decision)
+
+```bash
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_bus_emit.py" \
+  wicked.rollout.decided \
+  '{"decision":"go","traffic_pct":10,"chain_id":"{chain_id}"}' 2>/dev/null || true
+```
+
+`decision`: one of `go`, `no-go`, `paused`. `traffic_pct`: integer 0–100.
+Payload: Tier 1 + Tier 2 only — no customer-cohort details.
+
+## Output format
+
+```markdown
+## Rollout Plan: {Feature Name}
+
+**Risk Assessment**: {LOW|MEDIUM|HIGH}
+**Strategy**: {Progressive|Canary|Big Bang}
+**Total Duration**: {duration}
+
+### Stages
+| Stage | Traffic | Duration | Success Criteria | Rollback Criteria |
+|-------|---------|----------|------------------|-------------------|
+| 1     | {%}     | {time}   | {criteria}       | {triggers} |
+
+### Monitoring
+**Metrics to Watch**: primary {metric}, error rate {threshold}, latency {threshold}
+**Alerts**: WARNING {condition} / CRITICAL {condition}
+
+### Rollback Plan
+**Automatic triggers**: {trigger 1}, {trigger 2}
+**Rollback procedure**:
+1. Set feature flag to 0%
+2. Verify traffic shifted
+3. Monitor error recovery
+4. Notify stakeholders
+
+### Communication
+- [ ] Engineering notified  [ ] Product aligned  [ ] Support prepared  [ ] Leadership informed
+
+### Next Steps
+1. Configure feature flag: {flag_name}
+2. Set up monitoring: {dashboard}
+3. Stage 1 launch: {date/time}
+```
+
+## Best practices
+
+- Start with internal users (0.1%), then canary (1–5%), then expand.
+- Each stage: minimum 24h to collect data, maximum 1 week to maintain momentum.
+- Always prefer feature flags over code deploys for rollback speed.
+- For HIGH risk: consider shadow mode or dark launch before Stage 1.


### PR DESCRIPTION
Product-collapse pattern (#910) applied to data + delivery.

- **data**: collapsed analyze/data/ml/pipeline → inline + `skills/data/refs/`. **Kept** ontology (real RDF engine).
- **delivery**: collapsed experiment/report/rollout → inline + `skills/delivery/refs/`. **Kept** setup (load-bearing interactive configurator — AskUserQuestion + shells real scripts, already zero-dispatch).
- **Agents:** this stream kept all 11 (data agents are genuinely referenced by integration-discovery/specialist.json; the **delivery agents it kept on a components.json-only basis will be re-evaluated in the follow-up orphan-purge** — components.json is regenerated centrally and is not a real usage reference).

**Net +622** (14 files, +798/−176 — no agent deletions here; the line win comes in the purge). validate PASS; 109 passed/2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)