### PR TITLE
chore(site): re-pin wicked-web to main for the reshaped shared chrome

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5573,7 +5573,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#76696aaa9a46e71070f92293ee44a265f331508a",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#813bebcd99d5094d48e54e3425e9c779a901a6b5",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-pins the `wicked-web` git dependency (shared chrome: Topbar/Footer/Base from `wicked-web/components`) to current `main` HEAD so the site picks up the control-loop reshape.

## What changed
- `site/package-lock.json`: `wicked-web` pin `76696aa` → `813bebc` (current wicked-web `origin/main` HEAD)

## Verification
- `npm run build` in `site` — GREEN
- Built `dist/index.html` contains the loop-role footer (Steer/Equip/Verify/Govern) and the `wg./we./wt./wc./wi.wickedagile.com` subdomain links
- OLD taxonomy ("Building Blocks"/"Utilities"/"Solutions") is GONE from the output

Only the dependency lockfile is committed — no `node_modules`, no `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)