### PR TITLE
fix(site): coherent mobile layouts for the toolbox + gate

### DIFF
--- a/site/src/components/react/ProveGate.tsx
+++ b/site/src/components/react/ProveGate.tsx
@@ -106,9 +106,23 @@ export default function ProveGate() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-[1240px] px-5 sm:px-8">
-      {/* ── the auto-playing gate — full width, across the top ── */}
-      <Reveal>
+    <div className="pg-outer mx-auto w-full max-w-[1240px] px-5 sm:px-8">
+      {/* ── title/intro — DOM-first so mobile reads it before the machine;
+             on desktop grid-areas float it back down beside the claim ── */}
+      <Reveal className="pg-a-intro">
+        <div className="pg-intro-col">
+          <p className="kicker" style={{ color: "var(--accent)" }}>02 / the gate</p>
+          <h2 className="pg-h2">Play the lying agent. Watch the gate refuse.</h2>
+          <p className="pg-intro">
+            Garden’s one non-negotiable, made drivable. It plays itself — breaking the
+            evidence and re-stamping the verdict. Flip a switch or pull the lever to take
+            control: the gate re-derives the claim instead of taking your word for it.
+          </p>
+        </div>
+      </Reveal>
+
+      {/* ── the auto-playing gate — full width, across the top on desktop ── */}
+      <Reveal className="pg-a-machine">
         <div
           className="pg-machine pg-machine--wide"
           role="region"
@@ -164,7 +178,7 @@ export default function ProveGate() {
       </Reveal>
 
       {/* persistent affordance — live state + how to take control */}
-      <div className="pg-afford" data-pinned={!auto}>
+      <div className="pg-afford pg-a-afford" data-pinned={!auto}>
         {auto ? (
           <>
             <span className="pg-afford-state pg-afford-live" aria-hidden>▶</span>
@@ -183,30 +197,18 @@ export default function ProveGate() {
         )}
       </div>
 
-      {/* ── title/intro (left) + the claim it re-derives (right) ── */}
-      <Reveal delay={0.06}>
-        <div className="pg-shell">
-          <div className="pg-intro-col">
-            <p className="kicker" style={{ color: "var(--accent)" }}>02 / the gate</p>
-            <h2 className="pg-h2">Play the lying agent. Watch the gate refuse.</h2>
-            <p className="pg-intro">
-              Garden’s one non-negotiable, made drivable. It plays itself — breaking the
-              evidence and re-stamping the verdict. Flip a switch or pull the lever to take
-              control: the gate re-derives the claim instead of taking your word for it.
-            </p>
-          </div>
-
-          {/* the claim handed to the visitor */}
-          <div className="pg-claim">
-            <span className="pg-claim-tape" aria-hidden />
-            <div className="pg-claim-kind">claim card · archetype: build</div>
-            <div className="pg-claim-text"><b>build:</b> all acceptance tests pass</div>
-            <p className="pg-claim-note">
-              The agent stamped this “done.” The gate re-runs the verifier, re-hashes
-              the recording, and checks the vault is even there. Break a condition and
-              prove it can’t be fooled.
-            </p>
-          </div>
+      {/* the claim handed to the visitor — desktop: right of the intro;
+          mobile: last, the detail the gate re-derives against */}
+      <Reveal delay={0.06} className="pg-a-claim">
+        <div className="pg-claim">
+          <span className="pg-claim-tape" aria-hidden />
+          <div className="pg-claim-kind">claim card · archetype: build</div>
+          <div className="pg-claim-text"><b>build:</b> all acceptance tests pass</div>
+          <p className="pg-claim-note">
+            The agent stamped this “done.” The gate re-runs the verifier, re-hashes
+            the recording, and checks the vault is even there. Break a condition and
+            prove it can’t be fooled.
+          </p>
         </div>
       </Reveal>
     </div>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -737,7 +737,7 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
   .cg-grid { grid-template-columns: 1fr; }
   .tb-afford { justify-content: flex-start; }
   .tb-afford-btn { margin-left: 0; }
-  .tb-stage-demo { min-height: 190px; padding: 18px; }
+  .tb-stage-demo { padding: 18px; }
   .tb-h2, .pg-h2, .cg-h2, .ib-h2 { font-size: clamp(1.7rem, 8vw, 2.4rem); }
   .gd-hero-h1 { font-size: clamp(2rem, 10vw, 3rem); }
   .pg-action { grid-template-columns: 1fr; }

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -468,13 +468,27 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
 .pg-afford-btn:hover { transform: translateY(-1px); filter: brightness(1.05); }
 .pg-afford-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-/* below the full-width gate: title/intro on the left, the claim it re-derives on the right */
-.pg-shell {
-  margin-top: clamp(1.25rem, 3vw, 2rem);
-  display: grid; gap: clamp(18px, 3vw, 44px);
+/* The gate lays out as a grid-areas mosaic so DOM order (intro → machine →
+   afford → claim) can differ from desktop visual order. Desktop: machine full
+   width across the top, the afford bar under it, then title/intro (7fr) beside
+   the claim it re-derives (5fr). Mobile flattens to a single column that keeps
+   the DOM order — intro first, then the machine (see the ≤1000 rule). */
+.pg-outer {
+  display: grid;
   grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  grid-template-areas:
+    "machine machine"
+    "afford  afford"
+    "intro   claim";
+  column-gap: clamp(18px, 3vw, 44px);
   align-items: start;
 }
+.pg-a-intro   { grid-area: intro; min-width: 0; }
+.pg-a-machine { grid-area: machine; min-width: 0; }
+.pg-a-afford  { grid-area: afford; }
+.pg-a-claim   { grid-area: claim; min-width: 0; }
+/* the intro/claim row sits below the afford bar — restore the old shell gap */
+.pg-a-intro, .pg-a-claim { margin-top: clamp(1.25rem, 3vw, 2rem); }
 .pg-intro-col { align-self: start; min-width: 0; }
 /* the gate is now full width across the top: lay its switch-bank beside the lever/stamp */
 .pg-machine--wide .pg-machine-body {
@@ -699,10 +713,24 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
 @media (max-width: 1000px) {
   .gd-hero-grid { grid-template-columns: 1fr; }
   .gd-hero-demo { max-width: 460px; }
+
+  /* TOOLBOX: single column, and put the STAGE (the playing demo + its spec)
+     FIRST so the content the visitor actually watches is up top, with the tool
+     picker directly beneath it — instead of a long rail burying the demo. */
   .tb-shell { grid-template-columns: 1fr; }
-  .pg-shell { grid-template-columns: 1fr; }
+  .tb-stage { order: -1; }
+
+  /* GATE: flatten to one column in DOM order — title/intro first, then the
+     machine, its affordance bar, and finally the claim card. */
+  .pg-outer {
+    grid-template-columns: 1fr;
+    grid-template-areas: "intro" "machine" "afford" "claim";
+  }
+  .pg-a-intro { margin-top: 0; }
+  .pg-a-machine, .pg-a-claim { margin-top: clamp(1rem, 3.5vw, 1.5rem); }
   .pg-machine--wide .pg-machine-body { grid-template-columns: 1fr; }
   .pg-claim { transform: none; }
+
   .cg-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 @media (max-width: 640px) {
@@ -719,5 +747,14 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
   .pg-lever[data-pulled="true"] .pg-lever-knob { top: 50%; left: 22px; }
   .pg-lever-word { margin-top: 0; }
   .hs-card { transform: none; }
+
+  /* Viewport-scale the biggest fixed type in the demos/stamps so nothing
+     overflows a ~360px phone. Upper bounds equal today's desktop values, so
+     ≥640px rendering is byte-identical. */
+  .tb-stage-demo { min-height: clamp(170px, 26svh, 210px); }
+  .dm-prove-stamp { font-size: clamp(1.5rem, 8vw, 2rem); }
+  .dm-prove-claim { font-size: clamp(0.9rem, 4vw, 1.02rem); }
+  .tb-stage-name { font-size: clamp(1.05rem, 5vw, 1.22rem); }
+  .pg-mark-sub { max-width: none; }
   .gd-hero-stats { gap: 0.5rem 1.1rem; }
 }


### PR DESCRIPTION
## What

Two homepage sections read incoherently once collapsed to a single column on phones. Fixes are confined to the `≤1000` / `≤640` breakpoints (or `clamp()`s whose upper bound equals today's desktop value), so **desktop is byte-identical**.

### 01 / the toolbox
On mobile the tool **rail** stacked *above* the **stage**, burying the actual demo the visitor watches under a six-item list. Now the stage (playing demo + spec) comes **first** (`order:-1`), with the tool picker directly beneath it — so the content is up top and the list reads as an obvious selector.

### 02 / the gate
On mobile the auto-playing machine rendered **before** the title/intro — backwards. `ProveGate` is restructured into a grid-areas mosaic (`.pg-outer`) so DOM order is `intro → machine → afford → claim`:

- **Desktop** (unchanged): `grid-template-areas` floats the machine full-width across the top, with title/intro (7fr) beside the claim card (5fr) below.
- **Mobile**: keeps the DOM order — title/intro **first**, then the machine (whose internal 2-col body, switches, and full-width lever/stamp all stack), then the claim card last.

### Viewport sizing
`clamp()` on the prove stamp, prove claim, stage name, and the stage-demo `min-height` (svh) so nothing overflows a ~360px phone. Upper bounds equal the existing desktop values.

## Verification
- `cd site && npm run build` — green.
- Measured at **390px**: no horizontal overflow (`scrollWidth 379 ≤ 390`); gate order intro → machine → afford → claim; machine body + action collapse to one column (switches → lever → stamp, all full-width); toolbox stage precedes rail.
- Measured at **1280px**: layout unchanged (machine full-width top → afford → intro|claim side-by-side; toolbox rail|stage side-by-side).

## Can't verify without a device
- Real touch interaction (pinning a tool, flipping switches, pulling the lever) on a physical phone.
- Rendering in Safari/iOS specifically (tested via Chromium at 390px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)