### PR TITLE
chore(deps): re-pin wicked-web (dropdown + featured crew chrome)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5573,7 +5573,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#813bebcd99d5094d48e54e3425e9c779a901a6b5",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#1bc55e61e280eaabc2bdb538af0f2dff1079e868",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-pins the shared `wicked-web` chrome dependency to current main HEAD (`1bc55e61e280eaabc2bdb538af0f2dff1079e868`) so the newly-merged wicked-web#17 (one-line family dropdown, featured wicked-crew, 5-deployed count, crew hover fixes) propagates into wicked-garden's site. `package.json` already pins via `github:mikeparcewski/wicked-web`; only `site/package-lock.json` needed re-resolution to pick up the new chrome. Site build verified green.