### PR TITLE
chore(deps): re-pin wicked-web (dropdown + featured crew chrome)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5573,7 +5573,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#1bc55e61e280eaabc2bdb538af0f2dff1079e868",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#a78f1f5b2c1c7ab87121ce4f1317cded6cd31a38",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-pins the shared `wicked-web` chrome dependency in `site/` to current main HEAD (`a78f1f5b2c1c`), re-resolving `site/package-lock.json` from the previous commit so that the merged changes from wicked-web#17 — the one-line family dropdown, featured wicked-crew entry, 5-deployed count, and crew hover fixes — actually propagate to this consumer. The `github:` spec in package.json was already correct; only the lockfile needed re-resolution. Site build (`astro build`) is green against the new chrome.