### PR TITLE
docs: codegraph→brain migration — spec + Phase 1a plan (amends ADR 0001)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -209,6 +209,8 @@ All skills, hooks, agents, and shell commands must work on macOS/Linux and Windo
 - Data lineage → `/wicked-garden:search:lineage`
 - Fall back to Grep/Glob only when the index is unavailable.
 
+**Code-relationship graph lives in wicked-brain** (ADR 0004): blast-radius/lineage/callers are brain's `graph-*` actions + the `wicked-brain:graph` skill, backed by a codegraph static graph + injected edges (bus/dispatch/capability, and garden's archetype edges via the drop-in `.codegraph-extractors/archetype.mjs`). The `search:*` commands are thin wrappers over brain; garden's old in-repo `scripts/_codegraph.py` + `scripts/codegraph/*` are superseded. wicked-patch consumes the same `.codegraph/codegraph.db` brain builds.
+
 ## AskUserQuestion Fallback (Dangerous Mode)
 
 When the session briefing notes `[Question Mode] Dangerous mode is active`, `AskUserQuestion` is broken (auto-completes empty). Commands MUST fall back to plain-text questions and wait for the user to answer.

--- a/.codegraph-extractors/archetype.mjs
+++ b/.codegraph-extractors/archetype.mjs
@@ -1,0 +1,67 @@
+// archetype.mjs — wicked-garden's PROPRIETARY injected-edge extractor, discovered
+// and run by wicked-brain's codegraph extractor registry (drop-in mechanism, ADR
+// 0004 / spec D3). It materializes archetype → playbook edges that no grep or
+// static call-graph can see: an archetype is wired to its playbook by a *naming
+// convention* (.claude-plugin/archetypes.json key ↔ skills/archetype/refs/<name>.md),
+// never by a symbol reference.
+//
+// Contract (brain's runExtractors): `export function extract({ db, sourcePath, nodes })`
+//   - db        : an open read-write better-sqlite3 Database for <repo>/.codegraph/codegraph.db
+//   - sourcePath: the repo root
+//   - nodes     : { ensureFileNode(db, relpath, lang?), ensureVirtualNode(db, id, kind, name) }
+//     (passed BY brain so this file imports NOTHING from brain or garden — the
+//      dependency arrow only ever points garden→brain.)
+// Returns a counts object with `edges_added`. Idempotent. Fail-open on a missing
+// catalog (returns zero) — brain works fine on repos without archetypes.
+//
+// Direction: an archetype DEPENDS ON its playbook (change refs/<name>.md → the
+// archetype's behavior changes). With brain's DEPENDENTS_BY="target", the edge is
+// source=archetype, target=playbook, so blast-radius(playbook) surfaces the archetype.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PROVENANCE = "injected:archetype";
+const NODE_KIND = "archetype";
+
+export function extract({ db, sourcePath, nodes }) {
+  // idempotent: clear this extractor's own edges + the synthetic nodes it owns
+  db.prepare("DELETE FROM edges WHERE provenance = ?").run(PROVENANCE);
+  db.prepare("DELETE FROM nodes WHERE kind = ?").run(NODE_KIND);
+
+  const catalogPath = join(sourcePath, ".claude-plugin", "archetypes.json");
+  if (!existsSync(catalogPath)) {
+    return { edges_added: 0, archetypes: 0, skipped: 0 };
+  }
+  let catalog;
+  try {
+    catalog = JSON.parse(readFileSync(catalogPath, "utf-8"));
+  } catch {
+    return { edges_added: 0, archetypes: 0, skipped: 0 };
+  }
+  const archetypes = catalog && catalog.archetypes;
+  if (!archetypes || typeof archetypes !== "object") {
+    return { edges_added: 0, archetypes: 0, skipped: 0 };
+  }
+
+  const insert = db.prepare(
+    "INSERT INTO edges (source, target, kind, metadata, provenance) VALUES (?,?,?,?,?)"
+  );
+  let added = 0;
+  let skipped = 0;
+  let count = 0;
+  for (const name of Object.keys(archetypes)) {
+    const playbookRel = `skills/archetype/refs/${name}.md`;
+    if (!existsSync(join(sourcePath, playbookRel))) {
+      skipped += 1; // archetype declared with no playbook on disk — flag, don't fabricate
+      continue;
+    }
+    const src = nodes.ensureVirtualNode(db, `archetype:${name}`, NODE_KIND, name);
+    const tgt = nodes.ensureFileNode(db, playbookRel);
+    insert.run(src, tgt, "references",
+      JSON.stringify({ injected: "archetype", archetype: name }), PROVENANCE);
+    added += 1;
+    count += 1;
+  }
+  return { edges_added: added, archetypes: count, skipped };
+}

--- a/commands/search/blast-radius.md
+++ b/commands/search/blast-radius.md
@@ -19,7 +19,7 @@ graph as of ADR 0004. Garden no longer maintains its own graph; it consumes brai
 > For **data-flow tracing** (UI field → DB column or reverse), use `/wicked-garden:search:lineage`.
 
 ## Arguments
-- `symbol` (required): the symbol to analyze (a file like `scripts/foo.py`, or a symbol name).
+- `symbol` (required): the symbol to analyze (a file node like `src/app.py`, or a symbol name).
 - `--depth` (optional): traversal depth (brain default applies if omitted).
 
 ## Instructions

--- a/commands/search/blast-radius.md
+++ b/commands/search/blast-radius.md
@@ -1,7 +1,8 @@
 ---
 description: |
-  Use when you need to know what would break or be affected by changing a symbol — traces both
-  dependencies (what this uses) and dependents (what uses this) via the graph index.
+  Use when you need to know what would break or be affected by changing a symbol — traces
+  dependents (what uses this) over the code-relationship graph, including injected edges
+  (bus/dispatch/capability) that grep and a static call-graph cannot see.
   NOT for full data lineage tracing (use search:lineage) or general code search (use wicked-brain:search).
 argument-hint: "<symbol> [--depth N]"
 phase_relevance: ["build", "review"]
@@ -10,78 +11,48 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:search:blast-radius
 
-Analyze what would be affected if you changed a symbol. Shows both what this symbol depends on and what depends on it.
+Analyze what would be affected if you changed a symbol — **delegates to wicked-brain's
+code-relationship graph** (`wicked-brain:graph`), which owns the unified static + injected
+graph as of ADR 0004. Garden no longer maintains its own graph; it consumes brain's.
 
-> **Scope**: `blast-radius` answers "what breaks if I change X?" — impact of changing a symbol (dependents graph).
-> For **data flow tracing** (UI field → DB column or reverse), use `/wicked-garden:search:lineage` instead.
+> **Scope**: `blast-radius` answers "what breaks if I change X?" (the dependents graph).
+> For **data-flow tracing** (UI field → DB column or reverse), use `/wicked-garden:search:lineage`.
 
 ## Arguments
-
-- `symbol` (required): The symbol to analyze
-- `--depth` (optional): How deep to traverse dependencies (default: 2)
+- `symbol` (required): the symbol to analyze (a file like `scripts/foo.py`, or a symbol name).
+- `--depth` (optional): traversal depth (brain default applies if omitted).
 
 ## Instructions
 
-1. **Query the codegraph graph** for static + injected dependents (the authoritative layer — covers what grep can't see):
+1. **Ensure the graph is fresh** (brain builds the codegraph static graph + runs the injected-edge extractors in one pass):
    ```bash
-   # Freshness first — a silently-stale graph gives confident wrong answers:
-   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" staleness
-   # Static refs (imports/calls/instantiations) resolved by the engine:
-   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" 2>/dev/null  # shim is library-only; run the CLI:
-   codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json
-
-   # INJECTED relationships grep + the static graph miss (bus producer→consumer,
-   # command→agent dispatch, agent→capability) — read straight from the graph DB:
-   python3 - "$SYMBOL" <<'PY'
-   import sqlite3, sys, pathlib
-   sym = sys.argv[1]
-   db = pathlib.Path(".codegraph/codegraph.db")
-   if not db.exists():
-       print("no index — run `codegraph index` first"); raise SystemExit
-   c = sqlite3.connect(str(db))
-   # dependents reaching this symbol's file via any injected edge
-   rows = c.execute(
-     "SELECT source, target, provenance, metadata FROM edges "
-     "WHERE provenance LIKE 'injected:%' AND (source LIKE ? OR target LIKE ?)",
-     (f"%{sym}%", f"%{sym}%")).fetchall()
-   for r in rows: print(r)
-   c.close()
-   PY
+   npx -y wicked-brain-call graph-index
    ```
-   `codegraph impact` gives static dependents; the `injected:%` query adds bus/dispatch/capability edges (materialized by `scripts/codegraph/inject_edges.py`, `inject_dispatch_edges.py`, `inject_capability_edges.py`). Union both — a complete blast radius needs the injected layer, since a command that *dispatches* an agent or a consumer that *subscribes* to an event has no literal reference for grep to find.
+   The result carries a `staleness` stamp; if `stale` is true after editing, re-run it.
 
-2. **Cross-reference via brain** (semantic neighbors the graph may not name):
+2. **Resolve the symbol to a graph node id.** Node ids are `file:<relpath>` for files, or `function:<hash>` etc. for symbols. For a file, use `file:<path>` directly. For a named symbol, find its id via brain:
    ```bash
-   PORT="$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_brain_port.py" 2>/dev/null || echo 4242)"
-   curl -s -X POST "http://localhost:${PORT}/api" \
-     -H "Content-Type: application/json" \
-     -d '{"action":"search","params":{"query":"<symbol>","limit":30}}'
+   npx -y wicked-brain-call symbols --query "<symbol>"     # or wicked-brain:lsp workspace-symbols
    ```
-   Use matching chunks to corroborate the dependent set.
 
-3. **If neither graph nor brain is available**: Use Grep and Glob to trace literal references only — and flag that injected relationships (bus/dispatch/capability) will be MISSING from the result. Suggest `codegraph index` + the inject extractors, or `wicked-brain:ingest`, for a complete picture.
+3. **Query blast radius from brain** (static + injected dependents in one answer — the authoritative layer):
+   ```bash
+   npx -y wicked-brain-call graph-blast-radius --node "file:<path-or-resolved-id>"
+   ```
+   The `dependents` array includes relationships grep can't see: a command that *dispatches* an agent (`injected:dispatch`), a consumer that *subscribes* to an event (`injected:bus`), an agent that *declares* a capability (`injected:capability`). Each result carries a `staleness` stamp.
 
-4. Report the impact assessment:
-   - **Dependencies** (outgoing): What this symbol uses/imports
-   - **Dependents** (incoming): What uses this symbol — static (from `codegraph impact`) AND injected (from the `injected:%` edges)
-   - Total blast radius count
-   - Files affected
+4. **Fallbacks** (in order):
+   - If `graph-blast-radius` returns `engine: "unavailable"`, codegraph isn't installed where brain runs — install it (`npx @colbymchenry/codegraph`) or set `WICKED_CODEGRAPH_BIN`, then `graph-index`.
+   - If brain is unreachable, fall back to `wicked-brain:search` for semantic neighbors, then Grep/Glob for literal refs — and **flag that injected relationships will be MISSING** from the result.
+
+5. Report: **dependents** (static + injected, with provenance), total blast-radius count, files affected, and the graph's staleness.
 
 ## Example
-
 ```
-/wicked-garden:search:blast-radius DatabaseConnection --depth 3
-/wicked-garden:search:blast-radius UserService
+/wicked-garden:search:blast-radius scripts/_bus.py
+/wicked-garden:search:blast-radius UserService --depth 3
 ```
-
-## Use Cases
-
-- **Pre-refactoring**: Know what will break before changing code
-- **Safe changes**: Identify low-risk symbols to modify
-- **Tech debt prioritization**: Focus on high-impact components
 
 ## Notes
-
-- **Requires a codegraph index**: run `codegraph index` (writes `.codegraph/codegraph.db`), then materialize the injected edges (`scripts/codegraph/inject_edges.py`, `inject_dispatch_edges.py`, `inject_capability_edges.py`) so the `injected:%` query returns bus/dispatch/capability dependents. Without an index, the graph steps no-op and you fall back to grep (literal refs only).
-- Deeper depth = more complete but slower analysis
-- For data lineage tracing (UI → DB), use `/wicked-garden:search:lineage` instead
+- The graph + queries live in **wicked-brain** now (ADR 0004); this command is a thin wrapper over `wicked-brain:graph`. For lineage (downstream dependencies) use `/wicked-garden:search:lineage`.
+- Garden contributes its proprietary **archetype** edges to brain's graph via the drop-in extractor `.codegraph-extractors/archetype.mjs` (discovered by brain's registry) — so archetype→playbook relationships are in the blast radius too.

--- a/commands/search/index.md
+++ b/commands/search/index.md
@@ -7,43 +7,32 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:search:index
 
-Refresh the two code-intelligence layers the other `search:*` commands query:
+Refresh the two code-intelligence layers the other `search:*` commands query. Both
+live in **wicked-brain** now (ADR 0004):
 
 - **semantic** (wicked-brain) — concept/symbol search, `wicked-brain:search`/`query`.
-- **structural** (codegraph) — `search:blast-radius`, `search:lineage`, and the wicked-patch family.
+- **structural** (codegraph graph, owned by brain) — `wicked-brain:graph` (blast-radius/lineage) and the wicked-patch family.
 
 ## Arguments
-
-- `path` (required): Directory to index.
+- `path` (required): directory to index (the brain server's `--source` repo).
 
 ## Instructions
 
 1. **Semantic layer** — invoke `/wicked-brain:ingest` with `<path>` (incremental; only changed files re-ingest).
 
-2. **Structural layer** — rebuild the codegraph graph, then re-apply the injected edges:
+2. **Structural layer** — one call rebuilds the codegraph static graph **and** re-applies every injected-edge extractor (built-in bus/dispatch/capability + any per-repo drop-ins under `.codegraph-extractors/`):
    ```bash
-   # first time on a repo: codegraph must be initialized before it can index
-   npx -y @colbymchenry/codegraph init 2>/dev/null || true
-   codegraph index "<path>"   # or: npx -y @colbymchenry/codegraph index "<path>"
-   # codegraph indexes CODE only; re-apply the injected layer (bus producer→consumer,
-   # command→agent dispatch, agent→capability) it doesn't know about and a re-index drops:
-   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
-      "${CLAUDE_PLUGIN_ROOT}/scripts/codegraph/inject_all.py" "<path>/.codegraph/codegraph.db"
+   npx -y wicked-brain-call graph-index
    ```
-   The `inject_all` step is **required** for `blast-radius`/`lineage` to surface the string-keyed
-   relationships grep and the static graph can't see (#916). Skipping it leaves the injected
-   layer empty after every re-index.
+   This replaces the old `codegraph index` + `inject_all.py` two-step — brain runs the build and the extractors in a single pass, so the injected layer is never left empty after a re-index. The result reports per-extractor counts, `total_injected_edges`, and a `staleness` stamp.
 
 3. **Verify**:
    ```bash
-   PORT="$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_brain_port.py" 2>/dev/null || echo 4242)"
-   curl -s -X POST "http://localhost:${PORT}/api" -H "Content-Type: application/json" \
-     -d '{"action":"stats","params":{}}'                       # brain chunk/tag counts
+   npx -y wicked-brain-call stats         # brain chunk/tag counts (semantic layer)
    ```
-   `inject_all` prints per-extractor edge counts + a `total_injected_edges` — report both.
+   and confirm `graph-index` reported `total_injected_edges > 0` on a repo with wiring.
 
 ## Notes
-
 - Both layers are incremental/idempotent — safe to re-run.
-- If `codegraph` isn't resolvable, the structural commands degrade to grep + brain (and say so);
-  run `codegraph index` once to enable blast-radius/lineage/patch.
+- Freshness is lazy by design (no file-watcher reindex). `graph-*` results carry `commits_behind`/`indexed_at`; re-run `graph-index` when stale.
+- If codegraph isn't resolvable where brain runs, `graph-*` returns `engine:"unavailable"` — install `@colbymchenry/codegraph` or set `WICKED_CODEGRAPH_BIN`.

--- a/commands/search/lineage.md
+++ b/commands/search/lineage.md
@@ -1,5 +1,5 @@
 ---
-description: Trace data lineage from source to sink (UI → DB or reverse)
+description: Trace data lineage / dependency flow (downstream dependencies or upstream dependents)
 argument-hint: "<symbol> [--direction upstream|downstream|both] [--depth N]"
 phase_relevance: ["*"]
 archetype_relevance: ["*"]
@@ -7,88 +7,41 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:search:lineage
 
-Trace data lineage paths through the codebase. Follow data flow from UI fields to database columns (downstream) or reverse (upstream).
+Trace flow through the code-relationship graph — **delegates to wicked-brain's
+`wicked-brain:graph`** (ADR 0004). Downstream = what the symbol depends on; upstream
+= what depends on it. Includes injected edges (bus/dispatch/capability/archetype)
+that grep and a static call-graph can't see.
 
-> **Scope**: `lineage` answers "where does this data come from / go to?" — data flow tracing (source → sink).
-> For **dependency impact** ("what breaks if I change X?"), use `/wicked-garden:search:blast-radius` instead.
+> **Scope**: `lineage` answers "where does this flow from / to?". For pure
+> "what breaks if I change X?" use `/wicked-garden:search:blast-radius`.
 
 ## Arguments
-
-- `symbol` (required): The symbol to trace from
-- `--direction` (optional): Direction to trace (default: downstream)
-  - `downstream`: Source → sink (e.g., UI field → DB column)
-  - `upstream`: Sink → source (e.g., DB column → UI fields)
-  - `both`: Trace in both directions
-- `--depth` (optional): Maximum traversal depth (default: 10)
+- `symbol` (required): the symbol/file to trace from (`file:<relpath>` or a resolved node id).
+- `--direction` (optional, default downstream): `downstream` (dependencies), `upstream` (dependents), or `both`.
+- `--depth` (optional): traversal depth (brain default applies if omitted).
 
 ## Instructions
 
-1. **Search brain for the symbol** to find its location and references:
-   ```bash
-   PORT="$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_brain_port.py" 2>/dev/null || echo 4242)"
-   curl -s -X POST "http://localhost:${PORT}/api" \
-     -H "Content-Type: application/json" \
-     -d '{"action":"search","params":{"query":"<symbol>","limit":20}}'
-   ```
-   If brain is unavailable or returns no results, fall back to Grep:
-   ```
-   Grep: <symbol> across all source files
-   ```
-   If no results at all, suggest: `wicked-brain:ingest` to index the codebase first.
+1. **Ensure the graph is fresh**: `npx -y wicked-brain-call graph-index` (builds codegraph + runs the injected-edge extractors; reports `staleness`).
 
-2. **Query the codegraph graph for reference flow** (when a `.codegraph/codegraph.db` index exists). The graph gives both static reference edges and the *injected* edges grep can't see (bus producer→consumer, command→agent dispatch, agent→capability) — useful when the data/reference path crosses a string-keyed link rather than a literal call:
-   ```bash
-   # Freshness first — a silently-stale graph gives confident wrong answers:
-   sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/_codegraph.py" staleness
-   codegraph impact <symbol> --json   # or: npx -y @colbymchenry/codegraph@latest impact <symbol> --json
-   # injected reference flow (string-keyed links static analysis misses):
-   sqlite3 .codegraph/codegraph.db \
-     "SELECT source, target, provenance FROM edges WHERE provenance LIKE 'injected:%' AND (source LIKE '%<symbol>%' OR target LIKE '%<symbol>%');"
-   ```
-   No index → skip this step (run `codegraph index` first for graph-backed lineage); fall back to Grep below.
+2. **Resolve the symbol to a node id** (`file:<relpath>` directly, or via `npx -y wicked-brain-call symbols --query "<symbol>"`).
 
-3. **Trace data flow** using Grep to follow the symbol through layers:
-   - Search for imports/requires of the file containing the symbol
-   - Search for function calls that pass the symbol as an argument
-   - Search for assignments, mappings, and transformations of the symbol
-   - Follow the chain through controller → service → repository → database layers
+3. **Trace** via brain:
+   - **downstream** (what it depends on): `npx -y wicked-brain-call graph-lineage --node "<id>"` → `dependencies`.
+   - **upstream** (what depends on it): `npx -y wicked-brain-call graph-blast-radius --node "<id>"` → `dependents`.
+   - **both**: run both and present each direction.
+   Each result includes injected edges (e.g. a consumer reached via `injected:bus`, an archetype via `injected:archetype`) and a `staleness` stamp.
 
-4. Report the lineage paths found:
-   - Show each path with steps from source to sink
-   - Include file locations at each step
-   - Note any gaps in the lineage chain
+4. **Fallbacks**: `engine:"unavailable"` → install codegraph where brain runs. Brain unreachable → `wicked-brain:search` + Grep for literal flow only (flag that injected/string-keyed links will be MISSING).
+
+5. Report each path (source → sink), file locations per step, provenance of injected hops, and gaps.
 
 ## Examples
-
 ```bash
-# Trace downstream from a UI field
-/wicked-garden:search:lineage firstName --direction downstream
-
-# Find all UI fields that use a database column
-/wicked-garden:search:lineage EMAIL --direction upstream
-
-# Trace both directions
+/wicked-garden:search:lineage file:scripts/_bus.py --direction upstream
 /wicked-garden:search:lineage User.email --direction both
 ```
 
-## Output
-
-### Table Format
-```
-| # | Source | Sink | Steps | Confidence | Complete |
-|---|--------|------|-------|------------|----------|
-| 1 | firstName | FIRST_NAME | 3 | high | yes |
-| 2 | lastName | LAST_NAME | 3 | medium | yes |
-```
-
-## Use Cases
-
-- **Impact analysis**: Before changing a database column, find all UI fields that use it
-- **Data flow documentation**: Understand how data flows through the system
-- **Debugging**: Trace why a UI field isn't displaying expected data
-- **Compliance**: Document which UI fields expose sensitive database columns
-
 ## Notes
-
-- Brain search provides indexed symbol locations; Grep traces the connections
-- Use `/wicked-garden:search:blast-radius` for reverse lineage (upstream consumers and impact analysis)
+- The graph + queries live in **wicked-brain** now; this command is a thin wrapper over `wicked-brain:graph`.
+- Use `/wicked-garden:search:blast-radius` for the dedicated "impact of changing X" view.

--- a/docs/adr/0004-code-graph-moves-to-wicked-brain.md
+++ b/docs/adr/0004-code-graph-moves-to-wicked-brain.md
@@ -1,0 +1,47 @@
+# ADR 0004 — Move the code-relationship graph to wicked-brain (inverts ADR 0001's homing)
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Supersedes:** the *homing* decision of [ADR 0001](0001-code-relationship-graph-engine.md) (graph lives in garden). **Keeps** ADR 0001's engine choice (codegraph) and the injected-edge concept.
+- **Context owners:** wicked-garden + wicked-brain
+- **Implements:** `docs/specs/2026-06-10-codegraph-to-brain-migration.md` (decisions D1–D6).
+
+## Context
+
+ADR 0001 adopted `@colbymchenry/codegraph` + wicked-garden-specific injected-edge extractors **inside garden**, and noted in passing that `search:blast-radius`/`lineage` were "wrongly" calling the brain (hardcoded to the wrong port) and concluded the fix was to *pull the graph into garden*.
+
+That instinct was backwards. "What breaks if I change X" / "what flows where" / "who depends on this" are **knowledge** questions about relationships — and the brain is the knowledge layer. It already shipped LSP-based code intelligence (`wicked-brain:lsp` advertised blast-radius/architecture). So the ecosystem had **two half-built code-intelligence stacks** answering overlapping questions in different repos. The decisive constraint: the graph is valuable to *every* repo, and requiring all of wicked-garden just to give a repo enhanced code/graph knowledge is unacceptable.
+
+## Decision
+
+**Move the code-relationship graph to `wicked-brain`.** Brain owns the engine integration, the unified graph, and every relationship query (blast-radius / callers / lineage). Garden becomes a **consumer**. The line is *knowing* (brain) vs *doing* (garden — deterministic refactor, gates, archetypes).
+
+Per the spec's locked decisions:
+- **D1/D2** Brain owns the graph + queries; **zero garden dependency** — brain is valuable standalone; the dependency arrow only ever points garden→brain.
+- **D3** Brain ships the generic/ecosystem extractors (bus, command→agent dispatch, capability); a **pluggable drop-in registry** (`<repo>/.codegraph-extractors/*.mjs`) lets any plugin contribute proprietary extractors (garden's archetype extractor) without brain importing the plugin.
+- **D4** codegraph = graph-of-record; LSP = live single-symbol precision (blast-radius/architecture moved off the lsp skill onto `wicked-brain:graph`).
+- **D5** Lazy staleness stamp + opt-in commit hook; **never** a watcher-driven full reindex (a known CPU-runaway hazard).
+- **D6** The graph DB stays codegraph-native (`<repo>/.codegraph/codegraph.db`); brain reads it directly via better-sqlite3.
+
+### What ADR 0001 keeps vs changes
+| | 0001 | 0004 |
+|---|---|---|
+| Engine | codegraph (adopt, runtime peer) | **unchanged** |
+| Injected-edge concept | yes | **unchanged** |
+| Home of the graph + queries | wicked-garden | **wicked-brain** |
+| blast-radius/lineage owner | garden commands | **brain `graph-*` actions + `wicked-brain:graph` skill** |
+| bus edge direction | `source=producer, target=consumer` (latent bug — blast-radius(producer) saw nothing) | **`source=consumer, target=producer`** (consumer depends on the producer's event contract; blast-radius(producer) surfaces the consumer) |
+
+## Consequences
+
+- **Any repo** gets relationship-graph knowledge by running wicked-brain — no garden required. Verified on a real repo: brain `graph-index` on wicked-garden built the static graph + 20 injected edges, and `blast-radius(scripts/_bus.py)` surfaced the `jam` consumer wired only by the `wicked.persona.contributed` event string (grep-invisible).
+- Garden's `scripts/_codegraph.py` + `scripts/codegraph/*` (the in-garden engine shim + extractors) are **superseded** by the brain implementation and are removed/aliased (this PR family).
+- `search:blast-radius` / `search:lineage` rewire to brain's `graph-*` actions (no more grep-with-extra-steps).
+- wicked-patch consumes the same codegraph-native `.codegraph/codegraph.db` brain builds (via `scripts/engineering/patch/codegraph_db.py`) — unchanged contract.
+- garden ships its proprietary **archetype** extractor as a brain drop-in (`.codegraph-extractors/archetype.mjs`), discovered by brain's registry — the D3 mechanism in action.
+
+## Implementation
+
+- wicked-brain: Phase 1a (graph core) + Phase 1b (injected edges + extractor registry) — see wicked-brain PR.
+- wicked-garden: Phase 2 — archetype drop-in, command rewire, this ADR, CLAUDE.md update.
+- Plans: `docs/plans/2026-06-10-codegraph-to-brain-phase1a-graph-core.md`, `docs/plans/2026-06-10-codegraph-to-brain-phase1b-injected-edges.md`.

--- a/docs/plans/2026-06-10-codegraph-to-brain-phase1a-graph-core.md
+++ b/docs/plans/2026-06-10-codegraph-to-brain-phase1a-graph-core.md
@@ -1,0 +1,838 @@
+# Codegraph → Brain, Phase 1a: Graph Core — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `wicked-brain` answer code-relationship queries (blast-radius, callers, lineage) from a codegraph-built static graph it owns — with zero `wicked-garden` dependency.
+
+**Architecture:** Brain shells the external `@colbymchenry/codegraph` CLI to *build* a per-repo SQLite graph at `<source>/.codegraph/codegraph.db`, then reads that DB **directly** via `better-sqlite3` (no query-time subprocess) to serve new `graph-*` API actions, exposed through a new `wicked-brain:graph` skill. Freshness is lazy: every query carries a "N commits behind HEAD" staleness stamp and rebuilds on demand — never coupled to the file watcher (Decision D5).
+
+**Tech Stack:** Node ≥18 ESM (`.mjs`), `better-sqlite3` v12 (read codegraph DB), `node:child_process` (shell codegraph CLI), `node:test` + `node:assert/strict`. The codegraph CLI itself requires **Node ≥22.5** (`node:sqlite`); brain runs on Node 26.
+
+**Repo:** `/Users/michael.parcewski/Projects/wicked-brain` (server source under `server/`). This plan does NOT touch wicked-garden.
+
+---
+
+## Subsequent plans (sequenced after this one)
+
+- **Phase 1b — injected edges + extractor framework** (brain): built-in extractors (bus producer→consumer, command→agent, hooks, agent→tool) + the drop-in extractor registry (Decision D3). Enriches this plan's graph; independently testable.
+- **Phase 2 — garden-side** (wicked-garden): repoint wicked-patch to brain's DB, ship the archetype extractor as a drop-in, alias/remove `search:*` commands, amend ADR 0001, update CLAUDE.md.
+
+Reference spec: `wicked-garden/docs/specs/2026-06-10-codegraph-to-brain-migration.md` (Decisions D1–D6).
+
+---
+
+## File structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `server/lib/codegraph-resolver.mjs` | Create | Resolve the codegraph CLI argv (env → brain config → PATH → node_modules → npx); kill-switch. Port of garden's `_codegraph.py::resolve_codegraph`. |
+| `server/lib/codegraph-index.mjs` | Create | `dbPath(source)`, `staleness(source)` (commits-behind HEAD), `runIndex(source)` (spawn `codegraph index`). |
+| `server/lib/codegraph-client.mjs` | Create | Open `.codegraph/codegraph.db` readonly; `blastRadius`, `callers`, `lineage` via BFS over the `edges` table; attaches staleness to every result. |
+| `server/bin/wicked-brain-server.mjs` | Modify (actions object ~L135–306) | Register `graph-index`, `graph-blast-radius`, `graph-callers`, `graph-lineage`; add the write one to `WRITE_ACTIONS`. |
+| `skills/wicked-brain-graph/SKILL.md` | Create | New `wicked-brain:graph` skill documenting the graph queries. |
+| `skills/wicked-brain-lsp/SKILL.md` | Modify (frontmatter) | Remove "blast radius" / "architecture map" trigger phrases (they were never implemented in LSP; they move here). |
+| `server/test/codegraph-resolver.test.mjs` | Create | Resolver ladder + kill-switch. |
+| `server/test/codegraph-index.test.mjs` | Create | dbPath + staleness (present/absent/behind). |
+| `server/test/codegraph-client.test.mjs` | Create | blastRadius/callers/lineage over a hand-built fixture DB. |
+| `docs/codegraph-contract.md` | Create (Task 1) | Pinned codegraph schema + edge-direction findings the client relies on. |
+
+**Edge-direction constant:** the client centralizes the dependents-traversal direction in ONE constant (`DEPENDENTS_BY`), set from Task 1's empirical finding, so a wrong guess is a one-line flip, not a rewrite.
+
+---
+
+## Task 1: Characterization spike — pin codegraph's schema + edge direction
+
+**Why:** Garden's `_codegraph.py` says the `nodes`/`edges` schema is `nodes(id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)` and `edges(source,target,kind,metadata,provenance)`, but its `inject_edges.py` comment is self-contradictory about blast-radius edge direction ("walk incoming edges" vs. an inserted producer→consumer edge that only resolves walking *outgoing*). We must observe the real behavior before writing traversal SQL.
+
+**Files:**
+- Create: `docs/codegraph-contract.md`
+
+- [ ] **Step 1: Build a graph on a tiny fixture**
+
+```bash
+cd /tmp && rm -rf cg-spike && mkdir cg-spike && cd cg-spike
+git init -q && printf '%s\n' "def base(): pass" > a.py
+printf '%s\n' "from a import base" "def caller(): return base()" > b.py
+git add -A && git commit -qm init
+npx -y @colbymchenry/codegraph index .
+```
+Expected: `.codegraph/codegraph.db` created; output reports nodes/edges counts.
+
+- [ ] **Step 2: Dump the real schema**
+
+```bash
+cd /tmp/cg-spike
+sqlite3 .codegraph/codegraph.db ".schema nodes" ".schema edges"
+sqlite3 .codegraph/codegraph.db "SELECT id,kind,name,file_path FROM nodes;"
+sqlite3 .codegraph/codegraph.db "SELECT source,target,kind FROM edges;"
+```
+Record the exact column lists for `nodes` and `edges`.
+
+- [ ] **Step 3: Determine blast-radius edge direction empirically**
+
+`b.py::caller` calls/imports `a.py::base`. So `base`'s dependents (blast radius) must include `caller`. Inspect the edge row for that relationship:
+- If the edge is `(source=<caller/b.py>, target=<base/a.py>)` → **dependents-of-X = rows WHERE target=X, collect `source`** → set `DEPENDENTS_BY = "target"`.
+- If reversed → `DEPENDENTS_BY = "source"`.
+
+```bash
+sqlite3 .codegraph/codegraph.db \
+  "SELECT source,target,kind FROM edges WHERE kind IN ('calls','imports','references');"
+```
+
+- [ ] **Step 4: Capture the index CLI contract**
+
+```bash
+npx -y @colbymchenry/codegraph index --help 2>&1 | head -40
+```
+Record: exact subcommand + flags for indexing a directory, and whether it accepts a path arg or uses cwd. (Used by `runIndex` in Task 3.)
+
+- [ ] **Step 5: Write the contract doc**
+
+Create `docs/codegraph-contract.md` with: the `nodes` columns, the `edges` columns, the resolved `DEPENDENTS_BY` value (with the evidence row), the index command form, and the codegraph version (`npx -y @colbymchenry/codegraph --version`). This is the single reference Tasks 3–4 cite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/michael.parcewski/Projects/wicked-brain
+git add docs/codegraph-contract.md
+git commit -m "docs(codegraph): pin schema + blast-radius edge direction from spike"
+```
+
+---
+
+## Task 2: `codegraph-resolver.mjs` — resolve the CLI
+
+**Files:**
+- Create: `server/lib/codegraph-resolver.mjs`
+- Test: `server/test/codegraph-resolver.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// server/test/codegraph-resolver.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCodegraph } from "../lib/codegraph-resolver.mjs";
+
+test("env override wins and is split into argv", () => {
+  const argv = resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "/opt/cg" } });
+  assert.deepEqual(argv, ["/opt/cg"]);
+});
+
+test("a .mjs/.js env target is invoked via node", () => {
+  const argv = resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "/x/cg.mjs" } });
+  assert.deepEqual(argv, ["node", "/x/cg.mjs"]);
+});
+
+test("set-but-empty env is the kill switch -> null", () => {
+  assert.equal(resolveCodegraph({ env: { WICKED_CODEGRAPH_BIN: "" } }), null);
+});
+
+test("brain config _meta/codegraph.json bin is honored", () => {
+  const brain = mkdtempSync(join(tmpdir(), "cg-cfg-"));
+  mkdirSync(join(brain, "_meta"), { recursive: true });
+  writeFileSync(join(brain, "_meta", "codegraph.json"), JSON.stringify({ bin: "/cfg/cg" }));
+  try {
+    const argv = resolveCodegraph({ env: {}, brainPath: brain, which: () => null });
+    assert.deepEqual(argv, ["/cfg/cg"]);
+  } finally {
+    rmSync(brain, { recursive: true, force: true });
+  }
+});
+
+test("falls back to npx when nothing else resolves", () => {
+  const argv = resolveCodegraph({ env: {}, which: (c) => (c === "npx" ? "/usr/bin/npx" : null) });
+  assert.deepEqual(argv, ["npx", "-y", "@colbymchenry/codegraph"]);
+});
+
+test("no npx and nothing resolves -> null", () => {
+  assert.equal(resolveCodegraph({ env: {}, which: () => null }), null);
+});
+```
+
+- [ ] **Step 2: Run it, verify failure**
+
+Run: `cd /Users/michael.parcewski/Projects/wicked-brain/server && node --test test/codegraph-resolver.test.mjs`
+Expected: FAIL — `Cannot find module '../lib/codegraph-resolver.mjs'`.
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// server/lib/codegraph-resolver.mjs
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { platform } from "node:os";
+
+const PACKAGE = "@colbymchenry/codegraph";
+
+function argvFor(target) {
+  // A .mjs/.js path is a script -> invoke via node; else run directly.
+  return /\.(mjs|js)$/.test(target) ? ["node", target] : [target];
+}
+
+function whichDefault(command) {
+  try {
+    const cmd = platform() === "win32" ? "where" : "which";
+    const out = execFileSync(cmd, [command], { encoding: "utf-8", timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"] });
+    return out.trim().split("\n")[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function configBin(brainPath) {
+  if (!brainPath) return null;
+  try {
+    const cfg = JSON.parse(readFileSync(join(brainPath, "_meta", "codegraph.json"), "utf-8"));
+    return typeof cfg.bin === "string" && cfg.bin.trim() ? cfg.bin.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the argv prefix that invokes codegraph, or null.
+ * Ladder: WICKED_CODEGRAPH_BIN (set-but-empty = kill switch) -> brain
+ * _meta/codegraph.json {bin} -> PATH -> source node_modules/.bin -> `npx`.
+ * @param {{env?:object, brainPath?:string, sourcePath?:string, which?:Function, allowNpx?:boolean}} opts
+ */
+export function resolveCodegraph(opts = {}) {
+  const { env = process.env, brainPath, sourcePath, which = whichDefault,
+    allowNpx = true } = opts;
+
+  if (Object.prototype.hasOwnProperty.call(env, "WICKED_CODEGRAPH_BIN")) {
+    const v = (env.WICKED_CODEGRAPH_BIN || "").trim();
+    return v ? argvFor(v) : null; // empty == kill switch
+  }
+  const cfg = configBin(brainPath);
+  if (cfg) return argvFor(cfg);
+
+  const onPath = which("codegraph");
+  if (onPath) return [onPath];
+
+  if (sourcePath) {
+    const local = join(sourcePath, "node_modules", ".bin", "codegraph");
+    if (existsSync(local)) return [local];
+  }
+  if (allowNpx && which("npx")) return ["npx", "-y", PACKAGE];
+  return null;
+}
+
+/** True iff a CONCRETE install resolves (not the npx last resort). */
+export function codegraphAvailable(opts = {}) {
+  return resolveCodegraph({ ...opts, allowNpx: false }) !== null;
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `node --test test/codegraph-resolver.test.mjs`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/lib/codegraph-resolver.mjs server/test/codegraph-resolver.test.mjs
+git commit -m "feat(codegraph): CLI resolution ladder + kill switch"
+```
+
+---
+
+## Task 3: `codegraph-index.mjs` — dbPath, staleness, runIndex
+
+**Files:**
+- Create: `server/lib/codegraph-index.mjs`
+- Test: `server/test/codegraph-index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// server/test/codegraph-index.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { dbPath, staleness } from "../lib/codegraph-index.mjs";
+
+test("dbPath points at <source>/.codegraph/codegraph.db", () => {
+  assert.equal(dbPath("/repo"), join("/repo", ".codegraph", "codegraph.db"));
+});
+
+test("staleness reports not-present when db is missing", () => {
+  const s = staleness("/no/such/repo");
+  assert.equal(s.present, false);
+  assert.equal(s.stale, null);
+});
+
+test("staleness reports commits behind HEAD", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-stale-"));
+  try {
+    const git = (...a) => execFileSync("git", ["-C", repo, ...a], { stdio: "pipe" });
+    git("init"); git("config", "user.email", "t@t"); git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "1"); git("add", "-A"); git("commit", "-m", "c1");
+    // build the db, then backdate it before a second commit
+    mkdirSync(join(repo, ".codegraph"), { recursive: true });
+    const db = join(repo, ".codegraph", "codegraph.db");
+    writeFileSync(db, "x");
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(db, past, past);
+    writeFileSync(join(repo, "g.txt"), "2"); git("add", "-A"); git("commit", "-m", "c2");
+
+    const s = staleness(repo);
+    assert.equal(s.present, true);
+    assert.equal(s.stale, true);
+    assert.ok(s.commits_behind >= 1);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `node --test test/codegraph-index.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// server/lib/codegraph-index.mjs
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { resolveCodegraph } from "./codegraph-resolver.mjs";
+
+export function dbPath(sourcePath) {
+  return join(sourcePath, ".codegraph", "codegraph.db");
+}
+
+/**
+ * How far the graph has drifted from HEAD. Fail-open: errors report
+ * present-but-unknown, never throw. Port of garden _codegraph.py::staleness.
+ * @returns {{present:boolean, stale:boolean|null, commits_behind:number|null, indexed_at:string|null}}
+ */
+export function staleness(sourcePath) {
+  const db = dbPath(sourcePath);
+  if (!existsSync(db)) {
+    return { present: false, stale: null, commits_behind: null, indexed_at: null };
+  }
+  try {
+    const mtimeMs = statSync(db).mtimeMs;
+    const iso = new Date(mtimeMs).toISOString();
+    const out = execFileSync("git",
+      ["-C", sourcePath, "rev-list", "--count", `--since=${iso}`, "HEAD"],
+      { encoding: "utf-8", timeout: 10_000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+    const behind = out ? parseInt(out, 10) : 0;
+    return { present: true, stale: behind > 0, commits_behind: behind, indexed_at: iso };
+  } catch {
+    return { present: true, stale: null, commits_behind: null, indexed_at: null };
+  }
+}
+
+/**
+ * Build/refresh the graph by shelling `codegraph index`. Resolves nothing ->
+ * returns {ok:false, error}. Never throws.
+ * NOTE: the index subcommand/flags are pinned in docs/codegraph-contract.md (Task 1).
+ */
+export function runIndex(sourcePath, opts = {}) {
+  return new Promise((resolve) => {
+    const argv = resolveCodegraph({ ...opts, sourcePath });
+    if (!argv) { resolve({ ok: false, error: "codegraph not resolvable" }); return; }
+    const [cmd, ...prefix] = argv;
+    const proc = spawn(cmd, [...prefix, "index", "."], {
+      cwd: sourcePath, stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    proc.stderr.on("data", (d) => { stderr += d.toString(); });
+    proc.on("error", (e) => resolve({ ok: false, error: e.message }));
+    proc.on("close", (code) =>
+      resolve(code === 0 ? { ok: true } : { ok: false, error: stderr.trim() || `exit ${code}` }));
+  });
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `node --test test/codegraph-index.test.mjs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/lib/codegraph-index.mjs server/test/codegraph-index.test.mjs
+git commit -m "feat(codegraph): dbPath + staleness stamp + index runner"
+```
+
+---
+
+## Task 4: `codegraph-client.mjs` — blast-radius / callers / lineage
+
+**Files:**
+- Create: `server/lib/codegraph-client.mjs`
+- Test: `server/test/codegraph-client.test.mjs`
+
+> The client reads codegraph's DB directly (no query-time subprocess). Schema from Task 1: `nodes(id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)`, `edges(source,target,kind,metadata,provenance)`. `DEPENDENTS_BY` is set from Task 1, Step 3 (default `"target"` — dependents of X are edge rows WHERE target=X, collecting `source`).
+
+- [ ] **Step 1: Write the failing test (hand-built fixture DB)**
+
+```javascript
+// server/test/codegraph-client.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { CodegraphClient } from "../lib/codegraph-client.mjs";
+
+function makeRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-client-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(`
+    CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+      file_path TEXT, language TEXT, start_line INT, end_line INT,
+      start_column INT, end_column INT, updated_at INT, signature TEXT);
+    CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, metadata TEXT, provenance TEXT);
+  `);
+  const n = db.prepare(`INSERT INTO nodes
+    (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)
+    VALUES (?,?,?,?,?,?,?,?,0,0,0,?)`);
+  n.run("file:a.py", "file", "a.py", "a.py", "a.py", "python", 1, 1, null);
+  n.run("file:b.py", "file", "b.py", "b.py", "b.py", "python", 1, 2, null);
+  n.run("file:c.py", "file", "c.py", "c.py", "c.py", "python", 1, 2, null);
+  // b and c depend on a  (edge source=dependent, target=dependency)
+  const e = db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)");
+  e.run("file:b.py", "file:a.py", "imports", null, "static");
+  e.run("file:c.py", "file:b.py", "calls", null, "static");
+  db.close();
+  return repo;
+}
+
+test("blastRadius returns transitive dependents of a node", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:a.py" });
+    const ids = r.dependents.map((d) => d.id).sort();
+    assert.deepEqual(ids, ["file:b.py", "file:c.py"]); // c depends on b depends on a
+    assert.equal(r.staleness.present, true);
+    c.close();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("callers returns direct dependents only", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.callers({ node: "file:a.py" });
+    assert.deepEqual(r.callers.map((d) => d.id), ["file:b.py"]);
+    c.close();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("lineage returns transitive dependencies (downstream)", () => {
+  const repo = makeRepo();
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.lineage({ node: "file:c.py" });
+    const ids = r.dependencies.map((d) => d.id).sort();
+    assert.deepEqual(ids, ["file:a.py", "file:b.py"]);
+    c.close();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("missing db -> engine unavailable, not an empty graph", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-empty-"));
+  try {
+    const c = new CodegraphClient(repo);
+    const r = c.blastRadius({ node: "file:a.py" });
+    assert.equal(r.engine, "unavailable");
+    c.close();
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `node --test test/codegraph-client.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// server/lib/codegraph-client.mjs
+import { existsSync } from "node:fs";
+import Database from "better-sqlite3";
+import { dbPath, staleness } from "./codegraph-index.mjs";
+
+// Set from Task 1, Step 3. "target": dependents-of-X are edges WHERE target=X
+// (collect `source`); dependencies-of-X are edges WHERE source=X (collect `target`).
+const DEPENDENTS_BY = "target";
+const DEPENDENCIES_BY = DEPENDENTS_BY === "target" ? "source" : "target";
+
+export class CodegraphClient {
+  #sourcePath;
+  #db = null;
+
+  constructor(sourcePath) { this.#sourcePath = sourcePath; }
+
+  #open() {
+    if (this.#db) return this.#db;
+    const p = dbPath(this.#sourcePath);
+    if (!existsSync(p)) return null;
+    this.#db = new Database(p, { readonly: true });
+    return this.#db;
+  }
+
+  close() { if (this.#db) { this.#db.close(); this.#db = null; } }
+
+  #nodeRows(ids) {
+    if (ids.length === 0) return [];
+    const db = this.#db;
+    const ph = ids.map(() => "?").join(",");
+    return db.prepare(
+      `SELECT id, kind, name, file_path, start_line, end_line FROM nodes WHERE id IN (${ph})`
+    ).all(...ids);
+  }
+
+  // Generic BFS over edges. fromCol = the column we match the frontier on;
+  // toCol = the column we collect as the next frontier.
+  #walk(start, { fromCol, toCol, maxDepth }) {
+    const db = this.#db;
+    const stmt = db.prepare(`SELECT DISTINCT ${toCol} AS next FROM edges WHERE ${fromCol} = ?`);
+    const seen = new Set();
+    let frontier = [start];
+    let depth = 0;
+    while (frontier.length && depth < maxDepth) {
+      const nextFrontier = [];
+      for (const node of frontier) {
+        for (const row of stmt.all(node)) {
+          if (row.next && row.next !== start && !seen.has(row.next)) {
+            seen.add(row.next);
+            nextFrontier.push(row.next);
+          }
+        }
+      }
+      frontier = nextFrontier;
+      depth += 1;
+    }
+    return [...seen];
+  }
+
+  #unavailable() {
+    return { engine: "unavailable", reason: `no graph at ${dbPath(this.#sourcePath)} — run graph-index`,
+      staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Transitive dependents of a node — "what breaks if I change X". */
+  blastRadius({ node, maxDepth = 25 }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { fromCol: DEPENDENTS_BY,
+      toCol: DEPENDENTS_BY === "target" ? "source" : "target", maxDepth });
+    return { node, dependents: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Direct dependents only (depth 1). */
+  callers({ node }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { fromCol: DEPENDENTS_BY,
+      toCol: DEPENDENTS_BY === "target" ? "source" : "target", maxDepth: 1 });
+    return { node, callers: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+
+  /** Transitive dependencies of a node — downstream lineage. */
+  lineage({ node, maxDepth = 25 }) {
+    if (!this.#open()) return this.#unavailable();
+    const ids = this.#walk(node, { fromCol: DEPENDENCIES_BY,
+      toCol: DEPENDENCIES_BY === "target" ? "source" : "target", maxDepth });
+    return { node, dependencies: this.#nodeRows(ids), staleness: staleness(this.#sourcePath) };
+  }
+}
+```
+
+> Note for the implementer: `#walk`'s `toCol` is derived inline so dependents collect the opposite column from the one matched. If Task 1 flips `DEPENDENTS_BY` to `"source"`, the derivations follow automatically — no other change needed.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `node --test test/codegraph-client.test.mjs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/lib/codegraph-client.mjs server/test/codegraph-client.test.mjs
+git commit -m "feat(codegraph): graph client — blast-radius/callers/lineage over edges"
+```
+
+---
+
+## Task 5: Wire the `graph-*` server actions
+
+**Files:**
+- Modify: `server/bin/wicked-brain-server.mjs` (the `actions` object ~L135–306; `WRITE_ACTIONS` set ~L311–321)
+- Test: `server/test/codegraph-actions.test.mjs` (Create)
+
+> The server constructs collaborators once at startup (`db`, `lsp`) from `brainPath`/`sourcePath`. Add a codegraph client + index runner the same way and register four actions. `graph-index` mutates → add to `WRITE_ACTIONS`.
+
+- [ ] **Step 1: Write the failing test (handlers are pure functions of params)**
+
+```javascript
+// server/test/codegraph-actions.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { makeGraphActions } from "../lib/codegraph-actions.mjs";
+
+function repoWithGraph() {
+  const repo = mkdtempSync(join(tmpdir(), "cg-act-"));
+  mkdirSync(join(repo, ".codegraph"), { recursive: true });
+  const db = new Database(join(repo, ".codegraph", "codegraph.db"));
+  db.exec(`CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+    file_path TEXT, language TEXT, start_line INT, end_line INT, start_column INT,
+    end_column INT, updated_at INT, signature TEXT);
+    CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, metadata TEXT, provenance TEXT);`);
+  db.prepare(`INSERT INTO nodes (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)
+    VALUES (?,?,?,?,?,?,1,1,0,0,0,NULL)`).run("file:a.py","file","a.py","a.py","a.py","python");
+  db.prepare(`INSERT INTO nodes (id,kind,name,qualified_name,file_path,language,start_line,end_line,start_column,end_column,updated_at,signature)
+    VALUES (?,?,?,?,?,?,1,1,0,0,0,NULL)`).run("file:b.py","file","b.py","b.py","b.py","python");
+  db.prepare("INSERT INTO edges (source,target,kind,metadata,provenance) VALUES (?,?,?,?,?)")
+    .run("file:b.py","file:a.py","imports",null,"static");
+  db.close();
+  return repo;
+}
+
+test("graph-blast-radius action returns dependents", () => {
+  const repo = repoWithGraph();
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    const r = actions["graph-blast-radius"]({ node: "file:a.py" });
+    assert.deepEqual(r.dependents.map((d) => d.id), ["file:b.py"]);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("graph-blast-radius on a graphless repo reports unavailable", () => {
+  const repo = mkdtempSync(join(tmpdir(), "cg-none-"));
+  try {
+    const actions = makeGraphActions({ sourcePath: repo });
+    assert.equal(actions["graph-blast-radius"]({ node: "x" }).engine, "unavailable");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `node --test test/codegraph-actions.test.mjs`
+Expected: FAIL — `Cannot find module '../lib/codegraph-actions.mjs'`.
+
+- [ ] **Step 3: Implement the action factory**
+
+```javascript
+// server/lib/codegraph-actions.mjs
+import { CodegraphClient } from "./codegraph-client.mjs";
+import { runIndex, staleness } from "./codegraph-index.mjs";
+
+/**
+ * Build the graph-* action handlers bound to a source repo. A fresh client per
+ * call keeps the readonly DB handle short-lived and always reopens after a rebuild.
+ */
+export function makeGraphActions({ sourcePath, brainPath } = {}) {
+  const withClient = (fn) => {
+    const c = new CodegraphClient(sourcePath);
+    try { return fn(c); } finally { c.close(); }
+  };
+  return {
+    "graph-blast-radius": (p = {}) => withClient((c) => c.blastRadius({ node: p.node, maxDepth: p.maxDepth })),
+    "graph-callers": (p = {}) => withClient((c) => c.callers({ node: p.node })),
+    "graph-lineage": (p = {}) => withClient((c) => c.lineage({ node: p.node, maxDepth: p.maxDepth })),
+    "graph-index": async () => {
+      const r = await runIndex(sourcePath, { brainPath, sourcePath });
+      return { ...r, staleness: staleness(sourcePath) };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `node --test test/codegraph-actions.test.mjs`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Register actions in the server**
+
+In `server/bin/wicked-brain-server.mjs`, near where `lsp`/`db` are constructed, add:
+
+```javascript
+import { makeGraphActions } from "../lib/codegraph-actions.mjs";
+// ... after sourcePath/brainPath are known:
+const graphActions = makeGraphActions({ sourcePath, brainPath });
+```
+
+Then spread the handlers into the `actions` object (alongside the `lsp-*` block ~L238–248):
+
+```javascript
+  ...graphActions,   // graph-index, graph-blast-radius, graph-callers, graph-lineage
+```
+
+And add the mutating one to the `WRITE_ACTIONS` set (~L311–321):
+
+```javascript
+const WRITE_ACTIONS = new Set([
+  /* ...existing... */
+  "graph-index",
+]);
+```
+
+- [ ] **Step 6: Smoke the live server action**
+
+```bash
+cd /Users/michael.parcewski/Projects/wicked-brain/server
+# in repo /tmp/cg-spike from Task 1, with .codegraph already built:
+node bin/wicked-brain-server.mjs --brain /tmp/cg-spike-brain --port 4399 --source /tmp/cg-spike &
+SRV=$!; sleep 1
+curl -s -XPOST localhost:4399/api -H 'content-type: application/json' \
+  -d '{"action":"graph-blast-radius","params":{"node":"file:a.py"}}'
+kill $SRV
+```
+Expected: JSON with a `dependents` array containing `file:b.py` and a `staleness` object.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/lib/codegraph-actions.mjs server/test/codegraph-actions.test.mjs server/bin/wicked-brain-server.mjs
+git commit -m "feat(codegraph): register graph-* server actions"
+```
+
+---
+
+## Task 6: `wicked-brain:graph` skill + trim the LSP skill
+
+**Files:**
+- Create: `skills/wicked-brain-graph/SKILL.md`
+- Modify: `skills/wicked-brain-lsp/SKILL.md` (frontmatter description only)
+
+- [ ] **Step 1: Create the graph skill**
+
+```markdown
+---
+name: wicked-brain:graph
+description: |
+  Code-relationship graph queries — blast radius, callers, and lineage — backed
+  by a codegraph static graph the brain owns. Answers "what breaks if I change X",
+  "who calls X", and "what does X depend on" across the whole repo, including
+  relationships a grep or single-file LSP lookup cannot see.
+
+  Use when: "blast radius", "what breaks if I change", "impact of changing X",
+  "who calls X", "what depends on X", "lineage", "what does X depend on",
+  "architecture map", "code relationship graph".
+---
+
+# wicked-brain:graph
+
+Relationship-graph intelligence over a codegraph-built SQLite graph. Distinct from
+`wicked-brain:lsp` (live, single-symbol def/ref/hover/diagnostics) — this is the
+whole-repo relationship graph and the home of blast-radius / lineage.
+
+## Queries (via `npx wicked-brain-call`)
+
+- `graph-index` — build/refresh the graph (`codegraph index .`). Run once per repo,
+  then on demand when results report they are stale.
+- `graph-blast-radius {node}` — transitive dependents of `node` ("what breaks if I change it").
+- `graph-callers {node}` — direct dependents only.
+- `graph-lineage {node}` — transitive dependencies (downstream).
+
+`node` ids follow codegraph's convention (e.g. `file:src/app.py`, or a symbol id).
+Every result carries a `staleness` stamp (`commits_behind`, `indexed_at`); if
+`stale` is true, re-run `graph-index`.
+
+## Freshness
+
+Lazy by design — the graph is never auto-rebuilt by a file watcher. Results tell you
+when they are behind HEAD; rebuild with `graph-index` (or wire the optional commit hook).
+```
+
+- [ ] **Step 2: Trim the LSP skill description**
+
+In `skills/wicked-brain-lsp/SKILL.md` frontmatter, remove the `"blast radius"` and `"architecture map"` trigger phrases from the `Use when:` line (they were never implemented in LSP and now live in `wicked-brain:graph`). Add a one-line pointer in the body:
+
+```markdown
+> For blast-radius / lineage / architecture (whole-repo relationships), use `wicked-brain:graph`.
+```
+
+- [ ] **Step 3: Verify install picks up the new skill**
+
+```bash
+cd /Users/michael.parcewski/Projects/wicked-brain
+node install.mjs 2>&1 | grep -i "skills installed"
+ls ~/.claude/skills/wicked-brain-graph/SKILL.md
+```
+Expected: install reports the skill count incremented by one; the file exists.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/wicked-brain-graph/SKILL.md skills/wicked-brain-lsp/SKILL.md
+git commit -m "feat(codegraph): wicked-brain:graph skill; move blast-radius off lsp skill"
+```
+
+---
+
+## Task 7: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite green**
+
+Run: `cd /Users/michael.parcewski/Projects/wicked-brain/server && npm test`
+Expected: all tests pass, including the four new files.
+
+- [ ] **Step 2: Real-repo blast-radius**
+
+```bash
+# Point at a real repo (e.g. wicked-brain itself), build, query.
+cd /Users/michael.parcewski/Projects/wicked-brain
+npx -y @colbymchenry/codegraph index .
+node server/bin/wicked-brain-server.mjs --brain ~/.wicked-brain/projects/cg-e2e --port 4398 --source "$PWD" &
+SRV=$!; sleep 1
+curl -s -XPOST localhost:4398/api -H 'content-type: application/json' \
+  -d '{"action":"graph-callers","params":{"node":"file:server/lib/sqlite-search.mjs"}}' | head -c 400
+kill $SRV
+```
+Expected: a `callers` array (non-empty if anything imports that module) + a `staleness` stamp with `stale:false` right after indexing.
+
+- [ ] **Step 3: Commit (if any doc tweaks)**
+
+```bash
+git add -A && git commit -m "test(codegraph): phase-1a e2e verification notes" || echo "nothing to commit"
+```
+
+---
+
+## Self-review (done at write time)
+
+- **Spec coverage:** D1 (brain owns queries) → Tasks 4–6. D2 (zero garden dep) → all code is brain-native `.mjs`, imports nothing from garden. D4 (codegraph=graph of record, LSP=live) → Task 6 moves blast-radius off LSP. D5 (lazy staleness, no watcher) → Task 3 staleness + Task 5 `graph-index` on demand, watcher untouched. D6 (DB stays codegraph-native) → `dbPath` = `<source>/.codegraph/codegraph.db`, opened readonly. D3 (extractor registry) + injected edges are **Phase 1b** — explicitly out of this plan.
+- **Placeholder scan:** none — every step has runnable code/commands. The one empirical unknown (edge direction) is isolated to Task 1 + the `DEPENDENTS_BY` constant.
+- **Type consistency:** `resolveCodegraph`, `dbPath`, `staleness`, `runIndex`, `CodegraphClient.{blastRadius,callers,lineage,close}`, `makeGraphActions` names are consistent across tasks and tests. Result shapes (`{dependents|callers|dependencies, staleness}` / `{engine:"unavailable"}`) match between client, actions, and their tests.
+- **Scope:** single shippable subsystem (graph-core); injected edges and garden-side work deferred to named follow-on plans.

--- a/docs/plans/2026-06-10-codegraph-to-brain-phase1b-injected-edges.md
+++ b/docs/plans/2026-06-10-codegraph-to-brain-phase1b-injected-edges.md
@@ -1,0 +1,44 @@
+# Codegraph → Brain, Phase 1b: Injected Edges + Extractor Registry — Plan
+
+> **For agentic workers:** executed via subagent-driven-development against the wicked-brain repo (branch `feat/codegraph-graph-core`, same as Phase 1a). Builds on Phase 1a's `codegraph-client`/`codegraph-index`.
+
+**Goal:** Materialize wicked-ecosystem **injected edges** (grep-/static-invisible, string-wired relationships) into the codegraph graph so blast-radius/lineage traverse them — with a pluggable registry so brain ships generic extractors and any plugin can drop in proprietary ones (Decision D3). **Zero garden dependency.**
+
+**Repo:** `/Users/michael.parcewski/Projects/wicked-brain` (worktree `.claude/worktrees/codegraph-phase1a`).
+
+---
+
+## Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| B1 | Brain **ships** built-in extractors that read only target-repo files/conventions: **bus** (`_bus_consumers.json` + emit sites), **dispatch** (`subagent_type:` in `commands/**/*.md` → `agents/<d>/<n>.md`), **capability** (agent `tool-capabilities:` frontmatter → `capability:<name>` nodes, **frontmatter-only — no registry import**). | These are wicked-bus / Claude-plugin conventions, not garden internals. No garden code is imported (the garden `capability` extractor's `_capability_registry` import is dropped — registry *filtering* becomes a drop-in concern). |
+| B2 | **Drop-in registry**: brain scans `<sourcePath>/.codegraph-extractors/*.mjs`, dynamic-imports each, runs its `extract({db, sourcePath, nodes})`. Absent dir → no-op. | D3 mechanism. Garden's proprietary archetype extractor (Phase 2) drops in here. Dependency points target→brain only; brain never imports the drop-in's repo. |
+| B3 | Extractors write to the codegraph SQLite **read-write** (better-sqlite3). Each is **idempotent**: `DELETE FROM edges WHERE provenance=?` (its own), re-insert. Self-node markdown/virtual nodes via `ensureFileNode`/`ensureVirtualNode` (codegraph indexes code, not .md — issue garden#916). | Matches the garden Python extractors' contract; injected edges co-locate in the same `nodes`/`edges` tables as the static graph (ADR 0001). |
+| B4 | `graph-index` runs the codegraph build **then** all extractors (built-in + drop-in) in one pass, so a single action yields the complete graph. Re-index drops injected edges (codegraph rebuild) → extractors re-apply every run. | One front door; blast-radius never sees a stale/empty injected layer. |
+
+Edge convention (from Phase-1a contract): edge `(source, target, kind, metadata, provenance)`; injected edges use `kind="references"`, `provenance="injected:<mechanism>"`, semantics in `metadata`. Direction matches static edges so `DEPENDENTS_BY="target"` blast-radius surfaces the dependent (e.g. consumer is a dependent of producer ⇒ edge `source=consumer? ...`). **NB:** the garden bus extractor inserts `edge(source=producer, target=consumer)`; verify against Phase-1a blast-radius direction during implementation and align so blast-radius(producer) surfaces the consumer (see Task B-real).
+
+## File structure (brain `server/`)
+
+| File | Responsibility |
+|---|---|
+| `lib/codegraph-nodes.mjs` | `ensureFileNode(db, relpath, lang?)`, `ensureVirtualNode(db, id, kind, name, filePath?)` — idempotent `INSERT OR IGNORE` populating all NOT NULL node cols. Port of `_graph_nodes.py`. |
+| `lib/codegraph-extractors/bus.mjs` | `extract({db, sourcePath})` — read `scripts/_bus_consumers.json` + grep `wicked|wg.x` event strings in `scripts/**/*.py`; insert producer→consumer edges (`injected:bus`). |
+| `lib/codegraph-extractors/dispatch.mjs` | command→agent edges from `subagent_type:` handles resolving to `agents/<d>/<n>.md` (`injected:dispatch`). |
+| `lib/codegraph-extractors/capability.mjs` | agent→`capability:<name>` edges from `tool-capabilities:` frontmatter (`injected:capability`); creates virtual capability nodes. |
+| `lib/codegraph-extract.mjs` | registry: `BUILTINS=[bus,dispatch,capability]`; `discoverDropins(sourcePath)` scans `<sourcePath>/.codegraph-extractors/*.mjs`; `runExtractors({db, sourcePath})` runs all, returns `{<label>:counts, total_injected_edges, dropins:[...]}`. Fail-open per extractor. |
+| `bin/wicked-brain-server.mjs` | `graph-index` action: after `runIndex`, open db read-write, `runExtractors`, return build + injection stats + staleness. |
+| `test/codegraph-nodes.test.mjs`, `test/codegraph-extract.test.mjs`, per-extractor tests | fixtures with the wiring; assert edges materialized + idempotency + drop-in discovery (present/absent). |
+
+## Tasks (TDD, subagent-driven)
+
+- **B1 nodes**: `codegraph-nodes.mjs` + test (ensure file/virtual node idempotent; all NOT NULL cols set).
+- **B2 bus extractor**: `extractors/bus.mjs` + test (fixture repo with `scripts/_bus_consumers.json` + a producer .py emitting the event + the consumer module node; assert producer→consumer edge with `injected:bus`; idempotent re-run).
+- **B3 dispatch + capability extractors** + tests (fixture command/agent .md with `subagent_type:` and `tool-capabilities:`).
+- **B4 registry**: `codegraph-extract.mjs` + test (runs builtins; discovers a drop-in `.mjs` in `.codegraph-extractors/` and runs it; absent dir → builtins only; one failing extractor doesn't abort the rest).
+- **B5 wire `graph-index`** to run extractors after build + test (action returns injection stats; read actions unaffected).
+- **B-real**: real-repo test — point brain at **wicked-garden**, `graph-index`, then `graph-blast-radius` on a bus producer module; assert a consumer wired only via the event string appears in the blast radius (a link grep cannot find). This is the Phase-1b acceptance + part of the goal's "tested on a real repo".
+
+## Out of scope
+Registry-filtered capability validation (drop-in concern); hooks event→script extractor (additive later); import-node→file resolution (Phase 1a limitation).

--- a/docs/specs/2026-06-10-codegraph-to-brain-migration.md
+++ b/docs/specs/2026-06-10-codegraph-to-brain-migration.md
@@ -1,0 +1,168 @@
+# North-Star Spec — move the code-relationship graph from `wicked-garden` into `wicked-brain`
+
+- **Date:** 2026-06-10
+- **Status:** Design (approved shape; pending written-spec review → implementation plan)
+- **Author:** brainstormed with Mike Parcewski
+- **Topic:** Relocate the codegraph-backed relationship graph (engine integration, injected-edge extractors, and the blast-radius / lineage / architecture query surface) out of `wicked-garden` and into `wicked-brain`, so any project — not just ones running garden — gets enhanced code/graph knowledge.
+- **Related:** docs/adr/0001-code-relationship-graph-engine.md (**this spec amends/inverts it**), docs/required-peers.md, `scripts/_codegraph.py`, `scripts/codegraph/`, the `wicked-brain-lsp` skill.
+
+---
+
+## 1. Context & motivation
+
+There are currently **two half-built code-intelligence stacks** answering overlapping questions in different places:
+
+- **garden's codegraph stack** — `scripts/_codegraph.py` (peer shim) + `scripts/codegraph/inject_*.py` (injected-edge extractors), feeding `search:blast-radius` / `search:lineage` and (eventually) wicked-patch's `--db`. Introduced by ADR 0001 (dated 2026-06-09).
+- **brain's LSP stack** — the `wicked-brain-lsp` skill already advertises "blast radius" and "architecture map" via language servers.
+
+Two blast-radius implementations, two homes, one concept. The smell is structural: **"what breaks if I change X" / "what flows where" / "what's connected to this" are knowledge questions about relationships** — and brain *is* the knowledge layer. Code-relationship comprehension is a thinking pattern, and thinking patterns belong in brain.
+
+ADR 0001 noticed `search:blast-radius` was "wrongly" calling the brain and concluded *pull the graph into garden*. **That was the wrong direction.** The original instinct (blast-radius = brain) was right; the fix is to move the *graph* to brain, not move the *query* to garden. The decisive secondary requirement: the graph is **valuable to everyone**, and requiring all of wicked-garden just to give a repo enhanced code/graph knowledge is unacceptable. The graph must be a standalone brain capability with **zero garden dependency**.
+
+**Thesis:** brain *knows* (the relationship graph + every query over it). Garden *does* (deterministic refactor, gates, archetypes) and is merely a *consumer* of the graph.
+
+---
+
+## 2. Decisions (locked)
+
+Settled during brainstorming; the spine of this spec.
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Ownership: brain owns the graph + all relationship queries; garden consumes.** The *knowing*-vs-*doing* line: brain knows (blast-radius, lineage, impact, callers, architecture); garden does (wicked-patch refactor, gates, archetypes). | Blast-radius is knowledge; knowledge lives in brain. Unifies the two stacks under one owner. **Amends ADR 0001.** |
+| D2 | **Dependency arrow points garden→brain only, never back.** Brain is fully valuable standalone for code/graph knowledge. | "Don't require all of garden just for brain to have graph knowledge." The graph is universally valuable. |
+| D3 | **Proprietary edges via a pluggable extractor-drop registry (option i).** Brain defines an extractor interface + a discovery dir, *ships* the generic/ecosystem extractors itself, and discovers + runs plugin-dropped extractors if present (ignores if absent). | Most "injected" edges are ecosystem/platform conventions (bus wiring, plugin frontmatter, hooks), not garden internals — brain should know them natively. The genuinely garden-proprietary ones (archetypes) drop in without a reverse dependency. Generalizes to any wicked-* plugin. |
+| D4 | **codegraph = graph of record; LSP = live precision (option A).** codegraph owns the persistent relationship graph, injected edges, and blast-radius / lineage / architecture. LSP keeps def/ref/hover/diagnostics and **stops being a second blast-radius**. No fusion layer. | LSP cannot represent injected edges (it only knows language semantics) and has no persistent whole-repo graph; codegraph is the only layer that can. Two clean lanes, each doing what it's best at. YAGNI on a merge/facade. |
+| D5 | **Freshness: lazy staleness-stamp baseline + optional commit-hook accelerator (A + C). No watcher full-reindex.** | The 40%-CPU runaway diagnosed on 2026-06-10 *was* a reindex loop (watcher → polling → repeated re-index). Lazy + staleness-stamped is structurally incapable of that failure. Commit-hook is an opt-in accelerator (garden's compiler already installs git hooks — precedent). |
+| D6 | **DB stays codegraph-native: `<repo>/.codegraph/codegraph.db` (per-repo, gitignored).** Brain records a pointer + staleness, does not relocate it. | It is codegraph's stable, self-describing contract; consumers (wicked-patch `--db`) expect it; it travels with the repo. |
+
+---
+
+## 3. Target architecture
+
+```
+codegraph CLI (peer, resolved via env→config→PATH→node_modules→npx)
+        │ index
+        ▼
+ <repo>/.codegraph/codegraph.db   ── per-repo, gitignored, codegraph-native ──┐
+        ▲                                                                      │
+        │ inject                                                               │ read
+  ┌─────┴──────────────────────────────────────────────┐                      │
+  │ brain BUILT-IN extractors (ship with brain):        │                      │
+  │   • bus producer→consumer  (emit + _bus_consumers)   │                      │
+  │   • command→agent          (subagent_type:)          │                      │
+  │   • hook event→script      (hooks.json)              │                      │
+  │   • agent→tool             (capability registry)     │                      │
+  │ brain DISCOVERED extractors (drop-in, optional):     │                      │
+  │   • garden: archetype→playbook/gate (archetypes.json)│                      │
+  └──────────────────────────────────────────────────────┘                     │
+                                                                                │
+ LSP servers ──live──▶ def/ref/hover/diagnostics      ◀── SEPARATE LANE         │
+                                                          (not blast-radius)     │
+                                                                                 │
+ brain GRAPH QUERIES  ◀───────────────────────────────────────────────────────┘
+   blast-radius · lineage · impact · callers · architecture
+   every answer carries a staleness stamp (N commits behind HEAD, indexed-at)
+
+ CONSUMERS:
+   • brain skill  `wicked-brain-graph`  (new) — the query surface
+   • garden wicked-patch (rename/add-field/remove) — consumes .codegraph.db as --db
+   • any other plugin
+```
+
+### 3.1 Component responsibilities
+
+| Component | Home | Does | Depends on |
+|---|---|---|---|
+| codegraph engine | external peer (`@colbymchenry/codegraph`, MIT) | static multi-language graph, column-precise, SQLite | Node ≥ 22.5 |
+| engine integration (resolve + run + staleness) | **brain** | resolution ladder, `index`, `impact`/`callers`, staleness stamp | codegraph peer |
+| extractor framework + interface + discovery | **brain** | define interface, discover + run extractors | — |
+| built-in extractors (bus / command→agent / hooks / capability) | **brain** | materialize ecosystem-convention edges | brain graph |
+| `wicked-brain-graph` skill | **brain** | blast-radius / lineage / impact / callers / architecture | brain graph |
+| LSP intelligence (`wicked-brain-lsp`) | **brain** | live def/ref/hover/diagnostics (blast-radius role removed) | language servers |
+| archetype extractor (drop-in) | **garden** | materialize archetype→gate edges into brain's graph | brain extractor interface |
+| wicked-patch (rename/add-field/remove) | **garden** | deterministic refactor; consumes `.codegraph.db` as `--db` | brain graph DB shape |
+
+---
+
+## 4. What moves / what stays
+
+| Today (garden) | Disposition | Note |
+|---|---|---|
+| `scripts/_codegraph.py` (engine shim, staleness) | **→ brain** | **Cross-language re-home, not a file copy** — brain's server is Node; this is Python. Re-implemented in brain's runtime. The resolution-ladder + staleness *semantics* port verbatim. |
+| `scripts/codegraph/inject_edges.py` (bus) | **→ brain built-in extractor** | reads `_bus_consumers.json` + emit sites — a wicked-bus convention, not a garden internal |
+| `scripts/codegraph/inject_dispatch_edges.py` (command→agent) | **→ brain built-in extractor** | `subagent_type:` is a Claude-Code plugin convention |
+| `scripts/codegraph/inject_capability_edges.py` (agent→tool) | **→ brain built-in extractor** | capability registry — ecosystem-wide |
+| `scripts/codegraph/_graph_nodes.py`, `inject_all.py` | **→ brain** | shared helpers + the orchestration entry |
+| archetype→gate extractor (proprietary; future) | **garden ships as drop-in** | discovered by brain at runtime; brain works without it |
+| `scripts/engineering/patch/{codegraph_db,patch}.py` | **stays garden** | repoint `--db` to `<repo>/.codegraph/codegraph.db`; a *doing* action |
+| `commands/search/{blast-radius,lineage,hotspots,index}.md` | **thin aliases → brain skills, or removed** | the query surface is brain's now |
+| `tests/codegraph/test_codegraph.py` | **engine/extractor tests → brain; garden keeps drop-in + patch-consumer tests** | |
+
+---
+
+## 5. Freshness & failure modes
+
+### 5.1 Freshness (D5)
+- **Baseline (lazy + staleness-stamped):** brain stamps how far `.codegraph.db` is behind HEAD (commits-behind + indexed-at — the `staleness()` logic already in `_codegraph.py`). Reindex runs **on explicit demand** or **when a query finds the graph stale past a threshold**. Zero idle CPU.
+- **Accelerator (opt-in, commit-driven):** a git `post-commit` / `pre-push` hook triggers reindex so the graph is commit-fresh. Off by default.
+- **Explicitly NOT** watcher-driven full reindex — that is the failure class diagnosed on 2026-06-10.
+
+### 5.2 Failure modes (fail-closed, never vacuous)
+| Condition | Behavior |
+|---|---|
+| codegraph unresolvable (no peer) | query returns `engine: "unavailable"` — **not** an empty/zero-edge graph that looks like a real answer |
+| graph stale | answer is returned **with** a `stale: true, commits_behind: N` flag; caller decides |
+| drop-in extractor absent | skipped silently — the standalone guarantee (D2) |
+| shim subprocess error/timeout | surfaced as data (`{error: ...}`), never raises (R4) |
+
+---
+
+## 6. Testing & the standalone guarantee
+
+- Engine resolver: resolution ladder (env → config → PATH → node_modules → npx) + the set-but-empty kill-switch.
+- Staleness math: present/absent DB, commits-behind computation, fail-open on git errors.
+- Each built-in extractor: deterministic edge materialization against a fixture repo (producer→consumer, command→agent, hooks, capability).
+- Extractor-drop discovery: present (runs) vs absent (skipped, graph still valid).
+- Query correctness: blast-radius / lineage over a known fixture graph with injected edges grep cannot see.
+- **Standalone guarantee (the load-bearing test):** brain's graph module imports **nothing** from garden — enforced in CI (the inverse of the compiler's existing "emitted gate imports nothing from the garden" AST test). This is what keeps D2's one-way arrow from silently regressing.
+
+---
+
+## 7. Implementation decomposition
+
+Two phases, sequenced — garden phase depends on brain having shipped the graph.
+
+### Phase 1 — `wicked-brain`
+1. Engine integration (resolve + `index` + `impact`/`callers` + staleness), Node-native.
+2. Extractor framework: interface + discovery dir + registry.
+3. Built-in extractors: bus, command→agent, hooks, capability.
+4. Graph query surface + new `wicked-brain-graph` skill (blast-radius / lineage / impact / callers / architecture).
+5. Remove blast-radius/architecture from `wicked-brain-lsp`'s advertised surface (keep live ops).
+6. Freshness: staleness stamp + opt-in commit hook.
+7. Standalone CI test (zero garden imports).
+
+### Phase 2 — `wicked-garden`
+1. Repoint wicked-patch (`codegraph_db.py` / `patch.py`) to brain's `.codegraph.db`.
+2. Ship the archetype extractor as a brain drop-in.
+3. Convert `search:{blast-radius,lineage,hotspots,index}` commands to thin aliases over brain skills, or remove.
+4. Delete the migrated `scripts/_codegraph.py` + `scripts/codegraph/*` from garden.
+5. **Amend ADR 0001** (record the inversion: graph → brain, not garden) — likely a new ADR 0004 superseding the relevant section.
+6. Update CLAUDE.md (storage/search sections) to point at brain for graph queries.
+
+---
+
+## 8. Out of scope (YAGNI)
+
+- A unified LSP+codegraph graph or a query facade over both (D4 rejected B and C).
+- Watcher-driven incremental reindex (D5 rejected B).
+- Relocating the graph DB under brain's project dir (D6 — keep codegraph-native).
+- Any general data-flow lineage layer beyond what codegraph + injected edges provide (deferred; was ADR 0001 roadmap step 5).
+
+---
+
+## 9. Related operational findings (non-blocking)
+
+Surfaced while diagnosing why brain appeared "down" on 2026-06-10 (separate from this migration, tracked separately):
+- **wicked-brain bug:** file-watcher polling fallback (after EMFILE) re-indexes unchanged files in a hot loop → ~40% CPU runaway. This spec's D5 ensures the *codegraph* reindex path cannot reproduce that class of bug, but the watcher bug itself is a brain-repo fix.
+- **wicked-garden bug:** the brain reachability probe (`_brain_api` / `_check_search_staleness`, 2s timeout) collapses slow/down/errored/non-JSON into one "not reachable — start wicked-brain" message, mis-reporting an up-but-slow server. Dogfooding issue to be filed.


### PR DESCRIPTION
## What
Design docs for relocating the code-relationship graph from wicked-garden into wicked-brain (knowing-vs-doing: brain owns the graph + queries; garden consumes). **Amends ADR 0001**, which had pulled the graph toward garden — inverted here so any repo gets graph knowledge without requiring garden.

- `docs/specs/2026-06-10-codegraph-to-brain-migration.md` — decisions D1–D6 (brain ownership, zero-garden-dependency, pluggable extractor-drop registry, codegraph=graph-of-record / LSP=live, lazy staleness + opt-in commit hook, codegraph-native DB).
- `docs/plans/2026-06-10-codegraph-to-brain-phase1a-graph-core.md` — the executed Phase-1a plan.

Implementation (Phase 1a) lands in the wicked-brain repo (separate PR). Phase 1b + Phase 2 plans follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)