### PR TITLE
feat(gate): auto-playing gate full-width on top; title/intro in left column

### DIFF
--- a/site/src/components/react/ProveGate.tsx
+++ b/site/src/components/react/ProveGate.tsx
@@ -106,7 +106,11 @@ export default function ProveGate() {
     <div className="mx-auto w-full max-w-[1240px] px-5 sm:px-8">
       {/* ── the auto-playing gate — full width, across the top ── */}
       <Reveal>
-        <div className="pg-machine pg-machine--wide">
+        <div
+          className="pg-machine pg-machine--wide"
+          role="group"
+          aria-label="Evidence gate — interactive demo: break a condition, pull PROVE, and watch the gate re-derive the verdict"
+        >
           <div className="pg-machine-head">
             <span>evidence conditions</span>
             <span>{verdict ? "gate: re-derived" : pulled ? "gate: re-deriving" : "gate: armed"}</span>

--- a/site/src/components/react/ProveGate.tsx
+++ b/site/src/components/react/ProveGate.tsx
@@ -86,7 +86,7 @@ export default function ProveGate() {
     takeControl();
     if (pulled) return;
     setPulled(true);
-    window.setTimeout(() => setVerdict(derive(state)), 460);
+    timers.current.push(window.setTimeout(() => setVerdict(derive(state)), 460));
   }
   function reset() {
     takeControl();
@@ -108,7 +108,7 @@ export default function ProveGate() {
       <Reveal>
         <div
           className="pg-machine pg-machine--wide"
-          role="group"
+          role="region"
           aria-label="Evidence gate — interactive demo: break a condition, pull PROVE, and watch the gate re-derive the verdict"
         >
           <div className="pg-machine-head">

--- a/site/src/components/react/ProveGate.tsx
+++ b/site/src/components/react/ProveGate.tsx
@@ -54,9 +54,12 @@ export default function ProveGate() {
     timers.current = [];
   }
 
-  // Any hands-on interaction pins the gate — the visitor is now driving.
+  // Any hands-on interaction pins the gate — the visitor is now driving. Always
+  // cancel pending timers (auto-play AND a queued manual-pull re-stamp), so a
+  // flip/reset right after a pull can't fire a stale setVerdict over the reset.
   function takeControl() {
-    if (auto) { setAuto(false); clearTimers(); }
+    clearTimers();
+    if (auto) setAuto(false);
   }
 
   // Self-playing timeline: reset → break a condition → pull → re-stamp → next.

--- a/site/src/components/react/ProveGate.tsx
+++ b/site/src/components/react/ProveGate.tsx
@@ -104,57 +104,15 @@ export default function ProveGate() {
 
   return (
     <div className="mx-auto w-full max-w-[1240px] px-5 sm:px-8">
+      {/* ── the auto-playing gate — full width, across the top ── */}
       <Reveal>
-        <p className="kicker" style={{ color: "var(--accent)" }}>02 / the gate</p>
-        <h2 className="pg-h2">Play the lying agent. Watch the gate refuse.</h2>
-        <p className="pg-intro">
-          Garden’s one non-negotiable, made drivable. It plays itself — breaking the
-          evidence and re-stamping the verdict. Flip a switch or pull the lever to take
-          control: the gate re-derives the claim instead of taking your word for it.
-        </p>
-      </Reveal>
-
-      {/* persistent affordance — mirrors the toolbox: live state + how to take control */}
-      <div className="pg-afford" data-pinned={!auto}>
-        {auto ? (
-          <>
-            <span className="pg-afford-state pg-afford-live" aria-hidden>▶</span>
-            <span className="pg-afford-text">
-              auto-playing the gate — <b>flip a switch or pull the lever</b> to take control
-            </span>
-          </>
-        ) : (
-          <>
-            <span className="pg-afford-state" aria-hidden>❚❚</span>
-            <span className="pg-afford-text">you’re driving the gate</span>
-            <button type="button" className="pg-afford-btn" onClick={resume}>
-              ▶ resume auto-play
-            </button>
-          </>
-        )}
-      </div>
-
-      <Reveal delay={0.06}>
-        <div className="pg-shell">
-          {/* the claim handed to the visitor */}
-          <div className="pg-claim">
-            <span className="pg-claim-tape" aria-hidden />
-            <div className="pg-claim-kind">claim card · archetype: build</div>
-            <div className="pg-claim-text"><b>build:</b> all acceptance tests pass</div>
-            <p className="pg-claim-note">
-              The agent stamped this “done.” The gate re-runs the verifier, re-hashes
-              the recording, and checks the vault is even there. Break a condition and
-              prove it can’t be fooled.
-            </p>
+        <div className="pg-machine pg-machine--wide">
+          <div className="pg-machine-head">
+            <span>evidence conditions</span>
+            <span>{verdict ? "gate: re-derived" : pulled ? "gate: re-deriving" : "gate: armed"}</span>
           </div>
 
-          {/* the machine */}
-          <div className="pg-machine">
-            <div className="pg-machine-head">
-              <span>evidence conditions</span>
-              <span>{verdict ? "gate: re-derived" : pulled ? "gate: re-deriving" : "gate: armed"}</span>
-            </div>
-
+          <div className="pg-machine-body">
             <div className="pg-switches">
               {CONDITIONS.map((c) => {
                 const on = state[c.id];
@@ -192,8 +150,55 @@ export default function ProveGate() {
                 )}
               </div>
             </div>
+          </div>
 
-            <button type="button" className="pg-reset" onClick={reset}>reset the bench</button>
+          <button type="button" className="pg-reset" onClick={reset}>reset the bench</button>
+        </div>
+      </Reveal>
+
+      {/* persistent affordance — live state + how to take control */}
+      <div className="pg-afford" data-pinned={!auto}>
+        {auto ? (
+          <>
+            <span className="pg-afford-state pg-afford-live" aria-hidden>▶</span>
+            <span className="pg-afford-text">
+              auto-playing the gate — <b>flip a switch or pull the lever</b> to take control
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="pg-afford-state" aria-hidden>❚❚</span>
+            <span className="pg-afford-text">you’re driving the gate</span>
+            <button type="button" className="pg-afford-btn" onClick={resume}>
+              ▶ resume auto-play
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* ── title/intro (left) + the claim it re-derives (right) ── */}
+      <Reveal delay={0.06}>
+        <div className="pg-shell">
+          <div className="pg-intro-col">
+            <p className="kicker" style={{ color: "var(--accent)" }}>02 / the gate</p>
+            <h2 className="pg-h2">Play the lying agent. Watch the gate refuse.</h2>
+            <p className="pg-intro">
+              Garden’s one non-negotiable, made drivable. It plays itself — breaking the
+              evidence and re-stamping the verdict. Flip a switch or pull the lever to take
+              control: the gate re-derives the claim instead of taking your word for it.
+            </p>
+          </div>
+
+          {/* the claim handed to the visitor */}
+          <div className="pg-claim">
+            <span className="pg-claim-tape" aria-hidden />
+            <div className="pg-claim-kind">claim card · archetype: build</div>
+            <div className="pg-claim-text"><b>build:</b> all acceptance tests pass</div>
+            <p className="pg-claim-note">
+              The agent stamped this “done.” The gate re-runs the verifier, re-hashes
+              the recording, and checks the vault is even there. Break a condition and
+              prove it can’t be fooled.
+            </p>
           </div>
         </div>
       </Reveal>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -468,10 +468,18 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
 .pg-afford-btn:hover { transform: translateY(-1px); filter: brightness(1.05); }
 .pg-afford-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
+/* below the full-width gate: title/intro on the left, the claim it re-derives on the right */
 .pg-shell {
-  margin-top: 1rem;
-  display: grid; gap: clamp(18px, 3vw, 40px);
-  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  margin-top: clamp(1.25rem, 3vw, 2rem);
+  display: grid; gap: clamp(18px, 3vw, 44px);
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  align-items: start;
+}
+.pg-intro-col { align-self: start; min-width: 0; }
+/* the gate is now full width across the top: lay its switch-bank beside the lever/stamp */
+.pg-machine--wide .pg-machine-body {
+  display: grid; gap: clamp(18px, 3.5vw, 48px);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: start;
 }
 .pg-claim {
@@ -693,6 +701,7 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
   .gd-hero-demo { max-width: 460px; }
   .tb-shell { grid-template-columns: 1fr; }
   .pg-shell { grid-template-columns: 1fr; }
+  .pg-machine--wide .pg-machine-body { grid-template-columns: 1fr; }
   .pg-claim { transform: none; }
   .cg-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }


### PR DESCRIPTION
## What
Restructures the **02 / the gate** section (`ProveGate`) per design feedback:

- The **auto-playing gate machine** now spans **full width across the top** (both columns) — its evidence switch-bank sits beside the lever/stamp via a new `.pg-machine-body` 2-col grid (stacks on mobile).
- The **kicker + title + intro** move into the **left column** of the row below; the **claim card** sits in the right column.

Show-then-tell: the auto-playing demo leads, the explanation supports it.

## Verify
`npm run build` (astro) GREEN; dist renders `.pg-machine--wide` + `.pg-machine-body` (full-width gate) and `.pg-intro-col` (title/intro left). Auto-play + drive-it-yourself behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x