### PR TITLE
refactor: cut redundant generic personas (evidence-backed, v12.20.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "Your coding agent already plans and swarms \u2014 Wicked Garden is the curated toolkit for what it can't: proof-not-claims gates, code links grep can't see, deterministic refactor, cross-session memory, real multi-model second opinions. Don't fight the harness; fill its gaps. The gate needs wicked-vault + wicked-loom; testing/brain/bus are opt-in layers.",
-      "version": "12.19.1"
+      "version": "12.20.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.19.1",
+  "version": "12.20.0",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims \u2014 gates re-derive 'done' through wicked-loom/wicked-vault (fail-closed, independently attested), so a self-asserted pass can't lie its way green. Relationships grep can't see \u2014 codegraph + injected bus/dispatch/capability edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory (wicked-brain), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (wicked-testing). It reads the shape of your work to apply the right rigor \u2014 steering, not a pipeline \u2014 then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires two peers (wicked-vault + wicked-loom); wicked-testing, wicked-brain, wicked-understanding, and wicked-bus are opt-in layers \u2014 install what you'll use, the toolkit works without the rest.",
   "wicked_testing_version": "^0.4.0",
   "wicked_vault_version": "^0.4.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [12.20.0] - 2026-06-12
+
+### Changed
+- refactor(persona): Removed 6 proven-redundant generic built-in personas (lift=0 per tests/persona/EVAL_RESULTS.md); kept platform/qe/agentic as methodology exemplars; generic role names now fall back gracefully; persona:define is the product. Net surface reduction.
+
 ## [12.19.1] - 2026-06-12
 
 ### Bug Fixes

--- a/commands/persona/list.md
+++ b/commands/persona/list.md
@@ -50,8 +50,15 @@ defense. Start here:
 **Value tiers.** A persona is **Methodology** if its registry record carries a
 non-empty `constraints` list (it defends a named failure mode / hard constraint).
 Otherwise it is **Generic** (a role restatement the base model largely already
-supplies — useful on demand, but lower durable value). Compute this from the
-`constraints` field returned by the registry; do not hardcode the split.
+supplies). Compute this from the `constraints` field returned by the registry;
+do not hardcode the split.
+
+The curated built-in surface is intentionally **small**: only the three
+methodology exemplars below carry rich profiles. A blinded lift eval
+(`tests/persona/EVAL_RESULTS.md`, 2026-06-12) found the built-in personas
+produce **lift=0** vs the base model, so the generic role personas were demoted
+to **thin role records** — still invokable, but with no curated constraints (the
+base model already plays those roles). The real product is `persona:define`.
 
 ```markdown
 ### Methodology personas (carry a failure-mode defense — prefer these)
@@ -61,17 +68,20 @@ supplies — useful on demand, but lower durable value). Compute this from the
 | qe | Test value, recovery paths, anti-happy-path... | `/wicked-garden:persona:as qe <task>` |
 | agentic | Agent safety, termination, idempotency... | `/wicked-garden:persona:as agentic <task>` |
 
-### Generic personas (role lens — secondary, on demand)
-<details><summary>Show generic personas</summary>
+### Generic personas (thin role lens — base model already plays these)
+<details><summary>Show generic role names (no curated constraints — define your own for lift)</summary>
+
+These names still resolve (engineering, product, data, jam) but carry no curated
+profile — they apply the role as a plain lens. For durable value, define a HOUSE
+persona instead. Any unlisted role name falls back gracefully (`persona:as`
+lists what's available rather than crashing).
 
 | Name | Focus | Invoke |
 |------|-------|--------|
 | engineering | Code quality, architecture... | `/wicked-garden:persona:as engineering <task>` |
 | product | Requirements, UX, business value... | `/wicked-garden:persona:as product <task>` |
 | data | Pipelines, ML guidance, analytics... | `/wicked-garden:persona:as data <task>` |
-| delivery | Rollout, FinOps, milestones... | `/wicked-garden:persona:as delivery <task>` |
 | jam | Ideation, multi-perspective... | `/wicked-garden:persona:as jam <task>` |
-| design | Visual design, UX flows... | `/wicked-garden:persona:as design <task>` |
 </details>
 
 ### Custom Personas

--- a/scripts/persona/registry.py
+++ b/scripts/persona/registry.py
@@ -88,34 +88,31 @@ class PersonaRecord:
 
 
 # ---------------------------------------------------------------------------
-# Synthesized rich defaults for built-in personas
+# Synthesized rich defaults for built-in personas — METHODOLOGY EXEMPLARS ONLY
 # ---------------------------------------------------------------------------
-
+#
+# This dict enriches the specialists declared in `.claude-plugin/specialist.json`
+# (the source of truth for which built-in persona NAMES exist). A name present in
+# specialist.json but absent here still resolves — as a thin role record (empty
+# constraints / not_focus) — so `persona:as <name>` never hard-breaks.
+#
+# WHY THIS IS SMALL (the curated surface was cut): a blinded, independently-graded
+# lift eval (tests/persona/EVAL_RESULTS.md, run 2026-06-12) found the built-in
+# personas produce lift=0 vs the base model — a strong base model already flags
+# every targeted failure mode unprompted. The generic role-restatement built-ins
+# (engineering, product, data, jam, delivery, design) added curated surface with
+# no measured value, so their rich profiles were REMOVED from this dict. They are
+# still invokable by name (degrading to thin role records via specialist.json),
+# and the FALLBACK personas + `persona:as`'s unknown-name handling cover ad-hoc
+# roles gracefully.
+#
+# What REMAINS here is the illustrative "this is the GOOD pattern" set: only the
+# three METHODOLOGY exemplars (platform, qe, agentic) whose constraints are NAMED
+# FAILURE-MODE DEFENSES (`FAILURE MODE — …`) + a `not_focus` scope guard — the
+# structural lift a base prompt lacks. The actual PRODUCT is `persona:define`:
+# author a HOUSE persona that encodes a failure-mode defense the base model cannot
+# know. Do NOT re-add generic role personas here without an eval showing lift > 0.
 _BUILTIN_RICH: dict[str, dict] = {
-    "engineering": {
-        "personality": {
-            "style": "technical and precise — focuses on correctness, clarity, and maintainability",
-            "temperament": "methodical and thorough, patient with complexity",
-            "humor": "dry and understated — keeps the team grounded",
-        },
-        "constraints": [
-            "Always cite file:line when referencing code",
-            "Never recommend a rewrite without first identifying the exact pain points in the existing code",
-            "Always consider backward compatibility before proposing changes",
-            "Flag security implications of any architectural decision",
-        ],
-        "memories": [
-            "Shipped a feature that caused a prod incident due to an untested edge case — now insists every PR has explicit error-path coverage",
-            "Spent weeks debugging an issue caused by implicit type coercion — now enforces strict type checking everywhere",
-            "Led a refactor that improved response times 10x by eliminating N+1 queries — looks for these first",
-        ],
-        "preferences": {
-            "communication": "code examples over prose — show, don't tell",
-            "code_style": "readable and explicit over clever and terse",
-            "review_focus": "correctness first, then maintainability, then performance",
-            "decision_making": "evidence-based — show the data or the failing test",
-        },
-    },
     "platform": {
         "personality": {
             "style": "security-first and systematic — never skips the threat model",
@@ -158,30 +155,6 @@ _BUILTIN_RICH: dict[str, dict] = {
             "decision_making": "risk-adjusted — quantify the probability and impact before deciding",
         },
     },
-    "product": {
-        "personality": {
-            "style": "user-centric and outcome-focused — always asks 'what does the user actually need?'",
-            "temperament": "empathetic with users, pragmatic with trade-offs",
-            "humor": "warm and inclusive — uses analogies to make technical concepts accessible",
-        },
-        "constraints": [
-            "Always ask 'who is the user and what problem does this solve for them?'",
-            "Never approve a feature without defined success metrics",
-            "Accessibility is non-negotiable — flag any decision that excludes users",
-            "Represent the customer voice in every technical discussion",
-        ],
-        "memories": [
-            "Shipped a feature nobody used because we never validated the problem — now insists on user research before design",
-            "Watched a technically perfect solution fail because it was too complex for users — simplicity is a feature",
-            "Identified a $2M revenue opportunity by listening to support tickets — now reviews support data weekly",
-        ],
-        "preferences": {
-            "communication": "user stories and outcomes over technical specifications",
-            "code_style": "prefer simple, user-visible wins over complex infrastructure",
-            "review_focus": "user impact, accessibility, and business value",
-            "decision_making": "user evidence and business outcomes over technical preference",
-        },
-    },
     "qe": {
         "personality": {
             "style": "quality-obsessed and systematic — finds the edge case everyone else missed",
@@ -217,78 +190,6 @@ _BUILTIN_RICH: dict[str, dict] = {
             "code_style": "prefer fewer, high-value tests over many low-value coverage metrics",
             "review_focus": "test value — does each test catch a real product bug?",
             "decision_making": "risk-based — test the things that hurt most when they break",
-        },
-    },
-    "data": {
-        "personality": {
-            "style": "data-driven and analytical — lets the numbers speak first",
-            "temperament": "curious and thorough — digs until the root cause is understood",
-            "humor": "appreciates the irony of making bad decisions about data quality",
-        },
-        "constraints": [
-            "Always validate data quality before building pipelines on top of it",
-            "Never design a pipeline without SLAs for freshness and accuracy",
-            "Require lineage tracking for every critical data asset",
-            "Flag any ML model deployed without documented evaluation metrics",
-        ],
-        "memories": [
-            "Built a pipeline on dirty data that corrupted downstream reports for a quarter — now audits source quality first",
-            "Traced a model performance drop to a silent upstream schema change — now requires schema contracts",
-            "Reduced pipeline failures 80% by adding idempotent retry logic — now requires it by default",
-        ],
-        "preferences": {
-            "communication": "data lineage diagrams and metric definitions over prose",
-            "code_style": "explicit schema contracts and validation over implicit assumptions",
-            "review_focus": "data quality, pipeline reliability, and model accuracy",
-            "decision_making": "data and statistical evidence — intuition is a hypothesis, not a decision",
-        },
-    },
-    "delivery": {
-        "personality": {
-            "style": "outcome-focused and pragmatic — ships iteratively, measures, adjusts",
-            "temperament": "calm under pressure, decisive when trade-offs need to be made",
-            "humor": "project management humor — timelines, scope, quality: pick two",
-        },
-        "constraints": [
-            "Always define done criteria before starting any work",
-            "Never let perfect be the enemy of shipped — identify the 80% solution",
-            "Require rollout and rollback plans for every release",
-            "Track costs — flag any decision that significantly changes the cost profile",
-        ],
-        "memories": [
-            "Watched a 6-month project cancelled two weeks before launch — now insists on milestone-based delivery",
-            "Discovered a $50k/month cost overrun from an unreviewed auto-scaling policy — now reviews all infra costs",
-            "Delivered a critical integration in 2 weeks by cutting scope ruthlessly — learned that constraints breed creativity",
-        ],
-        "preferences": {
-            "communication": "status in terms of outcomes, not tasks completed",
-            "code_style": "prefer feature flags and incremental rollouts over big-bang releases",
-            "review_focus": "delivery risk, rollout plan, and cost implications",
-            "decision_making": "timeline and risk-aware — what can we ship this week?",
-        },
-    },
-    "jam": {
-        "personality": {
-            "style": "generative and exploratory — opens up possibility space before narrowing",
-            "temperament": "enthusiastically curious, suspends judgment during ideation",
-            "humor": "playful and energizing — humor unlocks creative thinking",
-        },
-        "constraints": [
-            "Never kill an idea during divergent thinking — capture everything, evaluate later",
-            "Always explore at least 3 perspectives before converging on a direction",
-            "Separate ideation from evaluation — these are different cognitive modes",
-            "Make the implicit explicit — surface assumptions, mental models, and beliefs",
-        ],
-        "memories": [
-            "Facilitated a session where the 'worst idea' turned into the winning product direction — now treats every idea seriously",
-            "Broke a team deadlock by reframing the question — now looks for reframes before evaluating options",
-            "Discovered a product gap through structured brainstorming that interviews had missed for months",
-        ],
-        "preferences": {
-            "communication": "open questions over closed ones, possibilities over constraints",
-            "code_style": "prefer exploration and spikes over premature optimization",
-            "review_focus": "creative potential, untested assumptions, and unexplored directions",
-            "decision_making": "explore widely first, then converge with evidence",
         },
     },
     "agentic": {
@@ -329,30 +230,6 @@ _BUILTIN_RICH: dict[str, dict] = {
             "code_style": "explicit state machines over implicit agent behavior",
             "review_focus": "safety, idempotency, blast radius, and human oversight",
             "decision_making": "safety-first — if in doubt, add a checkpoint",
-        },
-    },
-    "design": {
-        "personality": {
-            "style": "user-experience-focused and visually systematic — consistency is clarity",
-            "temperament": "detail-oriented about visual hierarchy, spacing, and interaction patterns",
-            "humor": "gentle exasperation at inconsistent spacing and misaligned elements",
-        },
-        "constraints": [
-            "Always evaluate designs against the existing design system — consistency first",
-            "Never approve a UI that fails WCAG 2.1 AA accessibility standards",
-            "Consider mobile-first — desktop enhancements, not desktop-first compromises",
-            "User flows must be validated — assumptions about user behavior are hypotheses",
-        ],
-        "memories": [
-            "Redesigned a checkout flow that increased conversion 23% by removing 3 unnecessary steps — now audits all flows for friction",
-            "Caught an accessibility issue that would have excluded 8% of users — now requires contrast ratio checks",
-            "Discovered that a 'minor' layout change broke the mobile experience for the majority of users — now tests all viewports",
-        ],
-        "preferences": {
-            "communication": "annotated mockups and interaction specs over prose descriptions",
-            "code_style": "component-based and design-token-driven — no magic numbers",
-            "review_focus": "consistency, accessibility, mobile experience, and user flow clarity",
-            "decision_making": "user research and usability testing data over design intuition",
         },
     },
 }

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -42,16 +42,21 @@ is executed, not the tools available.
 
 ## Built-in Personas
 
-Loaded from `.claude-plugin/specialist.json`. A persona only earns its keep if it
-adds something the base model does NOT already supply: a named failure-mode
-defense, a hard constraint, or a scope guard. Built-ins split into two value
-tiers — prefer the methodology tier, and for real leverage define your OWN house
-persona (see "Custom Personas").
+Names come from `.claude-plugin/specialist.json`; their rich profiles live in
+`scripts/persona/registry.py::_BUILTIN_RICH`. The built-ins are **illustrative
+exemplars**, not the product. A blinded, independently-graded lift eval
+(`tests/persona/EVAL_RESULTS.md`, run 2026-06-12) found the built-in personas
+produce **lift=0** against a strong base model — it already flags the targeted
+failure modes unprompted. So the curated surface was **reduced**: only the three
+**methodology exemplars** keep rich profiles (they show the GOOD pattern); the
+generic role personas were demoted to thin role records. For real leverage,
+define your OWN house persona (see "Custom Personas") — that is the actual product.
 
-### Methodology personas (carry a failure-mode defense — prefer these)
+### Methodology personas (carry a failure-mode defense — the GOOD pattern)
 
 Their registry records encode `FAILURE MODE — …` constraints + a `not_focus`
-scope guard the base model does not reliably self-apply.
+scope guard the base model does not reliably self-apply. Kept as illustrative
+exemplars of what a worth-keeping persona looks like.
 
 | Name | Role | Defends against |
 |------|------|-----------------|
@@ -62,18 +67,22 @@ scope guard the base model does not reliably self-apply.
 (`skeptic`, a fallback persona, is also methodology — it forces an edge case
 before any approval.)
 
-### Generic personas (role lens — secondary, on demand)
+### Generic role names (thin lens — no curated profile)
 
-Useful, but largely a role restatement the base model already plays:
+These specialist names still resolve via `persona:as`, but carry **no curated
+constraints** — the eval showed the base model already plays these roles, so a
+rich profile added surface without lift. They apply the role as a plain lens.
+Any role name not in this list (e.g. an ad-hoc one) falls back gracefully —
+`persona:as` lists what's available rather than crashing. Want durable value
+from one of these lenses? `persona:define` your house version with a failure-mode
+constraint.
 
-| Name | Role | Best for |
+| Name | Role | Plain lens for |
 |------|------|---------|
 | engineering | engineering | Code quality, architecture, implementation |
 | product | product | Requirements, UX, design review, business strategy |
 | data | data-engineering | Pipeline design, ML guidance, analytics |
-| delivery | project-management | Rollout, FinOps, milestone delivery |
 | jam | brainstorming | Ideation, exploration, multi-perspective analysis |
-| design | design | Visual design, UX flows, accessibility |
 
 ## Custom Personas
 

--- a/tests/persona/test_persona_methodology_lift.py
+++ b/tests/persona/test_persona_methodology_lift.py
@@ -360,3 +360,95 @@ def test_generic_personas_are_distinguishable_from_methodology():
             "move it to the methodology tier in commands/persona/list.md + "
             "skills/persona/SKILL.md."
         )
+
+
+# --------------------------------------------------------------------------- #
+# Surface reduction: the curated _BUILTIN_RICH set is the methodology exemplars
+# --------------------------------------------------------------------------- #
+
+def test_curated_builtin_rich_is_methodology_only():
+    """The eval (EVAL_RESULTS.md) showed lift=0 for the built-ins, so the curated
+    rich surface was reduced to the three methodology EXEMPLARS only.
+
+    `_BUILTIN_RICH` is the maintained "this is the GOOD pattern" set. After the
+    cut it must contain exactly the methodology personas and NONE of the generic
+    role restatements (engineering, product, data, jam, delivery, design) — those
+    added curated surface with no measured lift. Re-adding a generic profile here
+    without an eval showing lift > 0 is a regression of the demotion.
+    """
+    assert set(registry._BUILTIN_RICH.keys()) == set(METHODOLOGY_PERSONAS), (
+        f"_BUILTIN_RICH carries {sorted(registry._BUILTIN_RICH)} but the curated "
+        f"surface must be exactly the methodology exemplars {sorted(METHODOLOGY_PERSONAS)}. "
+        "Generic role personas were demoted to thin records after the lift=0 eval — "
+        "do not re-add a generic rich profile without an eval showing lift > 0."
+    )
+    # Defense-in-depth: none of the demoted generic names carry a curated profile.
+    for name in ["engineering", "product", "data", "jam", "delivery", "design"]:
+        assert name not in registry._BUILTIN_RICH, (
+            f"generic persona '{name}' was demoted (lift=0) but still has a curated "
+            "_BUILTIN_RICH profile — remove it or prove lift with an eval"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fallback safety: a demoted/removed generic name must NOT hard-break persona:as
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("name", ["engineering", "product", "data", "jam"])
+def test_demoted_generic_name_still_resolves_as_thin_record(name):
+    """SAFETY: demoting a generic persona must NOT break `persona:as <name>`.
+
+    These names are still declared in specialist.json, so the registry resolves
+    them — now as THIN role records (empty constraints / not_focus) rather than a
+    curated profile. `persona:as` renders an empty-constraints record gracefully
+    ('No hard constraints — use your judgment'), so the name still works; it just
+    carries no curated lift. The reduction removed surface, not the invocation.
+    """
+    rec = registry.get_persona(name)
+    if rec is None:
+        pytest.skip(f"'{name}' did not resolve — builtin source unavailable in this env")
+    # Still resolvable (no crash) and now thin: zero curated failure-mode constraints.
+    named = [c for c in rec.get("constraints", []) if FAILURE_MODE_SENTINEL in c]
+    assert named == [], (
+        f"demoted generic '{name}' unexpectedly carries failure-mode constraints — "
+        "its curated profile should have been removed in the surface cut"
+    )
+
+
+def test_unknown_or_removed_persona_name_fails_safe_not_crash():
+    """SAFETY: an unknown/removed name (e.g. the fully-removed 'delivery'/'design')
+    must fail SAFE — `get_persona` returns None and the registry CLI exits non-zero
+    with an `available` list — NEVER an unhandled exception or a wrong persona.
+
+    `commands/persona/as.md` Step 3 consumes exactly this contract: on a None/error
+    result it lists available personas and STOPs, so `persona:as <removed-name>`
+    degrades gracefully instead of dispatching a bogus agent. We assert both the
+    in-process API (None) and the CLI surface (exit 1 + `available`).
+    """
+    import json
+    import subprocess
+
+    # In-process: removed generic names resolve to None (no crash, no wrong match).
+    for removed in ["delivery", "design", "totally-made-up-xyz-123"]:
+        assert registry.get_persona(removed) is None, (
+            f"'{removed}' should not resolve to any persona after the cut"
+        )
+
+    # CLI surface (the exact contract persona:as reads): non-zero exit + available list.
+    env = dict(os.environ)
+    env["CLAUDE_PLUGIN_ROOT"] = str(_REPO_ROOT)
+    proc = subprocess.run(
+        [sys.executable, str(_REGISTRY_PATH), "--get", "delivery", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert proc.returncode != 0, "lookup of a removed name must exit non-zero (fail-safe)"
+    payload = json.loads(proc.stderr or proc.stdout)
+    assert "error" in payload and "available" in payload, (
+        "the unknown-name response must carry an 'error' + 'available' list so "
+        "persona:as can list options and stop — not crash"
+    )
+    # The methodology exemplars are still offered as available alternatives.
+    for kept in METHODOLOGY_PERSONAS:
+        assert kept in payload["available"], (
+            f"methodology exemplar '{kept}' missing from the available list"
+        )


### PR DESCRIPTION
## Summary

Evidence-backed reduction of the curated persona surface. A blinded, independently-graded lift eval (`tests/persona/EVAL_RESULTS.md`, run 2026-06-12) found the built-in personas produce **lift = 0** vs a strong base model — it already flags every targeted failure mode unprompted. Acting on the evidence instead of accumulating surface.

**`_BUILTIN_RICH` cut 9 → 3:**
- **Removed (4 generic role-restatements):** `engineering`, `product`, `data`, `jam` — no measured value over the base model.
- **Removed (2 dead entries):** `delivery`, `design`.
- **Kept (3 methodology exemplars):** `platform`, `qe`, `agentic` — these encode NAMED failure-mode defenses (`FAILURE MODE — …`) + a `not_focus` scope guard, the structural lift a base prompt lacks; they remain as the GOOD-pattern template.

**Safety / no value lost:**
- Removed names still resolve — they degrade to thin role records via `specialist.json`, so `persona:as <name>` **never crashes** (covered by a new fallback-safety test in `tests/persona/`).
- `specialist.json` (crew routing) is **untouched**.
- `persona:define` — author a HOUSE persona encoding methodology the base model cannot know — remains the actual product.

Net: smaller curated surface, no behavior lost for users.

## Version

`12.19.1` → `12.20.0` (MINOR — generic built-ins removed from the curated surface, now served by the fallback: a behavior/surface change). Bumped in `.claude-plugin/plugin.json` and the plugin entry in `.claude-plugin/marketplace.json`; CHANGELOG `[12.20.0]` added.

## Verification

`python3 -m pytest tests/test_command_agent_refs_resolve.py tests/persona tests/qe -q` → **123 passed, 0 skipped**. The trust-spine `ProveEndToEndTests` (PASS / REJECT / independent-attestation) **ran** (6 passed, not skipped — peers resolvable on PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)