### PR TITLE
fix: make the code-intelligence layer actually deliver (#916) + orphan-analyzer worktree bug

### DIFF
--- a/commands/search/index.md
+++ b/commands/search/index.md
@@ -1,5 +1,5 @@
 ---
-description: Build unified index for code and documents in a directory
+description: Build/refresh the code-intelligence index (semantic brain + structural codegraph)
 argument-hint: "<path>"
 phase_relevance: ["*"]
 archetype_relevance: ["*"]
@@ -7,41 +7,40 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:search:index
 
-Build a searchable index of code symbols and document content. Indexing is now handled by the brain knowledge layer.
+Refresh the two code-intelligence layers the other `search:*` commands query:
+
+- **semantic** (wicked-brain) — concept/symbol search, `wicked-brain:search`/`query`.
+- **structural** (codegraph) — `search:blast-radius`, `search:lineage`, and the wicked-patch family.
 
 ## Arguments
 
-- `path` (required): Directory to index
+- `path` (required): Directory to index.
 
 ## Instructions
 
-1. **Delegate to brain ingest** — all indexing now goes through `wicked-brain:ingest`:
+1. **Semantic layer** — invoke `/wicked-brain:ingest` with `<path>` (incremental; only changed files re-ingest).
 
-   Tell the user:
-   > Indexing is now handled by the brain. Running `wicked-brain:ingest` to index your codebase.
-
-   Then invoke `/wicked-brain:ingest` with the provided path.
-
-2. **Verify the index** by checking brain stats:
+2. **Structural layer** — rebuild the codegraph graph, then re-apply the injected edges:
    ```bash
-   curl -s -X POST http://localhost:4242/api \
-     -H "Content-Type: application/json" \
-     -d '{"action":"stats","params":{}}'
+   codegraph index "<path>"   # or: npx -y @colbymchenry/codegraph index "<path>"
+   # codegraph indexes CODE only; re-apply the injected layer (bus producer→consumer,
+   # command→agent dispatch, agent→capability) it doesn't know about and a re-index drops:
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+      "${CLAUDE_PLUGIN_ROOT}/scripts/codegraph/inject_all.py" "<path>/.codegraph/codegraph.db"
    ```
+   The `inject_all` step is **required** for `blast-radius`/`lineage` to surface the string-keyed
+   relationships grep and the static graph can't see (#916). Skipping it leaves the injected
+   layer empty after every re-index.
 
-3. Report the results showing chunk and tag counts from the brain stats response.
-
-## Examples
-
-```bash
-# Basic indexing
-/wicked-garden:search:index /path/to/project
-
-# This is equivalent to:
-/wicked-brain:ingest /path/to/project
-```
+3. **Verify**:
+   ```bash
+   curl -s -X POST http://localhost:4243/api -H "Content-Type: application/json" \
+     -d '{"action":"stats","params":{}}'                       # brain chunk/tag counts
+   ```
+   `inject_all` prints per-extractor edge counts + a `total_injected_edges` — report both.
 
 ## Notes
 
-- Re-running only updates changed files (incremental)
-- Check `wicked-brain-status` to verify indexing results
+- Both layers are incremental/idempotent — safe to re-run.
+- If `codegraph` isn't resolvable, the structural commands degrade to grep + brain (and say so);
+  run `codegraph index` once to enable blast-radius/lineage/patch.

--- a/scripts/ci/find_orphan_agents.py
+++ b/scripts/ci/find_orphan_agents.py
@@ -98,7 +98,12 @@ def _scan_files() -> List[Path]:
     for p in _REPO.rglob("*"):
         if not p.is_file() or p.suffix not in _SCAN_EXT:
             continue
-        if any(part in _EXCLUDE_PARTS for part in p.parts):
+        # Exclude on the path RELATIVE to the repo root — otherwise, when this runs
+        # from inside a git worktree (which lives at .claude/worktrees/agent-X/), the
+        # worktree's own ".claude" prefix would match and exclude the entire repo,
+        # making every agent look orphaned.
+        rel = p.relative_to(_REPO)
+        if any(part in _EXCLUDE_PARTS for part in rel.parts):
             continue
         out.append(p)
     return out

--- a/scripts/codegraph/_graph_nodes.py
+++ b/scripts/codegraph/_graph_nodes.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""_graph_nodes.py — self-noding helpers for the injected-edge extractors.
+
+codegraph indexes *code* (it parses source with tree-sitter). wicked-garden's
+load-bearing relationships, though, are wired between **markdown** files —
+``commands/<d>/<c>.md`` dispatches to ``agents/<d>/<a>.md`` via a ``subagent_type``
+string; an agent declares a ``capability`` in YAML. codegraph never creates nodes
+for those .md files (or for a virtual capability), so an injected edge had nothing
+to anchor to and every edge was skipped (issue #916).
+
+These helpers let an extractor **self-node**: create the node it needs (idempotently)
+rather than requiring codegraph to have indexed it. Real code files that codegraph
+already indexed are untouched (``INSERT OR IGNORE`` is a no-op when the node exists),
+so the injected graph composes with the static one in the same ``nodes``/``edges``
+tables — exactly the co-location ADR 0001 specified.
+
+Stdlib-only. The schema's NOT NULL columns are all populated (the original
+capability-node insert omitted them — a latent constraint violation).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+# Every column the codegraph `nodes` table requires NOT NULL, beyond the ones we set.
+_INSERT_NODE = (
+    "INSERT OR IGNORE INTO nodes "
+    "(id, kind, name, qualified_name, file_path, language, "
+    " start_line, end_line, start_column, end_column, updated_at) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?)"
+)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def ensure_file_node(conn: sqlite3.Connection, relpath: str,
+                     *, language: str = "markdown") -> str:
+    """Ensure a ``file:<relpath>`` node exists; return its id.
+
+    For a .md command/agent file codegraph skipped, this creates a synthetic file
+    node so dispatch/capability edges can anchor. For a real source file codegraph
+    already indexed, the INSERT OR IGNORE is a no-op (the real node is preserved)."""
+    nid = f"file:{relpath}"
+    conn.execute(_INSERT_NODE,
+                 (nid, "file", Path(relpath).name, relpath, relpath, language,
+                  1, 1, _now_ms()))
+    return nid
+
+
+def ensure_virtual_node(conn: sqlite3.Connection, node_id: str, kind: str,
+                        name: str, *, file_path: str | None = None) -> str:
+    """Ensure a synthetic non-file node (e.g. ``capability:<name>``) exists; return id.
+
+    Populates every NOT NULL column the schema demands (the original capability
+    insert set only id/kind/name/file_path and would violate the constraint)."""
+    conn.execute(_INSERT_NODE,
+                 (node_id, kind, name, name, file_path or node_id, "virtual",
+                  0, 0, _now_ms()))
+    return node_id
+
+
+__all__ = ["ensure_file_node", "ensure_virtual_node"]

--- a/scripts/codegraph/inject_all.py
+++ b/scripts/codegraph/inject_all.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""inject_all.py — run every injected-edge extractor against the codegraph graph.
+
+`codegraph index` rebuilds the *static* graph (symbols + imports/calls/refs) and
+knows nothing about wicked-garden's injected layer — the string-keyed relationships
+grep and a static call-graph can't see:
+
+  - bus producer → consumer        (emit + _bus_consumers.json)
+  - command → agent dispatch       (subagent_type)
+  - agent → capability             (tool-capabilities + CAPABILITY_REGISTRY)
+
+Those edges are INSERTed on top of the static graph and are dropped whenever the
+graph is re-indexed. This is the single entry point — search:index, CI, or a
+pre-push refresh — that re-applies all of them in one pass, so blast-radius and
+lineage see the complete picture instead of a stale or empty injected layer (#916).
+
+Stdlib-only. Idempotent (each extractor clears and re-inserts only its own edges).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import inject_capability_edges  # noqa: E402
+import inject_dispatch_edges  # noqa: E402
+import inject_edges  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[2]
+# (label, module) — bus first (anchors to real code nodes), then the markdown layers
+_EXTRACTORS = (
+    ("bus", inject_edges),
+    ("dispatch", inject_dispatch_edges),
+    ("capability", inject_capability_edges),
+)
+
+
+def inject_all(db_path: Path) -> Dict[str, Any]:
+    """Run every extractor against db_path; return per-extractor stats + a total."""
+    out: Dict[str, Any] = {}
+    total = 0
+    for label, module in _EXTRACTORS:
+        stats = module.inject(db_path)
+        out[label] = stats
+        total += int(stats.get("edges_added", 0))
+    out["total_injected_edges"] = total
+    return out
+
+
+def main() -> int:
+    db = Path(sys.argv[1]) if len(sys.argv) > 1 else _REPO / ".codegraph" / "codegraph.db"
+    if not db.exists():
+        print(json.dumps({"error": f"codegraph db not found at {db}; run `codegraph index` first"}))
+        return 1
+    print(json.dumps(inject_all(db), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codegraph/inject_capability_edges.py
+++ b/scripts/codegraph/inject_capability_edges.py
@@ -46,6 +46,10 @@ _SCRIPTS = _REPO / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
+# self-noding helpers live beside this script
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _graph_nodes import ensure_file_node, ensure_virtual_node  # noqa: E402
+
 
 def _registry_capabilities() -> Set[str]:
     """The set of capability names defined in CAPABILITY_REGISTRY.
@@ -107,23 +111,6 @@ def _agent_capabilities() -> List[Tuple[str, str]]:
     return out
 
 
-def _file_node_id(conn: sqlite3.Connection, relpath: str) -> str | None:
-    """codegraph file node ids are 'file:<relpath>'. Confirm it exists."""
-    nid = f"file:{relpath}"
-    row = conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone()
-    return nid if row else None
-
-
-def _ensure_capability_node(conn: sqlite3.Connection, cap: str) -> str:
-    """Create (idempotently) the synthetic ``capability:<name>`` node, return its id."""
-    nid = f"capability:{cap}"
-    conn.execute(
-        "INSERT OR IGNORE INTO nodes (id, kind, name, file_path) VALUES (?, ?, ?, ?)",
-        (nid, _CAPABILITY_NODE_KIND, cap, None),
-    )
-    return nid
-
-
 def inject(db_path: Path) -> Dict[str, int]:
     conn = sqlite3.connect(str(db_path))
     try:
@@ -132,14 +119,12 @@ def inject(db_path: Path) -> Dict[str, int]:
         conn.execute("DELETE FROM edges WHERE provenance = ?", (_INJECTED_PROVENANCE,))
         conn.execute("DELETE FROM nodes WHERE kind = ?", (_CAPABILITY_NODE_KIND,))
         pairs = _agent_capabilities()
-        added, skipped = 0, 0
+        added = 0
         caps_created: Set[str] = set()
         for agent_rel, cap in pairs:
-            src = _file_node_id(conn, agent_rel)
-            if src is None:  # agent file not indexed in this graph — skip
-                skipped += 1
-                continue
-            tgt = _ensure_capability_node(conn, cap)
+            # self-node the agent .md (codegraph indexes code, not markdown — #916)
+            src = ensure_file_node(conn, agent_rel)
+            tgt = ensure_virtual_node(conn, f"capability:{cap}", _CAPABILITY_NODE_KIND, cap)
             caps_created.add(cap)
             conn.execute(
                 "INSERT INTO edges (source, target, kind, metadata, provenance) "
@@ -150,7 +135,9 @@ def inject(db_path: Path) -> Dict[str, int]:
             )
             added += 1
         conn.commit()
-        return {"edges_added": added, "skipped": skipped,
+        # skipped stays 0: caps absent from the registry are dropped in
+        # _agent_capabilities(), and we now create whatever node we need.
+        return {"edges_added": added, "skipped": 0,
                 "capabilities": len(caps_created), "pairs": len(pairs)}
     finally:
         conn.close()

--- a/scripts/codegraph/inject_dispatch_edges.py
+++ b/scripts/codegraph/inject_dispatch_edges.py
@@ -36,6 +36,10 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
+# self-noding helper lives beside this script
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _graph_nodes import ensure_file_node  # noqa: E402
+
 _REPO = Path(__file__).resolve().parents[2]
 _COMMANDS_DIR = _REPO / "commands"
 _AGENTS_DIR = _REPO / "agents"
@@ -89,26 +93,18 @@ def _dispatches() -> List[Tuple[str, str, str]]:
     return out
 
 
-def _file_node_id(conn: sqlite3.Connection, relpath: str) -> str | None:
-    """codegraph file node ids are 'file:<relpath>'. Confirm it exists."""
-    nid = f"file:{relpath}"
-    row = conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone()
-    return nid if row else None
-
-
 def inject(db_path: Path) -> Dict[str, int]:
     conn = sqlite3.connect(str(db_path))
     try:
         # idempotent: clear prior injected dispatch edges
         conn.execute("DELETE FROM edges WHERE provenance = ?", (_INJECTED_PROVENANCE,))
         dispatches = _dispatches()
-        added, skipped = 0, 0
+        added = 0
         for cmd_rel, agent_rel, handle in dispatches:
-            src = _file_node_id(conn, cmd_rel)
-            tgt = _file_node_id(conn, agent_rel)
-            if src is None or tgt is None:
-                skipped += 1
-                continue
+            # self-node the .md command + agent (codegraph indexes code, not markdown,
+            # so these file nodes don't exist until we create them — issue #916)
+            src = ensure_file_node(conn, cmd_rel)
+            tgt = ensure_file_node(conn, agent_rel)
             conn.execute(
                 "INSERT INTO edges (source, target, kind, metadata, provenance) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -118,7 +114,9 @@ def inject(db_path: Path) -> Dict[str, int]:
             )
             added += 1
         conn.commit()
-        return {"edges_added": added, "skipped": skipped, "dispatches": len(dispatches)}
+        # skipped stays 0: _dispatches() already drops handles that don't resolve to
+        # an agent file, and we now create whatever node we need.
+        return {"edges_added": added, "skipped": 0, "dispatches": len(dispatches)}
     finally:
         conn.close()
 

--- a/tests/codegraph/test_codegraph.py
+++ b/tests/codegraph/test_codegraph.py
@@ -23,6 +23,8 @@ for _p in (_REPO / "scripts", _REPO / "scripts" / "codegraph"):
         sys.path.insert(0, str(_p))
 
 import _codegraph as cg  # noqa: E402
+import _graph_nodes as gn  # noqa: E402
+import inject_all as iall  # noqa: E402
 import inject_capability_edges as ice  # noqa: E402
 import inject_dispatch_edges as idis  # noqa: E402
 import inject_edges as ie  # noqa: E402
@@ -68,13 +70,26 @@ class ResolverTests(unittest.TestCase):
 
 
 def _codegraph_shaped_db(path: str, file_relpaths):
+    """Create a db with codegraph's REAL nodes/edges schema (incl. its NOT NULL
+    columns), so self-noding INSERTs are exercised exactly as against a live graph."""
     conn = sqlite3.connect(path)
-    conn.execute("CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, file_path TEXT)")
-    conn.execute("CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, "
-                 "target TEXT, kind TEXT, metadata TEXT, line INT, col INT, provenance TEXT)")
+    conn.execute(
+        "CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT NOT NULL, name TEXT NOT NULL, "
+        "qualified_name TEXT NOT NULL, file_path TEXT NOT NULL, language TEXT NOT NULL, "
+        "start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, start_column INTEGER NOT NULL, "
+        "end_column INTEGER NOT NULL, docstring TEXT, signature TEXT, visibility TEXT, "
+        "is_exported INTEGER, is_async INTEGER, is_static INTEGER, is_abstract INTEGER, "
+        "decorators TEXT, type_parameters TEXT, updated_at INTEGER NOT NULL)"
+    )
+    conn.execute("CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, "
+                 "target TEXT NOT NULL, kind TEXT NOT NULL, metadata TEXT, line INT, col INT, "
+                 "provenance TEXT)")
     for rel in file_relpaths:
-        conn.execute("INSERT INTO nodes (id, kind, name, file_path) VALUES (?,?,?,?)",
-                     (f"file:{rel}", "file", rel, rel))
+        conn.execute(
+            "INSERT INTO nodes (id, kind, name, qualified_name, file_path, language, "
+            "start_line, end_line, start_column, end_column, updated_at) "
+            "VALUES (?, 'file', ?, ?, ?, 'python', 1, 1, 0, 0, 0)",
+            (f"file:{rel}", rel, rel, rel))
     conn.commit()
     conn.close()
 
@@ -185,20 +200,32 @@ class InjectDispatchEdgesTests(unittest.TestCase):
             self.assertEqual(row[0], f"file:{cmd_rel}")
             self.assertEqual(row[1], f"file:{agent_rel}")
 
-    def test_skips_when_agent_node_absent(self):
-        # The dispatch is real, but the agent file is NOT a node in this graph
-        # (only the command is). The edge must be skipped, not fabricated — this is
-        # the "grep can't link them" guard: no node, no edge.
+    def test_self_nodes_md_files_when_absent_issue_916(self):
+        # codegraph indexes CODE, not the .md command/agent files — so in a real
+        # graph NEITHER node exists. The extractor must self-node both and still
+        # create the edge. The old behavior (skip when the node was absent) left the
+        # entire command→agent layer empty for this markdown-defined plugin (#916).
         dispatches = idis._dispatches()
         if not dispatches:
             self.skipTest("no resolvable command→agent dispatch")
-        cmd_rel, _agent_rel, _handle = dispatches[0]
+        cmd_rel, agent_rel, _handle = dispatches[0]
         with tempfile.TemporaryDirectory() as d:
             dbp = str(Path(d) / "cg.db")
-            _codegraph_shaped_db(dbp, [cmd_rel])  # command node only
+            _codegraph_shaped_db(dbp, [])  # empty graph — no .md nodes, as codegraph leaves it
             stats = idis.inject(Path(dbp))
-            self.assertEqual(stats["edges_added"], 0)
-            self.assertGreaterEqual(stats["skipped"], 1)
+            self.assertGreaterEqual(stats["edges_added"], 1)
+            self.assertEqual(stats["skipped"], 0)
+            conn = sqlite3.connect(dbp)
+            edge = conn.execute(
+                "SELECT 1 FROM edges WHERE provenance='injected:dispatch' "
+                "AND source=? AND target=?", (f"file:{cmd_rel}", f"file:{agent_rel}")
+            ).fetchone()
+            src_node = conn.execute("SELECT 1 FROM nodes WHERE id=?", (f"file:{cmd_rel}",)).fetchone()
+            tgt_node = conn.execute("SELECT 1 FROM nodes WHERE id=?", (f"file:{agent_rel}",)).fetchone()
+            conn.close()
+            self.assertIsNotNone(edge, "dispatch edge not created from self-noded .md files")
+            self.assertIsNotNone(src_node, "command .md was not self-noded")
+            self.assertIsNotNone(tgt_node, "agent .md was not self-noded")
 
     def test_inject_is_idempotent(self):
         dispatches = idis._dispatches()
@@ -268,23 +295,33 @@ class InjectCapabilityEdgesTests(unittest.TestCase):
             self.assertIsNotNone(node, "synthetic capability node not created")
             self.assertEqual(node[1], "capability")
 
-    def test_skips_when_agent_node_absent(self):
-        # Agent declares a real registry capability, but the agent file is not a
-        # node in this graph → no edge, no synthetic node fabricated.
+    def test_self_nodes_agent_and_capability_when_absent_issue_916(self):
+        # The agent .md isn't a codegraph node (codegraph indexes code, not markdown).
+        # The extractor must self-node the agent file AND create the synthetic
+        # capability node, then wire the edge. The old behavior skipped everything,
+        # leaving the agent→capability layer empty (#916).
         pairs = ice._agent_capabilities()
         if not pairs:
             self.skipTest("no resolvable agent→capability pair")
+        agent_rel, cap = pairs[0]
         with tempfile.TemporaryDirectory() as d:
             dbp = str(Path(d) / "cg.db")
-            _codegraph_shaped_db(dbp, [])  # no nodes at all
+            _codegraph_shaped_db(dbp, [])  # empty graph
             stats = ice.inject(Path(dbp))
-            self.assertEqual(stats["edges_added"], 0)
+            self.assertGreaterEqual(stats["edges_added"], 1)
+            self.assertEqual(stats["skipped"], 0)
             conn = sqlite3.connect(dbp)
-            cnodes = conn.execute(
-                "SELECT count(*) FROM nodes WHERE kind='capability'"
-            ).fetchone()[0]
+            edge = conn.execute(
+                "SELECT 1 FROM edges WHERE provenance='injected:capability' "
+                "AND source=? AND target=?", (f"file:{agent_rel}", f"capability:{cap}")
+            ).fetchone()
+            anode = conn.execute("SELECT 1 FROM nodes WHERE id=?", (f"file:{agent_rel}",)).fetchone()
+            cnode = conn.execute("SELECT kind FROM nodes WHERE id=?", (f"capability:{cap}",)).fetchone()
             conn.close()
-            self.assertEqual(cnodes, 0)
+            self.assertIsNotNone(edge, "capability edge not created from self-noded agent .md")
+            self.assertIsNotNone(anode, "agent .md was not self-noded")
+            self.assertIsNotNone(cnode, "synthetic capability node not created")
+            self.assertEqual(cnode[0], "capability")
 
     def test_inject_is_idempotent(self):
         pairs = ice._agent_capabilities()
@@ -309,6 +346,63 @@ class InjectCapabilityEdgesTests(unittest.TestCase):
             conn.close()
             self.assertEqual(edges, n2)
             self.assertEqual(cnodes, distinct_caps)  # one node per referenced cap, no dupes
+
+
+class GraphNodeHelperTests(unittest.TestCase):
+    """The self-noding helpers populate every NOT NULL column and are idempotent."""
+
+    def test_ensure_file_node_satisfies_schema_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [])  # real schema, no rows
+            conn = sqlite3.connect(dbp)
+            nid1 = gn.ensure_file_node(conn, "commands/x/y.md")
+            nid2 = gn.ensure_file_node(conn, "commands/x/y.md")  # idempotent
+            conn.commit()
+            self.assertEqual(nid1, nid2)
+            row = conn.execute(
+                "SELECT kind, language, file_path FROM nodes WHERE id=?", (nid1,)
+            ).fetchone()
+            count = conn.execute("SELECT count(*) FROM nodes WHERE id=?", (nid1,)).fetchone()[0]
+            conn.close()
+            self.assertEqual(count, 1)
+            self.assertEqual(row[0], "file")
+            self.assertEqual(row[1], "markdown")  # .md self-nodes carry markdown language
+
+    def test_ensure_virtual_node_satisfies_schema(self):
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, [])
+            conn = sqlite3.connect(dbp)
+            nid = gn.ensure_virtual_node(conn, "capability:foo", "capability", "foo")
+            conn.commit()
+            row = conn.execute("SELECT kind, name FROM nodes WHERE id=?", (nid,)).fetchone()
+            conn.close()
+            self.assertEqual(row, ("capability", "foo"))
+
+
+class InjectAllTests(unittest.TestCase):
+    """The orchestrator runs every extractor and sums the injected edges."""
+
+    def test_runs_all_extractors_and_totals(self):
+        dispatches = idis._dispatches()
+        pairs = ice._agent_capabilities()
+        rels = sorted({c for c, _, _ in dispatches} | {a for _, a, _ in dispatches}
+                      | {a for a, _ in pairs})
+        with tempfile.TemporaryDirectory() as d:
+            dbp = str(Path(d) / "cg.db")
+            _codegraph_shaped_db(dbp, rels)
+            out = iall.inject_all(Path(dbp))
+            self.assertIn("bus", out)
+            self.assertIn("dispatch", out)
+            self.assertIn("capability", out)
+            expected = sum(out[k]["edges_added"] for k in ("bus", "dispatch", "capability"))
+            self.assertEqual(out["total_injected_edges"], expected)
+            # the markdown layers must contribute (the #916 fix) when dispatches/pairs exist
+            if dispatches:
+                self.assertGreaterEqual(out["dispatch"]["edges_added"], 1)
+            if pairs:
+                self.assertGreaterEqual(out["capability"]["edges_added"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Keeps the code stuff and makes it valuable** — the differentiators the reviewer pass flagged as plumbed-but-hollow now work end-to-end.

### #916 — blast-radius/lineage injected layer was dead
The command→agent and agent→capability extractors produced **0 edges**: they anchored to `file:<*.md>` nodes, but codegraph indexes **code, not markdown**, so those nodes never existed → every edge skipped. The headline differentiator over grep (string-keyed links) didn't work for this markdown-defined plugin.

- **`scripts/codegraph/_graph_nodes.py`** — shared self-noding helpers; extractors now create synthetic file/virtual nodes for the .md files codegraph skips, then wire the edge (real code nodes untouched). Also fixes a latent NOT-NULL violation in the old capability-node insert.
- **dispatch 0→9 edges, capability 0→9** — verified: `ux-designer←ux-review`, `persona-agent←persona:as`, `council←jam:council`, `version-control←{implementer,backend-engineer,senior-engineer,security-engineer}`.
- **`inject_all.py`** — orchestrator; one-pass refresh of all 3 layers.
- **`commands/search/index.md`** — now refreshes BOTH layers (brain + codegraph) and runs `inject_all` so the injected layer survives a re-index; fixed brain port 4242→4243.

### Orphan-analyzer worktree bug (shipped v12.12.0)
`find_orphan_agents.py` excluded `.claude` by absolute path → run from inside a worktree (`.claude/worktrees/...`) it excluded the whole repo and called every agent orphaned. Now relative to repo root.

### Tests
Flipped the two 'skip when node absent' tests (which encoded the #916 bug) into regression tests proving self-noding; added `_graph_nodes` + `inject_all` coverage. **Full suite 519 passed**; validate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)