### PR TITLE
fix(site): correct stale family agent count 80→67

### DIFF
--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -371,7 +371,9 @@ export function colorVarOf(id: RoleId): string {
 export const STATS = {
   projects: PROJECTS.length,
   accounts: 0,
-  agents: 80,
+  // Hand-maintained family-wide agent total = garden 23 + testing 40 + brain 4.
+  // Update on any agent add/cut (garden was 36, cut to 23 in the v12 lift-eval pass).
+  agents: 67,
   archetypes: 9,
   harnesses: 7,
 };


### PR DESCRIPTION
The GitHub Pages Hero stat showed a hardcoded `agents: 80`. After the evidence-based v12 cut of 13 garden agents (36→23), the real family total is **67** (garden 23 + testing 40 + brain 4 — also = 80 − 13). Added a maintenance comment with the breakdown. Site-only change (Astro), plugin manifests untouched; Pages redeploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)