### PR TITLE
chore(deps): re-pin wicked-web (dropdown + featured crew chrome)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5573,7 +5573,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#a78f1f5b2c1c7ab87121ce4f1317cded6cd31a38",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#79a307bfe32055bb6d5022f30bd6f15d874fb3c6",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-pins the shared chrome dependency `wicked-web` to current main HEAD (79a307bfe32055bb6d5022f30bd6f15d874fb3c6), re-resolving `site/package-lock.json` so the newly-merged wicked-web#17 chrome — the one-line family dropdown, featured wicked-crew, 5-deployed count, and crew hover fixes — actually propagates to wicked-garden's site. Lockfile bumped from `a78f1f5b` to the new HEAD; site build is green.