### PR TITLE
fix(sentinel): claim-gate the answer tier at Stop (it never checked for a claim)

### DIFF
--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -955,16 +955,14 @@ _SEARCH_INVOCATION_RE = re.compile(
 
 
 def _handle_bash(tool_input: dict, tool_response) -> dict:
-    """Track bash activity + run the claim-sentinel ref-watch.
+    """Track bash activity.
 
-    The ref-watch is the tool-agnostic claim detector: it never parses the
-    command (gh / glab / raw git / an API curl all look different) — it diffs
-    the publish-shaped refs every command converges on. When origin's default
-    branch advances or a new tag appears with no re-derived verdict on the
-    sentinel ledger, it emits an answer-tier message (act, or the skip is
-    logged). Throttled + fail-open inside refwatch_tick.
+    The claim sentinel used to ref-watch here on every Bash call; it moved to
+    the Stop hook where it is claim-gated (fires only when the turn's final
+    message asserts done/passing/shipped). See scripts/sentinel/invariants.py
+    ::claim_tick and hooks/scripts/stop.py. Publish-time protection (an actual
+    push to main or a tag) remains the block tier in scripts/sentinel/pre_push.py.
     """
-    messages = []
     try:
         from _session import SessionState
         state = SessionState.load()
@@ -973,33 +971,7 @@ def _handle_bash(tool_input: dict, tool_response) -> dict:
         state.save()
     except Exception:
         pass
-
-    # --- Claim sentinel: ref-watch (state diff, never command matching) ---
-    try:
-        import sys as _sys
-        _sentinel_dir = str(_PLUGIN_ROOT / "scripts" / "sentinel")
-        if _sentinel_dir not in _sys.path:
-            _sys.path.insert(0, _sentinel_dir)
-        from invariants import refwatch_tick, render  # type: ignore
-        from _session import SessionState
-        state = SessionState.load()
-
-        def _get(key):
-            return getattr(state, key, None)
-
-        def _set(key, value):
-            state.update(**{key: value})
-
-        violation = refwatch_tick(_get, _set)
-        if violation:
-            messages.append(render(violation))
-    except Exception:
-        pass  # the sentinel must never break the hook
-
-    result = {"continue": True}
-    if messages:
-        result["systemMessage"] = "\n".join(messages)
-    return result
+    return {"continue": True}
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -22,6 +22,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 # Add shared scripts directory to path
 _PLUGIN_ROOT = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).resolve().parents[2]))
@@ -59,6 +60,80 @@ def _get_session_id() -> str:
 def _session_dir(subdir: str) -> Path:
     tmpdir = (os.environ.get("TMPDIR") or __import__("tempfile").gettempdir()).rstrip("/")
     return Path(tmpdir) / subdir / _get_session_id()
+
+
+# ---------------------------------------------------------------------------
+# Claim sentinel (answer tier) — claim-gated at the Stop boundary.
+# Replaces the old PostToolUse ref-watch that fired on every Bash call. Reads
+# the turn's final assistant message from the transcript; only a real
+# done/passing/shipped claim with no verdict for HEAD produces a nudge.
+# ---------------------------------------------------------------------------
+
+def _extract_text(content) -> Optional[str]:
+    """Pull concatenated text from a transcript message's `content` — either a
+    raw string or a list of {type:'text', text:...} blocks."""
+    if isinstance(content, str):
+        return content or None
+    if isinstance(content, list):
+        parts = [b["text"] for b in content
+                 if isinstance(b, dict) and b.get("type") == "text" and b.get("text")]
+        return "\n".join(parts) if parts else None
+    return None
+
+
+def _read_final_assistant_text(transcript_path: str) -> Optional[str]:
+    """Return the text of the LAST assistant message in the transcript JSONL,
+    or None. Fail-open — any read/parse error yields None (no claim => no fire)."""
+    try:
+        p = Path(transcript_path)
+        if not p.is_file():
+            return None
+        last = None
+        for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(rec, dict):
+                continue
+            msg = rec.get("message") if isinstance(rec.get("message"), dict) else None
+            role = (msg or {}).get("role") or rec.get("role") or rec.get("type")
+            if role != "assistant":
+                continue
+            text = _extract_text((msg or {}).get("content", rec.get("content")))
+            if text:
+                last = text
+        return last
+    except Exception:
+        return None
+
+
+def _check_claim_sentinel(input_data: dict) -> list:
+    """If the turn's final assistant message asserts done/passing/shipped and
+    HEAD has no re-derived verdict, return a one-line nudge (debounced per sha
+    per session via SessionState). Fail-open — never breaks Stop."""
+    try:
+        transcript = input_data.get("transcript_path")
+        final_text = _read_final_assistant_text(transcript) if transcript else None
+        if not final_text:
+            return []
+        sys.path.insert(0, str(_PLUGIN_ROOT / "scripts" / "sentinel"))
+        from invariants import claim_tick, render  # type: ignore
+        from _session import SessionState
+        state = SessionState.load()
+        cwd = input_data.get("cwd")
+        violation = claim_tick(
+            lambda k: getattr(state, k, None),
+            lambda k, v: state.update(**{k: v}),
+            final_message=final_text,
+            cwd=Path(cwd) if cwd else None,
+        )
+        return [render(violation)] if violation else []
+    except Exception:
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +579,11 @@ def main():
         reflection = ""
         # for this session (post-first-Stop) — only join with separator if both
         # halves have content.
-        prepend_messages = outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages
+        # Answer-tier claim sentinel — claim-gated, computed here (after
+        # _persist_session_state) so its debounce write is the last state write
+        # of the turn (avoids clobbering session_ended).
+        sentinel_messages = _check_claim_sentinel(input_data)
+        prepend_messages = sentinel_messages + outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages
         if prepend_messages and reflection:
             final_message = "\n".join(prepend_messages) + "\n\n" + reflection
         elif prepend_messages:

--- a/scripts/_session.py
+++ b/scripts/_session.py
@@ -208,12 +208,13 @@ class SessionState:
     # List of hint IDs like ["grep_search", "manual_review", "debugging"].
     hints_shown: list | None = None
 
-    # Claim sentinel (scripts/sentinel/invariants.py) — ref-watch state.
-    # sentinel_refs caches the last {ref: sha} snapshot of publish-shaped refs
-    # (origin default branch + newest tag); sentinel_last_check throttles the
-    # snapshot to at most once per few seconds so hot Bash loops stay cheap.
-    sentinel_refs: dict | None = None
-    sentinel_last_check: float = 0.0
+    # Claim sentinel (scripts/sentinel/invariants.py::claim_tick) — Stop-hook
+    # debounce. The answer tier nudges at most once per unproven HEAD sha per
+    # session when a done/passing claim is made without a re-derived verdict;
+    # this records the sha already nudged so the same unproven state never
+    # re-fires within a session. MUST be a declared field — update() drops
+    # unknown keys, so a transient attr would never persist across Stop calls.
+    sentinel_claim_sha: str = ""
 
     # OneDrive / spaces-in-paths resolution (Issue #321).
     # Stores the resolved canonical base path when cwd is under a OneDrive

--- a/scripts/sentinel/invariants.py
+++ b/scripts/sentinel/invariants.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess  # noqa: S404 — argv lists only, shell=False
 import time
 from pathlib import Path
@@ -46,7 +47,6 @@ from typing import Any, Dict, List, Optional
 _GIT_TIMEOUT = 5
 _LEDGER_MAX_STAMPS = 200          # ledger read window (recent stamps only)
 _RECENT_HISTORY = 80              # a verdict covers a sha within this many ancestors
-_REFWATCH_THROTTLE_S = 5          # min seconds between ref snapshots (hot-loop guard)
 _PLAYBOOK_STALE_COMMITS = 30      # repo-playbooks "drifted" threshold
 
 
@@ -156,70 +156,78 @@ def log_sentinel_event(repo: Path, event: str, detail: Dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 1 — ref-watch: a done-shaped ref advance must have a verdict.
-# Tool-agnostic by construction: gh/glab/raw git/API all converge on the refs.
+# Invariant 1 — claim-gate (answer tier): a done/passing CLAIM must have a
+# verdict. Fires at the Stop boundary, and only when the turn's final message
+# actually asserts done/passing/shipped — never as a side effect of a tool
+# call. Ship/publish protection (an actual push to main or a tag) is the BLOCK
+# tier (pre_push.py + CI); this is the harness backstop nudge.
+#
+# History: this replaced a PostToolUse ref-watch that keyed off git-ref state
+# (origin default branch + newest tag advancing) with no claim check, wired to
+# a blanket Bash matcher — so any Bash call (git log, cat, find) during pure
+# planning tripped "the claim sentinel that never checked for a claim".
 # ---------------------------------------------------------------------------
 
-def snapshot_refs(repo: Path) -> Dict[str, str]:
-    """{ref: sha} for the publish-shaped refs: remote default branch + newest tag."""
-    out: Dict[str, str] = {}
-    for ref in ("refs/remotes/origin/main", "refs/remotes/origin/master"):
-        sha = _git(repo, "rev-parse", "--verify", "--quiet", ref)
-        if sha:
-            out[ref] = sha
-            break
-    newest_tag = _git(repo, "for-each-ref", "refs/tags",
-                      "--sort=-creatordate", "--count=1", "--format=%(refname)|%(objectname)")
-    if newest_tag and "|" in newest_tag:
-        name, sha = newest_tag.split("|", 1)
-        out[name] = sha
-    return out
+# Verification-completion phrases. Deliberately conservative — the failure mode
+# being fixed is OVER-firing, so we match explicit verification/publish
+# assertions, not bare "done" (too common in progress chatter).
+_CLAIM_PATTERNS = (
+    r"\btests?\s+(?:all\s+)?(?:pass|passing|passes|passed)\b",
+    r"\ball\s+tests?\s+(?:are\s+)?(?:pass|passing|green)",
+    r"\ball\s+green\b",
+    r"\ball\s+checks?\s+(?:pass|passing|green)",
+    r"\bbuild\s+(?:is\s+)?clean\b",
+    r"\bready\s+to\s+(?:merge|ship)\b",
+    r"\bshipped\b",
+    r"\bship(?:ping)?\s+it\b",
+    r"\bit\s+works\b",
+    r"\bverified\b",
+)
+_CLAIM_RE = re.compile("|".join(_CLAIM_PATTERNS), re.IGNORECASE)
 
 
-def check_done_claim(repo: Path, before: Dict[str, str],
-                     after: Dict[str, str]) -> Optional[Dict[str, Any]]:
-    """Answer-tier. Fired when a publish-shaped ref moved (origin default branch
-    advanced, or a new tag appeared) and no re-derived verdict covers the new sha."""
-    moved: List[str] = []
-    for ref, sha in after.items():
-        if before.get(ref) != sha:
-            moved.append(ref)
-    if not moved:
-        return None
-    new_sha = after.get(moved[0], "")
-    stamp = verdict_for(repo, new_sha or None)
-    if stamp:
-        return None
-    violation = {
-        "tier": "answer",
-        "invariant": "done-claim-verdict",
-        "evidence": f"{', '.join(moved)} advanced to {new_sha[:9]} with no re-derived verdict on record",
-        "action": ("Run `/wicked-garden:prove` to re-derive the claim now, or state the override "
-                   "reason — this advance is logged either way."),
-    }
-    log_sentinel_event(repo, "unverified_publish",
-                       {"refs": moved, "sha": new_sha, "invariant": "done-claim-verdict"})
-    return violation
+def is_done_claim(text: Optional[str]) -> bool:
+    """True iff `text` asserts verified completion / shipping — a 'done' claim.
+    Conservative by design (matches explicit verification/publish phrases, not
+    bare 'done') so planning and progress chatter never trip the sentinel."""
+    if not text:
+        return False
+    return bool(_CLAIM_RE.search(text))
 
 
-def refwatch_tick(state_get, state_set, cwd: Optional[Path] = None) -> Optional[Dict[str, Any]]:
-    """The PostToolUse entry point. `state_get(key)`/`state_set(key, value)` wrap
-    SessionState so this module stays import-light. Throttled; fail-open."""
+def claim_tick(state_get, state_set, *, final_message: Optional[str],
+               cwd: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Stop-hook entry point. Fires ONLY when the turn's final assistant message
+    asserts done/passing/shipped (is_done_claim) AND the repo HEAD has no
+    re-derived verdict. Debounced once per unproven sha per session. Fail-open.
+
+    `state_get(key)`/`state_set(key, value)` wrap SessionState so this module
+    stays import-light."""
     try:
-        now = time.time()
-        last = state_get("sentinel_last_check") or 0
-        if now - float(last) < _REFWATCH_THROTTLE_S:
+        if not is_done_claim(final_message):
             return None
         repo = repo_toplevel(cwd)
         if repo is None:
             return None
-        before = state_get("sentinel_refs") or {}
-        after = snapshot_refs(repo)
-        state_set("sentinel_refs", after)
-        state_set("sentinel_last_check", now)
-        if not before:  # first snapshot of the session — baseline only
+        head = _git(repo, "rev-parse", "HEAD")
+        if not head:
             return None
-        return check_done_claim(repo, before, after)
+        if verdict_for(repo, head):  # a re-derived verdict covers HEAD — suppress
+            return None
+        if state_get("sentinel_claim_sha") == head:  # debounce: once per sha/session
+            return None
+        state_set("sentinel_claim_sha", head)
+        violation = {
+            "tier": "answer",
+            "invariant": "done-claim-verdict",
+            "evidence": (f"a done/passing claim was made but HEAD {head[:9]} has no "
+                         "re-derived verdict on record"),
+            "action": ("Run `/wicked-garden:prove` to re-derive the claim now, or state "
+                       "the override reason — the claim is logged either way."),
+        }
+        log_sentinel_event(repo, "unverified_claim",
+                           {"sha": head, "invariant": "done-claim-verdict"})
+        return violation
     except Exception:  # noqa: BLE001 — sentinel never breaks a hook
         return None
 
@@ -388,7 +396,7 @@ def render(violation: Dict[str, Any]) -> str:
 
 __all__ = [
     "repo_toplevel", "stamp_verdict", "verdict_for", "log_sentinel_event",
-    "snapshot_refs", "check_done_claim", "refwatch_tick",
+    "is_done_claim", "claim_tick",
     "check_evidence_freshness", "check_session_capture",
     "check_playbook_freshness", "session_end_lines", "render",
 ]

--- a/tests/sentinel/test_invariants.py
+++ b/tests/sentinel/test_invariants.py
@@ -46,15 +46,6 @@ def _make_repo(base: Path, name: str = "work") -> Path:
     return repo
 
 
-def _add_origin(base: Path, repo: Path) -> Path:
-    bare = base / "origin.git"
-    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True, timeout=10)
-    _git(repo, "remote", "add", "origin", str(bare))
-    _git(repo, "push", "-q", "origin", "main")
-    _git(repo, "fetch", "-q", "origin")
-    return bare
-
-
 class _TempHome(unittest.TestCase):
     """Redirect the ledger (under ~) into a temp HOME."""
 
@@ -95,59 +86,67 @@ class LedgerTests(_TempHome):
                           "only satisfied+re-derived stamps are a verdict")
 
 
-class RefWatchTests(_TempHome):
-    def test_detects_unverified_main_advance(self):
+class ClaimGateTests(_TempHome):
+    """Answer tier is claim-gated at Stop: it fires only when the turn's final
+    message asserts done/passing/shipped AND HEAD has no verdict. The old
+    ref-watch fired on git-ref state regardless of any claim (every Bash call
+    during planning tripped it); push/publish protection now lives only in
+    pre_push.py (block tier) + CI."""
+
+    def test_is_done_claim_detects_verification_assertions(self):
+        for msg in (
+            "All tests pass — 12/12 green.",
+            "Done. Shipped it and it's ready to merge.",
+            "The build is clean and all checks pass.",
+        ):
+            self.assertTrue(inv.is_done_claim(msg), msg)
+
+    def test_is_done_claim_ignores_planning_and_progress(self):
+        for msg in (
+            "Here's my plan: first I'll explore the codebase.",
+            "Let me investigate why the brain isn't starting.",
+            "I'll write the spec next so we can review it.",
+            "",
+            None,
+        ):
+            self.assertFalse(inv.is_done_claim(msg), repr(msg))
+
+    def test_claim_tick_silent_without_a_claim(self):
+        # Regression: an unproven HEAD must NOT fire during planning/progress.
         repo = _make_repo(self.base)
-        _add_origin(self.base, repo)
-        before = inv.snapshot_refs(repo)
-        self.assertIn("refs/remotes/origin/main", before)
-        (repo / "f.txt").write_text("two\n")
-        _git(repo, "commit", "-aqm", "c2")
-        _git(repo, "push", "-q", "origin", "main")
-        _git(repo, "fetch", "-q", "origin")
-        after = inv.snapshot_refs(repo)
-        violation = inv.check_done_claim(repo, before, after)
-        self.assertIsNotNone(violation, "unverified origin/main advance must fire")
-        self.assertEqual(violation["invariant"], "done-claim-verdict")
-        # the detection itself is recorded (the skip is evidence)
+        store: dict = {}
+        self.assertIsNone(inv.claim_tick(
+            store.get, store.__setitem__,
+            final_message="Here's the plan; nothing is done yet.", cwd=repo))
+
+    def test_claim_tick_fires_on_unverified_done_claim(self):
+        repo = _make_repo(self.base)
+        store: dict = {}
+        v = inv.claim_tick(store.get, store.__setitem__,
+                           final_message="All tests pass, shipped it.", cwd=repo)
+        self.assertIsNotNone(v)
+        self.assertEqual(v["invariant"], "done-claim-verdict")
         trail = inv._ledger_path(repo).with_suffix(".events.jsonl")
         self.assertTrue(trail.exists())
-        self.assertIn("unverified_publish", trail.read_text())
+        self.assertIn("unverified_claim", trail.read_text())
 
-    def test_verified_advance_stays_silent(self):
+    def test_claim_tick_suppressed_by_verdict(self):
         repo = _make_repo(self.base)
-        _add_origin(self.base, repo)
-        before = inv.snapshot_refs(repo)
-        (repo / "f.txt").write_text("two\n")
-        _git(repo, "commit", "-aqm", "c2")
         inv.stamp_verdict(repo, overall="PASS", satisfied=True, re_derived=True)
-        _git(repo, "push", "-q", "origin", "main")
-        _git(repo, "fetch", "-q", "origin")
-        after = inv.snapshot_refs(repo)
-        self.assertIsNone(inv.check_done_claim(repo, before, after))
-
-    def test_new_tag_is_publish_shaped(self):
-        repo = _make_repo(self.base)
-        before = inv.snapshot_refs(repo)
-        _git(repo, "tag", "v1.0.0")
-        after = inv.snapshot_refs(repo)
-        violation = inv.check_done_claim(repo, before, after)
-        self.assertIsNotNone(violation, "a new tag with no verdict must fire")
-
-    def test_refwatch_tick_baselines_then_detects_and_throttles(self):
-        repo = _make_repo(self.base)
-        _add_origin(self.base, repo)
         store: dict = {}
-        get, setv = store.get, store.__setitem__
-        with patch.object(inv, "_REFWATCH_THROTTLE_S", 0):
-            self.assertIsNone(inv.refwatch_tick(get, setv, cwd=repo))  # baseline
-            (repo / "f.txt").write_text("two\n")
-            _git(repo, "commit", "-aqm", "c2")
-            _git(repo, "push", "-q", "origin", "main")
-            _git(repo, "fetch", "-q", "origin")
-            self.assertIsNotNone(inv.refwatch_tick(get, setv, cwd=repo))
-        # throttle: immediate re-tick is suppressed
-        self.assertIsNone(inv.refwatch_tick(get, setv, cwd=repo))
+        self.assertIsNone(inv.claim_tick(
+            store.get, store.__setitem__,
+            final_message="All tests pass.", cwd=repo))
+
+    def test_claim_tick_debounces_per_sha(self):
+        repo = _make_repo(self.base)
+        store: dict = {}
+        first = inv.claim_tick(store.get, store.__setitem__,
+                               final_message="all green, done", cwd=repo)
+        self.assertIsNotNone(first)
+        second = inv.claim_tick(store.get, store.__setitem__,
+                                final_message="all green, done", cwd=repo)
+        self.assertIsNone(second, "same unproven HEAD must not re-fire in a session")
 
 
 class EvidenceFreshnessTests(_TempHome):


### PR DESCRIPTION
## Problem
The "claim sentinel" answer tier fired on **git-ref state, not on a claim**. `refwatch_tick` ran from `PostToolUse` on a blanket `Bash` matcher, so any Bash call (`git log`, `cat`, `find`) during pure planning tripped it whenever `origin/main` or the newest tag was ahead of the last proven SHA. It was sticky across sessions (the per-session `sentinel_refs` baseline) and only silenced by running `prove`. It was the claim sentinel that never checked for a claim.

## Fix (root cause, not stopgap)
- **Relocate** answer-tier detection `PostToolUse/Bash → Stop` — a claim is asserted at a turn boundary, not as a side effect of a shell command.
- **Gate on a real done-claim**: `stop.py` reads the turn's final assistant message from the transcript; `is_done_claim()` matches explicit verification/publish phrases (conservative — never bare "done") and only then runs `claim_tick`.
- **Probe `verdict_for(HEAD)`** (the work being claimed) — this drops the cross-session ref-diff that caused the stickiness entirely.
- **Debounce** once per unproven SHA per session (`SessionState.sentinel_claim_sha`, a declared field — `update()` drops unknown keys).
- **Block tier (`pre_push.py`) unchanged** — publish protection on actual pushes to main/tags stays there; this answer tier is the claim-aware backstop.

Removed the now-dead `refwatch_tick`/`check_done_claim`/`snapshot_refs` and the `sentinel_refs`/`sentinel_last_check` state fields.

## Tests
`RefWatchTests → ClaimGateTests`, including the regression **planning must not fire**. 18/18 pass, plus an end-to-end check of the live `stop.py` wiring (planning→silent, claim→one nudge, debounce→silent, verdict→silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)