### PR TITLE
chore: add Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>mikeparcewski/wicked-ci#v1.1.0"
+  ]
+}


### PR DESCRIPTION
Adds `renovate.json` extending the shared `wicked-ci#v1.1.0` preset so garden joins the family's grouped Action/dep upgrade cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)