### PR TITLE
fix(pages): build at domain root for custom domain wg.wickedagile.com

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,12 +26,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Resolve the deploy target. A committed site/public/CNAME means a CUSTOM DOMAIN rooted at
+      # "/" (assets must resolve from the domain root, not a repo subpath); without one we're a
+      # GitHub Pages PROJECT site under /<repo>. Deriving from the CNAME keeps this fork-friendly:
+      # forks with no CNAME build as a project site, forks with one build at their domain root.
+      - name: Resolve deploy target (custom domain vs project site)
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          if [ -f site/public/CNAME ]; then
+            DOMAIN="$(tr -d '[:space:]' < site/public/CNAME)"
+            echo "SITE_URL=https://$DOMAIN" >> "$GITHUB_ENV"
+            echo "BASE_PATH=/" >> "$GITHUB_ENV"
+            echo "Custom domain → site=https://$DOMAIN base=/"
+          else
+            echo "SITE_URL=https://$OWNER.github.io" >> "$GITHUB_ENV"
+            echo "BASE_PATH=/$REPO" >> "$GITHUB_ENV"
+            echo "Project site → base=/$REPO"
+          fi
+
       - name: Build with Astro
         uses: withastro/action@v6
-        # Derive site + base from the repo so this works on any fork without edits.
-        env:
-          SITE_URL: https://${{ github.repository_owner }}.github.io
-          BASE_PATH: /${{ github.event.repository.name }}
+        # SITE_URL + BASE_PATH come from the resolve step above (ambient via $GITHUB_ENV).
         with:
           path: ./site
           node-version: 22

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+wg.wickedagile.com


### PR DESCRIPTION
## Problem

After switching GitHub Pages to the custom domain **wg.wickedagile.com**, assets 404 — the page requests `/wicked-garden/_astro/…`.

`pages.yml` hard-codes the build target from repo metadata:
```
SITE_URL: https://<owner>.github.io
BASE_PATH: /<repo>          # → /wicked-garden
```
So Astro keeps rewriting assets under `/wicked-garden/…`, which is correct for a project site but wrong for a custom domain rooted at `/`. The deploy target changed; the build base didn't.

## Fix

Derive the target from a committed **`site/public/CNAME`**:
- **CNAME present** → `SITE_URL=https://<domain>`, `BASE_PATH=/` (custom domain, root)
- **CNAME absent** → `SITE_URL=https://<owner>.github.io`, `BASE_PATH=/<repo>` (project site)

Also commits `site/public/CNAME` (`wg.wickedagile.com`) so the domain is canonical and **survives every deploy** (Astro copies `public/` → output). Fork-friendly: forks without a CNAME still build as a project site.

Repo-context values (`owner`/`repo`) moved into `env:` (no interpolation in `run:`).

## Verified locally
`SITE_URL=https://wg.wickedagile.com BASE_PATH=/ npm run build`:
- `index.html` → `/_astro/index.*.css`, `/favicon.svg` (root-relative)
- **zero** `/wicked-garden/` references
- `dist/CNAME` = `wg.wickedagile.com`

Merging to `main` triggers the Pages deploy and fixes the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)