### PR TITLE
fix(hooks): fire heavy-cadence teardown reliably on Stop, not just SessionEnd (#842)

### DIFF
--- a/hooks/scripts/session_end.py
+++ b/hooks/scripts/session_end.py
@@ -48,10 +48,21 @@ def main() -> None:
     )
 
     try:
-        from _heavy_cadence import run_heavy_cadence, TRIGGER_SESSION_END  # type: ignore
-        messages = run_heavy_cadence(
-            TRIGGER_SESSION_END, session_id=session_id, plugin_root=_PLUGIN_ROOT
+        from _heavy_cadence import (  # type: ignore
+            run_heavy_cadence, already_ran_this_session, TRIGGER_SESSION_END,
         )
+        # De-dupe guard (v9.2.16, #842): the Stop hook now also carries the
+        # heavy-cadence teardown (SessionEnd is unreliable — fires on <40% of
+        # exits). If a Stop already ran the heavy work for this session, skip —
+        # the work is done and the sidecar already records it. Otherwise run it
+        # here; SessionEnd is the best end-of-session snapshot when it fires.
+        if already_ran_this_session(session_id):
+            _log("session", "debug", "session_end.dedupe_skip")
+            messages = []
+        else:
+            messages = run_heavy_cadence(
+                TRIGGER_SESSION_END, session_id=session_id, plugin_root=_PLUGIN_ROOT
+            )
     except Exception as e:
         # Fail open — SessionEnd must never block the user closing their CLI.
         print(f"[wicked-garden] session_end error: {e}", file=sys.stderr)

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -535,12 +535,16 @@ def main():
         # 5. Event store retention purge
         _purge_old_events()
 
-        # 6. Heavy cadence (v9.2.15) — formerly per-turn, now per-session-end
-        # primary via the SessionEnd hook (hooks/scripts/session_end.py).
-        # Stop only runs the heavy work as a 60-min FALLBACK for the partial-
-        # session failure mode (CLI killed, network drop, user walked away —
-        # SessionEnd never fires). Sidecar at <local store>/wicked-garden/
-        # heavy-cadence/last_run.json gates the fallback deterministically.
+        # 6. Heavy cadence — Stop is a reliable co-primary carrier of the
+        # teardown (v9.2.16, #842). SessionEnd fires on <40% of exits (~1% for
+        # agents), so it can't be the sole primary. Stop fires every turn and IS
+        # reliable, so it now runs the SAME heavy work, guarded by
+        # should_run_fallback() to fire at most ONCE per session: a de-dupe on
+        # session_id (so SessionEnd + Stop never double-run and per-turn Stops
+        # don't repeat) plus a turn-count-OR-60-min gate that catches short
+        # sessions SessionEnd would have dropped. Sidecar at <local store>/
+        # wicked-garden/heavy-cadence/last_run.json makes the guard
+        # deterministic and records which trigger actually ran the work.
         consolidation_messages: list = []
         decay_messages: list = []
         telemetry_messages: list = []
@@ -550,7 +554,7 @@ def main():
             from _heavy_cadence import (  # type: ignore
                 run_heavy_cadence, should_run_fallback, TRIGGER_STOP_FALLBACK,
             )
-            if should_run_fallback():
+            if should_run_fallback(session_id=session_id, turn_count=turn_count):
                 fallback_messages = run_heavy_cadence(
                     TRIGGER_STOP_FALLBACK, session_id=session_id, plugin_root=_PLUGIN_ROOT,
                 )

--- a/scripts/_heavy_cadence.py
+++ b/scripts/_heavy_cadence.py
@@ -20,10 +20,33 @@ The v9.2.11 audit + v9.2.15 quick brainstorm settled on Option C (hybrid):
     failure mode (CLI killed, network drop, user walks away — SessionEnd
     never fires).
 
+v9.2.16 dogfood fix (#842): live telemetry showed SessionEnd fires for only
+~40% of human and ~1% of agent sessions — SessionEnd is simply NOT emitted on
+most exit paths (non-interactive `claude -p` runs, agent kills, crashes, abrupt
+closes). The 60-min-only Stop gate meant short sessions (<60 min) that never
+emit SessionEnd got NO heavy teardown at all — 78% of runs fell through to the
+"fallback" path, i.e. the fallback WAS the primary path and it still missed the
+short-session case. Verdict: UNHEALTHY (Pi/OpenCode's predicted failure mode).
+
+The deterministic fix: stop no longer *hopes* SessionEnd fires. The Stop hook —
+which fires reliably every turn — now carries the SAME heavy-cadence teardown,
+guarded so it runs at most ONCE per session:
+  - De-dupe by session_id: the sidecar records which session_id last ran heavy
+    cadence. `should_run_fallback()` returns False when that session_id matches
+    the current one, so (a) SessionEnd + Stop never double-run for one session,
+    and (b) Stop never re-runs the heavy work on every subsequent turn.
+  - Turn-count OR time gate: a *new* session that has not yet run heavy cadence
+    fires when it has accrued FALLBACK_TURN_THRESHOLD turns OR the 60-min
+    catch-up interval has elapsed — whichever comes first. The turn arm catches
+    short-wall-clock agent/`-p` sessions that never emit SessionEnd; the time
+    arm catches long, low-turn idle sessions.
+SessionEnd still runs first when it *does* fire (best end-of-session snapshot);
+it de-dupes against the sidecar so it no-ops if Stop already ran this session.
+
 A sidecar file at <local store>/wicked-garden/heavy-cadence/last_run.json
-records `last_heavy_run_ts` + `trigger` so the Stop fallback is deterministic.
-SessionState is per-session (resets on new session), so it can't gate cross-
-session fallback — sidecar is the right persistence boundary.
+records `last_heavy_run_ts` + `trigger` + `session_id` so the guard is
+deterministic. SessionState is per-session (resets on new session), so it can't
+gate cross-session fallback — sidecar is the right persistence boundary.
 
 Brain calls themselves are unchanged. Only WHEN they fire changed.
 
@@ -58,6 +81,14 @@ from typing import List, Optional
 #  - Same magnitude as wicked-brain's own stale-content thresholds so brain
 #    decay decisions remain timely even under fallback.
 FALLBACK_INTERVAL_SECS: int = 60 * 60
+
+# Turn-count arm of the Stop gate (v9.2.16, #842). A session that has taken
+# this many turns without heavy cadence having run yet is "worth a teardown"
+# even if <60 min of wall-clock has passed since the last run. Catches busy
+# short-wall-clock sessions (a lot happened fast) whose SessionEnd never fired.
+# 30 mirrors the "typical 30-turn session" figure the per-turn cadence audit
+# used. De-dupe by session_id still bounds this to one run per session.
+FALLBACK_TURN_THRESHOLD: int = 30
 
 SIDECAR_DIR_NAME: str = "heavy-cadence"
 SIDECAR_FILENAME: str = "last_run.json"
@@ -138,27 +169,72 @@ def _write_sidecar(trigger: str, session_id: Optional[str] = None) -> None:
             pass
 
 
-def should_run_fallback(now_ts: Optional[float] = None) -> bool:
-    """Return True if Stop should run the heavy cadence as a fallback.
+def already_ran_this_session(session_id: Optional[str]) -> bool:
+    """Return True if heavy cadence already ran for `session_id` this session.
 
-    Triggers True when:
-      - sidecar file missing (first run ever for this project)
-      - sidecar exists but `last_heavy_run_ts` is unparseable
-      - last run was more than FALLBACK_INTERVAL_SECS ago
+    The de-dupe guard (v9.2.16, #842). The sidecar records the session_id of
+    the last heavy run; if it matches the current session, the work is done —
+    whether SessionEnd or an earlier Stop did it. Both terminal hooks consult
+    this so SessionEnd + Stop never double-run for one session.
 
-    Defaults False when the sidecar is fresh — most Stop calls are per-turn
-    and should NOT trigger heavy work.
+    Fail-open to False (i.e. "not yet run") when session_id is unknown/empty or
+    the sidecar has no recorded run — an unknown session cannot be matched, so
+    the caller falls back to the time/turn gate rather than silently skipping.
     """
+    if not session_id:
+        return False
+    data = _read_sidecar()
+    return bool(data.get("last_heavy_run_ts")) and data.get("session_id") == str(session_id)
+
+
+def should_run_fallback(
+    session_id: Optional[str] = None,
+    turn_count: int = 0,
+    now_ts: Optional[float] = None,
+) -> bool:
+    """Return True if the Stop hook should run the heavy cadence teardown.
+
+    v9.2.16 (#842): Stop is now a reliable co-primary carrier of the teardown,
+    not a rare 60-min fallback. SessionEnd fires on <40% of exits, so relying on
+    it dropped short sessions entirely. Stop fires every turn and IS reliable —
+    this gate makes it run the heavy work at most ONCE per session:
+
+      1. De-dupe guard — if heavy cadence already ran for THIS `session_id`
+         (SessionEnd, or an earlier Stop this session), return False. This is
+         what makes carrying the teardown on every Stop safe: it fires once,
+         then no-ops for the rest of the session, and never double-runs against
+         a SessionEnd that also fires.
+      2. Never run for any session yet, or an unparseable timestamp → True
+         (seed / self-heal).
+      3. Otherwise a NEW session that has not run heavy cadence: fire when it
+         has accrued `FALLBACK_TURN_THRESHOLD` turns OR the 60-min catch-up
+         interval has elapsed since the last run — whichever comes first.
+
+    `session_id`/`turn_count` are optional so the pre-v9.2.16 call shape
+    (`should_run_fallback()` / `should_run_fallback(now_ts=...)`) still resolves
+    to the pure time gate.
+    """
+    # 1. De-dupe: this session already got its teardown.
+    if already_ran_this_session(session_id):
+        return False
+
     data = _read_sidecar()
     raw_ts = data.get("last_heavy_run_ts")
+
+    # 2. Never run, or corrupt timestamp → fire to seed / self-heal.
     if not raw_ts:
-        return True  # never run — fire fallback to seed the sidecar
+        return True
     try:
         last_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
-        return True  # corrupt timestamp — treat as never-run
+        return True
+
     now_dt = datetime.fromtimestamp(now_ts, tz=timezone.utc) if now_ts else datetime.now(timezone.utc)
     elapsed = (now_dt - last_dt).total_seconds()
+
+    # 3. New session, not yet torn down: turn arm OR time arm, whichever first.
+    if turn_count >= FALLBACK_TURN_THRESHOLD:
+        return True
     return elapsed >= FALLBACK_INTERVAL_SECS
 
 

--- a/scripts/_heavy_cadence.py
+++ b/scripts/_heavy_cadence.py
@@ -98,6 +98,39 @@ SIDECAR_FILENAME: str = "last_run.json"
 TRIGGER_SESSION_END: str = "session_end"
 TRIGGER_STOP_FALLBACK: str = "stop_fallback"
 
+# Fallback/sentinel session ids used when neither stdin nor $CLAUDE_SESSION_ID
+# supplies a real id (both stop.py and session_end.py default to "default").
+# These are NON-dedupable: an id-less session cannot be uniquely identified, so
+# recording one as a dedup key would suppress heavy-cadence teardown PERMANENTLY
+# for every subsequent id-less session (#842 dedup wedge). Treating them as
+# non-dedupable makes id-less sessions always fall through to the time/turn gate
+# while real session ids still de-dupe exactly once per session.
+_NON_DEDUP_SESSION_IDS = frozenset({"", "default", "unknown"})
+
+
+def _is_dedupable_session_id(session_id: Optional[str]) -> bool:
+    """True only for a real session id that may be used as a de-dupe key.
+
+    False for None/empty and the ``default``/``unknown`` fallback sentinels —
+    those must never short-circuit the run (see _NON_DEDUP_SESSION_IDS).
+    """
+    return bool(session_id) and str(session_id) not in _NON_DEDUP_SESSION_IDS
+
+
+def _parse_iso_ts(raw_ts) -> Optional[datetime]:
+    """Parse a sidecar ``last_heavy_run_ts`` defensively.
+
+    Returns a tz-aware datetime, or None when the value is missing, not a
+    string, or unparseable (corrupt/partial/migrated sidecar). Callers treat
+    None as "no trustworthy run recorded" rather than trusting a bad value.
+    """
+    if not raw_ts or not isinstance(raw_ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
 
 def _utc_iso_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -180,11 +213,19 @@ def already_ran_this_session(session_id: Optional[str]) -> bool:
     Fail-open to False (i.e. "not yet run") when session_id is unknown/empty or
     the sidecar has no recorded run — an unknown session cannot be matched, so
     the caller falls back to the time/turn gate rather than silently skipping.
+
+    The ``default``/``unknown`` fallback sentinels are treated as NON-dedupable
+    (#842): once a run recorded under ``default``, a bare equality check would
+    make every subsequent id-less session dedupe against it and never run heavy
+    cadence again. A recorded timestamp that is present but UNPARSEABLE
+    (corrupt/partial/migrated) is likewise NOT trusted as "already ran".
     """
-    if not session_id:
+    if not _is_dedupable_session_id(session_id):
         return False
     data = _read_sidecar()
-    return bool(data.get("last_heavy_run_ts")) and data.get("session_id") == str(session_id)
+    if _parse_iso_ts(data.get("last_heavy_run_ts")) is None:
+        return False
+    return data.get("session_id") == str(session_id)
 
 
 def should_run_fallback(
@@ -219,14 +260,10 @@ def should_run_fallback(
         return False
 
     data = _read_sidecar()
-    raw_ts = data.get("last_heavy_run_ts")
 
-    # 2. Never run, or corrupt timestamp → fire to seed / self-heal.
-    if not raw_ts:
-        return True
-    try:
-        last_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
+    # 2. Never run, or corrupt/unparseable timestamp → fire to seed / self-heal.
+    last_dt = _parse_iso_ts(data.get("last_heavy_run_ts"))
+    if last_dt is None:
         return True
 
     now_dt = datetime.fromtimestamp(now_ts, tz=timezone.utc) if now_ts else datetime.now(timezone.utc)

--- a/tests/test_heavy_cadence_redesign.py
+++ b/tests/test_heavy_cadence_redesign.py
@@ -1,0 +1,401 @@
+"""tests/test_heavy_cadence_redesign.py — heavy-cadence teardown reliability.
+
+Provenance: pre-v9.2.15, four heavy functions ran on EVERY Stop hook (per turn):
+  - _run_memory_decay        (~30 brain `lint` calls/session)
+  - _run_working_consolidation (~30 brain `compile` calls/session, 10s each)
+  - _run_quality_telemetry   (timeline.jsonl appends inflated 30x)
+  - _run_guard_pipeline      (findings.json overwritten per-turn)
+
+v9.2.15 moved them to a SessionEnd primary + 60-min Stop fallback, with a
+sidecar at <local store>/wicked-garden/heavy-cadence/last_run.json persisting
+`last_heavy_run_ts` cross-session.
+
+v9.2.16 (#842) — dogfood telemetry showed SessionEnd fires for only ~40% of
+human and ~1% of agent sessions; the 60-min-only Stop gate dropped short
+sessions entirely (78% of runs were the "fallback", and short sessions still
+got nothing). The deterministic fix:
+  - Stop carries the SAME teardown, guarded to run at most ONCE per session.
+  - De-dupe by session_id so SessionEnd + Stop never double-run and per-turn
+    Stops don't repeat (already_ran_this_session()).
+  - Turn-count-OR-60-min gate (FALLBACK_TURN_THRESHOLD) so busy short sessions
+    still get teardown even when SessionEnd never fires.
+
+T1: deterministic — sidecar read/write under tmp_path, frozen-time gate tests
+T3: isolated — monkeypatches `_sidecar_path` to point at tmp
+T4: single focus — de-dupe + turn/time gate + orchestration contracts
+T6: docstring cites #842 and the audit findings.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+
+
+@pytest.fixture
+def tmp_sidecar(tmp_path, monkeypatch):
+    """Redirect the heavy-cadence sidecar to a tmp file."""
+    import _heavy_cadence  # noqa
+    sentinel = tmp_path / "last_run.json"
+    monkeypatch.setattr(_heavy_cadence, "_sidecar_path", lambda: sentinel)
+    return sentinel
+
+
+def _write_sidecar_file(path: Path, *, minutes_ago: float, session_id: str = "",
+                        trigger: str = "session_end") -> None:
+    """Seed the sidecar with a run `minutes_ago` in the past."""
+    ts = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "last_heavy_run_ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trigger": trigger,
+        "session_id": session_id,
+    }))
+
+
+# ---------------------------------------------------------------------------
+# Sidecar read / write contract
+# ---------------------------------------------------------------------------
+
+def test_sidecar_read_returns_empty_dict_when_missing(tmp_sidecar):
+    import _heavy_cadence
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+def test_sidecar_read_returns_empty_dict_on_corrupt_json(tmp_sidecar):
+    import _heavy_cadence
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text("{not json")
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+def test_sidecar_write_persists_iso_timestamp_and_trigger(tmp_sidecar):
+    import _heavy_cadence
+    _heavy_cadence._write_sidecar("session_end", session_id="test-session")
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["trigger"] == "session_end"
+    assert data["session_id"] == "test-session"
+    assert "last_heavy_run_ts" in data
+    assert data["last_heavy_run_ts"].endswith("Z")
+    assert len(data["last_heavy_run_ts"]) == 20
+
+
+def test_sidecar_write_no_op_when_path_unresolvable(tmp_path, monkeypatch):
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_sidecar_path", lambda: None)
+    _heavy_cadence._write_sidecar("session_end")  # must not raise
+    assert _heavy_cadence._read_sidecar() == {}
+
+
+def test_sidecar_write_is_atomic(tmp_sidecar):
+    """v9.2.15 council mitigation: _write_sidecar must use temp-file + os.replace
+    so a concurrent reader sees either the old sidecar OR the new sidecar, never
+    a half-written file. Verify no `.tmp.*` leftovers and valid final JSON."""
+    import _heavy_cadence
+    _heavy_cadence._write_sidecar("session_end", session_id="atomicity-test")
+
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["session_id"] == "atomicity-test"
+
+    leftovers = list(tmp_sidecar.parent.glob(f"{tmp_sidecar.name}.tmp.*"))
+    assert leftovers == [], (
+        f"Atomic write left behind temp file(s): {leftovers}. "
+        f"Contract: write to <name>.tmp.<pid> then os.replace."
+    )
+
+
+def test_sidecar_temp_path_uses_pid_disambiguation():
+    """Parallel writers must not collide on the same temp path before either
+    calls os.replace — the temp path must include os.getpid()."""
+    import _heavy_cadence
+    import inspect
+    src = inspect.getsource(_heavy_cadence._write_sidecar)
+    assert "os.getpid()" in src, (
+        "_write_sidecar temp path must include os.getpid() to disambiguate "
+        "parallel writers."
+    )
+    assert "os.replace" in src, (
+        "_write_sidecar must use os.replace (atomic on POSIX + Windows) "
+        "instead of bare write_text."
+    )
+
+
+# ---------------------------------------------------------------------------
+# De-dupe guard (v9.2.16, #842) — the keystone reliability contract
+# ---------------------------------------------------------------------------
+
+def test_already_ran_false_when_session_id_unknown(tmp_sidecar):
+    """An unknown/empty session_id can never be matched — return False so the
+    caller falls through to the time/turn gate rather than silently skipping."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="sess-A")
+    assert _heavy_cadence.already_ran_this_session(None) is False
+    assert _heavy_cadence.already_ran_this_session("") is False
+
+
+def test_already_ran_false_when_sidecar_missing(tmp_sidecar):
+    import _heavy_cadence
+    assert _heavy_cadence.already_ran_this_session("sess-A") is False
+
+
+def test_already_ran_true_when_session_matches(tmp_sidecar):
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="sess-A")
+    assert _heavy_cadence.already_ran_this_session("sess-A") is True
+
+
+def test_already_ran_false_when_session_differs(tmp_sidecar):
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="sess-A")
+    assert _heavy_cadence.already_ran_this_session("sess-B") is False
+
+
+def test_fallback_deduped_when_session_already_ran(tmp_sidecar):
+    """The core de-dupe: once heavy cadence ran for this session (SessionEnd or
+    an earlier Stop), should_run_fallback() must return False for that session —
+    even with a huge turn_count — so Stop does not re-run it every turn and does
+    not double-run against SessionEnd."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="sess-A")
+    assert _heavy_cadence.should_run_fallback(session_id="sess-A", turn_count=999) is False
+
+
+def test_session_end_and_stop_do_not_double_run(tmp_sidecar, monkeypatch):
+    """End-to-end de-dupe: after run_heavy_cadence records session 'S', a
+    subsequent Stop for the SAME session must not fire again."""
+    import _heavy_cadence
+    for fn in ("_run_memory_decay", "_run_memory_consolidation", "_run_guard_pipeline"):
+        monkeypatch.setattr(_heavy_cadence, fn, lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: [])
+
+    # SessionEnd (or a first Stop) runs and records session 'S'.
+    _heavy_cadence.run_heavy_cadence("session_end", session_id="S")
+    assert json.loads(tmp_sidecar.read_text())["session_id"] == "S"
+
+    # A later Stop for the same session is de-duped.
+    assert _heavy_cadence.should_run_fallback(session_id="S", turn_count=999) is False
+
+
+# ---------------------------------------------------------------------------
+# Turn-count OR time gate — catches short sessions SessionEnd would drop
+# ---------------------------------------------------------------------------
+
+def test_fallback_fires_when_sidecar_missing(tmp_sidecar):
+    """First Stop call ever must run the teardown to seed the sidecar."""
+    import _heavy_cadence
+    assert _heavy_cadence.should_run_fallback(session_id="sess-A", turn_count=0) is True
+
+
+def test_fallback_turn_arm_fires_below_time_window(tmp_sidecar):
+    """A NEW session (different session_id) that crosses the turn threshold must
+    fire even though <60 min elapsed — catches busy short-wall-clock sessions
+    (e.g. agent runs) whose SessionEnd never fired."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=5, session_id="prev-session")
+    assert _heavy_cadence.should_run_fallback(
+        session_id="new-session", turn_count=_heavy_cadence.FALLBACK_TURN_THRESHOLD
+    ) is True
+
+
+def test_fallback_suppressed_when_new_session_short_and_recent(tmp_sidecar):
+    """A NEW session with few turns AND <60 min since the last run must NOT
+    fire — a heavy run just happened, so brain/telemetry state is fresh and a
+    2-turn session is not worth a second teardown."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=5, session_id="prev-session")
+    assert _heavy_cadence.should_run_fallback(
+        session_id="new-session", turn_count=3
+    ) is False
+
+
+def test_fallback_time_arm_fires_when_last_run_older_than_60_min(tmp_sidecar):
+    """A run 70 minutes ago MUST trigger the teardown (catch-up case) even for a
+    low-turn session — the time arm covers long idle sessions."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=70, session_id="prev-session")
+    assert _heavy_cadence.should_run_fallback(session_id="new-session", turn_count=0) is True
+
+
+def test_fallback_suppressed_within_60_min_window_legacy_call(tmp_sidecar):
+    """Backward-compat: the pre-v9.2.16 call shape (no session_id, no turn_count)
+    still resolves to the pure 60-min time gate — 30 min ago → suppressed."""
+    import _heavy_cadence
+    _write_sidecar_file(tmp_sidecar, minutes_ago=30, session_id="sess-A")
+    assert _heavy_cadence.should_run_fallback() is False
+
+
+def test_fallback_fires_on_corrupt_timestamp(tmp_sidecar):
+    """A malformed timestamp is treated as never-run — defensive self-heal."""
+    import _heavy_cadence
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text(json.dumps({
+        "last_heavy_run_ts": "not-an-iso-timestamp",
+        "trigger": "session_end",
+        "session_id": "other",
+    }))
+    assert _heavy_cadence.should_run_fallback(session_id="sess-A", turn_count=0) is True
+
+
+def test_fallback_interval_is_60_minutes():
+    """Locked constant — change is a deliberate decision."""
+    import _heavy_cadence
+    assert _heavy_cadence.FALLBACK_INTERVAL_SECS == 60 * 60
+
+
+def test_fallback_turn_threshold_is_30():
+    """Locked constant — the turn arm of the gate."""
+    import _heavy_cadence
+    assert _heavy_cadence.FALLBACK_TURN_THRESHOLD == 30
+
+
+# ---------------------------------------------------------------------------
+# run_heavy_cadence orchestration — runs all four + writes sidecar
+# ---------------------------------------------------------------------------
+
+def test_run_heavy_cadence_writes_sidecar_after_run(tmp_sidecar, monkeypatch):
+    """Every successful invocation persists timestamp + trigger + session_id so
+    the next Stop's de-dupe/gate has a deterministic answer."""
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: [])
+
+    messages = _heavy_cadence.run_heavy_cadence("session_end", session_id="test")
+    assert messages == []
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["trigger"] == "session_end"
+    assert data["session_id"] == "test"
+
+
+def test_run_heavy_cadence_stop_fallback_records_correct_trigger(tmp_sidecar, monkeypatch):
+    """When the Stop path runs the teardown, the sidecar records stop_fallback —
+    so the trigger distribution reflects which path actually did the work."""
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: [])
+
+    _heavy_cadence.run_heavy_cadence(
+        _heavy_cadence.TRIGGER_STOP_FALLBACK, session_id="agent-sess"
+    )
+    data = json.loads(tmp_sidecar.read_text())
+    assert data["trigger"] == "stop_fallback"
+    assert data["session_id"] == "agent-sess"
+
+
+def test_run_heavy_cadence_aggregates_messages(tmp_sidecar, monkeypatch):
+    """All four functions' messages flow through to the caller."""
+    import _heavy_cadence
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: ["[Memory] Decay: 1, 2"])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", lambda root: ["[Memory] Consolidation: 3, 4"])
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: ["[Telemetry] Drift detected"])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: ["[Guard] 5 findings"])
+
+    messages = _heavy_cadence.run_heavy_cadence("stop_fallback", session_id="test")
+    assert len(messages) == 4
+    assert any("Decay" in m for m in messages)
+    assert any("Consolidation" in m for m in messages)
+    assert any("Drift" in m for m in messages)
+    assert any("Guard" in m for m in messages)
+
+
+def test_run_heavy_cadence_does_not_write_sidecar_on_raise(tmp_sidecar, monkeypatch):
+    """If a heavy function raises (test stub without the real fail-open), the
+    sidecar is NOT written — preserving the "next Stop retries" property."""
+    import _heavy_cadence
+    def boom(root, *args):
+        raise RuntimeError("brain unreachable")
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_decay", lambda root: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_memory_consolidation", boom)
+    monkeypatch.setattr(_heavy_cadence, "_run_quality_telemetry", lambda root, sid: [])
+    monkeypatch.setattr(_heavy_cadence, "_run_guard_pipeline", lambda root: [])
+    with pytest.raises(RuntimeError):
+        _heavy_cadence.run_heavy_cadence("session_end", session_id="s")
+    assert not tmp_sidecar.exists()
+
+
+# ---------------------------------------------------------------------------
+# stop.py contract: carries the teardown with the de-duped gate
+# ---------------------------------------------------------------------------
+
+def test_stop_py_no_longer_calls_heavy_functions_directly():
+    """stop.py must invoke the heavy work only via run_heavy_cadence() inside
+    the should_run_fallback() branch, never the four functions directly."""
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+    direct_calls = [
+        line for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+        and any(call in line for call in (
+            "_run_memory_decay()",
+            "_run_working_consolidation()",
+            "_run_quality_telemetry(",
+            "_run_guard_pipeline()",
+        ))
+        and "def " not in line
+    ]
+    assert not direct_calls, (
+        f"stop.py main flow still calls heavy functions directly: {direct_calls}"
+    )
+
+
+def test_stop_py_imports_heavy_cadence():
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+    assert "from _heavy_cadence import" in text
+    assert "should_run_fallback" in text
+    assert "run_heavy_cadence" in text
+
+
+def test_stop_py_passes_session_id_and_turn_count_to_gate():
+    """v9.2.16: the Stop gate must be per-session (de-dupe) and turn-aware, so
+    stop.py must pass BOTH session_id and turn_count into should_run_fallback."""
+    text = (REPO_ROOT / "hooks" / "scripts" / "stop.py").read_text()
+    assert "should_run_fallback(session_id=session_id, turn_count=turn_count)" in text, (
+        "stop.py must call should_run_fallback with session_id + turn_count so "
+        "the de-dupe guard and turn arm are active."
+    )
+
+
+# ---------------------------------------------------------------------------
+# session_end.py contract: de-dupes against a Stop that already ran
+# ---------------------------------------------------------------------------
+
+def test_session_end_py_uses_dedupe_guard():
+    """SessionEnd must skip the teardown when a Stop already ran it this
+    session — otherwise SessionEnd + Stop double-run."""
+    text = (REPO_ROOT / "hooks" / "scripts" / "session_end.py").read_text()
+    assert "already_ran_this_session" in text, (
+        "session_end.py must consult already_ran_this_session() to de-dupe "
+        "against a Stop that already carried the teardown."
+    )
+
+
+def test_session_end_py_exists_and_imports():
+    p = REPO_ROOT / "hooks" / "scripts" / "session_end.py"
+    assert p.exists(), f"SessionEnd script missing at {p}"
+    import session_end  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# hooks.json: both terminal events are wired to the teardown carriers
+# ---------------------------------------------------------------------------
+
+def test_hooks_json_wires_sessionend_and_stop():
+    """Both SessionEnd and Stop must be wired — Stop is now a reliable
+    co-primary carrier, not just a rare fallback."""
+    h = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text())
+    events = h["hooks"]
+    assert "SessionEnd" in events
+    assert "Stop" in events
+    se_cmd = events["SessionEnd"][0]["hooks"][0]["command"]
+    assert "session_end" in se_cmd, f"SessionEnd does not invoke session_end: {se_cmd}"
+    stop_cmd = events["Stop"][0]["hooks"][0]["command"]
+    assert "stop" in stop_cmd, f"Stop does not invoke stop: {stop_cmd}"

--- a/tests/test_heavy_cadence_redesign.py
+++ b/tests/test_heavy_cadence_redesign.py
@@ -35,8 +35,15 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
-sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+
+# conftest.py owns the suite-wide sys.path contract: it guarantees scripts/ at
+# sys.path[0] (so `_heavy_cadence` and package imports resolve). Do NOT prepend
+# here — inserting hooks/scripts at position 0 would shadow scripts/ and break
+# that contract. Append hooks/scripts at the END purely for the direct
+# `import session_end` / stop.py reads below; scripts/ stays at position 0.
+_HOOKS_SCRIPTS = str(REPO_ROOT / "hooks" / "scripts")
+if _HOOKS_SCRIPTS not in sys.path:
+    sys.path.append(_HOOKS_SCRIPTS)
 
 
 @pytest.fixture
@@ -155,6 +162,46 @@ def test_already_ran_false_when_session_differs(tmp_sidecar):
     import _heavy_cadence
     _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="sess-A")
     assert _heavy_cadence.already_ran_this_session("sess-B") is False
+
+
+def test_default_session_id_is_not_dedupable(tmp_sidecar):
+    """#842 dedup wedge: the fallback session id 'default' (used when neither
+    stdin nor $CLAUDE_SESSION_ID supplies an id) must NEVER be treated as a
+    de-dupe key. Otherwise, once a run records session_id='default', every
+    later id-less session would dedupe against it and heavy cadence would be
+    permanently suppressed. A sidecar recorded under 'default' must still report
+    already_ran=False for a subsequent 'default' session, and should_run_fallback
+    must fall through to the time/turn gate (fire when the sidecar is fresh-seed
+    or the gate opens) rather than short-circuiting to False."""
+    import _heavy_cadence
+    # A prior id-less run recorded under the 'default' sentinel.
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="default")
+    # Never treated as "already ran" for any of the fallback sentinels.
+    assert _heavy_cadence.already_ran_this_session("default") is False
+    assert _heavy_cadence.already_ran_this_session("unknown") is False
+    # And the de-dupe short-circuit in should_run_fallback is skipped: the turn
+    # arm still fires for a busy 'default' session instead of being suppressed.
+    assert _heavy_cadence.should_run_fallback(
+        session_id="default", turn_count=_heavy_cadence.FALLBACK_TURN_THRESHOLD
+    ) is True
+    # A real session id recorded a run still de-dupes exactly once.
+    _write_sidecar_file(tmp_sidecar, minutes_ago=1, session_id="real-sess")
+    assert _heavy_cadence.already_ran_this_session("real-sess") is True
+
+
+def test_already_ran_false_on_corrupt_timestamp(tmp_sidecar):
+    """A present-but-unparseable last_heavy_run_ts (corrupt/partial/migrated
+    sidecar) must NOT be trusted as proof a run happened — even when the
+    session_id matches. Treat it as not-run so the caller re-derives via the
+    time/turn gate instead of silently suppressing teardown forever."""
+    import _heavy_cadence
+    tmp_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    tmp_sidecar.write_text(json.dumps({
+        "last_heavy_run_ts": "not-an-iso-timestamp",
+        "trigger": "session_end",
+        "session_id": "sess-A",
+    }))
+    assert _heavy_cadence.already_ran_this_session("sess-A") is False
 
 
 def test_fallback_deduped_when_session_already_ran(tmp_sidecar):


### PR DESCRIPTION
Fixes #842.

## Problem
Live telemetry showed the SessionEnd heavy-cadence hook fired for only ~40% of human and ~1% of agent sessions — **78% fell through to `stop_fallback`**, so heavy-cadence teardown was mostly skipped (verdict: UNHEALTHY).

## Fix
Don't depend on SessionEnd firing. Route the **same** heavy-cadence teardown through the **Stop** path with a **de-dupe guard** so SessionEnd + Stop can't double-run, and record the correct `trigger` on the sidecar regardless of which terminal event actually occurs.

## Adversarial review: **approved** (root cause addressed)
Non-blocking follow-ups noted for a later pass: session_id='default' fallback when neither stdin nor $CLAUDE_SESSION_ID provides one (narrow dedup-wedge edge); short sessions ending without SessionEnd rely on the 60-min catch-up.

## Tests
`pytest tests/test_heavy_cadence_redesign.py` → **30 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)