### PR TITLE
feat: the claim sentinel — claim-time gates via state transitions, no command lists

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# wicked-garden claim sentinel — local pre-push gate (layer 1 of 3).
+#
+# Tool-agnostic by construction: gh, glab, IDEs, and raw git all shell `git
+# push`, and git fires this hook regardless of the caller — no command list.
+# It blocks a push of the default branch or a tag when no re-derived verdict
+# covers the pushed sha (the sentinel ledger is stamped by every prove/gate
+# run via scripts/qe/vault_gate.gate_satisfied).
+#
+#   override: `git push --no-verify`  — git's own explicit-skip; the server
+#   layer (required CI check) still gates, and the skip is visible in history.
+#
+# Enable with:  git config core.hooksPath .githooks
+# stdin: "<local_ref> <local_sha> <remote_ref> <remote_sha>" per pushed ref.
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 "$PLUGIN_ROOT/scripts/sentinel/pre_push.py" "$@" \
+  || python "$PLUGIN_ROOT/scripts/sentinel/pre_push.py" "$@"

--- a/commands/search/blast-radius.md
+++ b/commands/search/blast-radius.md
@@ -24,6 +24,8 @@ Analyze what would be affected if you changed a symbol. Shows both what this sym
 
 1. **Query the codegraph graph** for static + injected dependents (the authoritative layer — covers what grep can't see):
    ```bash
+   # Freshness first — a silently-stale graph gives confident wrong answers:
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" staleness
    # Static refs (imports/calls/instantiations) resolved by the engine:
    sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" 2>/dev/null  # shim is library-only; run the CLI:
    codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json

--- a/commands/search/hotspots.md
+++ b/commands/search/hotspots.md
@@ -11,7 +11,8 @@ Rank symbols by incoming reference count to expose god-objects, coupling hotspot
 
 ## Instructions
 
-1. **Primary path — codegraph** (when `.codegraph/codegraph.db` exists):
+1. **Freshness check** — `sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" staleness` — surface the warning line if stale.
+2. **Primary path — codegraph** (when `.codegraph/codegraph.db` exists):
    ```bash
    python3 - <<'PY'
    import sqlite3, pathlib
@@ -35,7 +36,7 @@ Rank symbols by incoming reference count to expose god-objects, coupling hotspot
    ```
    Report the ranked list. Call out anything with an unusually high count as a likely god-object or coupling hotspot worth refactoring. Note that injected edges (provenance LIKE `'injected:%'`) are included — a heavily-dispatched agent or capability appears here too.
 
-2. **Fallback — brain** (no `.codegraph` index):
+3. **Fallback — brain** (no `.codegraph` index):
    ```bash
    PORT="$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_brain_port.py" 2>/dev/null || echo 4242)"
    curl -s -X POST "http://localhost:${PORT}/api" \

--- a/commands/search/lineage.md
+++ b/commands/search/lineage.md
@@ -38,6 +38,8 @@ Trace data lineage paths through the codebase. Follow data flow from UI fields t
 
 2. **Query the codegraph graph for reference flow** (when a `.codegraph/codegraph.db` index exists). The graph gives both static reference edges and the *injected* edges grep can't see (bus producer→consumer, command→agent dispatch, agent→capability) — useful when the data/reference path crosses a string-keyed link rather than a literal call:
    ```bash
+   # Freshness first — a silently-stale graph gives confident wrong answers:
+   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" staleness
    codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json
    # injected reference flow (string-keyed links static analysis misses):
    sqlite3 .codegraph/codegraph.db \

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -3,7 +3,7 @@
 PostToolUse / PostToolUseFailure hook — wicked-garden unified post-tool dispatcher.
 
 Consolidates: crew posttool_task, delivery metrics_refresh, mem task_checkpoint,
-search mark_stale, qe change_tracker, agentic detect_framework,
+search mark_stale, agentic detect_framework,
 observability trace_writer.
 
 Dispatches by tool_name from hook payload:
@@ -11,8 +11,8 @@ Dispatches by tool_name from hook payload:
   Write / Edit                         → stale file marking + QE change tracking + MEMORY.md guard
   Task                                 → subagent activity tracking
   Read                                 → large-file-read warning + agentic framework detection
-  Bash                                 → activity tracking + discovery hints
-  Grep / Glob                          → discovery hints for search commands
+  Bash                                 → activity tracking + claim-sentinel ref-watch
+  Grep / Glob                          → no-op (ambient tips retired; sentinel replaced them)
   PostToolUseFailure (any tool_name)   → failure counting + auto issue detection
 
 Traces are written to a session-scoped JSONL file in $TMPDIR (local only).
@@ -101,80 +101,13 @@ def _bus_as_truth_flag_on() -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Discovery hints — "did you know?" suggestions (Issue #322)
-#
-# Each hint has an ID, a one-line suggestion, and fires at most once per session.
-# Detects patterns in tool usage and suggests wicked-garden commands that could
-# do the job better. Lightweight — single SessionState read/write.
-# ---------------------------------------------------------------------------
-
-_DISCOVERY_HINTS = {
-    "grep_search": (
-        "[Tip] wicked-garden has semantic code search: "
-        "`wicked-brain:search <query>` finds symbols with context, "
-        "or `/wicked-garden:search:blast-radius <symbol>` for impact analysis."
-    ),
-    "manual_review": (
-        "[Tip] For structured code review with senior-engineer perspective, "
-        "try `/wicked-garden:engineering:review`."
-    ),
-    "debugging": (
-        "[Tip] For systematic debugging with root cause analysis, "
-        "try `/wicked-garden:engineering:debug`."
-    ),
-    "requirements": (
-        "[Tip] For structured requirements elicitation, "
-        "try `/wicked-garden:product:elicit`."
-    ),
-    "architecture": (
-        "[Tip] For architecture analysis and design review, "
-        "try `/wicked-garden:engineering:arch`."
-    ),
-    "data_analysis": (
-        "[Tip] For interactive data analysis with DuckDB, "
-        "try `/wicked-garden:data:analyze`."
-    ),
-}
-
-
-def _try_discovery_hint(hint_id: str) -> str | None:
-    """Emit a discovery hint if it hasn't been shown this session.
-
-    Returns the hint message, or None if already shown or on any error.
-    At most one hint is shown per session to avoid nagging.
-    """
-    try:
-        from _session import SessionState
-        state = SessionState.load()
-        shown = state.hints_shown or []
-
-        # Cap: at most 2 hints per session total to stay subtle
-        if len(shown) >= 2:
-            return None
-
-        if hint_id in shown:
-            return None
-
-        hint_text = _DISCOVERY_HINTS.get(hint_id)
-        if not hint_text:
-            return None
-
-        shown.append(hint_id)
-        state.update(hints_shown=shown)
-        return hint_text
-    except Exception:
-        return None
-
-
-# ---------------------------------------------------------------------------
 # Handler: Grep / Glob (discovery hint for search commands)
 # ---------------------------------------------------------------------------
 
 def _handle_grep_glob(tool_name: str, tool_input: dict) -> dict:
-    """On repeated Grep/Glob usage, suggest wicked-garden search commands."""
-    hint = _try_discovery_hint("grep_search")
-    if hint:
-        return {"continue": True, "systemMessage": hint}
+    """No-op handler. The ambient discovery tips that lived here were retired —
+    repetition trained the agent to ignore the channel. Claim-time signals
+    (scripts/sentinel/) replaced them."""
     return {"continue": True}
 
 
@@ -183,11 +116,8 @@ def _handle_grep_glob(tool_name: str, tool_input: dict) -> dict:
 # (stale file marking, QE change tracking)
 # ---------------------------------------------------------------------------
 
-_QE_CHANGE_THRESHOLD = 3
-
-
 def _handle_write_edit(tool_input: dict) -> dict:
-    """Mark file as stale for search index + track change count for QE nudge + scenario staleness + CLAUDE.md/AGENTS.md sync."""
+    """Mark file as stale for search index + CLAUDE.md/AGENTS.md sync directive."""
     file_path = tool_input.get("file_path", "")
     if not file_path:
         return {"continue": True}
@@ -203,10 +133,10 @@ def _handle_write_edit(tool_input: dict) -> dict:
     _mark_file_stale(file_path)
     _brain_reindex_file(file_path)
 
-    # 2. QE change tracking
-    qe_nudge = _track_qe_change(file_path)
-    if qe_nudge:
-        messages.append(qe_nudge)
+    # 2. The QE threshold nudge was retired: it recommended test menus off a
+    #    file-count heuristic (it once suggested unit tests for a README edit).
+    #    The testing signal now fires at claim time via the sentinel's
+    #    evidence-freshness invariant (scripts/sentinel/invariants.py).
 
     # v9.2.2: dropped the [Scenarios] staleness nudge entirely. The heuristic
     # (any edit under commands/{domain}/ or skills/{domain}/ → "scenarios in
@@ -330,146 +260,6 @@ def _brain_reindex_file(file_path: str) -> None:
         urllib.request.urlopen(req, timeout=2)
     except Exception:
         pass  # brain re-index is best-effort, never blocks the hook
-
-
-def _track_qe_change(file_path: str):
-    """Track changed file via SessionState. Return nudge message if threshold crossed.
-
-    When no active crew project exists, classifies accumulated file changes as
-    UI/API/both and suggests specific QE tools (AC-6: one-off work coverage).
-    """
-    try:
-        from _session import SessionState
-        state = SessionState.load()
-        # stale_files already includes this file (added by _mark_file_stale above)
-        stale = state.stale_files or []
-        unique_count = len(stale)
-
-        if unique_count >= _QE_CHANGE_THRESHOLD and not state.qe_nudged:
-            state.update(qe_nudged=True)
-
-            # Check if a crew project is active — if so, crew handles QE via execute.md
-            # v9.2.5: replaced a getattr on a phantom field with active_project_id
-            # which is the slug bootstrap actually writes when a crew project is
-            # active. Same intent ("is a crew project active?"), real producer.
-            has_crew = bool(getattr(state, "active_project_id", None))
-            if has_crew:
-                return (
-                    f"[QE] {unique_count} files changed this session. "
-                    "Crew project active — QE testing will run during the test phase."
-                )
-
-            # No crew project: classify files and suggest specific QE tools
-            # Full testing pyramid: unit → integration → functional → E2E
-            change_type = _classify_changed_files(stale)
-
-            if change_type == "ui":
-                return (
-                    f"[QE] {unique_count} UI files changed this session. "
-                    "Recommended testing:\n"
-                    "- **Unit**: `/wicked-testing:authoring` — generate unit tests for changed components\n"
-                    "- **Visual**: `/wicked-garden:product:screenshot` — capture UI state + visual diff\n"
-                    "- **Scenario**: `/wicked-testing:plan` — generate user journey test scenarios\n"
-                    "- **Regression**: run existing test suite to verify no breakage\n"
-                    "- **Acceptance**: `/wicked-testing:execution` — evidence-gated acceptance tests"
-                )
-            elif change_type == "api":
-                return (
-                    f"[QE] {unique_count} API files changed this session. "
-                    "Recommended testing:\n"
-                    "- **Unit**: `/wicked-testing:authoring` — generate unit tests for changed logic\n"
-                    "- **Integration**: test API contracts — request/response schema validation\n"
-                    "- **Security**: `/wicked-garden:platform:security` — auth boundaries + input validation\n"
-                    "- **Scenario**: `/wicked-testing:plan` — generate endpoint test scenarios\n"
-                    "- **Regression**: run existing test suite to verify no breakage\n"
-                    "- **Acceptance**: `/wicked-testing:execution` — evidence-gated acceptance tests"
-                )
-            elif change_type == "both":
-                return (
-                    f"[QE] {unique_count} files changed (UI + API) this session. "
-                    "Recommended testing:\n"
-                    "- **Unit**: `/wicked-testing:authoring` — generate unit tests for changed code\n"
-                    "- **Integration**: test API contracts + component integration\n"
-                    "- **Visual**: `/wicked-garden:product:screenshot` — capture UI state + visual diff\n"
-                    "- **Security**: `/wicked-garden:platform:security` — auth + input validation\n"
-                    "- **Scenario**: `/wicked-testing:plan` — generate E2E user journey scenarios\n"
-                    "- **Regression**: run existing test suite to verify no breakage\n"
-                    "- **Acceptance**: `/wicked-testing:execution` — evidence-gated acceptance tests"
-                )
-            else:
-                short_paths = [Path(f).name for f in sorted(stale)]
-                return (
-                    f"[QE] {unique_count} files changed this session "
-                    f"({', '.join(short_paths[:5])}). "
-                    "Recommended testing:\n"
-                    "- **Unit**: `/wicked-testing:authoring` — generate unit tests\n"
-                    "- **Regression**: run existing test suite\n"
-                    "- **Scenario**: `/wicked-testing:plan` — generate test scenarios"
-                )
-        return None
-    except Exception:
-        return None
-
-
-def _classify_changed_files(file_paths: list) -> str:
-    """Classify accumulated changed files using change_type_detector logic.
-
-    Returns: "ui", "api", "both", or "unknown".
-    Imports classify_file from scripts/crew/change_type_detector.py (stdlib-only).
-    Falls back to "unknown" on any import or classification error.
-    """
-    try:
-        scripts_crew = _PLUGIN_ROOT / "scripts" / "crew"
-        if str(scripts_crew) not in sys.path:
-            sys.path.insert(0, str(scripts_crew))
-        from change_type_detector import classify_file
-
-        ui_count = 0
-        api_count = 0
-        for fp in file_paths:
-            classification, _ = classify_file(fp)
-            if classification == "ui":
-                ui_count += 1
-            elif classification == "api":
-                api_count += 1
-            elif classification == "ambiguous":
-                ui_count += 1
-                api_count += 1
-
-        if ui_count and api_count:
-            return "both"
-        if ui_count:
-            return "ui"
-        if api_count:
-            return "api"
-        return "unknown"
-    except Exception:
-        return "unknown"
-
-
-# ---------------------------------------------------------------------------
-# Handler: Task (subagent dispatch tracking + permission failure detection)
-# ---------------------------------------------------------------------------
-
-# Patterns that indicate a subagent completed without doing work due to
-# permission/access issues (Issue #318). Checked case-insensitively.
-_PERMISSION_FAILURE_PATTERNS = [
-    "i need bash access",
-    "bash permission was denied",
-    "permission denied",
-    "tool was not available",
-    "i don't have access to",
-    "i do not have access to",
-    "unable to execute bash",
-    "bash tool is not available",
-    "don't have permission",
-    "do not have permission",
-    "requires bash access",
-    "couldn't run the command",
-    "could not run the command",
-    "bash tool was denied",
-    "not permitted to run",
-]
 
 
 def _check_permission_failure(tool_response) -> str | None:
@@ -1164,22 +954,16 @@ _SEARCH_INVOCATION_RE = re.compile(
 )
 
 
-def _looks_like_search_invocation(command_lower: str) -> bool:
-    """Return True iff ``command_lower`` actually invokes grep/rg/ag/ripgrep.
-
-    Caller passes the lowercased command string.  Returns False on empty
-    input or any regex failure (fail-quiet — discovery hints are advisory).
-    """
-    if not command_lower:
-        return False
-    try:
-        return bool(_SEARCH_INVOCATION_RE.search(command_lower))
-    except (TypeError, re.error):
-        return False
-
-
 def _handle_bash(tool_input: dict, tool_response) -> dict:
-    """Track bash activity + detect usage patterns for discovery hints."""
+    """Track bash activity + run the claim-sentinel ref-watch.
+
+    The ref-watch is the tool-agnostic claim detector: it never parses the
+    command (gh / glab / raw git / an API curl all look different) — it diffs
+    the publish-shaped refs every command converges on. When origin's default
+    branch advances or a new tag appears with no re-derived verdict on the
+    sentinel ledger, it emits an answer-tier message (act, or the skip is
+    logged). Throttled + fail-open inside refwatch_tick.
+    """
     messages = []
     try:
         from _session import SessionState
@@ -1190,17 +974,27 @@ def _handle_bash(tool_input: dict, tool_response) -> dict:
     except Exception:
         pass
 
-    # --- Discovery hints from bash command patterns ---
-    command = (tool_input.get("command") or "").lower()
-    if command:
-        # Theme 9: bare ``"grep " in command`` matches comments like
-        # ``# grep is fine``.  Require the tool to appear at command start
-        # OR after a separator (``;``, ``&&``, ``||``, ``|``, newline) so
-        # the hint only fires on actual invocations, not stale references.
-        if _looks_like_search_invocation(command):
-            hint = _try_discovery_hint("grep_search")
-            if hint:
-                messages.append(hint)
+    # --- Claim sentinel: ref-watch (state diff, never command matching) ---
+    try:
+        import sys as _sys
+        _sentinel_dir = str(_PLUGIN_ROOT / "scripts" / "sentinel")
+        if _sentinel_dir not in _sys.path:
+            _sys.path.insert(0, _sentinel_dir)
+        from invariants import refwatch_tick, render  # type: ignore
+        from _session import SessionState
+        state = SessionState.load()
+
+        def _get(key):
+            return getattr(state, key, None)
+
+        def _set(key, value):
+            state.update(**{key: value})
+
+        violation = refwatch_tick(_get, _set)
+        if violation:
+            messages.append(render(violation))
+    except Exception:
+        pass  # the sentinel must never break the hook
 
     result = {"continue": True}
     if messages:

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -369,100 +369,6 @@ def _suggest_jam(prompt: str, state) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Discovery hints — prompt-based command suggestions (Issue #322)
-# ---------------------------------------------------------------------------
-
-_DISCOVERY_PATTERNS = [
-    {
-        "id": "manual_review",
-        "signals": ["review this code", "code review", "review the changes", "review my code",
-                     "check this code", "look at the code quality", "review this pr",
-                     "review this pull request"],
-        "hint": (
-            "[Tip] For a structured code review with senior-engineer perspective, "
-            "try `/wicked-garden:engineering:review`."
-        ),
-    },
-    {
-        "id": "debugging",
-        "signals": ["debug", "why is this failing", "root cause", "not working",
-                     "figure out why", "investigate this error", "this bug",
-                     "troubleshoot", "diagnose"],
-        "hint": (
-            "[Tip] For systematic debugging with root cause analysis, "
-            "try `/wicked-garden:engineering:debug`."
-        ),
-    },
-    {
-        "id": "requirements",
-        "signals": ["requirements", "user stories", "write requirements",
-                     "define the requirements", "gather requirements",
-                     "acceptance criteria", "what should this do"],
-        "hint": (
-            "[Tip] For structured requirements elicitation, "
-            "try `/wicked-garden:product:elicit`."
-        ),
-    },
-    {
-        "id": "architecture",
-        "signals": ["architecture", "system design", "how should i architect",
-                     "design this system", "technical design", "design doc"],
-        "hint": (
-            "[Tip] For architecture analysis and design review, "
-            "try `/wicked-garden:engineering:arch`."
-        ),
-    },
-    {
-        "id": "data_analysis",
-        "signals": ["analyze this csv", "analyze this data", "data analysis",
-                     "look at the data", "explore this dataset", "analyze the spreadsheet"],
-        "hint": (
-            "[Tip] For interactive data analysis with DuckDB, "
-            "try `/wicked-garden:data:analyze`."
-        ),
-    },
-]
-
-
-def _suggest_discovery(prompt: str, state) -> str | None:
-    """Return a discovery hint if prompt matches a pattern and hint not yet shown.
-
-    At most one discovery hint per session. Does not fire if the prompt already
-    references a wicked-garden command.
-    """
-    lower = prompt.lower()
-
-    # Skip if already using wicked-garden commands
-    if "/wicked-garden:" in lower or ":wicked-garden:" in lower:
-        return None
-
-    # Check session state for already-shown hints
-    hints_shown = (getattr(state, "hints_shown", None) or []) if state else []
-
-    # Cap: at most 1 discovery hint from prompt matching per session
-    prompt_hints = [h for h in hints_shown if h.startswith("prompt:")]
-    if prompt_hints:
-        return None
-
-    for pattern in _DISCOVERY_PATTERNS:
-        hint_id = pattern["id"]
-        if hint_id in hints_shown:
-            continue
-        if any(sig in lower for sig in pattern["signals"]):
-            try:
-                if state:
-                    shown = list(hints_shown)
-                    shown.append(hint_id)
-                    shown.append(f"prompt:{hint_id}")
-                    state.update(hints_shown=shown)
-            except Exception:
-                pass
-            return pattern["hint"]
-
-    return None
-
-
-# ---------------------------------------------------------------------------
 # Complexity + risk scoring (inline, no API calls, no external imports)
 # ---------------------------------------------------------------------------
 
@@ -1158,10 +1064,8 @@ def main():
         if jam_hint:
             all_parts.append(jam_hint)
 
-        # Discovery hints: suggest commands based on prompt intent (Issue #322)
-        discovery_hint = _suggest_discovery(prompt, state)
-        if discovery_hint:
-            all_parts.append(discovery_hint)
+        # (Prompt-time discovery tips retired — ambient suggestions trained the
+        # agent to ignore the channel; claim-time sentinel signals replaced them.)
 
         # If nothing material to inject (simple-edit, no WIP, no onboarding,
         # no hints), suppress the entire <system-reminder> block — this is

--- a/hooks/scripts/session_end.py
+++ b/hooks/scripts/session_end.py
@@ -57,6 +57,26 @@ def main() -> None:
         print(f"[wicked-garden] session_end error: {e}", file=sys.stderr)
         messages = []
 
+    # Claim sentinel — info-tier session-close lines (never blocking): a
+    # significant session that captured zero brain memories, or repo playbooks
+    # (wicked-understanding) that have drifted well behind HEAD. Observed state
+    # only; each check is fail-open and silent when its layer is absent.
+    try:
+        sentinel_dir = str(_PLUGIN_ROOT / "scripts" / "sentinel")
+        if sentinel_dir not in sys.path:
+            sys.path.insert(0, sentinel_dir)
+        from invariants import session_end_lines  # type: ignore
+        from _session import SessionState  # type: ignore
+        state = SessionState.load()
+        started = float(getattr(state, "created_at_epoch", 0) or 0)
+        if not started:
+            started = time.time() - 3600  # unknown start — assume the last hour
+        activity = int(getattr(state, "bash_count", 0) or 0) + int(
+            getattr(state, "memory_compliance_tasks_completed", 0) or 0)
+        messages.extend(session_end_lines(None, started, activity))
+    except Exception:  # noqa: BLE001 — the sentinel never blocks session end
+        pass
+
     elapsed_ms = int((time.monotonic() - _t0) * 1000)
     _log("session", "info", "session_end.done", ms=elapsed_ms,
          detail={"messages": len(messages)})

--- a/hooks/scripts/task_completed.py
+++ b/hooks/scripts/task_completed.py
@@ -271,6 +271,41 @@ def main():
             )
             system_message = (system_message or "") + evidence_nudge
 
+        # Claim sentinel — a completed deliverable task is the in-session "done"
+        # moment. Two invariants, both answer-tier, both observed-state (never a
+        # guess): (1) does a re-derived verdict cover HEAD? (2) is the recorded
+        # testing evidence fresher than the modified source? Fail-open.
+        if subject and _is_deliverable_task(subject):
+            try:
+                sentinel_dir = str(_PLUGIN_ROOT / "scripts" / "sentinel")
+                if sentinel_dir not in sys.path:
+                    sys.path.insert(0, sentinel_dir)
+                from invariants import (  # type: ignore
+                    check_evidence_freshness, log_sentinel_event, render,
+                    repo_toplevel, verdict_for,
+                )
+                repo = repo_toplevel()
+                if repo is not None:
+                    if verdict_for(repo) is None:
+                        violation = {
+                            "tier": "answer",
+                            "invariant": "done-claim-verdict",
+                            "evidence": (f'task "{subject}" completed with no re-derived '
+                                         "verdict covering HEAD"),
+                            "action": ("Run `/wicked-garden:prove` to re-derive the claim, "
+                                       "or state the override reason — this completion is "
+                                       "logged either way."),
+                        }
+                        log_sentinel_event(repo, "unverified_task_done",
+                                           {"task": subject,
+                                            "invariant": "done-claim-verdict"})
+                        system_message = ((system_message + "\n") if system_message else "") + render(violation)
+                    stale = check_evidence_freshness(repo)
+                    if stale:
+                        system_message = ((system_message + "\n") if system_message else "") + render(stale)
+            except Exception:  # noqa: BLE001 — the sentinel never breaks the hook
+                pass
+
         output: dict = {"ok": True}
         if system_message:
             output["systemMessage"] = system_message

--- a/scripts/_codegraph.py
+++ b/scripts/_codegraph.py
@@ -95,6 +95,35 @@ def db_path(project_dir: Optional[Path] = None) -> Path:
     return base / ".codegraph" / "codegraph.db"
 
 
+def staleness(project_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """How far the graph has drifted from HEAD — the anti-false-confidence stamp.
+
+    A stale graph is fine; a *silently* stale graph gives blast-radius/lineage/
+    patch answers that look authoritative and aren't. This lives in the shim —
+    the single path every consumer flows through — so no caller can forget it.
+
+    Returns {present, stale, commits_behind, indexed_at} (commits_behind = commits
+    committed after the db's mtime). Fail-open: errors report present-but-unknown,
+    never raise (R4)."""
+    base = Path(project_dir) if project_dir else Path.cwd()
+    db = db_path(base)
+    if not db.exists():
+        return {"present": False, "stale": None, "commits_behind": None, "indexed_at": None}
+    try:
+        import time as _time
+        mtime = db.stat().st_mtime
+        iso = _time.strftime("%Y-%m-%dT%H:%M:%S", _time.localtime(mtime))
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            ["git", "-C", str(base), "rev-list", "--count", f"--since={iso}", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        behind = int(proc.stdout.strip()) if proc.returncode == 0 and proc.stdout.strip() else 0
+        return {"present": True, "stale": behind > 0, "commits_behind": behind,
+                "indexed_at": iso}
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return {"present": True, "stale": None, "commits_behind": None, "indexed_at": None}
+
+
 def _default_run(prefix: List[str], args: List[str], timeout: int,
                  cwd: Optional[str] = None) -> Dict[str, Any]:
     try:
@@ -134,8 +163,30 @@ def run_json(args: List[str], *, timeout: int = _DEFAULT_TIMEOUT,
         return {"exit_code": run["exit_code"], "json": None,
                 "stdout": run["stdout"], "stderr": run["stderr"],
                 "error": "codegraph returned non-JSON output"}
-    return {"exit_code": run["exit_code"], "json": parsed,
-            "stdout": run["stdout"], "stderr": run["stderr"], "error": None}
+    out = {"exit_code": run["exit_code"], "json": parsed,
+           "stdout": run["stdout"], "stderr": run["stderr"], "error": None}
+    # Anti-false-confidence: every engine answer carries its own freshness.
+    out["staleness"] = staleness(project_dir)
+    return out
 
 
-__all__ = ["resolve_codegraph", "codegraph_available", "db_path", "run_json"]
+__all__ = ["resolve_codegraph", "codegraph_available", "db_path", "run_json",
+           "staleness"]
+
+
+if __name__ == "__main__":
+    # CLI: `python3 scripts/_codegraph.py staleness` — one line for command docs
+    # (blast-radius / lineage / hotspots / index) to surface before query results.
+    import sys as _sys
+    if len(_sys.argv) > 1 and _sys.argv[1] == "staleness":
+        s = staleness()
+        if not s["present"]:
+            print("codegraph: no index (.codegraph/codegraph.db missing) — run `codegraph index .`")
+        elif s["stale"]:
+            print(f"codegraph: index is {s['commits_behind']} commits behind HEAD "
+                  f"(built {s['indexed_at']}) — results may miss recent changes; "
+                  "re-run `codegraph index .` + inject_all for current answers")
+        else:
+            print(f"codegraph: index fresh (built {s['indexed_at']})")
+    else:
+        print(json.dumps({"error": "usage: _codegraph.py staleness"}))

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -208,6 +208,13 @@ class SessionState:
     # List of hint IDs like ["grep_search", "manual_review", "debugging"].
     hints_shown: list | None = None
 
+    # Claim sentinel (scripts/sentinel/invariants.py) — ref-watch state.
+    # sentinel_refs caches the last {ref: sha} snapshot of publish-shaped refs
+    # (origin default branch + newest tag); sentinel_last_check throttles the
+    # snapshot to at most once per few seconds so hot Bash loops stay cheap.
+    sentinel_refs: dict | None = None
+    sentinel_last_check: float = 0.0
+
     # OneDrive / spaces-in-paths resolution (Issue #321).
     # Stores the resolved canonical base path when cwd is under a OneDrive
     # or CloudStorage directory (macOS ~/Library/CloudStorage/OneDrive - .../...).

--- a/scripts/qe/vault_gate.py
+++ b/scripts/qe/vault_gate.py
@@ -221,6 +221,29 @@ def cross_check(
 # The gate
 # ---------------------------------------------------------------------------
 
+def _sentinel_stamp(project_dir: Path, result: Dict[str, Any],
+                    scope: str, phase: str) -> None:
+    """Stamp this verdict into the claim-sentinel ledger (fail-open).
+
+    gate_satisfied is the single front door for re-derivation, so stamping here
+    means every prove/gate run — from any command, any cwd — leaves the record
+    the sentinel's claim-time invariants (ref-watch, TaskCompleted) check against."""
+    try:
+        from pathlib import Path as _P
+        import sys as _sys
+        sentinel_dir = _P(__file__).resolve().parents[1] / "sentinel"
+        if str(sentinel_dir) not in _sys.path:
+            _sys.path.insert(0, str(sentinel_dir))
+        from invariants import stamp_verdict  # type: ignore
+        stamp_verdict(_P(project_dir),
+                      overall=str(result.get("overall", "ERROR")),
+                      satisfied=bool(result.get("satisfied")),
+                      re_derived=bool(result.get("re_derived")),
+                      scope=scope, phase=phase)
+    except Exception:  # noqa: BLE001 — the sentinel must never break the gate
+        return
+
+
 def gate_satisfied(
     project_dir: Path,
     scope: str,
@@ -248,7 +271,7 @@ def gate_satisfied(
         cc = cross_check(scope, phase, project_dir=Path(project_dir),
                          with_attestations=with_attestations)
         if cc.get("available"):
-            return {
+            result = {
                 "satisfied": cc.get("overall") == "PASS",
                 "re_derived": True,
                 "gate": "vault-cross-check",
@@ -258,6 +281,8 @@ def gate_satisfied(
                 "detail": cc.get("detail"),
                 "error": cc.get("error"),
             }
+            _sentinel_stamp(Path(project_dir), result, scope, phase)
+            return result
         # Resolver pointed at a vault but it could not be run (offline npx,
         # missing executable). Fail closed — do not invent a PASS.
         if require:

--- a/scripts/sentinel/invariants.py
+++ b/scripts/sentinel/invariants.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""invariants.py — the claim sentinel: state-transition gates without command lists.
+
+The design problem (session-tested): steering that fires at *prompt time* ("this
+is a build!") or as ambient tips gets ignored — the agent overrides even MUST
+wording when local context says "irrelevant", and nothing records the skip. What
+changes behavior is a check that fires **at the claim moment**, carries **observed
+evidence**, names **one action**, and makes skipping a **recorded decision**.
+
+And you can't catch claim moments by pattern-matching commands (`gh pr merge`,
+raw `git push`, `glab`, an API curl, next year's tool…). You catch the state all
+of them converge on:
+
+  - a **git ref moving** is the universal "ship it" (ref-watch, below);
+  - a **task completing** is the universal in-session "done" (TaskCompleted hook);
+  - the **session ending** is the last exit (info tier).
+
+Each toolkit component already has one observable state-store, so every gate here
+is an *invariant between two observable states* — never a command match:
+
+  invariant                 observable A            observable B
+  ------------------------  ----------------------  -------------------------
+  done-claim has a verdict  sentinel verdict ledger ref advance / task done
+  evidence is fresh         .wicked-testing ledger  mtime of modified files
+  learnings captured        brain memory dir        session activity
+  playbooks current         repo-* skill dirs       commits since their mtime
+
+Tiers: info (one line, ignorable) → **answer** (the agent must act or the skip
+is logged to the bus as `wicked.sentinel.*` — the skip becomes evidence) →
+block (git pre-push / CI, outside this module). Everything here fails OPEN on
+error (a broken sentinel must never break a session) but never invents an OK.
+
+Stdlib-only. All git access via argv subprocess, short timeouts, throttled.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess  # noqa: S404 — argv lists only, shell=False
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_GIT_TIMEOUT = 5
+_LEDGER_MAX_STAMPS = 200          # ledger read window (recent stamps only)
+_RECENT_HISTORY = 80              # a verdict covers a sha within this many ancestors
+_REFWATCH_THROTTLE_S = 5          # min seconds between ref snapshots (hot-loop guard)
+_PLAYBOOK_STALE_COMMITS = 30      # repo-playbooks "drifted" threshold
+
+
+# ---------------------------------------------------------------------------
+# git plumbing (fail-open: None / {} on any error)
+# ---------------------------------------------------------------------------
+
+def _git(repo: Path, *args: str) -> Optional[str]:
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, shell=False
+            ["git", "-C", str(repo), *args],
+            capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        )
+        if proc.returncode != 0:
+            return None
+        return proc.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def repo_toplevel(cwd: Optional[Path] = None) -> Optional[Path]:
+    top = _git(Path(cwd) if cwd else Path.cwd(), "rev-parse", "--show-toplevel")
+    return Path(top) if top else None
+
+
+# ---------------------------------------------------------------------------
+# The verdict ledger — stamped by the gate, read by every claim check.
+# Keyed by repo toplevel (NOT cwd) so gate runs and hook checks agree even when
+# they run from different directories of the same repo.
+# ---------------------------------------------------------------------------
+
+def _ledger_path(repo: Path) -> Path:
+    slug = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()[:12]
+    base = Path.home() / ".something-wicked" / "wicked-garden" / "sentinel"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{slug}.jsonl"
+
+
+def stamp_verdict(repo: Path, *, overall: str, satisfied: bool,
+                  re_derived: bool, scope: str = "", phase: str = "") -> None:
+    """Record a gate verdict for the repo's current HEAD. Called by the
+    produces-gate (vault_gate.gate_satisfied) — the single front door — so any
+    prove/gate run anywhere stamps the ledger. Fail-open."""
+    try:
+        sha = _git(repo, "rev-parse", "HEAD")
+        if not sha:
+            return
+        rec = {"sha": sha, "overall": overall, "satisfied": bool(satisfied),
+               "re_derived": bool(re_derived), "scope": scope, "phase": phase,
+               "ts": time.time()}
+        with _ledger_path(repo).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+    except Exception:  # noqa: BLE001 — sentinel must never break the gate
+        return
+
+
+def _recent_stamps(repo: Path) -> List[Dict[str, Any]]:
+    try:
+        p = _ledger_path(repo)
+        if not p.exists():
+            return []
+        lines = p.read_text(encoding="utf-8").splitlines()[-_LEDGER_MAX_STAMPS:]
+        return [json.loads(ln) for ln in lines if ln.strip()]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def verdict_for(repo: Path, sha: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """The most recent satisfied+re-derived stamp covering `sha` (default HEAD):
+    the stamped commit must be the sha itself or one of its recent ancestors."""
+    target = sha or _git(repo, "rev-parse", "HEAD")
+    if not target:
+        return None
+    history = _git(repo, "rev-list", f"-{_RECENT_HISTORY}", target)
+    if history is None:
+        return None
+    recent = set(history.splitlines())
+    for rec in reversed(_recent_stamps(repo)):
+        if rec.get("sha") in recent and rec.get("satisfied") and rec.get("re_derived"):
+            return rec
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Override / detection events → the bus (fire-and-forget; the skip is evidence)
+# ---------------------------------------------------------------------------
+
+def log_sentinel_event(repo: Path, event: str, detail: Dict[str, Any]) -> None:
+    """Emit wicked.sentinel.<event> to the bus if available; always append to a
+    local trail so the record exists even without the bus layer."""
+    payload = {"repo": str(repo), "ts": time.time(), **detail}
+    try:
+        trail = _ledger_path(repo).with_suffix(".events.jsonl")
+        with trail.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"event": event, **payload}) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        import sys
+        plugin_scripts = Path(__file__).resolve().parents[1]
+        if str(plugin_scripts) not in sys.path:
+            sys.path.insert(0, str(plugin_scripts))
+        from _bus import emit_event  # type: ignore
+        emit_event(f"wicked.sentinel.{event}", payload)
+    except Exception:  # noqa: BLE001 — bus is an opt-in layer; fail open
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — ref-watch: a done-shaped ref advance must have a verdict.
+# Tool-agnostic by construction: gh/glab/raw git/API all converge on the refs.
+# ---------------------------------------------------------------------------
+
+def snapshot_refs(repo: Path) -> Dict[str, str]:
+    """{ref: sha} for the publish-shaped refs: remote default branch + newest tag."""
+    out: Dict[str, str] = {}
+    for ref in ("refs/remotes/origin/main", "refs/remotes/origin/master"):
+        sha = _git(repo, "rev-parse", "--verify", "--quiet", ref)
+        if sha:
+            out[ref] = sha
+            break
+    newest_tag = _git(repo, "for-each-ref", "refs/tags",
+                      "--sort=-creatordate", "--count=1", "--format=%(refname)|%(objectname)")
+    if newest_tag and "|" in newest_tag:
+        name, sha = newest_tag.split("|", 1)
+        out[name] = sha
+    return out
+
+
+def check_done_claim(repo: Path, before: Dict[str, str],
+                     after: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    """Answer-tier. Fired when a publish-shaped ref moved (origin default branch
+    advanced, or a new tag appeared) and no re-derived verdict covers the new sha."""
+    moved: List[str] = []
+    for ref, sha in after.items():
+        if before.get(ref) != sha:
+            moved.append(ref)
+    if not moved:
+        return None
+    new_sha = after.get(moved[0], "")
+    stamp = verdict_for(repo, new_sha or None)
+    if stamp:
+        return None
+    violation = {
+        "tier": "answer",
+        "invariant": "done-claim-verdict",
+        "evidence": f"{', '.join(moved)} advanced to {new_sha[:9]} with no re-derived verdict on record",
+        "action": ("Run `/wicked-garden:prove` to re-derive the claim now, or state the override "
+                   "reason — this advance is logged either way."),
+    }
+    log_sentinel_event(repo, "unverified_publish",
+                       {"refs": moved, "sha": new_sha, "invariant": "done-claim-verdict"})
+    return violation
+
+
+def refwatch_tick(state_get, state_set, cwd: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """The PostToolUse entry point. `state_get(key)`/`state_set(key, value)` wrap
+    SessionState so this module stays import-light. Throttled; fail-open."""
+    try:
+        now = time.time()
+        last = state_get("sentinel_last_check") or 0
+        if now - float(last) < _REFWATCH_THROTTLE_S:
+            return None
+        repo = repo_toplevel(cwd)
+        if repo is None:
+            return None
+        before = state_get("sentinel_refs") or {}
+        after = snapshot_refs(repo)
+        state_set("sentinel_refs", after)
+        state_set("sentinel_last_check", now)
+        if not before:  # first snapshot of the session — baseline only
+            return None
+        return check_done_claim(repo, before, after)
+    except Exception:  # noqa: BLE001 — sentinel never breaks a hook
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — evidence freshness: a claim is stale when source moved after
+# the newest recorded evidence. Applies only when the testing layer is present.
+# ---------------------------------------------------------------------------
+
+def _newest_evidence_ts(repo: Path) -> Optional[float]:
+    root = repo / ".wicked-testing"
+    if not root.is_dir():
+        return None
+    newest = 0.0
+    try:
+        for p in root.rglob("*"):
+            if p.is_file():
+                ts = p.stat().st_mtime
+                if ts > newest:
+                    newest = ts
+    except OSError:
+        return None
+    return newest or None
+
+
+def check_evidence_freshness(repo: Path) -> Optional[Dict[str, Any]]:
+    """Answer-tier (only when .wicked-testing exists). Modified-but-uncommitted /
+    just-committed files newer than the newest evidence record = stale claim."""
+    newest_evidence = _newest_evidence_ts(repo)
+    if newest_evidence is None:
+        return None  # testing layer absent or no runs — not applicable
+    changed = _git(repo, "diff", "--name-only", "HEAD")
+    if changed is None:
+        return None
+    paths = [repo / ln for ln in changed.splitlines() if ln.strip()]
+    newest_src = 0.0
+    for p in paths:
+        try:
+            ts = p.stat().st_mtime
+            if ts > newest_src:
+                newest_src = ts
+        except OSError:
+            continue
+    if newest_src <= newest_evidence:
+        return None
+    age_min = (newest_src - newest_evidence) / 60
+    return {
+        "tier": "answer",
+        "invariant": "evidence-freshness",
+        "evidence": (f"source files changed {age_min:.0f}m after the newest "
+                     f".wicked-testing evidence — the recorded runs predate this work"),
+        "action": "Re-run the relevant scenario (/wicked-testing:run) or state why the evidence still holds.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3+4+5 — session-end info tier (one line each, never blocking)
+# ---------------------------------------------------------------------------
+
+def _brain_memory_dir(repo: Path) -> Optional[Path]:
+    projects = Path.home() / ".wicked-brain" / "projects"
+    if not projects.is_dir():
+        return None
+    try:
+        for proj in projects.iterdir():
+            cfg = proj / "_meta" / "config.json"
+            if cfg.is_file():
+                try:
+                    src = json.loads(cfg.read_text(encoding="utf-8")).get("source_path", "")
+                    if src and Path(src).resolve() == repo.resolve():
+                        mem = proj / "memory"
+                        return mem if mem.is_dir() else None
+                except (json.JSONDecodeError, OSError):
+                    continue
+    except OSError:
+        return None
+    return None
+
+
+def check_session_capture(repo: Path, session_start_ts: float,
+                          activity_count: int) -> Optional[Dict[str, Any]]:
+    """Info-tier: a significant session (>= 10 tracked activities) that captured
+    zero brain memories. Only applies when the brain layer is present."""
+    if activity_count < 10:
+        return None
+    mem = _brain_memory_dir(repo)
+    if mem is None:
+        return None  # brain layer absent for this repo — not applicable
+    try:
+        wrote = any(p.stat().st_mtime >= session_start_ts
+                    for p in mem.glob("*.md"))
+    except OSError:
+        return None
+    if wrote:
+        return None
+    return {
+        "tier": "info",
+        "invariant": "session-capture",
+        "evidence": f"{activity_count} tracked activities this session, 0 memories captured",
+        "action": "Worth one `wicked-brain:memory` store (decision/gotcha) before you go?",
+    }
+
+
+def check_playbook_freshness(repo: Path) -> Optional[Dict[str, Any]]:
+    """Info-tier: wicked-understanding playbooks exist but the repo has moved
+    well past them (commits since their newest mtime > threshold)."""
+    roots = [Path.home() / ".claude" / "skills"]
+    cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    if cfg:
+        roots.append(Path(cfg) / "skills")
+    newest = 0.0
+    for root in roots:
+        try:
+            if root.is_dir():
+                for entry in root.iterdir():
+                    if entry.is_dir() and entry.name.startswith(("repo-", "fix-bug", "add-feature")):
+                        ts = entry.stat().st_mtime
+                        if ts > newest:
+                            newest = ts
+        except OSError:
+            continue
+    if not newest:
+        return None  # understanding layer absent — not applicable
+    iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(newest))
+    count = _git(repo, "rev-list", "--count", f"--since={iso}", "HEAD")
+    try:
+        behind = int(count) if count else 0
+    except ValueError:
+        return None
+    if behind < _PLAYBOOK_STALE_COMMITS:
+        return None
+    return {
+        "tier": "info",
+        "invariant": "playbook-freshness",
+        "evidence": f"repo playbooks were generated ~{behind} commits ago",
+        "action": "Re-run `repo-analyst` so the how-to playbooks track HEAD.",
+    }
+
+
+def session_end_lines(cwd: Optional[Path], session_start_ts: float,
+                      activity_count: int) -> List[str]:
+    """The Stop/SessionEnd bundle — info-tier lines only, each fail-open."""
+    repo = repo_toplevel(cwd)
+    if repo is None:
+        return []
+    lines: List[str] = []
+    for check in (lambda: check_session_capture(repo, session_start_ts, activity_count),
+                  lambda: check_playbook_freshness(repo)):
+        try:
+            v = check()
+        except Exception:  # noqa: BLE001
+            v = None
+        if v:
+            lines.append(f"[Sentinel:{v['invariant']}] {v['evidence']} → {v['action']}")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Rendering — one consistent voice for the answer tier
+# ---------------------------------------------------------------------------
+
+def render(violation: Dict[str, Any]) -> str:
+    return (f"[Sentinel:{violation['invariant']}] {violation['evidence']}.\n"
+            f"→ {violation['action']}")
+
+
+__all__ = [
+    "repo_toplevel", "stamp_verdict", "verdict_for", "log_sentinel_event",
+    "snapshot_refs", "check_done_claim", "refwatch_tick",
+    "check_evidence_freshness", "check_session_capture",
+    "check_playbook_freshness", "session_end_lines", "render",
+]

--- a/scripts/sentinel/pre_push.py
+++ b/scripts/sentinel/pre_push.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""pre_push.py — the claim sentinel's local pre-push gate (layer 1 of 3).
+
+Reads git's pre-push stdin ("<local_ref> <local_sha> <remote_ref> <remote_sha>"
+per line) and BLOCKS (exit 1) when a *publish-shaped* ref — the remote default
+branch or any tag — is being pushed with no re-derived verdict covering the
+pushed sha on the sentinel ledger. Feature-branch pushes always pass: the claim
+moment is publishing "done", not sharing work-in-progress.
+
+Layers (see scripts/sentinel/invariants.py):
+  1. this hook            — local, fires for ANY tool that pushes through git
+  2. required CI check    — server-side, catches gh-pr-merge/web/API paths
+  3. harness ref-watch    — detects + records what slipped past both
+
+Override: `git push --no-verify` (git's own explicit skip — visible, and the
+server layer still gates). Fail-open on machinery errors: a broken sentinel
+must never brick pushes; only a *present ledger with no verdict* blocks.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariants import log_sentinel_event, repo_toplevel, verdict_for  # noqa: E402
+
+_ZERO_SHA = "0" * 40
+_DEFAULT_BRANCH_REFS = ("refs/heads/main", "refs/heads/master")
+
+
+def _publish_shaped(remote_ref: str) -> bool:
+    return remote_ref in _DEFAULT_BRANCH_REFS or remote_ref.startswith("refs/tags/")
+
+
+def main() -> int:
+    try:
+        repo = repo_toplevel()
+        if repo is None:
+            return 0  # not a repo — nothing to gate
+        blocked = []
+        for line in sys.stdin.read().splitlines():
+            parts = line.split()
+            if len(parts) != 4:
+                continue
+            _local_ref, local_sha, remote_ref, _remote_sha = parts
+            if local_sha == _ZERO_SHA:  # deletion — not a done-claim
+                continue
+            if not _publish_shaped(remote_ref):
+                continue
+            if verdict_for(repo, local_sha) is None:
+                blocked.append((remote_ref, local_sha))
+        if not blocked:
+            return 0
+        for remote_ref, sha in blocked:
+            print(
+                f"[Sentinel:done-claim-verdict] pushing {remote_ref} @ {sha[:9]} "
+                "with no re-derived verdict on record.\n"
+                "→ Run `/wicked-garden:prove` (stamps the ledger via the gate), "
+                "or override deliberately with `git push --no-verify` — the server "
+                "gate still applies.",
+                file=sys.stderr,
+            )
+            log_sentinel_event(repo, "prepush_blocked",
+                               {"ref": remote_ref, "sha": sha,
+                                "invariant": "done-claim-verdict"})
+        return 1
+    except Exception:  # noqa: BLE001 — machinery failure must not brick pushes
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/sentinel/test_invariants.py
+++ b/tests/sentinel/test_invariants.py
@@ -1,0 +1,257 @@
+"""Tests for the claim sentinel (scripts/sentinel/invariants.py + pre_push.py).
+
+The sentinel's whole premise is state-diff over command-match, so these tests
+exercise it against REAL temp git repos (init/commit/push to a bare remote) —
+no mocking of git. The ledger is redirected to a temp HOME so tests never touch
+the developer's real ~/.something-wicked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO = Path(__file__).resolve().parents[2]
+for _p in (_REPO / "scripts", _REPO / "scripts" / "sentinel"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import invariants as inv  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, timeout=10)
+    if proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {proc.stderr}")
+    return proc.stdout.strip()
+
+
+def _make_repo(base: Path, name: str = "work") -> Path:
+    repo = base / name
+    repo.mkdir()
+    _git(repo, "init", "-b", "main", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("one\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "c1")
+    return repo
+
+
+def _add_origin(base: Path, repo: Path) -> Path:
+    bare = base / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True, timeout=10)
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "-q", "origin", "main")
+    _git(repo, "fetch", "-q", "origin")
+    return bare
+
+
+class _TempHome(unittest.TestCase):
+    """Redirect the ledger (under ~) into a temp HOME."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self._home = patch.dict(os.environ, {"HOME": str(self.base / "home")})
+        self._home.start()
+        (self.base / "home").mkdir()
+
+    def tearDown(self):
+        self._home.stop()
+        self._tmp.cleanup()
+
+
+class LedgerTests(_TempHome):
+    def test_stamp_then_verdict_for_head(self):
+        repo = _make_repo(self.base)
+        self.assertIsNone(inv.verdict_for(repo))
+        inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=True,
+                          scope="t", phase="build")
+        stamp = inv.verdict_for(repo)
+        self.assertIsNotNone(stamp)
+        self.assertEqual(stamp["overall"], "PASS")
+
+    def test_verdict_covers_recent_ancestor(self):
+        repo = _make_repo(self.base)
+        inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=True)
+        (repo / "f.txt").write_text("two\n")
+        _git(repo, "commit", "-aqm", "c2")  # HEAD moved past the stamp
+        self.assertIsNotNone(inv.verdict_for(repo), "ancestor stamp must cover HEAD")
+
+    def test_unsatisfied_or_claim_only_stamps_do_not_count(self):
+        repo = _make_repo(self.base)
+        inv.stamp_verdict(repo, overall="FAIL", satisfied=False, re_derived=True)
+        inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=False)
+        self.assertIsNone(inv.verdict_for(repo),
+                          "only satisfied+re-derived stamps are a verdict")
+
+
+class RefWatchTests(_TempHome):
+    def test_detects_unverified_main_advance(self):
+        repo = _make_repo(self.base)
+        _add_origin(self.base, repo)
+        before = inv.snapshot_refs(repo)
+        self.assertIn("refs/remotes/origin/main", before)
+        (repo / "f.txt").write_text("two\n")
+        _git(repo, "commit", "-aqm", "c2")
+        _git(repo, "push", "-q", "origin", "main")
+        _git(repo, "fetch", "-q", "origin")
+        after = inv.snapshot_refs(repo)
+        violation = inv.check_done_claim(repo, before, after)
+        self.assertIsNotNone(violation, "unverified origin/main advance must fire")
+        self.assertEqual(violation["invariant"], "done-claim-verdict")
+        # the detection itself is recorded (the skip is evidence)
+        trail = inv._ledger_path(repo).with_suffix(".events.jsonl")
+        self.assertTrue(trail.exists())
+        self.assertIn("unverified_publish", trail.read_text())
+
+    def test_verified_advance_stays_silent(self):
+        repo = _make_repo(self.base)
+        _add_origin(self.base, repo)
+        before = inv.snapshot_refs(repo)
+        (repo / "f.txt").write_text("two\n")
+        _git(repo, "commit", "-aqm", "c2")
+        inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=True)
+        _git(repo, "push", "-q", "origin", "main")
+        _git(repo, "fetch", "-q", "origin")
+        after = inv.snapshot_refs(repo)
+        self.assertIsNone(inv.check_done_claim(repo, before, after))
+
+    def test_new_tag_is_publish_shaped(self):
+        repo = _make_repo(self.base)
+        before = inv.snapshot_refs(repo)
+        _git(repo, "tag", "v1.0.0")
+        after = inv.snapshot_refs(repo)
+        violation = inv.check_done_claim(repo, before, after)
+        self.assertIsNotNone(violation, "a new tag with no verdict must fire")
+
+    def test_refwatch_tick_baselines_then_detects_and_throttles(self):
+        repo = _make_repo(self.base)
+        _add_origin(self.base, repo)
+        store: dict = {}
+        get, setv = store.get, store.__setitem__
+        with patch.object(inv, "_REFWATCH_THROTTLE_S", 0):
+            self.assertIsNone(inv.refwatch_tick(get, setv, cwd=repo))  # baseline
+            (repo / "f.txt").write_text("two\n")
+            _git(repo, "commit", "-aqm", "c2")
+            _git(repo, "push", "-q", "origin", "main")
+            _git(repo, "fetch", "-q", "origin")
+            self.assertIsNotNone(inv.refwatch_tick(get, setv, cwd=repo))
+        # throttle: immediate re-tick is suppressed
+        self.assertIsNone(inv.refwatch_tick(get, setv, cwd=repo))
+
+
+class EvidenceFreshnessTests(_TempHome):
+    def test_not_applicable_without_testing_layer(self):
+        repo = _make_repo(self.base)
+        self.assertIsNone(inv.check_evidence_freshness(repo))
+
+    def test_stale_when_source_newer_than_evidence(self):
+        repo = _make_repo(self.base)
+        ev = repo / ".wicked-testing" / "evidence"
+        ev.mkdir(parents=True)
+        rec = ev / "run.json"
+        rec.write_text("{}")
+        old = time.time() - 3600
+        os.utime(rec, (old, old))
+        (repo / "f.txt").write_text("modified after evidence\n")  # uncommitted
+        violation = inv.check_evidence_freshness(repo)
+        self.assertIsNotNone(violation)
+        self.assertEqual(violation["invariant"], "evidence-freshness")
+
+    def test_fresh_evidence_is_silent(self):
+        repo = _make_repo(self.base)
+        (repo / "f.txt").write_text("modified\n")
+        ev = repo / ".wicked-testing" / "evidence"
+        ev.mkdir(parents=True)
+        (ev / "run.json").write_text("{}")  # written after the source change
+        self.assertIsNone(inv.check_evidence_freshness(repo))
+
+
+class PrePushTests(_TempHome):
+    def _run_prepush(self, repo: Path, stdin: str):
+        env = dict(os.environ)
+        return subprocess.run(
+            [sys.executable, str(_REPO / "scripts" / "sentinel" / "pre_push.py")],
+            input=stdin, capture_output=True, text=True, timeout=15,
+            cwd=str(repo), env=env,
+        )
+
+    def test_blocks_unverified_main_push(self):
+        repo = _make_repo(self.base)
+        sha = _git(repo, "rev-parse", "HEAD")
+        proc = self._run_prepush(
+            repo, f"refs/heads/main {sha} refs/heads/main {_z()}\n")
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        self.assertIn("done-claim-verdict", proc.stderr)
+
+    def test_passes_verified_main_push(self):
+        repo = _make_repo(self.base)
+        inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=True)
+        sha = _git(repo, "rev-parse", "HEAD")
+        proc = self._run_prepush(
+            repo, f"refs/heads/main {sha} refs/heads/main {_z()}\n")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_feature_branch_push_never_gated(self):
+        repo = _make_repo(self.base)
+        sha = _git(repo, "rev-parse", "HEAD")
+        proc = self._run_prepush(
+            repo, f"refs/heads/feat/x {sha} refs/heads/feat/x {_z()}\n")
+        self.assertEqual(proc.returncode, 0)
+
+
+def _z() -> str:
+    return "0" * 40
+
+
+class GateStampIntegrationTests(_TempHome):
+    def test_gate_satisfied_stamps_ledger_on_rederived_pass(self):
+        """vault_gate.gate_satisfied is the front door — a re-derived PASS must
+        leave a sentinel stamp without the gate knowing sentinel internals."""
+        repo = _make_repo(self.base)
+        qe = _REPO / "scripts" / "qe"
+        if str(qe) not in sys.path:
+            sys.path.insert(0, str(qe))
+        import vault_gate  # noqa: WPS433
+        fake_cc = {"available": True, "overall": "PASS", "claims": [],
+                   "contract_version": 1, "detail": None, "error": None}
+        with patch.object(vault_gate, "resolve_vault", return_value=["vault"]), \
+             patch.object(vault_gate, "cross_check", return_value=fake_cc):
+            result = vault_gate.gate_satisfied(repo, "scope", "build")
+        self.assertTrue(result["satisfied"])
+        self.assertIsNotNone(inv.verdict_for(repo),
+                             "gate_satisfied must stamp the sentinel ledger")
+
+
+class SessionEndTests(_TempHome):
+    def test_capture_check_silent_without_brain_layer(self):
+        repo = _make_repo(self.base)
+        self.assertIsNone(inv.check_session_capture(repo, time.time() - 100, 50))
+
+    def test_capture_check_fires_for_active_uncaptured_session(self):
+        repo = _make_repo(self.base)
+        proj = Path(os.environ["HOME"]) / ".wicked-brain" / "projects" / "p1"
+        (proj / "_meta").mkdir(parents=True)
+        (proj / "memory").mkdir()
+        (proj / "_meta" / "config.json").write_text(
+            json.dumps({"source_path": str(repo)}))
+        v = inv.check_session_capture(repo, time.time() - 100, 50)
+        self.assertIsNotNone(v)
+        self.assertEqual(v["invariant"], "session-capture")
+        # writing a memory silences it
+        (proj / "memory" / "m.md").write_text("learned")
+        self.assertIsNone(inv.check_session_capture(repo, time.time() - 100, 50))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the design from the steering discussion: **catch the claim moment, not the command.** gh/glab/raw-git/API all converge on observable state — refs moving, tasks completing, sessions ending — so the sentinel gates there.

- **Verdict ledger** stamped by `gate_satisfied` (every prove/gate run); **ref-watch** (PostToolUse) fires answer-tier when a publish-shaped ref advances unverified — and logs it (**the skip becomes evidence**, `wicked.sentinel.*` on the bus + local trail).
- **`.githooks/pre-push`** blocks publishing main/tags without a verdict (tool-agnostic: git fires it for any caller; `--no-verify` = explicit override; feature branches never gated). This very PR's branch push passed through it live.
- **Evidence freshness** (source newer than newest `.wicked-testing` record) at TaskCompleted; **info tier** at SessionEnd (session-capture, playbook drift). 
- **Codegraph staleness in the shim** — every result carries its freshness; it immediately flagged our own index as 12 commits stale.
- **Steering detox**: retired the ambient `[Tip]`s + the `[QE]` nudge (false positives killed the channel's credibility).

16 new tests against real temp git repos; full suite **531 passed**; validate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)