### PR TITLE
fix(search): codegraph init before first index (real-repo finding #1)

### DIFF
--- a/commands/search/index.md
+++ b/commands/search/index.md
@@ -22,6 +22,8 @@ Refresh the two code-intelligence layers the other `search:*` commands query:
 
 2. **Structural layer** — rebuild the codegraph graph, then re-apply the injected edges:
    ```bash
+   # first time on a repo: codegraph must be initialized before it can index
+   npx -y @colbymchenry/codegraph init 2>/dev/null || true
    codegraph index "<path>"   # or: npx -y @colbymchenry/codegraph index "<path>"
    # codegraph indexes CODE only; re-apply the injected layer (bus producer→consumer,
    # command→agent dispatch, agent→capability) it doesn't know about and a re-index drops:


### PR DESCRIPTION
First finding from the cognitive_iq real-repo test: fresh repos error on `codegraph index` without `codegraph init`. The garden never hit it (initialized back in the prototype). `search:index` now inits idempotently first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)