### PR TITLE
fix(peers): widen wicked_testing_version pin to ^0.6.0 (v12.25.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "Your coding agent already plans and swarms \u2014 Wicked Garden is the curated toolkit for what it can't: proof-not-claims gates, code links grep can't see, deterministic refactor, cross-session memory, real multi-model second opinions. Don't fight the harness; fill its gaps. The gate needs wicked-vault + wicked-loom; testing/brain/bus are opt-in layers.",
-      "version": "12.25.0"
+      "version": "12.25.1"
     }
   ],
   "version": "2.0.0"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "wicked-garden",
-  "version": "12.25.0",
+  "version": "12.25.1",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims \u2014 gates re-derive 'done' through wicked-loom/wicked-vault (fail-closed, independently attested), so a self-asserted pass can't lie its way green. Relationships grep can't see \u2014 codegraph + injected bus/dispatch/capability edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory (wicked-brain), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (wicked-testing). It reads the shape of your work to apply the right rigor \u2014 steering, not a pipeline \u2014 then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires two peers (wicked-vault + wicked-loom); wicked-testing, wicked-brain, wicked-understanding, and wicked-bus are opt-in layers \u2014 install what you'll use, the toolkit works without the rest.",
-  "wicked_testing_version": "^0.4.0",
+  "wicked_testing_version": "^0.6.0",
   "wicked_vault_version": "^0.4.0",
   "wicked_brain_version": "^0.15.0",
   "wicked_bus_version": "^2.0.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [12.25.1] - 2026-06-17
+
+### Bug Fixes
+- fix(peers): `wicked_testing_version` pin `^0.4.0` → `^0.6.0` — the caret probe locks 0.x pins to the minor, so the current wicked-testing **0.6.x** line was out-of-range against `^0.4.0` and crew commands were blocked. Widen the enforced peer floor (mirrors the earlier `^0.3.0` → `^0.4.0` fix). Sibling floors `wicked_vault ^0.4.0` / `wicked_bus ^2.0.0` still cover 0.4.3 / 2.2.3; the declarative `wicked_brain` / `wicked_loom` floors are unchanged.
+
 ## [12.21.0] - 2026-06-12
 
 ### Changed


### PR DESCRIPTION
## What
Widen the **probe-enforced** peer floor `wicked_testing_version` `^0.4.0` → `^0.6.0`, and cut **v12.25.1** (plugin.json + marketplace.json).

## Why
The wicked-testing probe's caret check locks 0.x pins to the minor (`^0.4.0` = `>=0.4.0 <0.5.0`). With wicked-testing now on the **0.6.x** line (0.6.1 released), the probe reported `out-of-range` and **blocked all crew commands**. Mirrors the earlier `^0.3.0 → ^0.4.0` fix.

## Scope (minimal)
- Only the **probe-enforced** `wicked_testing_version` pin changes.
- `wicked_vault ^0.4.0` / `wicked_bus ^2.0.0` already cover 0.4.3 / 2.2.3 — unchanged.
- `wicked_brain` / `wicked_loom` floors are **declarative-only** intentional minimums (no probe) — unchanged.

## Verification
Ran the actual probe against the plugin root after the bump: `{status: ok, version: 0.6.1, pin: ^0.6.0}` → crew unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)