### PR TITLE
chore(release): v12.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "Your coding agent already plans and swarms \u2014 Wicked Garden is the curated toolkit for what it can't: proof-not-claims gates, code links grep can't see, deterministic refactor, cross-session memory, real multi-model second opinions. Don't fight the harness; fill its gaps. The gate needs wicked-vault + wicked-loom; testing/brain/bus are opt-in layers.",
-      "version": "12.24.0"
+      "version": "12.25.0"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.24.0",
+  "version": "12.25.0",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims \u2014 gates re-derive 'done' through wicked-loom/wicked-vault (fail-closed, independently attested), so a self-asserted pass can't lie its way green. Relationships grep can't see \u2014 codegraph + injected bus/dispatch/capability edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory (wicked-brain), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (wicked-testing). It reads the shape of your work to apply the right rigor \u2014 steering, not a pipeline \u2014 then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires two peers (wicked-vault + wicked-loom); wicked-testing, wicked-brain, wicked-understanding, and wicked-bus are opt-in layers \u2014 install what you'll use, the toolkit works without the rest.",
   "wicked_testing_version": "^0.4.0",
   "wicked_vault_version": "^0.4.0",


### PR DESCRIPTION
## Release v12.25.0 (minor)

Version bump **12.24.0 → 12.25.0** across the synced manifests.

### Ships
- **Council CLI registry** + the **`swarm` skill** — the registry-driven multi-CLI council + parallel-verification swarm codified in #955 (`feat(jam,swarm)`, commit `1a357be3`).

### Changed files
- `.claude-plugin/plugin.json` → `.version` = `12.25.0`
- `.claude-plugin/marketplace.json` → wicked-garden plugin entry `version` = `12.25.0`

`pyproject.toml` is intentionally left untouched (independent tooling version; never synced with the plugin release line).

### Validation
- `scripts/ci/validate.py`: **PASS (0 errors, 0 warnings)** — version-sync confirmed (marketplace == plugin == `12.25.0`).

> Branch is for admin-merge + tag by the maintainer. No tag created here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)