### PR TITLE
content(council): Antigravity replaces Gemini in the review panel

### DIFF
--- a/site/src/components/react/Toolbox.tsx
+++ b/site/src/components/react/Toolbox.tsx
@@ -65,7 +65,7 @@ function PatchDemo() {
 
 function CouncilDemo() {
   const models = [
-    { m: "gemini", v: "ship", ok: true },
+    { m: "antigravity", v: "ship", ok: true },
     { m: "codex", v: "ship", ok: true },
     { m: "claude", v: "blocks: race", ok: false },
   ];

--- a/site/src/data/garden.ts
+++ b/site/src/data/garden.ts
@@ -109,7 +109,7 @@ export const TOOLS: Tool[] = [
     kind: "multi-model panel",
     hue: "solo",
     gap: "asks itself for a second opinion",
-    fill: "Convenes a real panel of independent external models (Gemini · Codex · …) — a second opinion that isn’t the model grading itself.",
+    fill: "Convenes a real panel of independent external models (Antigravity · Codex · …) — a second opinion that isn’t the model grading itself.",
     cmd: "wicked-garden-jam",
     cmdLabel: "garden skill · council",
   },


### PR DESCRIPTION
The gemini CLI is sunsetted; the family standardized on **Antigravity**. Updates garden's **council** (multi-model second-opinion panel) to list Antigravity instead of Gemini:

- `CouncilDemo` model roster (`Toolbox.tsx`) — `gemini` → `antigravity`
- council capability blurb (`garden.ts`) — `(Gemini · Codex · …)` → `(Antigravity · Codex · …)`

This is the review-*model* roster (models that judge), distinct from the coding-*CLI* worker roster crew drives. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpniabdmx6H4HsjLTjFd1x