### PR TITLE
chore(deps): re-pin wicked-web (dropdown + featured crew chrome)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5573,7 +5573,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#79a307bfe32055bb6d5022f30bd6f15d874fb3c6",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#f99187a440747eb1d8ad1f71ff6a5fb0a8c2fe69",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-resolves `site/package-lock.json` to pin the shared chrome dependency `wicked-web` at main HEAD (`f99187a440747eb1d8ad1f71ff6a5fb0a8c2fe69`), propagating wicked-web#17 into wicked-garden's site: the one-line family dropdown, featured wicked-crew entry, updated 5-deployed count, and crew hover fixes. Consumers pin `github:mikeparcewski/wicked-web` in package.json but the lockfile pins a specific commit, so this bump is what actually delivers the new chrome. Only the lockfile changed; `cd site && npm run build` is green.