### PR TITLE
feat(jam,swarm): registry-driven multi-CLI council + parallel-verification swarm

### DIFF
--- a/.claude-plugin/components.json
+++ b/.claude-plugin/components.json
@@ -4,7 +4,7 @@
   "summary": {
     "commands": 77,
     "agents": 23,
-    "skills": 66,
+    "skills": 67,
     "hooks": 13,
     "specialists": 7
   },
@@ -36,6 +36,7 @@
     "runtime-exec": ["runtime-exec"],
     "search": ["codebase-narrator"],
     "smaht": ["discovery", "intent", "propose-skills", "smaht"],
+    "swarm": ["swarm"],
     "wickedizer": ["wickedizer"],
     "workflow": ["workflow"],
     "worktrees": ["worktrees"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "Your coding agent already plans and swarms \u2014 Wicked Garden is the curated toolkit for what it can't: proof-not-claims gates, code links grep can't see, deterministic refactor, cross-session memory, real multi-model second opinions. Don't fight the harness; fill its gaps. The gate needs wicked-vault + wicked-loom; testing/brain/bus are opt-in layers.",
-      "version": "12.23.0"
+      "version": "12.24.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.23.0",
+  "version": "12.24.0",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims \u2014 gates re-derive 'done' through wicked-loom/wicked-vault (fail-closed, independently attested), so a self-asserted pass can't lie its way green. Relationships grep can't see \u2014 codegraph + injected bus/dispatch/capability edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory (wicked-brain), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (wicked-testing). It reads the shape of your work to apply the right rigor \u2014 steering, not a pipeline \u2014 then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires two peers (wicked-vault + wicked-loom); wicked-testing, wicked-brain, wicked-understanding, and wicked-bus are opt-in layers \u2014 install what you'll use, the toolkit works without the rest.",
   "wicked_testing_version": "^0.4.0",
   "wicked_vault_version": "^0.4.0",

--- a/agents/jam/council.md
+++ b/agents/jam/council.md
@@ -35,38 +35,88 @@ then come back with 2-4 specific options.
 Proceeding with open-ended evaluation...
 ```
 
-### 2. Detect Available CLIs
+### 2. Detect + Probe Available CLIs (registry-driven)
 
-Check which external LLM CLIs are available:
+Do NOT hand-maintain a `which` list. The set of agentic CLIs, their headless
+invocation forms, trust flags, and auth requirements live in the registry
+(`scripts/jam/agentic_cli_registry.py`, 20+ CLIs). Detection AND a usability
+**probe** are driven by `scripts/jam/detect_clis.py`:
 
 ```bash
-which codex 2>/dev/null && echo "codex:available" || echo "codex:missing"
-which copilot 2>/dev/null && echo "copilot:available" || echo "copilot:missing"
-which gemini 2>/dev/null && echo "gemini:available" || echo "gemini:missing"
-which opencode 2>/dev/null && echo "opencode:available" || echo "opencode:missing"
-which pi 2>/dev/null && echo "pi:available" || echo "pi:missing"
-which aider 2>/dev/null && echo "aider:available" || echo "aider:missing"
-which llm 2>/dev/null && echo "llm:available" || echo "llm:missing"
-which aichat 2>/dev/null && echo "aichat:available" || echo "aichat:missing"
-which goose 2>/dev/null && echo "goose:available" || echo "goose:missing"
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/jam/detect_clis.py" --probe --json
 ```
 
-### 3. Quorum Check
+This returns:
+```json
+{
+  "detected":   [{"key","display_name","binary","resolved_path","version", ...}],
+  "usable":     ["gemini","copilot", ...],
+  "unusable":   [{"cli":"codex","reason":"auth: 401 ..."}, ...],
+  "collisions": [{"binary":"grok","keys":["grok","grok-cli"]}]
+}
+```
 
-| Available External CLIs | Behavior |
-|------------------------|----------|
-| 0 | Refuse council. Suggest `/wicked-garden:jam:brainstorm` instead. |
-| 1 | Run as "brainstorm with external guest" — warn this isn't a true council. |
+**Why probe, not just detect:** a binary on PATH is not a usable council seat.
+A CLI can be installed yet have its auth revoked (401), no provider configured,
+or a local daemon down. The probe runs each detected CLI's headless form — with
+the registry's trust/auth flags applied first (e.g. codex `--skip-git-repo-check`,
+gemini `--skip-trust`, copilot `--allow-all-tools`) — on a trivial prompt,
+**sandboxed** in a fresh tempdir, **stdin from devnull**, under a per-CLI
+**timeout**, and classifies each:
+
+- **usable** — sane reply came back.
+- **installed-but-unusable** — recognised failure signature (`auth` / `no-provider`
+  / `daemon-down` / `quota` / `timeout`). These do NOT count toward quorum.
+
+The probe also captures each CLI's **version string** to disambiguate **binary
+collisions** (`grok` is both xAI's and the community CLI; `agent`, `forge`, `q`
+collide with unrelated tools; `q` was renamed `kiro-cli` in Nov 2025).
+
+Only the `usable` external CLIs are convened. Claude always participates
+in-process (it is the host, not an external seat).
+
+### 3. Quorum Check (on USABLE external CLIs)
+
+Quorum is counted over **usable external** CLIs (from the probe's `usable`
+list), never raw detections.
+
+| Usable External CLIs | Behavior |
+|----------------------|----------|
+| 0 | No external seats. **Fall back to the subagent tier** (step 3.5) — never refuse outright. If even that is unavailable, suggest `/wicked-garden:jam:brainstorm`. |
+| 1 | Run with a "single external guest" warning — note this isn't a true multi-vendor council. Optionally top up with subagent seats (step 3.5). |
 | 2+ | Full council mode. |
 
-If below quorum:
+If zero usable external CLIs were found, state what was detected-but-unusable
+and why, so the user can fix auth/config:
 ```
-Council requires 2+ independent external LLM CLIs for meaningful multi-model deliberation.
-Found: {count} external CLI(s).
+Council found {detected} installed CLI(s) but {unusable} are unusable
+(e.g. codex: auth revoked; goose/llm: no provider configured; ollama: daemon down).
+Filling council seats with Task() subagents instead (see below).
+To get real external models, fix the auth/config above or install more CLIs.
+```
 
-Suggestion: Use /wicked-garden:jam:brainstorm for single-model exploration,
-or install additional CLIs (codex, copilot, gemini, opencode, pi, aider, llm, aichat, goose).
+### 3.5. Fallback: the alt-execution (subagent) tier
+
+**A council must always have a real, plural set of independent perspectives.**
+If fewer than 2 **usable external** CLIs are available, fill the empty seats
+with `Task()` subagents so deliberation still happens. These are *in-harness*
+seats (still Claude-family), so they are a weaker form of diversity than
+external vendors — label them as such in the synthesis. Each subagent:
+
+- gets the SAME question scaffold (step 4),
+- runs in isolation (no subagent sees another's output — dispatch in parallel),
+- is given a distinct framing persona so the perspectives differ
+  (e.g. "architect", "security reviewer", "operator/SRE", "skeptic").
+
 ```
+Task(subagent_type="wicked-garden:crew:reviewer",
+     prompt="You are the COUNCIL's {persona} seat. Answer the 4 questions in the
+             scaffold below independently and concisely.\n\n{scaffold}")
+```
+
+Aim to reach at least 2-3 total seats (external + subagent). Always disclose in
+the synthesis which seats were external CLIs vs subagent fallbacks.
 
 ### 4. Build Question Scaffold
 
@@ -88,68 +138,55 @@ Answer these 4 questions:
 4. DISQUALIFIER: Is any option fundamentally unviable? If so, which one and why? If all are viable, say "None."
 ```
 
-### 5. Dispatch to External CLIs (ISOLATION ENFORCED)
+### 5. Convene the Usable External CLIs (ISOLATION ENFORCED, registry-driven)
 
-**Non-negotiable**: Each model responds independently. No model sees another model's output. All calls run in parallel.
+**Non-negotiable**: Each model responds independently. No model sees another
+model's output. No CLI sees another CLI's output. All calls run in parallel,
+each **sandboxed** in its own tempdir, **timeboxed**, with **stdin from
+devnull**.
 
-For each available CLI, dispatch the question scaffold:
+Do NOT hardcode a per-CLI bash block. Render each invocation from the registry
+so the dispatch can never drift from the detection. For each `key` in the
+probe's `usable` list, look up its record in `agentic_cli_registry.py` and
+build the command from `headless_invocation` + `trust_flags`, feeding the
+scaffold per the record's `input_mode`:
 
-Write the question scaffold to a temp file first, then pipe to each CLI. This avoids shell quoting issues with apostrophes and special characters in the topic/options.
+| `input_mode` | How the scaffold is delivered |
+|--------------|-------------------------------|
+| `prompt-arg` | substitute the scaffold into `{PROMPT}` in the template |
+| `stdin`      | pipe the scaffold file into the command on stdin |
+| `at-file`    | attach the scaffold file (e.g. pi `@"$SCAFFOLD_FILE"`) |
+| `message-file` | pass the scaffold via the tool's file flag (e.g. aider `--message-file`) |
+| `model-arg`  | local runners — insert `{MODEL}` then the prompt (probe skips these unless a model is known) |
+
+Write the scaffold to a temp file once (avoids shell-quoting issues with
+apostrophes / special chars in the topic), then render+dispatch per CLI:
 
 ```bash
-# Write scaffold to temp file (done once)
-SCAFFOLD_FILE="${TMPDIR:-/tmp}/council-scaffold-$$.md"
+SCAFFOLD_FILE="$(python3 -c 'import tempfile,os;print(os.path.join(tempfile.gettempdir(),"council-scaffold.md"))')"
 cat > "$SCAFFOLD_FILE" <<'SCAFFOLD_EOF'
 {question_scaffold_content}
 SCAFFOLD_EOF
 ```
 
-**Codex:**
+The registry already encodes the trust/auth flags each CLI needs for headless
+use (codex `--skip-git-repo-check`, gemini `--skip-trust`, copilot
+`--allow-all-tools`, aider's inline `--yes-always --no-git --no-auto-commits
+--no-stream --no-analytics`, amp `--dangerously-allow-all`, etc.). Apply them;
+do not re-derive them by hand. Example renders for `prompt-arg` CLIs (gemini,
+copilot, opencode-run, codex-exec) — substitute the scaffold text for
+`{PROMPT}`:
+
 ```bash
-cat "$SCAFFOLD_FILE" | codex exec "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
+gemini -p "<scaffold>" --skip-trust
+copilot -p "<scaffold>" --allow-all-tools
+opencode run "<scaffold>"
+codex exec "<scaffold>" --skip-git-repo-check
 ```
 
-**Copilot:**
-```bash
-cat "$SCAFFOLD_FILE" | copilot -p "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely." --output-format text --available-tools=""
-```
-
-**Gemini:**
-```bash
-cat "$SCAFFOLD_FILE" | gemini "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
-```
-
-**OpenCode:**
-```bash
-cat "$SCAFFOLD_FILE" | opencode run "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
-```
-
-**Pi** (npm `@mariozechner/pi-coding-agent` — uses `@file` attach + `-p` for non-interactive):
-```bash
-pi -p "You are evaluating options for a technical decision. Answer the 4 questions in the attached file precisely and concisely." @"$SCAFFOLD_FILE"
-```
-
-**Aider** (code-editor orientation — use `--no-git --yes-always --no-auto-commits` to answer without touching files; needs a writable cwd):
-```bash
-aider --message-file "$SCAFFOLD_FILE" --no-git --yes-always --no-auto-commits --no-stream --no-analytics 2>&1
-```
-
-**llm** (Simon Willison's `llm` — pipe-native; picks up default model from `llm models default`):
-```bash
-cat "$SCAFFOLD_FILE" | llm "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
-```
-
-**aichat** (multi-provider aggregator — `-S` disables streaming so output is captured cleanly):
-```bash
-cat "$SCAFFOLD_FILE" | aichat -S "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
-```
-
-**Goose** (Block Goose agent — `run -i -` reads instructions from stdin):
-```bash
-cat "$SCAFFOLD_FILE" | goose run -i - --system "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely."
-```
-
-Run ALL available CLIs in parallel using multiple Bash tool calls in a single message.
+For `message-file` (aider) and `at-file` (pi) CLIs, pass the scaffold file
+rather than inlining it. Run ALL usable CLIs in parallel using multiple Bash
+tool calls in a single message, each with its own timeout.
 
 ### 6. Claude's Own Evaluation
 
@@ -178,7 +215,10 @@ Each model's response becomes one entry:
 }
 ```
 
-- Use `persona_name` = model name (e.g., "Claude", "Codex", "Copilot", "Gemini", "OpenCode", "Pi", "Aider", "llm", "aichat", "Goose").
+- Use `persona_name` = the CLI's `display_name` from the registry (e.g.
+  "Claude", "Codex", "Gemini", "Copilot", "OpenCode", "Pi", "Antigravity", …).
+  For a subagent fallback seat (step 3.5), use the persona framing and mark it,
+  e.g. `persona_name: "Subagent: architect"`.
 - `persona_type` is always `council` for these entries.
 - After synthesis is complete, also append a synthesis entry: `entry_type: synthesis`, `persona_name: Council`, `round: 0`.
 

--- a/commands/jam/council.md
+++ b/commands/jam/council.md
@@ -7,7 +7,7 @@ archetype_relevance: ["*"]
 
 # /wicked-garden:jam:council
 
-Structured evaluation tool that uses real external LLM CLIs (Codex, Gemini, OpenCode, Pi) to get genuinely independent model perspectives. Unlike brainstorm (free-form creative exploration), council is a **rigid evaluation tool** for when you have defined options and need a verdict.
+Structured evaluation tool that uses real external LLM CLIs — registry-driven (20+ CLIs: Codex, Gemini, Copilot, OpenCode, Pi, Aider, Goose, Amp, Droid, …; see `scripts/jam/agentic_cli_registry.py`) — to get genuinely independent model perspectives. Installed CLIs are detected AND usability-probed via `scripts/jam/detect_clis.py --probe` (auth-revoked / unconfigured / daemon-down CLIs are excluded). When fewer than 2 usable external CLIs are present, council seats are filled with `Task()` subagents so deliberation always happens. Unlike brainstorm (free-form creative exploration), council is a **rigid evaluation tool** for when you have defined options and need a verdict.
 
 **Key distinction**: `quick` = 60s ideation, `brainstorm` = full session (generation/explore), `council` = structured evaluation (decide).
 

--- a/scripts/jam/agentic_cli_registry.py
+++ b/scripts/jam/agentic_cli_registry.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""
+agentic_cli_registry.py — machine-readable registry of agentic / chat / local
+LLM CLIs that wicked-garden's council can convene.
+
+This is the single source of truth for "which command-line LLM tools exist,
+how do you invoke them headlessly, and what auth/trust do they need". It
+mirrors the dataclass + stdlib-only pattern of ``scripts/_capability_registry.py``:
+no third-party imports, ``from __future__ import annotations``, ``@dataclass``,
+detection via ``shutil.which``.
+
+The council orchestration (``agents/jam/council.md``) is driven by this
+registry: it detects installed CLIs, probes their headless usability, and
+renders the per-CLI invocation from these records rather than hardcoding a
+drifting bash block per tool.
+
+Headless invocation templates use a ``{PROMPT}`` placeholder (and ``{MODEL}``
+for local runners). ``trust_flags`` are appended for non-interactive runs so a
+CLI does not block on a permission / trust / git-repo prompt. Records flagged
+``confidence="confirm-on-probe"`` have an UNCERTAIN headless flag — the probe
+in ``detect_clis.py`` must verify them before the council relies on them.
+
+Usage:
+    from agentic_cli_registry import (
+        AGENTIC_CLI_REGISTRY, AgenticCLI, COUNCIL_CLIS, detect,
+    )
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Record type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgenticCLI:
+    """One command-line LLM tool the council can talk to.
+
+    Fields capture everything the orchestrator needs to detect the binary,
+    invoke it headlessly with the SAME prompt every other CLI gets, classify
+    its usability, and disambiguate binary collisions by version string.
+    """
+
+    key: str  # stable registry id (kebab-case)
+    display_name: str  # human-facing name for synthesis attribution
+    binary: str  # primary binary name for shutil.which()
+    vendor: str  # who ships it
+    category: str  # "agentic-coder" | "chat" | "local-runner"
+    headless_invocation: str  # argv-ish template using {PROMPT} (and {MODEL})
+    input_mode: str  # "prompt-arg" | "stdin" | "at-file" | "message-file" | "model-arg"
+    model_flag_style: str  # "-m" | "--model" | "provider-model" | "config-only" | "model-arg" | "none"
+    version_probe: list[str]  # argv to print version (collision disambiguation)
+    auth_hint: str  # what auth / config / daemon it needs
+    install: dict[str, str] = field(default_factory=dict)  # {darwin,linux,generic}
+    trust_flags: list[str] = field(default_factory=list)  # appended for headless runs
+    alt_binaries: list[str] = field(default_factory=list)  # other names the tool may install as
+    confidence: str = "verified"  # "verified" | "confirm-on-probe"
+    collision_note: str = ""  # binary-name collision / rename caveat
+    enabled_for_council: bool = True  # False = excluded from default convening
+
+    def binaries(self) -> list[str]:
+        """Primary binary first, then any alternates."""
+        return [self.binary, *self.alt_binaries]
+
+    def render(self, prompt: str, model: str = "") -> str:
+        """Fill the headless template. {PROMPT} and {MODEL} are substituted;
+        trust flags are NOT injected here (the probe / orchestrator appends
+        them) so this stays a faithful echo of the registry template."""
+        return self.headless_invocation.replace("{PROMPT}", prompt).replace(
+            "{MODEL}", model
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry — one record per CLI
+# ---------------------------------------------------------------------------
+# VERIFIED entries hard-code a confirmed headless form. CONFIRM-ON-PROBE
+# entries have an uncertain headless flag and MUST be verified by the probe
+# before the council relies on them.
+
+AGENTIC_CLI_REGISTRY: dict[str, AgenticCLI] = {
+    # ----- VERIFIED: agentic coders -----
+    "claude": AgenticCLI(
+        key="claude",
+        display_name="Claude",
+        binary="claude",
+        vendor="Anthropic",
+        category="agentic-coder",
+        headless_invocation='claude -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["claude", "--version"],
+        trust_flags=["--dangerously-skip-permissions"],
+        auth_hint="Anthropic OAuth or ANTHROPIC_API_KEY",
+        install={"generic": "bundled with Claude Code"},
+        confidence="verified",
+        collision_note="Council host. Claude participates in-process, not as an external CLI seat.",
+    ),
+    "codex": AgenticCLI(
+        key="codex",
+        display_name="Codex",
+        binary="codex",
+        vendor="OpenAI",
+        category="agentic-coder",
+        headless_invocation='codex exec "{PROMPT}"',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="-m",
+        version_probe=["codex", "--version"],
+        trust_flags=["--skip-git-repo-check"],
+        auth_hint="`codex login` or OPENAI_API_KEY",
+        install={"darwin": "brew install codex", "generic": "npm i -g @openai/codex"},
+        confidence="verified",
+    ),
+    "gemini": AgenticCLI(
+        key="gemini",
+        display_name="Gemini",
+        binary="gemini",
+        vendor="Google",
+        category="agentic-coder",
+        headless_invocation='gemini -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="-m",
+        version_probe=["gemini", "--version"],
+        trust_flags=["--skip-trust"],  # or env GEMINI_CLI_TRUST_WORKSPACE=true
+        auth_hint="Google login or GEMINI_API_KEY",
+        install={"generic": "npm i -g @google/gemini-cli"},
+        confidence="verified",
+    ),
+    "agy": AgenticCLI(
+        key="agy",
+        display_name="Antigravity",
+        binary="agy",
+        vendor="Google Antigravity",
+        category="agentic-coder",
+        headless_invocation='agy -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",  # `agy models` to list
+        version_probe=["agy", "--version"],
+        trust_flags=["--dangerously-skip-permissions"],
+        auth_hint="Antigravity login",
+        install={"generic": "agy install"},
+        confidence="verified",
+    ),
+    "pi": AgenticCLI(
+        key="pi",
+        display_name="Pi",
+        binary="pi",
+        vendor="earendil-works",
+        category="agentic-coder",
+        headless_invocation='pi -p "{PROMPT}"',
+        input_mode="prompt-arg",  # also supports @file attach
+        model_flag_style="provider-model",  # --provider X --model Y
+        version_probe=["pi", "--version"],
+        auth_hint="provider API key (Google default; OpenAI/Anthropic/etc.)",
+        install={"generic": "npm i -g @mariozechner/pi-coding-agent"},
+        confidence="verified",
+    ),
+    "opencode": AgenticCLI(
+        key="opencode",
+        display_name="OpenCode",
+        binary="opencode",
+        vendor="opencode",
+        category="agentic-coder",
+        headless_invocation='opencode run "{PROMPT}"',
+        input_mode="prompt-arg",  # also supports -f file
+        model_flag_style="-m",  # provider/model
+        version_probe=["opencode", "--version"],
+        auth_hint="`opencode auth` provider login",
+        install={"darwin": "brew install opencode", "generic": "https://github.com/sst/opencode"},
+        confidence="verified",
+    ),
+    "aider": AgenticCLI(
+        key="aider",
+        display_name="Aider",
+        binary="aider",
+        vendor="Aider",
+        category="agentic-coder",
+        headless_invocation=(
+            'aider --message "{PROMPT}" --yes-always --no-git '
+            "--no-auto-commits --no-stream --no-analytics"
+        ),
+        input_mode="message-file",  # --message-file FILE preferred for scaffolds; -m to pick model
+        model_flag_style="--model",
+        version_probe=["aider", "--version"],
+        trust_flags=[],  # trust handled inline by the flags in the invocation
+        auth_hint="model provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / …)",
+        install={"darwin": "brew install aider", "generic": "pip install aider-install"},
+        confidence="verified",
+        collision_note="Expects a writable cwd (.aider.* cache); run from a scratch tempdir.",
+    ),
+    "copilot": AgenticCLI(
+        key="copilot",
+        display_name="Copilot",
+        binary="copilot",
+        vendor="GitHub",
+        category="agentic-coder",
+        headless_invocation='copilot -p "{PROMPT}" --allow-all-tools',
+        input_mode="prompt-arg",
+        model_flag_style="--model",
+        version_probe=["copilot", "--version"],
+        trust_flags=["--allow-all-tools"],  # REQUIRED for headless (else blocks on tool approval)
+        auth_hint="GitHub auth (Copilot subscription)",
+        install={"generic": "npm i -g @github/copilot"},
+        confidence="verified",
+    ),
+    "goose": AgenticCLI(
+        key="goose",
+        display_name="Goose",
+        binary="goose",
+        vendor="Block",
+        category="agentic-coder",
+        headless_invocation='goose run -t "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="config-only",
+        version_probe=["goose", "--version"],
+        auth_hint="`goose configure` provider setup",
+        install={"darwin": "brew install block-goose-cli"},
+        confidence="verified",
+    ),
+    "cursor-agent": AgenticCLI(
+        key="cursor-agent",
+        display_name="Cursor Agent",
+        binary="cursor-agent",
+        vendor="Cursor",
+        category="agentic-coder",
+        headless_invocation='cursor-agent -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["cursor-agent", "--version"],
+        alt_binaries=["agent"],
+        auth_hint="`cursor-agent login`",
+        install={"generic": "cursor install"},
+        confidence="verified",
+        collision_note=(
+            "Alt binary 'agent' collides with other tools. QUIRK: `-p` may hang — "
+            "rely on the per-CLI timeout to bound it."
+        ),
+    ),
+    "amp": AgenticCLI(
+        key="amp",
+        display_name="Amp",
+        binary="amp",
+        vendor="Sourcegraph",
+        category="agentic-coder",
+        headless_invocation='amp -x "{PROMPT}"',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="none",
+        version_probe=["amp", "--version"],
+        trust_flags=["--dangerously-allow-all"],
+        auth_hint="Amp API key (consumes credits)",
+        install={"generic": "npm i -g @sourcegraph/amp"},
+        confidence="verified",
+    ),
+    "droid": AgenticCLI(
+        key="droid",
+        display_name="Droid",
+        binary="droid",
+        vendor="Factory",
+        category="agentic-coder",
+        headless_invocation='droid exec "{PROMPT}"',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="none",
+        version_probe=["droid", "--version"],
+        trust_flags=["--auto", "medium"],
+        auth_hint="~/.factory/config.json",
+        install={"generic": "factory install"},
+        confidence="verified",
+    ),
+    "qwen": AgenticCLI(
+        key="qwen",
+        display_name="Qwen Code",
+        binary="qwen",
+        vendor="Alibaba",
+        category="agentic-coder",
+        headless_invocation='qwen -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["qwen", "--version"],
+        auth_hint="OAuth or provider key",
+        install={"generic": "npm i -g @qwen-code/qwen-code"},
+        confidence="verified",
+    ),
+    "openhands": AgenticCLI(
+        key="openhands",
+        display_name="OpenHands",
+        binary="openhands",
+        vendor="OpenHands",
+        category="agentic-coder",
+        headless_invocation='openhands --headless -t "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["openhands", "--version"],
+        auth_hint="LLM config (provider key)",
+        install={"generic": "pip install openhands-ai"},
+        confidence="verified",
+    ),
+    "interpreter": AgenticCLI(
+        key="interpreter",
+        display_name="Open Interpreter",
+        binary="interpreter",
+        vendor="Open Interpreter",
+        category="agentic-coder",
+        headless_invocation='interpreter -y "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["interpreter", "--version"],
+        trust_flags=["-y"],
+        auth_hint="model provider key",
+        install={"generic": "pip install open-interpreter"},
+        confidence="verified",
+        collision_note="Executes code locally by design — treat output as untrusted.",
+    ),
+    "gptme": AgenticCLI(
+        key="gptme",
+        display_name="gptme",
+        binary="gptme",
+        vendor="gptme",
+        category="agentic-coder",
+        headless_invocation='gptme "{PROMPT}" --non-interactive',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["gptme", "--version"],
+        auth_hint="provider API key",
+        install={"generic": "pip install gptme"},
+        confidence="verified",
+    ),
+    "crush": AgenticCLI(
+        key="crush",
+        display_name="Crush",
+        binary="crush",
+        vendor="Charm",
+        category="agentic-coder",
+        headless_invocation='crush run "{PROMPT}" --quiet',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="config-only",
+        version_probe=["crush", "--version"],
+        auth_hint="provider API key",
+        install={"darwin": "brew install charmbracelet/tap/crush"},
+        confidence="verified",
+    ),
+    # ----- VERIFIED: chat clients -----
+    "llm": AgenticCLI(
+        key="llm",
+        display_name="llm",
+        binary="llm",
+        vendor="Simon Willison",
+        category="chat",
+        headless_invocation='llm "{PROMPT}"',
+        input_mode="prompt-arg",  # also pipe-native (stdin)
+        model_flag_style="-m",
+        version_probe=["llm", "--version"],
+        auth_hint="`llm keys set <provider>`",
+        install={"darwin": "brew install llm", "generic": "pip install llm"},
+        confidence="verified",
+    ),
+    "aichat": AgenticCLI(
+        key="aichat",
+        display_name="aichat",
+        binary="aichat",
+        vendor="sigoden",
+        category="chat",
+        headless_invocation='aichat -S "{PROMPT}"',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="-m",  # client:model
+        version_probe=["aichat", "--version"],
+        auth_hint="config provider key",
+        install={"darwin": "brew install aichat"},
+        confidence="verified",
+        collision_note="-S disables streaming so output captures cleanly.",
+    ),
+    "mods": AgenticCLI(
+        key="mods",
+        display_name="mods",
+        binary="mods",
+        vendor="Charm",
+        category="chat",
+        headless_invocation='mods "{PROMPT}"',  # also: echo "{PROMPT}" | mods
+        input_mode="stdin",  # stdin-native; prompt-arg also works
+        model_flag_style="config-only",
+        version_probe=["mods", "--version"],
+        auth_hint="provider API key",
+        install={"darwin": "brew install charmbracelet/tap/mods"},
+        confidence="verified",
+    ),
+    "sgpt": AgenticCLI(
+        key="sgpt",
+        display_name="ShellGPT",
+        binary="sgpt",
+        vendor="shell-gpt",
+        category="chat",
+        headless_invocation='sgpt "{PROMPT}"',
+        input_mode="prompt-arg",  # also accepts stdin
+        model_flag_style="config-only",
+        version_probe=["sgpt", "--version"],
+        trust_flags=[],  # NB: --execute runs shell commands — NEVER enable for council
+        auth_hint="OPENAI_API_KEY",
+        install={"generic": "pip install shell-gpt"},
+        confidence="verified",
+        collision_note="`--execute`/`-s` runs shell commands; council must never pass it.",
+    ),
+    "q": AgenticCLI(
+        key="q",
+        display_name="Amazon Q",
+        binary="q",
+        vendor="Amazon",
+        category="chat",
+        headless_invocation='q chat --no-interactive --trust-all-tools "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["q", "--version"],
+        alt_binaries=["kiro-cli"],
+        trust_flags=["--trust-all-tools"],
+        auth_hint="AWS Builder ID",
+        install={"generic": "AWS CLI install"},
+        confidence="verified",
+        collision_note=(
+            "'q' is a very common binary name (collision risk). QUIRK: renamed to "
+            "`kiro-cli` (Nov 2025) — verify version string before trusting."
+        ),
+    ),
+    # ----- VERIFIED: local runner -----
+    "ollama": AgenticCLI(
+        key="ollama",
+        display_name="Ollama",
+        binary="ollama",
+        vendor="Ollama",
+        category="local-runner",
+        headless_invocation='ollama run {MODEL} "{PROMPT}"',
+        input_mode="model-arg",  # model name then prompt
+        model_flag_style="model-arg",
+        version_probe=["ollama", "--version"],
+        auth_hint="no auth, but REQUIRES the daemon (`ollama serve`) + a pulled model",
+        install={"darwin": "brew install ollama", "generic": "https://ollama.com/download"},
+        confidence="verified",
+        collision_note="Needs a running daemon AND a pulled model; bare `ollama run` with no model fails.",
+    ),
+    # ----- CONFIRM-ON-PROBE: headless flag uncertain, verify before relying -----
+    "grok": AgenticCLI(
+        key="grok",
+        display_name="Grok (xAI)",
+        binary="grok",
+        vendor="xAI Grok Build",
+        category="agentic-coder",
+        headless_invocation='grok -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["grok", "--version"],
+        auth_hint="xAI API key",
+        install={"generic": "see xAI Grok Build docs"},
+        confidence="confirm-on-probe",
+        collision_note="Binary 'grok' collides with community grok-cli — disambiguate by version.",
+    ),
+    "grok-cli": AgenticCLI(
+        key="grok-cli",
+        display_name="Grok CLI (community)",
+        binary="grok",
+        vendor="community",
+        category="agentic-coder",
+        headless_invocation='grok -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["grok", "--version"],
+        auth_hint="xAI / provider key",
+        install={"generic": "npm i -g grok-cli (community)"},
+        confidence="confirm-on-probe",
+        collision_note="Shares the 'grok' binary with xAI's official build — version string disambiguates.",
+    ),
+    "forge": AgenticCLI(
+        key="forge",
+        display_name="Forge",
+        binary="forge",
+        vendor="forgecode",
+        category="agentic-coder",
+        headless_invocation='forge -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["forge", "--version"],
+        auth_hint="provider API key",
+        install={"generic": "see forgecode docs"},
+        confidence="confirm-on-probe",
+        collision_note="Binary 'forge' collides with Foundry's forge (Solidity) — disambiguate by version.",
+    ),
+    "continue": AgenticCLI(
+        key="continue",
+        display_name="Continue",
+        binary="cn",
+        vendor="Continue",
+        category="agentic-coder",
+        headless_invocation='cn -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["cn", "--version"],
+        auth_hint="provider config",
+        install={"generic": "see continue.dev docs"},
+        confidence="confirm-on-probe",
+    ),
+    "cline": AgenticCLI(
+        key="cline",
+        display_name="Cline",
+        binary="cline",
+        vendor="Cline",
+        category="agentic-coder",
+        headless_invocation='cline "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["cline", "--version"],
+        auth_hint="provider config",
+        install={"generic": "see cline docs"},
+        confidence="confirm-on-probe",
+    ),
+    "cody": AgenticCLI(
+        key="cody",
+        display_name="Cody (deprecated)",
+        binary="cody",
+        vendor="Sourcegraph",
+        category="agentic-coder",
+        headless_invocation='cody chat -m "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="-m",
+        version_probe=["cody", "--version"],
+        auth_hint="Sourcegraph enterprise token",
+        install={"generic": "DEPRECATED — enterprise-only"},
+        confidence="confirm-on-probe",
+        collision_note="DEPRECATED / enterprise-only.",
+        enabled_for_council=False,
+    ),
+    "plandex": AgenticCLI(
+        key="plandex",
+        display_name="Plandex (winding down)",
+        binary="plandex",
+        vendor="Plandex",
+        category="agentic-coder",
+        headless_invocation='plandex tell "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["plandex", "--version"],
+        auth_hint="provider key",
+        install={"generic": "see plandex docs"},
+        confidence="confirm-on-probe",
+        collision_note="Project winding down.",
+        enabled_for_council=False,
+    ),
+    "mistral-vibe": AgenticCLI(
+        key="mistral-vibe",
+        display_name="Mistral Vibe",
+        binary="vibe",
+        vendor="Mistral",
+        category="agentic-coder",
+        headless_invocation='vibe -p "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["vibe", "--version"],
+        auth_hint="Mistral API key (paid)",
+        install={"generic": "see Mistral docs (paid)"},
+        confidence="confirm-on-probe",
+    ),
+    "mentat": AgenticCLI(
+        key="mentat",
+        display_name="Mentat",
+        binary="mentat",
+        vendor="AbanteAI",
+        category="agentic-coder",
+        headless_invocation='mentat "{PROMPT}"',
+        input_mode="prompt-arg",
+        model_flag_style="none",
+        version_probe=["mentat", "--version"],
+        auth_hint="OPENAI_API_KEY",
+        install={"generic": "pip install mentat"},
+        confidence="confirm-on-probe",
+        collision_note="Primarily interactive — headless behaviour uncertain.",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Council ordering — preferred convening order for external CLIs.
+# Claude is the in-process host (not an external seat) so it is NOT listed here.
+# Order roughly tracks confidence + diversity of vendor/provider.
+# ---------------------------------------------------------------------------
+
+COUNCIL_CLIS: list[str] = [
+    "codex",
+    "gemini",
+    "copilot",
+    "opencode",
+    "pi",
+    "agy",
+    "aider",
+    "goose",
+    "amp",
+    "droid",
+    "cursor-agent",
+    "qwen",
+    "crush",
+    "openhands",
+    "gptme",
+    "interpreter",
+    "llm",
+    "aichat",
+    "mods",
+    "sgpt",
+    "q",
+    "ollama",
+]
+
+
+def council_clis(include_disabled: bool = False) -> list[AgenticCLI]:
+    """Return council-eligible CLI records in convening order.
+
+    Skips Claude (in-process host) and, unless ``include_disabled``, any record
+    with ``enabled_for_council=False`` (deprecated / winding-down tools).
+    Confirm-on-probe records ARE included — the probe gates their actual use.
+    """
+    out: list[AgenticCLI] = []
+    seen: set[str] = set()
+    for key in COUNCIL_CLIS:
+        cli = AGENTIC_CLI_REGISTRY.get(key)
+        if cli is None or key in seen:
+            continue
+        if not include_disabled and not cli.enabled_for_council:
+            continue
+        out.append(cli)
+        seen.add(key)
+    # Append any council-eligible records not explicitly ordered above.
+    for key, cli in AGENTIC_CLI_REGISTRY.items():
+        if key in seen or key == "claude":
+            continue
+        if not include_disabled and not cli.enabled_for_council:
+            continue
+        out.append(cli)
+        seen.add(key)
+    return out
+
+
+def detect(probe: bool = False) -> dict:
+    """Detect which registry CLIs are installed via ``shutil.which``.
+
+    With ``probe=False`` (default) this is a pure PATH scan — no subprocesses,
+    safe to call anywhere. The ``probe=True`` path (actually running each CLI's
+    headless form to classify usable vs unusable) lives in ``detect_clis.py`` so
+    this module stays import-light and side-effect-free; calling ``detect(probe=True)``
+    here raises to make that boundary explicit.
+
+    Returns:
+        {
+          "detected": [ {key, display_name, binary, resolved_path, category,
+                         confidence, enabled_for_council}, ... ],
+          "collisions": [ {binary, keys:[...]}, ... ],
+        }
+    """
+    if probe:
+        raise NotImplementedError(
+            "Usability probing lives in detect_clis.py (subprocess-based). "
+            "Call agentic_cli_registry.detect() for a pure PATH scan, or run "
+            "detect_clis.py --probe for the full probe."
+        )
+
+    detected: list[dict] = []
+    binary_to_keys: dict[str, list[str]] = {}
+
+    for key, cli in AGENTIC_CLI_REGISTRY.items():
+        # Track every binary this record could claim, for collision reporting.
+        for b in cli.binaries():
+            binary_to_keys.setdefault(b, []).append(key)
+        # Resolve the first of (primary, *alts) that exists on PATH.
+        resolved = None
+        used_binary = cli.binary
+        for b in cli.binaries():
+            found = shutil.which(b)
+            if found:
+                resolved = found
+                used_binary = b
+                break
+        if resolved:
+            detected.append(
+                {
+                    "key": key,
+                    "display_name": cli.display_name,
+                    "binary": used_binary,
+                    "resolved_path": resolved,
+                    "category": cli.category,
+                    "confidence": cli.confidence,
+                    "enabled_for_council": cli.enabled_for_council,
+                }
+            )
+
+    collisions = [
+        {"binary": b, "keys": keys}
+        for b, keys in sorted(binary_to_keys.items())
+        if len(keys) > 1
+    ]
+
+    return {"detected": detected, "collisions": collisions}
+
+
+if __name__ == "__main__":  # pragma: no cover — manual inspection
+    import json
+
+    print(json.dumps(detect(probe=False), indent=2))

--- a/scripts/jam/detect_clis.py
+++ b/scripts/jam/detect_clis.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+detect_clis.py — detect & probe agentic LLM CLIs for the council.
+
+Reads ``agentic_cli_registry.py`` and answers two questions the council needs:
+
+  1. Which registered CLIs are INSTALLED on this machine (``shutil.which``)?
+  2. With ``--probe``: which installed CLIs are actually USABLE right now —
+     i.e. running their headless form (+ trust flags) on a trivial prompt
+     returns a sane reply — vs INSTALLED-BUT-UNUSABLE (auth revoked, no
+     provider configured, daemon down, …)?
+
+The probe is the difference between "the binary is on PATH" and "the council
+can get a real answer out of it". A CLI can be installed yet 401, or print
+"no provider configured", or fail to reach a local daemon. Those seats must
+NOT be counted toward quorum.
+
+Safety / cross-platform contract (mirrors _capability_registry.py + CLAUDE.md):
+  * stdlib only — no third-party imports.
+  * detection via ``shutil.which``.
+  * each probe runs with ``subprocess.run(..., timeout=N, stdin=DEVNULL,
+    cwd=<fresh tempdir under tempfile.gettempdir()>)`` so a hanging CLI is
+    bounded, nothing reads our stdin, and no CLI mutates the real project.
+  * never perl/bash-isms, never a bare ``/tmp``.
+
+Modes:
+  detect_clis.py                 # PATH scan, human output
+  detect_clis.py --json          # PATH scan, JSON
+  detect_clis.py --probe         # PATH scan + usability probe (JSON-capable)
+  detect_clis.py --list          # dump the registry (no detection)
+  detect_clis.py --list --json   # registry dump as JSON
+
+Output JSON shape (--probe):
+  {
+    "detected":   [ {key, display_name, binary, resolved_path, category,
+                     confidence, enabled_for_council, version}, ... ],
+    "usable":     [ "<key>", ... ],
+    "unusable":   [ {"cli": "<key>", "reason": "<class>: <detail>"}, ... ],
+    "collisions": [ {"binary": "...", "keys": [...]}, ... ]
+  }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+
+# Import the registry. Works both when run as a file from anywhere
+# (sys.path bootstrap) and when imported as a module.
+try:
+    from agentic_cli_registry import (  # type: ignore
+        AGENTIC_CLI_REGISTRY,
+        AgenticCLI,
+        detect as registry_detect,
+    )
+except ModuleNotFoundError:  # pragma: no cover — path bootstrap for direct runs
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from agentic_cli_registry import (  # type: ignore
+        AGENTIC_CLI_REGISTRY,
+        AgenticCLI,
+        detect as registry_detect,
+    )
+
+
+# Trivial prompt: cheap, deterministic, and the reply is easy to sanity-check.
+PROBE_PROMPT = "Reply with the single word: pong"
+
+# Per-CLI probe timeout (seconds). Agentic coders spin up tools/MCP and can be
+# slow on a cold start; this bounds a hang (e.g. cursor-agent `-p`) without
+# starving a legitimately-slow-but-working CLI. Local runners get longer
+# because first-token latency on a cold model load is high.
+DEFAULT_TIMEOUT = 45
+LOCAL_RUNNER_TIMEOUT = 60
+
+# ---------------------------------------------------------------------------
+# Error-signature classification.
+# A CLI that is installed-but-unusable fails in a recognisable way. We match
+# stdout+stderr (lower-cased) against these signatures to label WHY a seat is
+# unusable, so the council can tell the user "codex: auth revoked" rather than
+# a generic failure. Order matters: first match wins.
+# ---------------------------------------------------------------------------
+
+_UNUSABLE_SIGNATURES: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "auth",
+        re.compile(
+            r"\b(401|403|unauthor|authentication (failed|required)|not (logged|signed) in"
+            r"|please (log ?in|sign ?in|run .*login)|invalid api key|api key (not|is missing)"
+            r"|expired (token|credential)|forbidden|access denied"
+            r"|credentials? (not found|missing|expired)|re-?authenticate)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "no-provider",
+        re.compile(
+            r"\b(no (provider|model) (configured|set|selected|available)"
+            r"|no api key|set (the )?\w*_?api_key|missing .*api[_ ]?key"
+            r"|configure (a )?(provider|model|api key)|run .*configure"
+            r"|no default model|model not (found|configured))\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "daemon-down",
+        re.compile(
+            r"\b(could not connect|connection refused|connection error"
+            r"|failed to connect|daemon (not|isn'?t) running|is the server running"
+            r"|ollama (server|app) (not|isn'?t) running|dial tcp|econnrefused"
+            r"|no such model|model .* not found, try pulling)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "quota",
+        re.compile(
+            r"\b(quota|rate ?limit|429|insufficient (credit|funds|balance)"
+            r"|billing|payment required|402)\b",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+# If a CLI exits non-zero with no recognised signature, we still mark it
+# unusable but with this generic label so the seat is not silently trusted.
+_GENERIC_UNUSABLE = "error"
+
+
+def _classify_failure(
+    returncode: int | None, combined: str, timed_out: bool
+) -> tuple[str, str] | None:
+    """Classify a probe run. Returns ``(reason_class, matched_line)`` for an
+    unusable run, or ``None`` if the run looks usable.
+
+    ``matched_line`` is the specific line that tripped the signature (e.g. the
+    401 line), so the human-facing reason is honest rather than echoing a
+    cosmetic banner line. A run is USABLE only when it did not time out, exited
+    0, and produced non-trivial stdout free of a failure signature (some CLIs
+    print the error to stdout yet still exit 0).
+    """
+    if timed_out:
+        return ("timeout", "")
+    lines = combined.splitlines()
+    for label, pat in _UNUSABLE_SIGNATURES:
+        for line in lines:
+            if pat.search(line):
+                return (label, line.strip())
+        # Fall back to a whole-text match (signature spanning the buffer).
+        if pat.search(combined):
+            return (label, "")
+    if returncode not in (0, None):
+        return (_GENERIC_UNUSABLE, "")
+    return None
+
+
+def _looks_like_real_reply(stdout: str) -> bool:
+    """A sane reply has some printable content beyond whitespace/banners.
+
+    We do NOT require the literal word 'pong' — models phrase things their own
+    way and some CLIs wrap output. We only require that *something* substantive
+    came back, since auth/provider/daemon failures produce either empty stdout
+    or an error string (already caught by signature matching)."""
+    stripped = stdout.strip()
+    return len(stripped) >= 2
+
+
+def _probe_version(cli: AgenticCLI, timeout: int) -> str:
+    """Capture the version string (disambiguates binary collisions like grok)."""
+    try:
+        proc = subprocess.run(
+            cli.version_probe,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=min(timeout, 15),
+        )
+        out = (proc.stdout or proc.stderr or "").strip()
+        # Keep it to the first line — version banners can be multi-line.
+        return out.splitlines()[0].strip() if out else ""
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return ""
+
+
+def _build_probe_argv(cli: AgenticCLI) -> list[str] | None:
+    """Build the headless argv for a probe run: rendered template + trust flags.
+
+    Returns None for CLIs that cannot be safely auto-probed with a trivial
+    prompt (e.g. ollama needs a model name we don't know). Those are reported
+    as detected but skipped by the probe with an explicit reason.
+    """
+    if cli.key == "ollama" or "{MODEL}" in cli.headless_invocation:
+        # Local runners need a concrete pulled model; we won't guess one.
+        return None
+
+    rendered = cli.render(PROBE_PROMPT)
+    try:
+        import shlex
+
+        argv = shlex.split(rendered, posix=(sys.platform != "win32"))
+    except ValueError:
+        return None
+    if not argv:
+        return None
+    # Append trust flags AFTER the template so headless runs don't block on a
+    # permission / trust / git-repo prompt.
+    argv.extend(cli.trust_flags)
+    return argv
+
+
+def _probe_one(cli: AgenticCLI) -> dict:
+    """Probe a single detected CLI. Returns {usable: bool, reason, version}."""
+    timeout = LOCAL_RUNNER_TIMEOUT if cli.category == "local-runner" else DEFAULT_TIMEOUT
+    version = _probe_version(cli, timeout)
+
+    argv = _build_probe_argv(cli)
+    if argv is None:
+        return {
+            "usable": False,
+            "reason": "skipped: requires a model/daemon not auto-probeable (e.g. ollama needs a pulled model + running daemon)",
+            "version": version,
+        }
+
+    tmpdir = tempfile.mkdtemp(prefix="wg-council-probe-")
+    timed_out = False
+    returncode: int | None = None
+    stdout = ""
+    stderr = ""
+    try:
+        proc = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=tmpdir,
+        )
+        returncode = proc.returncode
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        stdout = (exc.stdout or b"").decode("utf-8", "replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = (exc.stderr or b"").decode("utf-8", "replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+    except (OSError, ValueError) as exc:
+        return {"usable": False, "reason": f"error: could not launch ({exc})", "version": version}
+    finally:
+        # Best-effort cleanup of the scratch cwd (aider et al. drop cache files).
+        try:
+            import shutil as _sh
+
+            _sh.rmtree(tmpdir, ignore_errors=True)
+        except Exception:
+            pass
+
+    combined = f"{stdout}\n{stderr}"
+    classified = _classify_failure(returncode, combined, timed_out)
+    if classified is None and _looks_like_real_reply(stdout):
+        return {"usable": True, "reason": None, "version": version}
+
+    if classified is None:
+        # Exited 0 but produced nothing substantive — treat as unusable so the
+        # council does not seat an empty responder.
+        reason, matched = "empty-response", ""
+    else:
+        reason, matched = classified
+
+    # Prefer the line that actually matched the failure signature (e.g. the
+    # 401 line); fall back to the first non-empty line if nothing matched
+    # (timeout / generic non-zero exit).
+    detail = matched
+    if not detail:
+        for line in combined.splitlines():
+            s = line.strip()
+            if s:
+                detail = s
+                break
+    detail = detail[:160]
+    full = f"{reason}: {detail}" if detail else reason
+    return {"usable": False, "reason": full, "version": version}
+
+
+def run_detect(probe: bool) -> dict:
+    """Detect installed CLIs and, if ``probe``, classify usable vs unusable."""
+    base = registry_detect(probe=False)
+    detected = base["detected"]
+    collisions = base["collisions"]
+
+    if not probe:
+        return {"detected": detected, "collisions": collisions}
+
+    usable: list[str] = []
+    unusable: list[dict] = []
+    for entry in detected:
+        key = entry["key"]
+        if key == "claude":
+            # Claude is the in-process host, not an external seat. Record its
+            # version for collision/audit purposes but don't probe it as a CLI.
+            cli = AGENTIC_CLI_REGISTRY[key]
+            entry["version"] = _probe_version(cli, DEFAULT_TIMEOUT)
+            continue
+        cli = AGENTIC_CLI_REGISTRY[key]
+        result = _probe_one(cli)
+        entry["version"] = result["version"]
+        if result["usable"]:
+            usable.append(key)
+        else:
+            unusable.append({"cli": key, "reason": result["reason"]})
+
+    return {
+        "detected": detected,
+        "usable": usable,
+        "unusable": unusable,
+        "collisions": collisions,
+    }
+
+
+def list_registry() -> dict:
+    """Dump the full registry as plain dicts (for --list)."""
+    return {
+        "clis": [asdict(cli) for cli in AGENTIC_CLI_REGISTRY.values()],
+        "count": len(AGENTIC_CLI_REGISTRY),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Human-readable rendering
+# ---------------------------------------------------------------------------
+
+def _emit_human_list(reg: dict) -> None:
+    sys.stdout.write(f"agentic CLI registry — {reg['count']} entries\n")
+    for cli in reg["clis"]:
+        flag = "" if cli["enabled_for_council"] else " [council-disabled]"
+        conf = "" if cli["confidence"] == "verified" else f" ({cli['confidence']})"
+        sys.stdout.write(
+            f"  {cli['key']:<14} {cli['category']:<14} {cli['vendor']}{conf}{flag}\n"
+        )
+
+
+def _emit_human_detect(result: dict, probed: bool) -> None:
+    detected = result["detected"]
+    sys.stdout.write(f"detected {len(detected)} installed CLI(s):\n")
+    usable = set(result.get("usable", []))
+    unusable_map = {u["cli"]: u["reason"] for u in result.get("unusable", [])}
+    for entry in detected:
+        key = entry["key"]
+        ver = entry.get("version", "")
+        ver_s = f"  v={ver}" if ver else ""
+        if not probed:
+            status = ""
+        elif key == "claude":
+            status = "  [in-process host]"
+        elif key in usable:
+            status = "  USABLE"
+        elif key in unusable_map:
+            status = f"  UNUSABLE — {unusable_map[key]}"
+        else:
+            status = ""
+        sys.stdout.write(f"  {key:<14} {entry['resolved_path']}{ver_s}{status}\n")
+
+    if probed:
+        sys.stdout.write(
+            f"\nquorum: {len(usable)} usable external CLI(s)"
+            + (
+                " — full council"
+                if len(usable) >= 2
+                else " — below quorum (fallback to Task() subagent seats)"
+            )
+            + "\n"
+        )
+
+    if result.get("collisions"):
+        sys.stdout.write("\nbinary collisions (disambiguate by version):\n")
+        for c in result["collisions"]:
+            sys.stdout.write(f"  {c['binary']}: {', '.join(c['keys'])}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect & probe agentic LLM CLIs for the wicked-garden council."
+    )
+    parser.add_argument("--probe", action="store_true", help="run headless usability probe")
+    parser.add_argument("--list", action="store_true", help="dump the registry and exit")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of human text")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        reg = list_registry()
+        if args.json:
+            sys.stdout.write(json.dumps(reg, indent=2) + "\n")
+        else:
+            _emit_human_list(reg)
+        return 0
+
+    result = run_detect(probe=args.probe)
+    if args.json:
+        sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    else:
+        _emit_human_detect(result, probed=args.probe)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/platform/prereq_doctor.py
+++ b/scripts/platform/prereq_doctor.py
@@ -181,45 +181,10 @@ TOOL_REGISTRY = {
         "category": "ai",
     },
     # --- Multi-Model CLIs ---
-    "codex": {
-        "name": "OpenAI Codex CLI",
-        "cli": "codex",
-        "test_cmd": ["codex", "--version"],
-        "install": {
-            "darwin": "brew install codex",
-            "linux": "npm install -g @openai/codex",
-            "generic": "npm install -g @openai/codex",
-        },
-        "docs": "https://github.com/openai/codex-cli",
-        "mcp_patterns": [],
-        "category": "ai",
-    },
-    "gemini": {
-        "name": "Google Gemini CLI",
-        "cli": "gemini",
-        "test_cmd": ["gemini", "--version"],
-        "install": {
-            "darwin": "npm install -g @google/gemini-cli",
-            "linux": "npm install -g @google/gemini-cli",
-            "generic": "npm install -g @google/gemini-cli",
-        },
-        "docs": "https://github.com/google-gemini/gemini-cli",
-        "mcp_patterns": [],
-        "category": "ai",
-    },
-    "opencode": {
-        "name": "OpenCode CLI",
-        "cli": "opencode",
-        "test_cmd": ["opencode", "--version"],
-        "install": {
-            "darwin": "brew install opencode",
-            "linux": "go install github.com/sst/opencode@latest",
-            "generic": "https://github.com/sst/opencode",
-        },
-        "docs": "https://github.com/sst/opencode",
-        "mcp_patterns": [],
-        "category": "ai",
-    },
+    # The agentic / chat / local-runner CLIs (category "ai") are DERIVED from
+    # scripts/jam/agentic_cli_registry.py and merged into TOOL_REGISTRY below
+    # (see _merge_agentic_cli_registry). This de-drifts what used to be three
+    # hardcoded entries (codex, gemini, opencode) from the council registry.
     # --- Scenario Testing Tools ---
     "hurl": {
         "name": "Hurl (HTTP testing)",
@@ -300,6 +265,71 @@ TOOL_REGISTRY = {
         "category": "testing",
     },
 }
+
+def _merge_agentic_cli_registry() -> None:
+    """Derive the agentic-CLI ("ai" category) entries from the council registry
+    (scripts/jam/agentic_cli_registry.py) and merge them into TOOL_REGISTRY.
+
+    This keeps prereq_doctor's multi-model list in lock-step with the council's
+    single source of truth instead of hardcoding a drifting subset. Maps the
+    AgenticCLI dataclass fields onto prereq_doctor's tool-entry schema.
+
+    Fail-OPEN: if the registry cannot be imported (e.g. a slim install without
+    scripts/jam/), TOOL_REGISTRY keeps whatever was hardcoded and nothing
+    breaks. Council-disabled / confirm-on-probe records are skipped so the
+    doctor only ever recommends installing tools we trust headlessly.
+    """
+    jam_dir = Path(__file__).resolve().parent.parent / "jam"
+    if not (jam_dir / "agentic_cli_registry.py").is_file():
+        return
+    added = str(jam_dir)
+    inserted = added not in sys.path
+    if inserted:
+        sys.path.insert(0, added)
+    try:
+        from agentic_cli_registry import AGENTIC_CLI_REGISTRY  # type: ignore
+    except Exception:
+        return
+    finally:
+        if inserted:
+            try:
+                sys.path.remove(added)
+            except ValueError:
+                pass
+
+    docs_by_key = {
+        "codex": "https://github.com/openai/codex",
+        "gemini": "https://github.com/google-gemini/gemini-cli",
+        "opencode": "https://github.com/sst/opencode",
+        "ollama": "https://ollama.com",
+        "claude": "https://docs.claude.com/claude-code",
+    }
+    for key, cli in AGENTIC_CLI_REGISTRY.items():
+        # Only surface tools the council trusts headlessly by default.
+        if not getattr(cli, "enabled_for_council", True):
+            continue
+        if getattr(cli, "confidence", "verified") != "verified":
+            continue
+        # Don't clobber an explicit hardcoded entry if one already exists.
+        if key in TOOL_REGISTRY:
+            continue
+        install = dict(getattr(cli, "install", {}) or {})
+        if "generic" not in install:
+            # Fall back to darwin/linux value so check_tool always has a hint.
+            install["generic"] = install.get("darwin") or install.get("linux") or "see vendor docs"
+        TOOL_REGISTRY[key] = {
+            "name": f"{cli.display_name} ({cli.vendor})",
+            "cli": cli.binary,
+            "test_cmd": list(cli.version_probe),
+            "install": install,
+            "docs": docs_by_key.get(key, "see vendor docs"),
+            "mcp_patterns": [],
+            "category": "ai",
+        }
+
+
+_merge_agentic_cli_registry()
+
 
 # Map selection names (from setup) to registry keys
 SELECTION_TO_CLI = {

--- a/skills/multi-model/SKILL.md
+++ b/skills/multi-model/SKILL.md
@@ -3,8 +3,10 @@ name: multi-model
 description: |
   Multi-model AI collaboration: discover installed LLM CLIs and orchestrate
   council sessions, cross-model reviews, and diverse perspective gathering.
-  Detects codex, copilot, gemini, opencode, pi, aider, llm, aichat, and goose
-  CLIs at runtime via PATH discovery.
+  Detects 20+ agentic/chat/local CLIs at runtime from a machine-readable
+  registry (scripts/jam/agentic_cli_registry.py) and usability-probes them
+  (scripts/jam/detect_clis.py --probe) so auth-revoked / unconfigured /
+  daemon-down CLIs are excluded.
   Decisions stored in wicked-brain:memory. Transcripts persisted via jam scripts.
 
   Use when: running a council session across multiple LLM CLIs, getting a
@@ -21,12 +23,19 @@ Each council member is a different model provider for genuine perspective divers
 
 ## How It Works
 
-The multi-model system uses **external LLM CLIs** discovered at runtime:
+The multi-model system uses **external LLM CLIs** discovered + probed at runtime
+from the registry — never a hand-maintained `which` list:
 
-1. **CLI Discovery** — `which codex copilot gemini opencode pi aider llm aichat goose` detects installed CLIs
-2. **Quorum Check** — Council requires 2+ external CLIs; 0 = refuse, 1 = warn
+1. **Detect + Probe** — `detect_clis.py --probe` reads the registry, `shutil.which`-es
+   each binary, then runs each detected CLI's headless form (with registry trust
+   flags) on a trivial prompt to classify **usable** vs **installed-but-unusable**
+   (auth revoked / no provider / daemon down). Captures version strings to
+   disambiguate binary collisions (`grok`, `agent`, `forge`, `q`).
+2. **Quorum Check** — Council requires 2+ **usable external** CLIs; below that,
+   fill seats with `Task()` subagents so a real council always convenes.
 3. **Question Scaffold** — All models answer the same fixed 4-question set
-4. **Parallel Dispatch** — Each CLI receives the scaffold via stdin pipe, runs independently
+4. **Parallel Dispatch** — Each usable CLI is invoked per its registry `input_mode`,
+   isolated + sandboxed + timeboxed, runs independently
 5. **Synthesis** — Claude synthesizes all perspectives with model attribution
 
 ## Quick Start
@@ -44,19 +53,27 @@ The multi-model system uses **external LLM CLIs** discovered at runtime:
 
 ## Supported CLIs
 
-| CLI | Install | Model / Provider |
-|-----|---------|------------------|
-| `codex` | `brew install codex` | OpenAI Codex |
-| `copilot` | `brew install copilot-cli` | GitHub Copilot |
-| `gemini` | `npm i -g @google/gemini-cli` | Google Gemini |
-| `opencode` | `brew install opencode` | Configurable (OpenAI/Anthropic/local) |
-| `pi` | `npm i -g @mariozechner/pi-coding-agent` | Configurable (Google default, OpenAI/Anthropic/etc.) |
-| `aider` | `brew install aider` | Configurable — code-editor orientation |
-| `llm` | `brew install llm` | Multi-provider aggregator (OpenAI, Anthropic, Mistral, local via plugins) |
-| `aichat` | `brew install aichat` | Multi-provider aggregator |
-| `goose` | `brew install block-goose-cli` | Block Goose agent (configurable provider) |
+The supported-CLI list is **not maintained here** — it lives in the registry
+(`scripts/jam/agentic_cli_registry.py`), one record per CLI with its headless
+invocation, input mode, model-flag style, trust flags, auth hint, and install
+commands. Run `detect_clis.py --list` to dump it. This is the de-drift source
+of truth; do not re-list flags in prose.
 
-Claude always participates as a council member alongside the external CLIs.
+The registry currently covers **20+ CLIs** across three categories:
+
+- **agentic-coder** — `claude`, `codex`, `gemini`, `agy` (Antigravity), `pi`,
+  `opencode`, `aider`, `copilot`, `goose`, `cursor-agent`, `amp`, `droid`,
+  `qwen`, `crush`, `openhands`, `gptme`, `interpreter` (+ confirm-on-probe:
+  `grok`, `forge`, `continue`, `cline`).
+- **chat** — `llm`, `aichat`, `mods`, `sgpt`, `q` (Amazon Q / `kiro-cli`).
+- **local-runner** — `ollama` (needs a running daemon + a pulled model).
+
+Records flagged `confirm-on-probe` have an uncertain headless flag — the probe
+verifies them before the council relies on them. Deprecated / winding-down
+tools (`cody`, `plandex`) ship `enabled_for_council=False`.
+
+Claude always participates as a council member (in-process host) alongside the
+usable external CLIs.
 
 ## Architecture
 
@@ -67,20 +84,16 @@ Claude always participates as a council member alongside the external CLIs.
 │  - Dispatches to council agent                       │
 ├─────────────────────────────────────────────────────┤
 │  Council Agent (agents/jam/council.md)               │
-│  - Detects CLIs via `which`                          │
+│  - detect_clis.py --probe (registry-driven)          │
 │  - Builds question scaffold (4 fixed questions)      │
-│  - Pipes scaffold to each CLI in parallel            │
+│  - Renders each usable CLI per its input_mode        │
 │  - Claude answers the same scaffold independently    │
 ├─────────────────────────────────────────────────────┤
-│  External CLI Dispatch                               │
-│  - cat scaffold.md | codex exec "..."                │
-│  - cat scaffold.md | gemini "..."                    │
-│  - cat scaffold.md | opencode run "..."              │
-│  - pi -p "..." @scaffold.md                          │
-│  - aider --message-file scaffold --no-git --yes     │
-│  - cat scaffold.md | llm "..."                       │
-│  - cat scaffold.md | aichat "..."                    │
-│  - cat scaffold.md | goose run -i -                  │
+│  Detect + Probe (scripts/jam/detect_clis.py)         │
+│  - registry → shutil.which → headless usability probe│
+│  - usable vs installed-but-unusable (auth/provider/  │
+│    daemon); version strings for collision disambig   │
+│  - <2 usable external → Task() subagent fallback tier│
 ├─────────────────────────────────────────────────────┤
 │  Synthesis (3-stage)                                 │
 │  - Stage 1: Raw responses per model                  │
@@ -130,9 +143,14 @@ Skill(skill="wicked-brain:memory", args="store \"Auth: JWT with 15min/7day expir
 
 ## Fallback Behavior
 
-If no external CLIs are detected, council refuses and suggests
-`/jam:brainstorm` (single-model, multi-persona) as an alternative.
-With only 1 CLI, it runs as "brainstorm with external guest" with a warning.
+Quorum is counted over **usable external** CLIs (post-probe), not raw
+detections. When fewer than 2 are usable, council fills the empty seats with
+`Task()` subagents (distinct framing personas, isolated + parallel) so a real
+council always convenes — these in-harness seats are weaker diversity than
+external vendors and are labelled as such in the synthesis. With exactly 1
+usable external CLI it runs as "single external guest" (optionally topped up
+with subagent seats). Only if neither external CLIs nor subagents are available
+does it suggest `/jam:brainstorm` (single-model, multi-persona).
 
 ## References
 

--- a/skills/multi-model/refs/copilot.md
+++ b/skills/multi-model/refs/copilot.md
@@ -7,6 +7,13 @@ archetype_relevance: ["*"]
 GitHub Copilot CLI for AI-assisted coding, code review, and multi-model collaboration.
 Copilot supports multiple backend models and excels at codebase-aware analysis.
 
+> **Registry is source of truth.** The council's headless invocation + trust
+> flags for copilot live in `scripts/jam/agentic_cli_registry.py`
+> (`copilot -p "{PROMPT}" --allow-all-tools`). For headless/council use,
+> `--allow-all-tools` is **required** — without it copilot blocks on tool
+> approval. Prefer the registry form over the older `--available-tools=""`
+> examples below.
+
 ## Installation and Setup
 
 ```bash
@@ -81,8 +88,8 @@ cat design.md | copilot -p "Critique this architecture" --output-format text > c
 # Security review
 git diff main | copilot -p "Flag security issues in these changes" --output-format text
 
-# Council dispatch (text-only, no tools, piped scaffold)
-cat "$SCAFFOLD_FILE" | copilot -p "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely." --output-format text --available-tools=""
+# Council dispatch — registry form (headless requires --allow-all-tools)
+copilot -p "You are evaluating options for a technical decision. Answer the 4 questions below precisely and concisely. <scaffold>" --allow-all-tools
 ```
 
 ## Command Reference

--- a/skills/multi-model/refs/goose.md
+++ b/skills/multi-model/refs/goose.md
@@ -4,7 +4,13 @@ archetype_relevance: ["*"]
 ---
 # Goose CLI — Usage Patterns
 
-Block's open-source AI agent. Goose is designed to *do things* — run tools, execute commands, read files — not just answer questions. In council mode it operates as a read-only responder via `goose run -i -`.
+Block's open-source AI agent. Goose is designed to *do things* — run tools, execute commands, read files — not just answer questions.
+
+> **Registry is source of truth.** The council's headless invocation for goose
+> lives in `scripts/jam/agentic_cli_registry.py` (`goose run -t "{PROMPT}"`,
+> `model_flag_style: config-only`, auth via `goose configure`). The stdin/`-i -`
+> and `--system` forms below are valid alternatives, but the registry `-t`
+> prompt-arg form is what the council renders.
 
 ## Installation and Setup
 

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: swarm
+description: |
+  Parallel verification-swarm orchestration playbook: fan out N scoped
+  subagents over N units of work (repos / modules / files), then run a
+  SEPARATE verifier wave that re-derives each result from a clean state —
+  self-graded "done" is rejected. Composes the crew agents, the qe
+  semantic-reviewer, /wicked-garden:prove, wicked-vault attestation, and
+  the worktrees + deliberate skills rather than reinventing them. This is
+  multi-AGENT parallel execution+verification; for independent multi-MODEL
+  perspectives use jam:council instead.
+
+  Use when: multi-unit / fan-out work ("review every repo", "resolve the
+  backlog with proof", "apply this across all modules", "audit each
+  service"), high-blast-radius changes that need independent verification,
+  or any run where a claimed "done" must be re-derivable from receipts.
+status: stable
+phase_relevance: ["build", "test", "review"]
+archetype_relevance: ["build", "review", "migrate", "modernize", "incident"]
+---
+
+# Swarm — parallel verification swarm
+
+Orchestrate **N units of work in parallel** (one scoped subagent per unit),
+then **independently verify** every result with a separate wave of agents that
+re-derive "done" from a clean state. The swarm's value is not the parallelism —
+it's that **no agent grades its own work**. A claimed "tests pass" / "done" that
+can't be re-derived from receipts is rejected.
+
+> **Swarm vs council.** `jam:council` gets independent *multi-model* opinions on
+> one decision (different vendors answer the same scaffold). Swarm gets parallel
+> *multi-agent* execution + verification over many units. Use council to decide;
+> use swarm to execute-and-prove. They compose: run a council inside the verify
+> wave for a high-stakes verdict (see `refs/independent-verification.md`).
+
+## Compose, don't reinvent
+
+This skill is orchestration prose. Every primitive it needs already exists in
+the garden — reference these, do not duplicate them:
+
+| Need | Use (existing garden piece) |
+|------|------------------------------|
+| Per-unit implementer subagent | `agents/crew/implementer.md` (already does parallel-when-independent + evidence) |
+| Per-unit recon subagent | `agents/crew/researcher.md` (read-only context gathering) |
+| Independent semantic verdict | `agents/qe/semantic-reviewer.md` (independent-by-construction; refuses to attest its own work) |
+| Fallback reviewer | `agents/crew/reviewer.md` (reviewer-separation + external-review rules baked in) |
+| Re-derive a claim (the receipt) | `/wicked-garden:prove` (run + freeze evidence + gate; fail-closed) |
+| Hard-gate independent sign-off | `/wicked-garden:prove --with-attestations` → `wicked-vault attest` (evaluator ≠ creator, G10) |
+| Blast-radius / scope lens | `wicked-garden:deliberate` (lens 2 + 3) and `/wicked-garden:search:blast-radius` |
+| Per-unit isolation + commit hygiene | `wicked-garden:worktrees` (dangling-commit trust-but-verify) |
+| Phase shape per unit | `wicked-garden:archetype` refs (`build` / `review` / `migrate`) |
+| Multi-model verdict in a wave | `wicked-garden:jam:council` |
+
+## The wave loop
+
+```
+0. recon      → parallel researcher agents → concept catalog + per-unit profiles
+   synthesize → fit-matrix + relevance tiers
+   checkpoint → ONE structured scope question to the user (skip under full latitude)
+1. implement  → N parallel implementer agents (one per unit, self-contained brief)
+                each writes DETAILED artifacts to disk, returns a ~150-word summary
+2. verify     → M parallel verifier agents (SEPARATE from implementers)
+                re-run from clean state, read the ACTUAL diff, render PASS/FAIL/PARTIAL
+3. receipts   → /wicked-garden:prove per claim; hard gates add --with-attestations
+4. ship       → branch per unit, conventional commits, CI-green, independent review,
+                clean merge tree, tag-driven release  (only when asked)
+```
+
+Each numbered step has a ref. Waves hand off **via disk artifacts**, never via
+the orchestrator's context — that is what keeps the parent lean and the run
+auditable.
+
+## Orchestrator hygiene (the parent context stays lean)
+
+- **Detail to disk, summary to context.** Subagents write the full profile /
+  plan / diff / receipt to the scratch dir and return ≤150 words. Never let a
+  subagent dump raw output into your context.
+- **One message, many Task calls** for each wave — that is what makes it
+  parallel. A serial run with no documented `serial_reason` is a protocol miss
+  (same rule `agents/crew/implementer.md` enforces).
+- **Background long/external work** and synthesize on completion rather than
+  blocking the wave.
+- **The verifier is a different agent than the implementer.** If the same agent
+  type did the work, the verdict is a self-grade — `agents/qe/semantic-reviewer.md`
+  and the vault `attest` both refuse `evaluator == creator`.
+
+## The two reusable briefs
+
+The mechanics that make this repeatable are the **briefs** handed to each wave.
+Both live in `refs/fan-out.md` (implementer) and `refs/independent-verification.md`
+(verifier) as copy-paste templates. The shape:
+
+- **Implementer brief** (per unit): read THIS unit's own rules/conventions →
+  impact analysis (blast radius) BEFORE changing → implement with **in-scope
+  tech-debt cleanup only** (no opportunistic refactor sprawl) → functionally
+  test **proportional to blast radius** → write artifacts to disk → return a
+  concise summary.
+- **Verifier brief** (per unit): ignore the implementer's prose → re-run the
+  suite/build from clean → read the ACTUAL diff → check over-claims (e.g. a
+  claimed "pre-existing failure" must actually fail on the BASE commit) →
+  render PASS / FAIL / PARTIAL → write the authoritative receipt.
+
+## Honest marking (no padding)
+
+Mark every finding `GAP` / `PARTIAL` / `ALREADY-COVERED`. Surface
+reverse-transfers and "you're already ahead of this" honestly. **A short true
+list beats a long speculative one.** Record considered-and-rejected items
+explicitly so they read as weighed, not missed. Details in
+`refs/receipts-and-evidence.md`.
+
+## Recon-first, then checkpoint
+
+Before an expensive fan-out, run the recon wave and synthesize a fit-matrix +
+relevance tiers, then **checkpoint scope with the user in a single structured
+question**. Under an explicit goal / full latitude, proceed without asking.
+Full procedure in `refs/recon-synthesis.md`.
+
+## Disk-artifact layout (waves hand off here)
+
+A scratch dir (the worked example this playbook was distilled from used
+`.cross-pollination/`) with a top synthesis/index doc, per-unit
+profile/plan/review/receipt files, and a deferred-items log. Exact tree in
+`refs/recon-synthesis.md` §layout and `refs/receipts-and-evidence.md`.
+
+## Refs
+
+- [refs/recon-synthesis.md](refs/recon-synthesis.md) — recon wave, fit-matrix, relevance tiers, the single checkpoint question, scratch-dir layout
+- [refs/fan-out.md](refs/fan-out.md) — parallel implementer wave + the **implementer brief template**, impact analysis, in-scope cleanup
+- [refs/independent-verification.md](refs/independent-verification.md) — the verifier wave + the **verifier brief template**, isolation, over-claim kills, PASS/FAIL/PARTIAL
+- [refs/receipts-and-evidence.md](refs/receipts-and-evidence.md) — verbatim receipts, prove/vault/wicked-testing composition, honest GAP/PARTIAL/ALREADY-COVERED marking
+- [refs/ship-discipline.md](refs/ship-discipline.md) — branch-per-unit, conventional commits, CI-green gate, independent review + resolve, clean merge tree, tag-driven release

--- a/skills/swarm/refs/fan-out.md
+++ b/skills/swarm/refs/fan-out.md
@@ -1,0 +1,104 @@
+# Fan-out — the parallel implementer wave
+
+Dispatch **N independent subagents in parallel**, one per unit of work
+(repo / module / file / service). One message, multiple `Task` calls — that
+is what makes it a swarm and not a loop.
+
+Use `agents/crew/implementer.md` as the agent. It already encodes the rules
+that matter here: parallel-when-independent dispatch, structured evidence in
+every `TaskUpdate`, and the guardrails (never auto-proceed on deploys / deletes /
+schema migrations). This ref adds the **per-unit brief** that scopes each one.
+
+## When a unit is independent
+
+A unit is safe to fan out in parallel when it:
+- touches disjoint files from the other units,
+- shares no mutable state with them, and
+- has no producer→consumer ordering against them.
+
+If two units edit the same file or one's output feeds another, either serialize
+those two (and record a `serial_reason`) or merge them into one unit. Everything
+else runs concurrently.
+
+## The implementer brief template
+
+Each subagent gets a **tight, self-contained** brief. It must not need the
+orchestrator's context to do its job — everything it needs is in the brief or
+discoverable from the unit itself.
+
+```
+You are the swarm implementer for unit: <unit-name> (<path / repo URL>).
+You run in parallel with sibling implementers on other units. You share no
+state with them. Do not touch anything outside this unit.
+
+SCRATCH DIR: <scratch>/<unit-name>/   (create it; write all detail here)
+
+1. GROUND IN THE UNIT'S OWN RULES FIRST.
+   Read this unit's own conventions before changing anything: its
+   AGENTS.md / CLAUDE.md / CONTRIBUTING, lint+test config, and any
+   wicked-understanding repo playbook (add-feature / fix-bug / write-tests).
+   Follow THIS unit's method, not a generic one.
+
+2. IMPACT ANALYSIS (blast radius) BEFORE you change anything.
+   What does this change touch? What depends on it? Use
+   /wicked-garden:search:blast-radius (or grep the call sites) and the
+   deliberate lens ("map the blast radius: what else shares this root cause").
+   Write blast-radius.md to your scratch dir. The blast radius SETS YOUR
+   TEST BAR (step 4) — a wide radius demands more verification.
+
+3. IMPLEMENT — in scope only.
+   - Make the smallest change that satisfies the goal.
+   - In-scope tech-debt cleanup ONLY: fix debt you are already editing.
+     NO opportunistic refactor sprawl — drift is the #1 cause of inflated
+     cycles (same rule as the build archetype's implement phase).
+   - Fix ROOT causes, not symptoms.
+
+4. FUNCTIONALLY TEST, proportional to blast radius.
+   | blast radius | test bar |
+   |--------------|----------|
+   | low (leaf, reversible) | one targeted test that exercises the change |
+   | medium | unit tests + 1-2 integration |
+   | high (shared code, many callers) | unit + integration + an acceptance check |
+   Run the unit's REAL test command. Capture exact command + output + exit code.
+
+5. WRITE DETAILED ARTIFACTS TO DISK (not to your reply):
+   <scratch>/<unit-name>/blast-radius.md, plan.md, diff.patch (or commit SHA),
+   test-output.txt (verbatim, with exit code), assumptions.md.
+
+6. RETURN A CONCISE SUMMARY (~150 words MAX). Include:
+   - what changed (1-2 sentences) and the scope you held to,
+   - the blast-radius verdict (low/medium/high),
+   - the test command + PASS/FAIL + exit code,
+   - the artifact paths,
+   - the base commit SHA you started from (the verifier needs it),
+   - anything you deferred (so it lands in the deferred log, not silently dropped).
+   Do NOT paste diffs or raw logs into the summary — those are on disk.
+```
+
+## Why the brief is shaped this way
+
+- **Self-contained** → the orchestrator's context stays lean; the subagent can
+  run in an isolated worktree without back-and-forth.
+- **Rules-first** → a unit's own conventions win over a generic house style;
+  this is the difference between a change that merges and one that bounces.
+- **Impact analysis before code** → you cannot pick the right test bar until you
+  know the blast radius. This is the hinge that makes verification proportional.
+- **In-scope cleanup only** → bounded debt repair without scope creep.
+- **Detail to disk, ~150 words back** → the receipts are auditable and the
+  verify wave reads the artifacts, not the implementer's prose.
+
+## Isolation + commit hygiene
+
+When implementers commit (each on its own branch — see `refs/ship-discipline.md`),
+follow `wicked-garden:worktrees`: a subagent's "Commit SHA: abc1234" can be a
+**dangling commit** that `git gc` will collect once its worktree is removed.
+**Trust-but-verify every reported SHA** with the ancestry check before you treat
+the work as landed. This matters double in a swarm because many agents commit
+concurrently.
+
+## Hand-off
+
+When the wave returns, you have N concise summaries in context and N detailed
+artifact sets on disk. Do **not** start verifying inline — dispatch the
+**separate** verify wave (`refs/independent-verification.md`), handing each
+verifier the unit's scratch dir + base commit SHA.

--- a/skills/swarm/refs/independent-verification.md
+++ b/skills/swarm/refs/independent-verification.md
@@ -1,0 +1,86 @@
+# Independent verification — the verify wave (the core)
+
+This is the mechanism the whole skill exists for. The verifier is a **separate
+agent from the implementer** that **re-derives** each result from a clean state.
+Self-graded "done" is rejected. This is the vault / `prove` ethos applied to a
+swarm: a claim is only true if it can be recomputed from frozen evidence.
+
+> **Independence is structural, not polite.** Use a *different* agent type than
+> the one that did the work. `agents/qe/semantic-reviewer.md` is independent by
+> construction and **refuses to attest code it authored**; `wicked-vault attest`
+> fails closed when `evaluator == creator` (G10). If you let the implementer
+> verify itself, you have a self-grade — the one thing this skill forbids.
+
+## Pick the verifier agent
+
+| Verdict needed | Agent |
+|----------------|-------|
+| Does the code do what the spec/AC MEANS? | `agents/qe/semantic-reviewer.md` (opus, independent-by-construction) |
+| General correctness when no specialist fits | `agents/crew/reviewer.md` (has reviewer-separation + external-review baked in) |
+| High-stakes verdict needing multiple opinions | `wicked-garden:jam:council` (independent multi-model) inside the wave |
+| The raw "did the suite actually pass" receipt | `/wicked-garden:prove` (run + gate) — see `refs/receipts-and-evidence.md` |
+
+Run M verifiers in parallel — one message, multiple `Task` calls — one per unit.
+
+## The verifier brief template
+
+```
+You are the swarm VERIFIER for unit: <unit-name>. You did NOT implement this.
+Your job is to re-derive the result from a clean state and render a verdict.
+Trust nothing the implementer asserted — re-derive it.
+
+INPUTS: <scratch>/<unit-name>/  (the implementer's artifacts) and
+        BASE COMMIT SHA: <sha>  (the state before the change).
+
+1. RE-RUN FROM CLEAN.
+   Check out / reset to a clean tree. Run the unit's REAL build + test suite
+   yourself. Do not read the implementer's test-output.txt as truth — produce
+   your own. Capture exact command + full output + exit code.
+
+2. READ THE ACTUAL DIFF, not the prose.
+   git diff <base-sha>..HEAD (or the diff.patch). Verify the change is what the
+   summary claimed, scoped where it claimed, with no smuggled-in extra edits.
+
+3. KILL FORCE-FITS AND OVER-CLAIMS.
+   - If the implementer said a failure is "pre-existing", CHECK OUT THE BASE
+     COMMIT and confirm it actually fails there. A "pre-existing failure" that
+     passes on base is a regression the implementer introduced — FAIL.
+   - If a test was weakened, skipped, or its assertion gutted to go green — FAIL.
+   - If the change does less than claimed — PARTIAL, and say exactly what's missing.
+
+4. RENDER THE VERDICT: PASS / FAIL / PARTIAL.
+   - PASS: re-ran clean, diff matches claim, no over-claims, tests genuinely green.
+   - PARTIAL: works but incomplete / claim overstated — list the gap.
+   - FAIL: does not re-derive — name the exact command + output that disproves it.
+
+5. WRITE THE AUTHORITATIVE RECEIPT to <scratch>/<unit-name>/receipt.md:
+   verdict, the exact command(s) you ran, their verbatim output + exit codes,
+   the base SHA and head SHA, and a one-line rationale. This receipt — not the
+   implementer's summary — is the record of truth for this unit.
+
+6. RETURN ~150 words: verdict + the single most load-bearing piece of evidence
+   (the command + exit code that proves it) + receipt path.
+```
+
+## The wave structure
+
+```
+implementers wave  →  (disk artifacts)  →  verifiers wave  →  (receipts)  →  prove gate
+```
+
+- The two waves never run as one agent. The hand-off is **disk artifacts**, so
+  the verifier starts from the implementer's outputs but re-derives the result
+  independently.
+- A unit is only "done" when its `receipt.md` says PASS **and** the claim is
+  re-derived through `/wicked-garden:prove` (next ref). A FAIL or PARTIAL goes
+  back to a fresh implementer slice — the original implementer does not get to
+  argue its way to PASS.
+
+## Why re-derivation beats assertion
+
+A traceability/claim heuristic reports an untagged-but-correct change as
+"missing" and a tagged-but-wrong one as "done" — both wrong (this is exactly
+why `semantic_review.py` is only a pre-filter and `agents/qe/semantic-reviewer.md`
+does the real read). The verifier closes that gap: it judges by re-running and
+reading, not by trusting a label or a summary. The verdict that **names the gap**
+is the value; never inflate to PASS to be helpful.

--- a/skills/swarm/refs/receipts-and-evidence.md
+++ b/skills/swarm/refs/receipts-and-evidence.md
@@ -1,0 +1,69 @@
+# Receipts & evidence — claims must be re-derivable
+
+A swarm produces **receipts, not assertions**. Every "done" / "tests pass" /
+"build clean" must be re-derivable from frozen evidence: the **exact command**,
+its **real output**, **exit code**, and the **commit SHA** it ran against. If you
+can't re-derive it, it isn't proven — it's a claim, and claims are rejected.
+
+## Compose the garden's evidence machinery — don't hand-roll it
+
+| Mechanism | Use it for |
+|-----------|------------|
+| `/wicked-garden:prove <claim> --by "<cmd>" [--verifier ...]` | The one-line receipt: runs the command, freezes its real exit code as wicked-vault evidence, gates by **re-running** the verifier. Exit 0 only on a re-derived PASS; **fail-closed** (exit 3) when the backend is down — never a vacuous pass. Works on **interim** artifacts too (prove a produce the moment it exists). |
+| `/wicked-garden:prove ... --with-attestations` | Hard gates (review / incident / migrate). Stays REJECT (`UNATTESTED`) until an **independent** evaluator runs `wicked-vault attest <id> --opinion pass`. The doer's own evidence cannot satisfy it — that is the anti-self-grade point. |
+| `wicked-vault attest <id> --opinion pass --evaluator <who>` | The independent sign-off itself. Fails closed on `evaluator == creator` and on weak/ambient identity (record under an explicit `--actor`, default `garden-prove`). |
+| `wicked-testing:*` verdicts (writer → executor → reviewer, isolated) | When the unit needs a full evidence-gated acceptance verdict rather than a single command receipt. The reviewer is isolated from execution — same independence principle as the verify wave. |
+
+This is the **Sentinel rule** made concrete: a done-claim needs a *re-derived
+verdict*, not a self-report. `/wicked-garden:prove` is the verb you reach for by
+reflex before telling the user a unit is done.
+
+## What a receipt looks like (verbatim, never paraphrased)
+
+Each unit's `receipt.md` (written by the **verifier**, not the implementer) holds:
+
+```
+unit:        <unit-name>
+verdict:     PASS | FAIL | PARTIAL
+base_sha:    <sha the change started from>
+head_sha:    <sha after the change>
+command:     <the exact command run, copy-pasteable>
+exit_code:   <real exit code>
+output: |
+  <verbatim stdout/stderr — the real thing, not a summary>
+prove:       <the /wicked-garden:prove JSON verdict: satisfied + re_derived>
+attestation: <artifact id + evaluator, for hard gates; else "n/a">
+rationale:   <one line>
+```
+
+Never write "tests pass" without the command + output + exit code that proves
+it. A receipt a reviewer can't re-run is not a receipt.
+
+## Honest marking — no padding
+
+The swarm's credibility comes from honesty, not volume. Mark every finding:
+
+- **GAP** — genuinely missing; should be added.
+- **PARTIAL** — half-there; name exactly what's missing.
+- **ALREADY-COVERED** — the unit is already ahead of this; say so plainly.
+
+Rules:
+- **Surface reverse-transfers and "you're already ahead" honestly.** If a unit
+  already does the thing better than the proposed change, that's a finding, not
+  an omission — and sometimes the change should flow the *other* way.
+- **A short true list beats a long speculative one.** Don't pad the fit-matrix
+  with maybes to look thorough.
+- **Record considered-and-rejected items explicitly** in `deferred.md` so they
+  read as *weighed, not missed*. "Considered X, rejected because Y" is a
+  stronger signal than silence.
+- **The verdict that names the gap is the value.** Never inflate a PARTIAL to
+  PASS, or a GAP to ALREADY-COVERED, to be agreeable.
+
+## Tie it back to the gate
+
+A unit is shippable only when: its `receipt.md` verdict is PASS **and**
+`/wicked-garden:prove` returns `satisfied: true, re_derived: true` for the
+claim **and** (for hard-gate work) an independent `wicked-vault attest --opinion
+pass` exists from an evaluator that is not the implementer. Anything short of
+that is PARTIAL or FAIL and loops back to a fresh implementer slice — see
+`refs/independent-verification.md`.

--- a/skills/swarm/refs/recon-synthesis.md
+++ b/skills/swarm/refs/recon-synthesis.md
@@ -1,0 +1,87 @@
+# Recon-first → synthesize → checkpoint
+
+Before an expensive fan-out, spend a little to learn a lot: run a parallel
+**recon wave**, synthesize the findings into a fit-matrix + relevance tiers, and
+**checkpoint scope with the user in a single structured question**. This is the
+swarm's analogue of the `deliberate` skill's "is this real / what's the blast
+radius" lenses, applied across many units at once.
+
+## The recon wave
+
+Dispatch parallel `agents/crew/researcher.md` subagents — read-only, one per
+unit (or one per concept you're trying to map). Each researcher:
+
+- profiles its unit: stack, conventions, test command, risk surfaces, owners,
+- maps where the candidate change would land and what it would touch,
+- writes a **per-unit profile** to disk and returns a concise summary.
+
+Recon agents are read-only, so they fan out freely with no isolation concerns.
+
+## Synthesize
+
+Once recon returns, the orchestrator synthesizes — this is *your* job, not a
+subagent's, because it's the cross-unit view:
+
+1. **Concept catalog** — the set of candidate changes / patterns / findings,
+   each named once with a stable id.
+2. **Per-unit profiles** — one row per unit (already on disk from recon).
+3. **Fit-matrix** — concept × unit. For each cell, does this concept apply to
+   this unit? Mark `GAP` (missing, should add) / `PARTIAL` (half-there) /
+   `ALREADY-COVERED` (unit is already ahead). See `refs/receipts-and-evidence.md`
+   for the honest-marking discipline — do not inflate the matrix.
+4. **Relevance tiers** — rank units/concepts so the fan-out spends effort where
+   it matters: Tier 1 (high impact, do now) → Tier 2 (worth doing) → Tier 3
+   (defer / log). A short true Tier-1 list beats a long speculative one.
+
+## The single checkpoint question
+
+A fan-out is expensive (N implementer + M verifier agents). Before you spend it,
+ask the user **one structured question** that pins scope:
+
+```
+Recon is done. Here's the fit-matrix and tiers:
+  Tier 1 (propose to do now): <units/concepts>
+  Tier 2 (worth doing):       <units/concepts>
+  Tier 3 (defer):             <units/concepts>
+Proceed with Tier 1 as the fan-out scope, or adjust?
+```
+
+One question, structured, scoped. Not a stream of clarifications.
+
+**Under an explicit goal / full latitude, skip the checkpoint and proceed** —
+the user already authorized the spend. (If `AskUserQuestion` is unavailable in
+dangerous mode, fall back to a plain-text question and wait — per the garden's
+AskUserQuestion fallback rule.)
+
+## Scratch-dir layout (the run is auditable from here)
+
+Waves hand off via disk. Lay the scratch dir out so anyone can reconstruct the
+run. The worked example this playbook was distilled from used `.cross-pollination/`;
+any stable scratch dir works (e.g. `.swarm/<run-id>/`):
+
+```
+<scratch>/                       e.g. .cross-pollination/  or  .swarm/<run-id>/
+├── INDEX.md                     top synthesis: concept catalog + fit-matrix + tiers + run status
+├── deferred.md                  deferred-items log — considered-and-rejected, Tier-3, "you're already ahead"
+├── <unit-a>/
+│   ├── profile.md               recon output (stack, conventions, test cmd, risk)
+│   ├── blast-radius.md          implementer impact analysis
+│   ├── plan.md                  what will change, scope held to
+│   ├── diff.patch               (or recorded commit SHA)
+│   ├── test-output.txt          implementer's run (verbatim + exit code)
+│   └── receipt.md               VERIFIER's authoritative receipt (the record of truth)
+├── <unit-b>/ ...
+└── <unit-n>/ ...
+```
+
+`INDEX.md` is the front door — it carries the fit-matrix and per-unit status
+(recon-done → implemented → verified → shipped). The `deferred.md` log is where
+considered-and-rejected items live so they read as **weighed, not missed**.
+
+## Why recon-first
+
+Fanning out before you've profiled the units means every implementer
+re-discovers the same context and you can't tell Tier-1 work from Tier-3 noise.
+A cheap parallel recon wave + one synthesis pass turns the expensive fan-out
+from "discover as you go" into "execute a scoped, tiered plan" — and gives the
+user one clean decision point instead of N mid-flight surprises.

--- a/skills/swarm/refs/ship-discipline.md
+++ b/skills/swarm/refs/ship-discipline.md
@@ -1,0 +1,90 @@
+# Ship discipline — branch, prove, review, merge, release
+
+Shipping is its own wave, and it only runs **when the user asks**. A swarm
+produces many units of verified work; landing them cleanly without trampling
+each other or skipping the gate is the discipline this ref captures. It composes
+`wicked-garden:worktrees` (isolation + dangling-commit safety) and the gate
+machinery from `refs/receipts-and-evidence.md`.
+
+> **Do not push / open PRs / release until explicitly asked.** The garden's
+> house rule: commit or push only when the user requests it; if on the default
+> branch, branch first. The swarm authors and verifies by default — shipping is
+> opt-in.
+
+## Branch per unit
+
+Each unit lands on **its own branch** — never a shared swarm branch — so units
+ship, review, and roll back independently:
+
+- One branch per unit (e.g. `swarm/<unit-name>/<change>`).
+- **Conventional commits** (`feat:` / `fix:` / `refactor:` / `chore:`) with the
+  body referencing the unit and the receipt. This keeps the provenance check in
+  `agents/crew/reviewer.md` happy (commit messages should reference traceability
+  anchors).
+- **Trust-but-verify every reported commit SHA** (`wicked-garden:worktrees` §1):
+  a subagent's reported SHA can be a dangling commit. Run the ancestry check
+  before you treat the work as on a branch — especially with many implementers
+  committing concurrently.
+
+## CI-green gate (the receipt, again)
+
+A unit does not merge on a green local run alone — the claim is re-derived:
+
+- `/wicked-garden:prove tests-pass --by "<unit test cmd>"` (and `build-clean`,
+  `lint-clean`) must return `satisfied: true, re_derived: true`.
+- For hard-gate units, `--with-attestations` + an independent
+  `wicked-vault attest --opinion pass` (evaluator ≠ implementer).
+- If the unit's repo has a compiled gate (`/wicked-garden:compile`), let
+  `.wicked/gate.py` run in CI — it re-derives through wicked-vault with no
+  garden runtime present.
+
+A red or fail-closed (`gate: "unavailable"`) result blocks the merge. Fix the
+cause; never narrate around a failing gate.
+
+## Independent code review + RESOLVE comments
+
+- Each unit's PR gets an **independent** review — a different agent/human than
+  the implementer (reviewer-separation; `agents/crew/reviewer.md` and the vault
+  both enforce evaluator ≠ creator). For high-stakes units run a
+  `wicked-garden:jam:council` for multi-model perspective.
+- **Resolve every bot/review comment** before merge — address it or reply why
+  it's out of scope. An unresolved comment is an open finding, not noise.
+
+## Clean merge tree
+
+- **Rebase stragglers onto main** before merging so the tree stays linear and
+  each unit's history is legible — don't let a late unit merge a stale base.
+- Merge units in dependency order if any depend on each other (most swarm units
+  are independent by construction — see `refs/fan-out.md`).
+- After merge, confirm the branch's work is actually in main by **ancestry**,
+  not by on-disk worktree presence (`wicked-garden:worktrees` §"authoritative
+  signal") — then delete the branch + log the deletion.
+
+## Tag-driven release + version sync
+
+- Release is **tag-driven**: cut a tag, let CI build/publish from it.
+- **Version-sync** anything that must agree (package manifest, lockfile, any
+  embedded version constant) in the same release commit — a drifted version is a
+  silent ship bug.
+
+## Root causes + second-order regressions
+
+- Fix **root causes**, not symptoms (the verify wave will catch a symptom-patch
+  that doesn't re-derive).
+- Watch for the **second-order regression** the change itself can introduce.
+  Worked example: a CI workflow edit that quietly **drops a test gate** — the
+  suite goes "green" because it stopped running, not because it passed. The
+  verifier's over-claim check (`refs/independent-verification.md` §3) is exactly
+  what catches this: re-run from clean and confirm the gate still actually runs.
+
+## The ship checklist (per unit)
+
+```
+[ ] on its own branch, conventional commits, SHA verified by ancestry
+[ ] /wicked-garden:prove → satisfied + re_derived for tests/build/lint
+[ ] hard-gate units: independent wicked-vault attest --opinion pass
+[ ] independent review done; all review/bot comments resolved
+[ ] rebased onto current main; clean tree
+[ ] (release) tag cut; versions synced
+[ ] branch merged, confirmed in main by ancestry, then deleted + logged
+```


### PR DESCRIPTION
Codifies two reusable "ways of working" into the plugin (authored + independently verified; CLI data from a research pass + the council I dogfooded this session).

## 1. Registry-driven multi-CLI council
- **`scripts/jam/agentic_cli_registry.py`** — machine-readable registry of **32 agentic/LLM CLIs** (was 9 in scattered prose / 3 in prereq_doctor). Per record: binary (+ alts), vendor, category, headless invocation, input-mode, model-flag style, trust/auth flags, version probe, install, confidence (verified vs confirm-on-probe), collision notes. Covers antigravity/`agy`, `pi`, codex, gemini, copilot, opencode, aider, goose, cursor-agent, amp, droid, qwen, openhands, interpreter, gptme, crush, llm, aichat, mods, sgpt, q, ollama, + confirm-on-probe (grok/forge/continue/cline/cody/plandex/…).
- **`scripts/jam/detect_clis.py`** — cross-platform (stdlib) detect + **usability probe**; classifies usable vs installed-but-unusable (auth-revoked / no-provider / daemon-down) with trust flags applied; disambiguates binary collisions (`grok`/`forge`/`agent`/`q`→`kiro-cli`).
- **`agents/jam/council.md`** — registry-driven (the hardcoded `which codex copilot gemini…` list is gone); adds the usability-probe + a **`Task()` subagent fallback tier** when <2 usable external CLIs.
- `scripts/platform/prereq_doctor.py` now derives its agentic-CLI list from the registry (23 vs 3); `skills/multi-model/SKILL.md` + `commands/jam/council.md` + refs reconciled (fixes the `--yes-always` drift + stale 4-CLI line).

## 2. Parallel verification-swarm skill
- **`skills/swarm/`** (SKILL.md + 5 refs) — the orchestration playbook: recon → synthesize → fan-out implementers → **independent verifier wave (no agent grades its own work)** → receipts → clean ship. **Composes** the crew agents, `qe:semantic-reviewer`, `/wicked-garden:prove` + `wicked-vault attest` (G10 evaluator≠creator), `worktrees`, and `jam:council` rather than duplicating them. Includes copy-paste implementer + verifier brief templates.

## Validation
- All Python parses, stdlib-only; `detect_clis.py --probe` runs clean via `_python.sh` (4 usable on the dev box: gemini, agy, opencode, copilot).
- `swarm/SKILL.md` ≤200 lines (slim-body); all ref links resolve; `components.json` reparses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
