### PR TITLE
feat(modernize): un-mock the extraction slice — shell real wicked-estate + wicked-core (#989)

### DIFF
--- a/scripts/modernize/_clients.py
+++ b/scripts/modernize/_clients.py
@@ -1,0 +1,309 @@
+"""CLI-backed clients for the modernize extraction slice (garden#989 — the un-mock).
+
+PHASE-1 ran the modernize workers against ``_mocks.EstateClient`` / ``_mocks.BrainClient``
+(canned fixtures). This module wires the REAL flow: the workers shell the actual
+``wicked-estate`` + ``wicked-core`` CLIs.
+
+Two seams, mirroring ``scripts/_loom.py``'s resolve precedence (env override ->
+config -> PATH -> node_modules -> None). We SHELL the binaries (argv lists, no
+shell string) and never import other-product code — so the disjoint-build
+"imports NO other-product code" doctrine holds at the letter.
+
+- ``estate_client(db)`` -> a CLI-backed :class:`CliEstateClient` when
+  ``wicked-estate`` resolves AND a store path is given, else the fixture-backed
+  ``_mocks.EstateClient``. Same six method names the workers already call, so no
+  SKILL.md changes.
+- ``core_client()`` -> a CLI-backed :class:`CliCoreClient` when ``wicked-core``
+  resolves, else ``None``. There is NO mock CoreClient: the mock lane is a
+  genuinely different flow (``_mocks.BrainClient`` + ``emit_domain_model``
+  assemble a doc in Python), whereas the real ``wicked-core domain-graph`` READS
+  THE STORE and builds ``requirements_graph.json`` itself — the doc-in/summary-out
+  shape does not exist on the real path.
+
+Cross-platform: argv lists via :mod:`subprocess` (never ``shell=True``);
+``shutil.which`` for resolution; stdlib only (no third-party deps).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+
+# --- binary resolution (mirrors scripts/_loom.py precedence) -----------------
+
+_CONFIG_PATH = Path.home() / ".something-wicked" / "wicked-garden" / "config.json"
+
+
+def _config_preference(key: str) -> Optional[str]:
+    """Read ``tool_preferences.{key}`` from garden's config.json; None on any
+    error (mirrors ``_loom._read_config_preference``)."""
+    try:
+        if not _CONFIG_PATH.exists():
+            return None
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):  # valid JSON but not an object -> no prefs
+            return None
+        prefs = data.get("tool_preferences")
+        if isinstance(prefs, dict):
+            value = prefs.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    except (json.JSONDecodeError, OSError, ValueError):  # ValueError = non-UTF-8 decode
+        return None
+    return None
+
+
+def _resolve_bin(
+    env_var: str,
+    package: str,
+    project_dir: Optional[Path] = None,
+) -> Optional[list[str]]:
+    """Resolve the argv prefix that invokes ``package``, or ``None``.
+
+    Ladder (first hit wins), matching ``_loom.resolve_loom`` (minus the
+    npx tail — these are compiled Rust binaries, not npm packages):
+      1. ``env_var`` env. Set-but-empty is the KILL-SWITCH -> None.
+      2. ``tool_preferences.<package>`` in config.json.
+      3. ``package`` on PATH (``shutil.which``).
+      4. project-local ``node_modules/.bin/<package>``.
+      else None (-> the caller falls back to the mock / hermetic lane).
+    """
+    if env_var in os.environ:
+        val = os.environ[env_var].strip()
+        # An explicit path wins; an empty string is the kill-switch.
+        return [val] if val else None
+
+    pref = _config_preference(package)
+    if pref:
+        return [pref]
+
+    found = shutil.which(package)
+    if found:
+        return [found]
+
+    base = Path(project_dir) if project_dir else Path.cwd()
+    local = base / "node_modules" / ".bin" / package
+    if local.exists():
+        return [str(local)]
+
+    return None
+
+
+# Bound every CLI call so a hung peer can't wedge extraction forever (matches
+# _loom's _DEFAULT_TIMEOUT). An unrunnable/hung binary fails LOUD + bounded,
+# never an indefinite hang or a raw OS traceback.
+_DEFAULT_TIMEOUT = 120
+
+
+def _invoke(argv: list[str]) -> subprocess.CompletedProcess:
+    """Run ``argv`` (argv list, never a shell string), bounded + fail-loud."""
+    try:
+        return subprocess.run(
+            argv, capture_output=True, text=True, timeout=_DEFAULT_TIMEOUT
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(f"{argv[0]} not found or not executable: {e}") from e
+    except OSError as e:
+        raise RuntimeError(f"{argv[0]} could not be executed: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"{argv[0]} exceeded {_DEFAULT_TIMEOUT}s: {argv[1:]!r}") from e
+
+
+def _run_json(argv: list[str]) -> Any:
+    """Run ``argv`` and parse its stdout as JSON. Fails LOUD on non-zero exit or
+    unparseable output — a silent empty would fail governance OPEN."""
+    proc = _invoke(argv)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{argv[0]} exited {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    out = proc.stdout.strip()
+    if not out:
+        raise RuntimeError(f"{argv[0]} produced no output for {argv[1:]!r}")
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"{argv[0]} output is not JSON: {e}: {out[:200]!r}") from e
+
+
+def _run(argv: list[str]) -> str:
+    """Run ``argv`` for its side effect (a write). Fails LOUD on non-zero exit."""
+    proc = _invoke(argv)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{argv[0]} exited {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc.stdout
+
+
+def _looks_like_symbol_id(value: str) -> bool:
+    """A SymbolId reference, never a bare name (the silent-multiply scar)."""
+    return isinstance(value, str) and value.startswith("sym::") and "::" in value[5:]
+
+
+# --- estate (the frozen read/write surface, CLI-backed) ----------------------
+
+class CliEstateClient:
+    """Shells ``wicked-estate`` for the six-method estate surface. Same interface
+    as ``_mocks.EstateClient`` so the workers are unchanged.
+
+    Reconciles four mock/CLI mismatches the recon flagged:
+      * ``resolve`` returns an object array -> extract each ``.symbol_id`` (mock
+        returned a bare ``list[str]``); ``--file`` is EXACT path equality.
+      * ``annotate`` ALWAYS passes ``--symbol`` (a bare name fans out to every
+        search hit) and ALWAYS ``--replace`` (the CLI defaults to APPEND, which
+        would stack duplicate rows across re-index runs).
+      * ``set_requirement`` routes to the ``semantics`` subcommand (node_semantics),
+        NOT ``annotate``.
+      * every op threads ``--db`` so writes + the later ``wicked-core`` read hit
+        the SAME store.
+    """
+
+    def __init__(self, bin_argv: list[str], db: str):
+        self._bin = list(bin_argv)
+        self._db = db
+
+    def _argv(self, *parts: str) -> list[str]:
+        return [*self._bin, *parts, "--db", self._db]
+
+    def read_clusters(self, params: dict | None = None) -> list[dict[str, Any]]:
+        # `--summary` is REQUIRED for the {id,size,members,...} object shape;
+        # bare `--json` emits array-of-arrays the mock consumers can't read.
+        # An optional `min` cluster-size filter maps to the `[min]` positional.
+        argv = self._bin + ["clusters"]
+        if params and params.get("min") is not None:
+            argv.append(str(int(params["min"])))
+        argv += ["--json", "--summary", "--db", self._db]
+        data = _run_json(argv)
+        return data if isinstance(data, list) else data.get("clusters", [])
+
+    def resolve(self, name: str, file: str | None = None,
+                kind: str | None = None) -> list[str]:
+        argv = self._argv("resolve", name, "--json")
+        if file is not None:
+            argv += ["--file", file]  # EXACT location.file equality (not basename)
+        if kind is not None:
+            argv += ["--kind", kind]
+        hits = _run_json(argv)
+        # Object array -> pull each SymbolId.
+        return [h["symbol_id"] for h in hits if isinstance(h, dict) and h.get("symbol_id")]
+
+    def annotate(self, symbol_id: str, type: str, key: str, value: str,
+                 confidence: float | None = None, provenance: str | None = None,
+                 replace: bool = True) -> None:
+        if not _looks_like_symbol_id(symbol_id):
+            raise ValueError(
+                f"refusing annotate on non-SymbolId {symbol_id!r} — a bare name fans "
+                "out to EVERY search hit (the duplicate-Charge scar); resolve() first"
+            )
+        argv = self._argv("annotate", "--symbol", symbol_id, "--type", type,
+                          "--key", key, "--value", value)
+        if confidence is not None:
+            argv += ["--confidence", repr(float(confidence))]
+        if provenance is not None:
+            argv += ["--provenance", provenance]
+        if replace:
+            argv.append("--replace")  # else the CLI APPENDs (stacks duplicates)
+        _run(argv)
+
+    def set_requirement(self, symbol_id: str, requirement: str,
+                        validated: bool) -> None:
+        if not _looks_like_symbol_id(symbol_id):
+            raise ValueError(
+                f"refusing set_requirement on non-SymbolId {symbol_id!r} — a bare "
+                "name is a silent no-op in estate; resolve() first"
+            )
+        # node_semantics (requirement/validated), a SEPARATE subcommand from annotate.
+        _run(self._argv("semantics", symbol_id, "--requirement", requirement,
+                        "--validated", "true" if validated else "false"))
+
+    def read_annotations(self, symbol_id: str) -> list[dict[str, Any]]:
+        if not _looks_like_symbol_id(symbol_id):
+            raise ValueError(
+                f"refusing read_annotations on non-SymbolId {symbol_id!r} — the "
+                "positional form name-SEARCHES and would silently miss a SymbolId; "
+                "resolve() first"
+            )
+        # MUST use `--symbol` (not the positional `<name>` form, which name-searches
+        # and returns an ARRAY of per-symbol objects — a SymbolId there matches
+        # nothing and yields [] silently). `--symbol` returns the single-symbol shape
+        # `{ "symbol": ..., "annotations": [...] }`.
+        data = _run_json(self._argv("annotations", "--symbol", symbol_id, "--json"))
+        if isinstance(data, dict):
+            return data.get("annotations", [])
+        # Defensive: an unexpected array shape is a contract break, not a silent [].
+        raise RuntimeError(
+            f"wicked-estate annotations --symbol returned {type(data).__name__}, "
+            "expected the single-symbol object {symbol, annotations[]}"
+        )
+
+    def find_by_annotation(self, key: str, value: str | None = None) -> list[str]:
+        # The real extraction flow does not use a reverse annotation lookup (the
+        # extractor resolves forward: name -> SymbolId -> annotate). There is no
+        # `wicked-estate find-by-annotation` verb, so this is unsupported on the
+        # CLI-backed path — fail loud rather than silently return [].
+        raise NotImplementedError(
+            "find_by_annotation is not available on the CLI-backed estate client "
+            "(no reverse-annotation verb); the real extractor resolves forward "
+            "name -> SymbolId -> annotate. Use the mock lane if a test needs it."
+        )
+
+
+# --- core (owns doc assembly on the real path) -------------------------------
+
+class CliCoreClient:
+    """Shells ``wicked-core`` for the coverage + domain-graph verbs. NOT a mock of
+    ``BrainClient`` — the real flow inverts who assembles the doc: ``wicked-core
+    domain-graph`` READS the store and builds ``requirements_graph.json`` itself.
+    """
+
+    def __init__(self, bin_argv: list[str]):
+        self._bin = list(bin_argv)
+
+    def coverage(self, db: str, out: str) -> dict[str, Any]:
+        """Emit the store's front-half coverage report to ``out`` and return it.
+        Optional — ``domain_graph`` recomputes coverage internally."""
+        _run([*self._bin, "coverage", "--db", db, "--out", out])
+        return json.loads(Path(out).read_text())
+
+    def domain_graph(self, db: str, out: str,
+                     coverage: str | None = None) -> dict[str, Any]:
+        """Build ``requirements_graph.json`` from the annotated store and return
+        the parsed doc. FAILS LOUD (raises) if the store's front-half coverage
+        < 1.0 (``wicked-core domain-graph`` gates fail-closed and writes nothing).
+        A supplied ``coverage`` file is an OPTIONAL cross-check that must agree."""
+        argv = [*self._bin, "domain-graph", "--db", db, "--out", out]
+        if coverage is not None:
+            argv += ["--coverage", coverage]
+        _run(argv)
+        return json.loads(Path(out).read_text())
+
+
+# --- factories ---------------------------------------------------------------
+
+ESTATE_ENV = "WICKED_ESTATE_BIN"
+CORE_ENV = "WICKED_CORE_BIN"
+
+
+def estate_client(db: Optional[str] = None,
+                  project_dir: Optional[Path] = None):
+    """A CLI-backed :class:`CliEstateClient` when ``wicked-estate`` resolves and a
+    store ``db`` is given, else the fixture-backed ``_mocks.EstateClient``."""
+    bin_argv = _resolve_bin(ESTATE_ENV, "wicked-estate", project_dir)
+    if bin_argv and db:
+        return CliEstateClient(bin_argv, db)
+    from modernize._mocks import EstateClient  # local: the mock is the hermetic lane
+    return EstateClient()
+
+
+def core_client(project_dir: Optional[Path] = None) -> Optional[CliCoreClient]:
+    """A CLI-backed :class:`CliCoreClient` when ``wicked-core`` resolves, else
+    ``None`` (the caller falls back to the hermetic ``_mocks.BrainClient`` +
+    ``emit_domain_model`` doc-assembly lane)."""
+    bin_argv = _resolve_bin(CORE_ENV, "wicked-core", project_dir)
+    return CliCoreClient(bin_argv) if bin_argv else None

--- a/scripts/modernize/_clients.py
+++ b/scripts/modernize/_clients.py
@@ -103,8 +103,11 @@ _DEFAULT_TIMEOUT = 120
 def _invoke(argv: list[str]) -> subprocess.CompletedProcess:
     """Run ``argv`` (argv list, never a shell string), bounded + fail-loud."""
     try:
+        # encoding="utf-8" pins decoding of the Rust binaries' UTF-8 output; bare
+        # text=True would use the active code page on Windows (mojibake/errors).
         return subprocess.run(
-            argv, capture_output=True, text=True, timeout=_DEFAULT_TIMEOUT
+            argv, capture_output=True, text=True, encoding="utf-8",
+            timeout=_DEFAULT_TIMEOUT,
         )
     except FileNotFoundError as e:
         raise RuntimeError(f"{argv[0]} not found or not executable: {e}") from e
@@ -146,6 +149,24 @@ def _looks_like_symbol_id(value: str) -> bool:
     return isinstance(value, str) and value.startswith("sym::") and "::" in value[5:]
 
 
+def _read_output_json(out: str, cmd: str) -> Any:
+    """Read + parse a CLI's ``--out`` file. A 0-exit that produced no file (or a
+    non-UTF-8/invalid one) is a contract break — fail LOUD with a descriptive
+    error, never a raw FileNotFoundError/UnicodeDecodeError. encoding is pinned
+    so a Windows code page can't corrupt the read."""
+    path = Path(out)
+    if not path.exists():
+        raise RuntimeError(f"{cmd} exited 0 but wrote no output file at {out!r}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError) as e:  # ValueError = UnicodeDecodeError
+        raise RuntimeError(f"{cmd} output {out!r} could not be read: {e}") from e
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"{cmd} output {out!r} is not JSON: {e}") from e
+
+
 # --- estate (the frozen read/write surface, CLI-backed) ----------------------
 
 class CliEstateClient:
@@ -180,7 +201,14 @@ class CliEstateClient:
             argv.append(str(int(params["min"])))
         argv += ["--json", "--summary", "--db", self._db]
         data = _run_json(argv)
-        return data if isinstance(data, list) else data.get("clusters", [])
+        # `clusters --json --summary` emits a JSON ARRAY of community objects. Any
+        # other shape is a contract break — fail loud, never a silent [].
+        if not isinstance(data, list):
+            raise RuntimeError(
+                f"wicked-estate clusters returned {type(data).__name__}, expected a "
+                "JSON array of community objects"
+            )
+        return data
 
     def resolve(self, name: str, file: str | None = None,
                 kind: str | None = None) -> list[str]:
@@ -190,7 +218,14 @@ class CliEstateClient:
         if kind is not None:
             argv += ["--kind", kind]
         hits = _run_json(argv)
-        # Object array -> pull each SymbolId.
+        # `resolve --json` emits a JSON ARRAY of hit objects (possibly empty). A
+        # non-list shape is a contract break — fail loud, NOT a fail-open [] that
+        # looks like "zero hits" and lets a downstream write silently no-op.
+        if not isinstance(hits, list):
+            raise RuntimeError(
+                f"wicked-estate resolve returned {type(hits).__name__}, expected a "
+                "JSON array of hit objects"
+            )
         return [h["symbol_id"] for h in hits if isinstance(h, dict) and h.get("symbol_id")]
 
     def annotate(self, symbol_id: str, type: str, key: str, value: str,
@@ -269,7 +304,7 @@ class CliCoreClient:
         """Emit the store's front-half coverage report to ``out`` and return it.
         Optional — ``domain_graph`` recomputes coverage internally."""
         _run([*self._bin, "coverage", "--db", db, "--out", out])
-        return json.loads(Path(out).read_text())
+        return _read_output_json(out, "wicked-core coverage")
 
     def domain_graph(self, db: str, out: str,
                      coverage: str | None = None) -> dict[str, Any]:
@@ -281,7 +316,7 @@ class CliCoreClient:
         if coverage is not None:
             argv += ["--coverage", coverage]
         _run(argv)
-        return json.loads(Path(out).read_text())
+        return _read_output_json(out, "wicked-core domain-graph")
 
 
 # --- factories ---------------------------------------------------------------

--- a/scripts/modernize/_clients.py
+++ b/scripts/modernize/_clients.py
@@ -105,16 +105,20 @@ def _invoke(argv: list[str]) -> subprocess.CompletedProcess:
     try:
         # encoding="utf-8" pins decoding of the Rust binaries' UTF-8 output; bare
         # text=True would use the active code page on Windows (mojibake/errors).
+        # stdin=DEVNULL: these CLIs never prompt, but inheriting the parent stdin
+        # would stall to the timeout if one ever did (keep the "bounded" contract).
         return subprocess.run(
             argv, capture_output=True, text=True, encoding="utf-8",
-            timeout=_DEFAULT_TIMEOUT,
+            stdin=subprocess.DEVNULL, timeout=_DEFAULT_TIMEOUT,
         )
     except FileNotFoundError as e:
         raise RuntimeError(f"{argv[0]} not found or not executable: {e}") from e
-    except OSError as e:
-        raise RuntimeError(f"{argv[0]} could not be executed: {e}") from e
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(f"{argv[0]} exceeded {_DEFAULT_TIMEOUT}s: {argv[1:]!r}") from e
+    except ValueError as e:  # invalid UTF-8 in the peer's stdout/stderr
+        raise RuntimeError(f"{argv[0]} produced undecodable (non-UTF-8) output: {e}") from e
+    except OSError as e:
+        raise RuntimeError(f"{argv[0]} could not be executed: {e}") from e
 
 
 def _run_json(argv: list[str]) -> Any:
@@ -269,13 +273,21 @@ class CliEstateClient:
         # nothing and yields [] silently). `--symbol` returns the single-symbol shape
         # `{ "symbol": ..., "annotations": [...] }`.
         data = _run_json(self._argv("annotations", "--symbol", symbol_id, "--json"))
-        if isinstance(data, dict):
-            return data.get("annotations", [])
-        # Defensive: an unexpected array shape is a contract break, not a silent [].
-        raise RuntimeError(
-            f"wicked-estate annotations --symbol returned {type(data).__name__}, "
-            "expected the single-symbol object {symbol, annotations[]}"
-        )
+        # Fail LOUD on any shape other than {..., annotations: [...]}. A silent []
+        # (missing key, or annotations set to null/object) would read as "no
+        # annotations" and mask a contract break.
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"wicked-estate annotations --symbol returned {type(data).__name__}, "
+                "expected the single-symbol object {symbol, annotations[]}"
+            )
+        anns = data.get("annotations")
+        if not isinstance(anns, list):
+            raise RuntimeError(
+                f"wicked-estate annotations --symbol: 'annotations' is "
+                f"{type(anns).__name__}, expected a list"
+            )
+        return anns
 
     def find_by_annotation(self, key: str, value: str | None = None) -> list[str]:
         # The real extraction flow does not use a reverse annotation lookup (the

--- a/skills/archetype/refs/modernize.md
+++ b/skills/archetype/refs/modernize.md
@@ -98,12 +98,13 @@ STEERS three fork workers that emit a document conforming to
 `@wicked/domain-model-schema@1.0.0` (vendored at
 `skills/modernize/vendor/domain-model.schema.json`): **modernize-extractor**
 (business rules with confidence + provenance → estate `requirement`
-annotations), **modernize-translator** (cluster → domain, drives
-`wicked-brain-domain`), **modernize-antagonist** (pre-build threat model). The
-document is the only thing that crosses repo lines (plus SymbolId strings): brain
-validates + stores it, crew gates on coverage. Garden clears no gate here — it is
-advisory steering; the coverage terminal is crew's. See
-`skills/modernize/SKILL.md`.
+annotations), **modernize-translator** (cluster → domain, invokes
+`wicked-core domain-graph` — which reads the annotated estate store and builds the
+requirements graph itself, coverage-gated fail-closed), **modernize-antagonist**
+(pre-build threat model). Estate annotations + SymbolId strings are what cross repo
+lines; core builds + coverage-gates the requirements graph, crew governs the run.
+Garden clears no gate here — it is advisory steering; the coverage terminal is
+core's fail-closed build. See `skills/modernize/SKILL.md`.
 
 ### blueprint
 

--- a/skills/modernize-extractor/SKILL.md
+++ b/skills/modernize-extractor/SKILL.md
@@ -25,24 +25,28 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 # Modernize Extractor
 
 You mine **testable business rules** from a legacy estate — *what the business
-requires*, not *how the old code happened to do it* — and emit them into a
-`domain-model@1.0.0` document that brain validates and stores. You are the
-`Creator` role in the crew coverage workflow: you produce the rule IP; a
-seat-distinct evaluator judges coverage, never you.
+requires*, not *how the old code happened to do it* — and **annotate them into the
+estate store** as typed `business_rule`/`risk` facts plus canonical `requirement`
+links. `wicked-core` later reads the store and builds the `domain-model@1.0.0`
+requirements graph (coverage-gated fail-closed). You are the `Creator` role in the
+crew coverage workflow: you produce the rule IP; a seat-distinct evaluator judges
+coverage, never you.
 
 ## Contract you emit against
 
 `vendor/domain-model.schema.json` (in the `wicked-garden-modernize` skill dir) —
-the vendored, pinned `@wicked/domain-model-schema@1.0.0`. **Never** import brain
-or estate code; you emit a document and reference SymbolId strings. The other
-products are mocked behind `scripts/modernize/_mocks.py`.
+the vendored, pinned `@wicked/domain-model-schema@1.0.0`. **Never** import core or
+estate code; you annotate the store and reference SymbolId strings. The peers are
+shelled via `scripts/modernize/_clients.py` (`estate_client` / `core_client`), or
+mocked behind `scripts/modernize/_mocks.py` when absent.
 
 ## The loop (per behavior-bearing node)
 
 1. **Resolve, don't guess the id.** For each node name, resolve to its estate
-   `SymbolId` first — a write keyed on a bare name is a silent no-op. In
-   PHASE-1 this goes through `_mocks.EstateClient.resolve(name)`; in production
-   it shells `wicked-estate nodes --json` / `resolve`.
+   `SymbolId` first — a write keyed on a bare name is a silent no-op / silent
+   fan-out. Via `estate_client(db).resolve(name, file=…)` — CLI-backed
+   `wicked-estate resolve <name> --json` (the client extracts each `.symbol_id`;
+   `--file` is exact path equality) — or the mock when no peer is present.
 2. **Read the source slice** for the node and extract the rule statement(s).
    This LLM step is *yours* — the deterministic engine injects it. Each rule:
    - `statement` — the business rule in plain terms (minLength 1).
@@ -55,13 +59,23 @@ products are mocked behind `scripts/modernize/_mocks.py`.
      `code-body` and/or `type-def`.
 3. **No silent maybe-correct.** Below threshold ⇒ RISK-flag the node (leave the
    requirement `status: "unresolvable"` / `review` with a reason), never assert.
-4. **Assemble + validate.** Feed the rules to
+4. **Write the estate projection** for every bound rule — the authoritative
+   output core later reads. Two coordinated writes via `estate_client(db)`, both
+   keyed by the resolved SymbolId (never a bare name), each field a separate CLI
+   arg (no pipe-packed string):
+   - `annotate(symbol_id, type="business_rule"` at/above threshold, else `"risk"`,
+     `key=<rule_id>, value=<statement>, confidence, provenance, replace=True)` —
+     `wicked-estate annotate --symbol <id> … --replace` (always `--replace`, else
+     the CLI APPENDs and stacks duplicates across re-index runs).
+   - `set_requirement(symbol_id, requirement=<statement>, validated=<resolved>)` —
+     `wicked-estate semantics <id> --requirement … --validated …`. This is what
+     core counts toward front-half coverage. A REFERENCE write — never copy the
+     symbol's structure back.
+5. **Cross-check (hermetic lane).** With no peer present, feed the rules to
    `scripts/modernize/emit_domain_model.py` (the deterministic assembler) and
-   validate with `scripts/modernize/validate_domain_model.py` before returning.
-5. **Write the estate projection** for every bound rule: the `requirement`
-   annotation (`semantics <symbol_id> --requirement … --validated …`) via
-   `_mocks.EstateClient.set_requirement(...)` in PHASE-1. This is a REFERENCE
-   write — you never copy the symbol's structure back.
+   validate with `scripts/modernize/validate_domain_model.py` before returning; on
+   the real path, core builds the graph from the store and the translator
+   validates core's output.
 
 ## Hard invariants (fail-closed — enforced by the assembler + validator)
 
@@ -77,9 +91,13 @@ products are mocked behind `scripts/modernize/_mocks.py`.
 6. Facts REFERENCE SymbolIds; never embed code/file/line.
 7. `metadata.schema_version == "1.0.0"`.
 
-## What is stubbed (PHASE-1 honesty)
+## What is wired vs stubbed
 
-The LLM rule read is real (yours); the estate CLI and brain engine are mocked
-(`_mocks.py`). Full field map + examples:
+The LLM rule read is real (yours). The estate write surface and core's
+domain-graph build are **wired to the live CLIs** via `_clients.py`
+(`estate_client` / `core_client`), falling back to `_mocks.py` when the peers are
+absent. The real end-to-end build needs a fully-annotated, INDEXED store
+(coverage == 1.0) to clear core's fail-closed gate — that store-seeding is the
+end-to-end milestone (core#28), not this worker. Full field map + examples:
 [../modernize/refs/domain-model-emit.md](../modernize/refs/domain-model-emit.md).
 Drive detail: [../modernize/refs/extraction-flow.md](../modernize/refs/extraction-flow.md).

--- a/skills/modernize-translator/SKILL.md
+++ b/skills/modernize-translator/SKILL.md
@@ -5,9 +5,10 @@ subagent_type: wicked-garden:modernize:translator
 description: |
   Domain-graph fork worker for the modernize archetype. Groups the estate's
   Louvain communities into business domains, attaches each requirement to its
-  cluster (advisory cluster_id provenance), and drives brain's domain-model
-  engine (wicked-brain-domain) to build the requirements graph — then validates
-  the assembled domain-model document against the vendored schema.
+  cluster (advisory cluster_id provenance), and invokes wicked-core's domain-graph
+  build (which reads the annotated estate store, recomputes coverage fail-closed,
+  and builds the requirements graph) — then validates core's output against the
+  vendored schema.
 
   Use when: dispatched by wicked-garden-modernize after rule extraction to turn
   a flat rule set into cluster-keyed domains; "group these into domains", "build
@@ -25,35 +26,43 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 # Modernize Translator
 
 You turn a **flat set of extracted rules** into a **cluster-keyed domain model**
-and drive brain's domain engine to build the requirements graph. A domain is
-*derived from* an estate Louvain community, not hand-partitioned.
+and invoke core's domain-graph build to produce the requirements graph. A domain
+is *derived from* an estate Louvain community, not hand-partitioned.
 
 ## Contract you emit against
 
-Same vendored `domain-model@1.0.0` schema as the extractor. You own the
-`domains{}` structure: each domain groups the requirements whose components fall
-in one estate community, carries an advisory `cluster_id` (the Louvain index),
-and declares its `entities{}`. You **drive brain**, you don't reimplement it.
+Same vendored `domain-model@1.0.0` schema as the extractor. Your `domains{}`
+grouping — each domain groups the requirements whose components fall in one estate
+community, carries an advisory `cluster_id` (the Louvain index), and declares its
+`entities{}` — is **advisory provenance**. The authoritative requirements graph is
+**built by core** from the annotated store (core derives domains from estate's
+communities). You **invoke core**, you don't reimplement it.
 
 ## The loop
 
 1. **Read clusters from estate** — the full-membership feed
-   `clusters --json --summary` → `[{id, size, members:[symbol_id], …}]`. In
-   PHASE-1 this is `_mocks.EstateClient.read_clusters()`; the id is a volatile
-   positional index, so key durable domains on a hash of the sorted member set,
-   not the raw id (record the raw id only as advisory `cluster_id`).
+   `clusters --json --summary` → `[{id, size, members:[symbol_id], …}]`, via
+   `estate_client(db).read_clusters()` (CLI) or `_mocks.EstateClient` (hermetic).
+   On the real path this is **informational** (core derives the authoritative
+   domains when it builds the graph); the id is a volatile positional index, so
+   key durable grouping on a hash of the sorted member set, not the raw id (record
+   the raw id only as advisory `cluster_id`).
 2. **Assign each requirement to a domain** by the community its
-   `legacy_components[]` SymbolIds belong to. A requirement whose components span
-   communities goes to the dominant one; note the split for the antagonist.
-3. **Drive brain's domain engine.** Call
-   `_mocks.BrainClient.build_domain_graph(doc)` (PHASE-1) — the stand-in for
-   `wicked-brain domain build --db <estate_db> --overlay annotations.jsonl`,
-   which builds `requirements_graph.json` (a capability plan, not a code
-   skeleton) with round-trip no-silent-drop. brain owns the engine + store;
-   you hand it the document and consume its summary.
-4. **Assemble + validate.** Merge the domain grouping into the document via
-   `scripts/modernize/emit_domain_model.py` and validate with
-   `scripts/modernize/validate_domain_model.py` before returning.
+   `legacy_components[]` SymbolIds belong to (advisory grouping / provenance for
+   the antagonist). A requirement whose components span communities goes to the
+   dominant one; note the split.
+3. **Invoke core's domain-graph build.** `core_client().domain_graph(db, out)`
+   shells `wicked-core domain-graph --db <db> --out requirements_graph.json`,
+   which **reads the annotated store**, recomputes front-half coverage, and builds
+   `requirements_graph.json` (a capability plan, not a code skeleton). It **fails
+   closed** (writes nothing, non-zero exit) if coverage < 1.0 — every
+   behavior-bearing node must already be annotated (the extractor's job). There is
+   **no doc handed in and no `--overlay`**: the store is the input. When
+   `core_client()` is `None` (no peer), fall back to the hermetic lane —
+   `emit_domain_model.py` assembles the doc and `_mocks.BrainClient` stands in.
+4. **Validate core's output.** Cross-check the built `requirements_graph.json`
+   with `scripts/modernize/validate_domain_model.py` (schema + hard invariants)
+   before returning.
 
 ## Invariants you must not break
 
@@ -65,9 +74,13 @@ and declares its `entities{}`. You **drive brain**, you don't reimplement it.
 - `metadata.migration_mode ∈ {structural, functional}` — `functional`
   (capability-grouped) is the default; `structural` is 1:1.
 
-## What is stubbed (PHASE-1 honesty)
+## What is wired vs stubbed
 
-The estate `clusters` read and the brain `domain build` call are both mocked
-(`_mocks.py`). The grouping heuristic (community → domain) and the schema
-assembly are real. Full field map:
+The estate `clusters` read and core's `domain-graph` build are **wired to the
+live CLIs** via `scripts/modernize/_clients.py` (`estate_client` / `core_client`),
+falling back to `_mocks.py` when the peers are absent. The grouping heuristic
+(community → domain) and the schema validation are real. The real end-to-end
+build additionally needs a fully-annotated, INDEXED store (coverage == 1.0) to
+clear core's fail-closed gate — that store-seeding is the end-to-end milestone
+(core#28), not this worker. Full field map:
 [../modernize/refs/domain-model-emit.md](../modernize/refs/domain-model-emit.md).

--- a/skills/modernize/SKILL.md
+++ b/skills/modernize/SKILL.md
@@ -4,8 +4,9 @@ user-invocable: true
 description: |
   Domain router for the modernize archetype's rule-extraction path: turn a
   legacy estate into a schema-conformant domain-model document (business rules
-  with confidence + provenance, entities, requirements) that brain validates and
-  stores and crew gates on coverage. Steers three fork workers.
+  with confidence + provenance, entities, requirements). The workers annotate the
+  estate store; wicked-core reads it and builds the requirements graph,
+  coverage-gating fail-closed. Steers three fork workers.
 
   Use when: "extract the business rules from this legacy codebase", "build a
   domain model / requirements graph from the estate", "reverse-engineer what
@@ -30,28 +31,31 @@ Domain-Brain contract.
 **The contract in one line:** the only thing that crosses repo lines is a
 document that validates against `@wicked/domain-model-schema@1.0.0` (vendored at
 `vendor/domain-model.schema.json`) plus an estate `SymbolId` string. Garden
-STEERS (emits + validates the document), brain EQUIPS (owns the schema + engine
-+ stores), estate GROUNDS (owns SymbolId identity + the graph), crew GOVERNS
-(gates on coverage). This skill mocks the other three behind fixtures.
+STEERS (annotates the estate store + cross-checks the built document), core
+BUILDS (`wicked-core domain-graph` reads the store, builds the requirements graph,
+and coverage-gates fail-closed), estate GROUNDS (owns SymbolId identity + the
+graph), crew GOVERNS (drives the run). The peer CLIs are shelled via
+`scripts/modernize/_clients.py`, or mocked behind fixtures when absent.
 
 ## The four-way seam
 
 ```
-crew GOVERNS  →  garden STEERS  →  brain EQUIPS  →  estate GROUNDS
-(coverage gate)  (this skill +      (domain-model    (SymbolId + graph
-                  3 fork workers)    engine + store)   + Louvain clusters)
+crew GOVERNS  →  garden STEERS  →  core BUILDS  →  estate GROUNDS
+(drives the run) (this skill +     (domain-graph +  (SymbolId + graph
+                  3 fork workers)   coverage gate)   + Louvain clusters)
 ```
 
-Garden never imports brain or estate code. It emits a document and references
-SymbolId strings; brain validates + stores; estate is the sole writer of graph
-structure.
+Garden never imports core or estate code — it shells their CLIs (argv lists, no
+shell string) or mocks them. It annotates the estate store and references SymbolId
+strings; core reads the store and builds + coverage-gates the requirements graph;
+estate is the sole writer of graph structure.
 
 ## Routing — the three fork workers
 
 | Ask | Worker | Produces |
 |-----|--------|----------|
 | Mine business rules from the estate → domain-model doc | [modernize-extractor](../modernize-extractor/SKILL.md) | `business_rules[]` with confidence + provenance; estate `requirement` annotations |
-| Group clusters into domains → drive brain's domain engine | [modernize-translator](../modernize-translator/SKILL.md) | `domains{}` keyed to estate Louvain communities; `requirements_graph.json` via brain |
+| Group clusters into domains → invoke core's domain-graph build | [modernize-translator](../modernize-translator/SKILL.md) | `domains{}` keyed to estate Louvain communities; `requirements_graph.json` built by `wicked-core domain-graph` |
 | Threat-model the extracted model before build | [modernize-antagonist](../modernize-antagonist/SKILL.md) | pre-build threat list / RISK-flag reasons |
 
 Dispatch a worker with `Task(subagent_type=...)` (colon back-compat) or by
@@ -96,24 +100,33 @@ sh "${CLAUDE_PLUGIN_ROOT}/scripts/_python.sh" \
   the vendored schema (no third-party dependency — the repo is stdlib+pytest
   only), plus the extra invariants the schema can't express (numeric confidence
   type, SymbolId-shaped references).
+- `scripts/modernize/_clients.py` — the selection seam: `estate_client(db)` /
+  `core_client()` return CLI-backed clients when `wicked-estate` / `wicked-core`
+  resolve, else the mocks. Shells the peers (argv lists, no shell string).
 - `scripts/modernize/_mocks.py` — the disjoint fixtures: a fake estate client
-  (canned clusters + `resolve`/`annotate`) and a fake brain client. **These mock
-  the other three products; no other-product code is imported.**
+  (canned clusters + `resolve`/`annotate`) and a fake brain client (the hermetic
+  doc-assembly lane). **These mock the peers; no other-product code is imported.**
 
-## Honest scope — implemented vs stubbed (PHASE-1)
+## Honest scope — implemented vs stubbed
 
 **Implemented + tested:** the vendored + pinned schema; the deterministic
-document assembler; the validator (schema + hard invariants); the fixture
-mocks; a conformant fixture document; the pytest suite that validates emitter
-output and the fixture against the schema.
+document assembler; the validator (schema + hard invariants); the CLI-backed
+clients (`_clients.py`) that shell the real `wicked-estate` + `wicked-core`, with
+argv-construction tests + an opt-in real-CLI lane; the fixture mocks; a conformant
+fixture document; the pytest suite that validates emitter output and the fixture
+against the schema.
 
-**Stubbed / mocked (the cross-repo seams):** the LLM rule-statement extraction
-step (rules are injected as input — the "skill-supplied extractor" seam); the
-real estate CLI (`clusters --json --summary`, `resolve`, `annotate`,
-`semantics`) — replaced by `_mocks.EstateClient`; the real brain engine
-(`wicked-brain domain build`) — replaced by `_mocks.BrainClient`. Wiring these
-to the live CLIs is the next phase; the interfaces are fixed by the contract so
-each side builds disjoint.
+**Wired to live CLIs (`_clients.py`):** the estate surface (`resolve`,
+`annotate --replace`, `semantics`, `clusters --json --summary`,
+`annotations`) → `CliEstateClient`; the domain-graph build
+(`wicked-core domain-graph` — reads the store, builds the requirements graph,
+coverage-gates fail-closed) → `CliCoreClient`. When the peers are absent, the
+selection seam falls back to `_mocks` for hermetic testing.
+
+**Still stubbed:** the LLM rule-statement extraction step (rules are injected as
+input — the "skill-supplied extractor" seam). And the real end-to-end run needs a
+fully-annotated, INDEXED store (coverage == 1.0) to clear core's fail-closed gate
+— that store-seeding step is the end-to-end milestone (core#28), not this slice.
 
 ## Ground in the repo's method first
 
@@ -126,5 +139,6 @@ repo-specific wiring. If present, load the matching playbook.
 - [refs/domain-model-emit.md](refs/domain-model-emit.md) — the full field map,
   the seven hard invariants, and the SymbolId reference rule.
 - [refs/extraction-flow.md](refs/extraction-flow.md) — how the extractor drives
-  estate (resolve → annotate → semantics) and brain, with the mock seam.
+  estate (resolve → annotate → semantics) and core (`domain-graph`), the
+  `_clients.py` selection seam, and the mock lane.
 - `vendor/README.md` — the vendored-schema pin + drift discipline.

--- a/skills/modernize/refs/extraction-flow.md
+++ b/skills/modernize/refs/extraction-flow.md
@@ -1,53 +1,75 @@
-# extraction-flow — how the extractor drives estate + brain (with the mock seam)
+# extraction-flow — how the extractor drives estate + core (with the mock seam)
 
-The modernize workers never import brain or estate code. They talk to a **fixed
-interface** and, in PHASE-1, a **mock implementation** of it. This ref documents
-the interface (the real CLI/engine contract) and the mock seam.
+The modernize workers never import estate or core code. They talk to a **fixed
+interface** and — depending on whether the peer CLIs are installed — either the
+**real CLI** (`scripts/modernize/_clients.py`) or, hermetically, a **mock**
+(`scripts/modernize/_mocks.py`). This ref documents the interface (the real
+CLI/engine contract) and the mock seam.
+
+## Which implementation runs (the seam)
+
+`scripts/modernize/_clients.py` picks the backing at call time, mirroring
+`scripts/_loom.py`'s precedence:
+
+- `estate_client(db)` → the CLI-backed `CliEstateClient` when **`wicked-estate`**
+  resolves (`WICKED_ESTATE_BIN` env → config.json `tool_preferences.wicked-estate`
+  → PATH → `node_modules/.bin`) **and** a store path is given; else the
+  fixture-backed `_mocks.EstateClient`.
+- `core_client()` → the CLI-backed `CliCoreClient` when **`wicked-core`** resolves
+  (`WICKED_CORE_BIN` → config.json `tool_preferences.wicked-core` → PATH →
+  `node_modules/.bin`); else `None`, and the caller falls back to the hermetic
+  `_mocks.BrainClient` + `emit_domain_model` doc-assembly lane. Set-but-empty
+  `WICKED_*_BIN` is the kill-switch (force mock).
 
 ## The estate surface (what the extractor + translator call)
 
-estate is the sole authority for graph structure. In production the workers
-shell its CLI; in PHASE-1 they call `scripts/modernize/_mocks.EstateClient`,
-which returns canned fixtures and records writes. The interface is the six-method
-`EstateClient` the Domain-Brain contract freezes:
+estate is the sole authority for graph structure. In production the workers shell
+its CLI (`CliEstateClient`); hermetically they call `_mocks.EstateClient`, which
+returns canned fixtures and records writes. Same six method names either way:
 
 | Method | Production CLI | Purpose |
 |---|---|---|
-| `read_clusters(params) -> [Community]` | `clusters --json --summary` | Full community membership (the `members:[symbol_id]` feed). The MCP `Communities` tool omits members, so the CLI is the contract. |
-| `resolve(name, file?, kind?) -> [symbol_id]` | `nodes --json` / `resolve` | name → SymbolId. **A write keyed on a bare name is a silent no-op** — always resolve first. |
-| `annotate(symbol_id, type, key, value, confidence, provenance, replace)` | `annotate --symbol <id> … --replace` | Typed k/v annotation (multi-valued). `--replace` = idempotent upsert; the workers always pass it so a re-index replaces rather than stacks. |
-| `set_requirement(symbol_id, requirement, validated)` | `semantics <id> --requirement … --validated …` | The single canonical requirement↔symbol link. |
-| `read_annotations(symbol_id) -> [Annotation]` | `annotations --symbol <id> --json` | Read back. |
-| `find_by_annotation(key, value?) -> [symbol_id]` | `nodes --annotated-with K[=V] --json` | Reverse lookup. |
+| `read_clusters(params) -> [Community]` | `clusters --json --summary` | Full community membership (the `members:[symbol_id]` feed). The MCP `Communities` tool omits members, so the CLI (with `--summary`, for the object shape) is the contract. |
+| `resolve(name, file?, kind?) -> [symbol_id]` | `resolve <name> --json [--file EXACT] [--kind]` | name → SymbolId. Returns an **object array**; the client extracts each `.symbol_id`. `--file` is **exact `location.file` equality**, not a basename. **A write keyed on a bare name is a silent no-op / silent fan-out** — always resolve first. |
+| `annotate(symbol_id, type, key, value, confidence, provenance, replace)` | `annotate --symbol <id> --type … --key … --value … [--confidence] [--provenance] --replace` | Typed k/v annotation (multi-valued). The client **always** passes `--symbol` (a bare name fans out to every search hit) and **always** `--replace` (the CLI defaults to APPEND, which stacks duplicate rows across re-index runs). |
+| `set_requirement(symbol_id, requirement, validated)` | `semantics <id> --requirement … --validated true\|false` | The single canonical requirement↔symbol link (node_semantics — a **separate** subcommand from `annotate`). |
+| `read_annotations(symbol_id) -> [Annotation]` | `annotations --symbol <id> --json` | Read back. **Must** use `--symbol` — the positional `annotations <name>` form name-*searches* and returns an array, so a SymbolId there matches nothing and yields `[]` silently. `--symbol` returns the single-symbol object `{symbol, annotations[]}`. |
+| `find_by_annotation(key, value?) -> [symbol_id]` | *(no CLI verb)* | Reverse lookup. **Not available on the CLI-backed path** — there is no reverse-annotation verb, and the real extractor resolves forward (name → SymbolId → annotate), so `CliEstateClient.find_by_annotation` raises. Mock-lane only. |
 
 ### The two coordinated writes per bound rule
 
 Ported from anti-legacy's `annotate()`, both keyed by SymbolId, **neither copying
-symbol structure**:
+symbol structure**. On the real CLI each field is a **separate argument** — there
+is no pipe-packed string:
 
-1. **Native projection into estate** (so estate queries see it): the compact
-   tagged requirement string — convention `"<rule_id>|<confidence>|<provenance>|<statement>"`
-   — plus `requirement_validated = 1` (RESOLVED at/above threshold) or `0`
-   (RISK). Reverse lookup via `by-requirement <REQ>`.
-2. **The domain-model document** row: `legacy_components[]` holds the SymbolId;
-   `provenance.ref` holds the SymbolId or file#anchor. **Nothing else about the
-   symbol is copied** — no name uniqueness, no file, no source text.
+1. **Native projection into estate** (so estate queries see it): a typed
+   annotation — `annotate(symbol_id, type="business_rule"` (RESOLVED, at/above the
+   confidence threshold) or `"risk"` (below threshold)`, key=<rule_id>,
+   value=<statement>, confidence=<c>, provenance=<p>, replace=True)`.
+2. **The canonical requirement link**: `set_requirement(symbol_id,
+   requirement=<statement>, validated=<resolved>)` (`semantics`). This is what the
+   later `wicked-core domain-graph` read counts toward front-half coverage.
 
 The traceability thread the workers must not break:
-`estate node (native file/line) → requirement annotation → business_rules[].id →
+`estate node (native file/line) → requirement/annotation → business_rules[].id →
 legacy_components[] → crew task → UAT verdict`. A broken link is a gate failure,
 not a warning.
 
-## The brain surface (what the translator calls)
+## The core surface (owns doc assembly — the inversion)
 
-brain owns the domain-model engine + store. The translator hands brain the
-assembled document and consumes its summary; it does **not** reimplement the
-engine. In PHASE-1 this is `scripts/modernize/_mocks.BrainClient`:
+**core owns the domain-model build.** The translator does **not** hand core an
+assembled document; it annotates the estate store (via the estate surface above),
+then invokes core, which **reads the store and builds `requirements_graph.json`
+itself**. `CliCoreClient`:
 
 | Method | Production | Purpose |
 |---|---|---|
-| `build_domain_graph(doc) -> summary` | `wicked-brain domain build --db <estate_db> --overlay annotations.jsonl` | Build `requirements_graph.json` (capability plan) with round-trip no-silent-drop. |
-| `validate(doc) -> ok` | brain-side schema validation | brain rejects a `schema_version` it has no validator for — no silent best-effort. |
+| `domain_graph(db, out, coverage?) -> doc` | `wicked-core domain-graph --db <db> --out requirements_graph.json [--coverage F]` | Reads the annotated store, **recomputes front-half coverage**, and builds the capability plan. **Fails closed** (writes nothing, non-zero exit) when coverage < 1.0 — so every behavior-bearing node must be annotated first. A supplied `--coverage` file is an optional cross-check that must agree. |
+| `coverage(db, out) -> report` | `wicked-core coverage --db <db> --out coverage.json` | Emit the store's front-half coverage report (optional — `domain_graph` recomputes internally). |
+
+There is **no `--overlay`** and **no doc-in/summary-out** shape: the store is the
+input, the built doc is the output. Garden's `validate_domain_model.py` then runs
+as a **consumer-side cross-check** on core's output against the vendored schema.
 
 ## Config-driven miner kind-sets (invariant 6)
 
@@ -62,22 +84,28 @@ The extractor must read the behavior/type/structural kind-sets from
 | `coverage.estate_behavior_kinds` | mainframe/IaC only | `[]` for a pure modern repo; `["db2_table","cics_program","step"]` on a mainframe estate |
 
 `emit_domain_model.py` accepts a `config` dict and defaults to these — the same
-document contract serves a COBOL estate and a Rust monorepo.
+document contract serves a COBOL estate and a Rust monorepo. (These mirror
+`wicked-core`'s `CoverageConfig.behavior_other_tags`; core is the coverage
+authority on the real path.)
 
 ## The disjoint-build mock seam
 
-`scripts/modernize/_mocks.py` is the whole point of the disjoint build: garden
-builds + tests its side against fixtures while brain, estate, and crew build
-theirs in parallel. The mocks:
+`scripts/modernize/_mocks.py` remains the hermetic lane: garden builds + tests
+its side against fixtures while estate and core build theirs. The real path
+(`_clients.py`) shells the peer CLIs — argv lists, never a shell string — so the
+"imports NO other-product code" doctrine holds either way. The mocks:
 
 - `EstateClient` — canned `read_clusters()` (a two-community fixture with member
   SymbolIds), `resolve()` (name → deterministic fixture SymbolId), and
   `annotate()`/`set_requirement()` that **record** calls so a test can assert the
   write happened (the anti-legacy silent-no-op scar is caught by asserting the
   recorded id is a real SymbolId, never a bare name).
-- `BrainClient` — `build_domain_graph()` returns a summary
-  `{domains, requirements, dropped}` and `validate()` runs the same stdlib
-  draft-07 schema check brain would (against the vendored schema).
+- `BrainClient` — the **hermetic doc-assembly lane** only (`build_domain_graph(doc)`
+  returns a `{domains, requirements, dropped}` summary and `validate()` runs the
+  stdlib draft-07 schema check). This does **not** model the real core flow (which
+  reads the store); it exists so `emit_domain_model.py` can assemble + validate a
+  document with no peers present. On the real path, `core_client()` returns a
+  `CliCoreClient` and this stand-in is not used.
 
-**No other-product code is imported.** When the real CLIs land, swap the mock for
-a CLI-backed impl with the identical interface — the workers don't change.
+**No other-product code is imported.** When the peer CLIs are present the
+`_clients.py` factories swap in the CLI-backed impls — the workers don't change.

--- a/skills/modernize/refs/extraction-flow.md
+++ b/skills/modernize/refs/extraction-flow.md
@@ -43,9 +43,10 @@ symbol structure**. On the real CLI each field is a **separate argument** — th
 is no pipe-packed string:
 
 1. **Native projection into estate** (so estate queries see it): a typed
-   annotation — `annotate(symbol_id, type="business_rule"` (RESOLVED, at/above the
-   confidence threshold) or `"risk"` (below threshold)`, key=<rule_id>,
-   value=<statement>, confidence=<c>, provenance=<p>, replace=True)`.
+   annotation `annotate(symbol_id, type=<t>, key=<rule_id>, value=<statement>,
+   confidence=<c>, provenance=<p>, replace=True)`, where `type` is
+   `"business_rule"` when the rule is RESOLVED (confidence at/above the threshold)
+   or `"risk"` when it is below threshold.
 2. **The canonical requirement link**: `set_requirement(symbol_id,
    requirement=<statement>, validated=<resolved>)` (`semantics`). This is what the
    later `wicked-core domain-graph` read counts toward front-half coverage.

--- a/tests/modernize/test_clients.py
+++ b/tests/modernize/test_clients.py
@@ -164,6 +164,25 @@ def test_read_clusters_threads_the_min_filter(monkeypatch):
     assert argv[:3] == ["wicked-estate", "clusters", "5"]
 
 
+def test_resolve_fails_loud_on_non_list_shape(monkeypatch):
+    # A dict/None where the CLI contract is a JSON array must RAISE, not fail-open
+    # to [] (which would look like "zero hits" and let a write silently no-op).
+    est, _ = _cli_estate(monkeypatch, json_return={"unexpected": "shape"})
+    with pytest.raises(RuntimeError, match="expected a JSON array of hit objects"):
+        est.resolve("charge")
+
+
+def test_read_clusters_fails_loud_on_non_list_shape(monkeypatch):
+    est, _ = _cli_estate(monkeypatch, json_return={"clusters": []})
+    with pytest.raises(RuntimeError, match="expected a JSON array of community objects"):
+        est.read_clusters()
+
+
+def test_read_output_json_fails_loud_on_missing_file(tmp_path):
+    with pytest.raises(RuntimeError, match="wrote no output file"):
+        _clients._read_output_json(str(tmp_path / "absent.json"), "wicked-core coverage")
+
+
 def test_read_annotations_uses_symbol_flag_not_positional(monkeypatch):
     est, cap = _cli_estate(monkeypatch, json_return={"symbol": "sym::b::A::a1",
                                                      "annotations": [{"key": "RULE-1"}]})

--- a/tests/modernize/test_clients.py
+++ b/tests/modernize/test_clients.py
@@ -206,6 +206,12 @@ def test_read_annotations_rejects_unexpected_array_shape(monkeypatch):
         est.read_annotations("sym::b::A::a1")
 
 
+def test_read_annotations_rejects_non_list_annotations_field(monkeypatch):
+    est, _ = _cli_estate(monkeypatch, json_return={"symbol": "x", "annotations": None})
+    with pytest.raises(RuntimeError, match="'annotations' is NoneType, expected a list"):
+        est.read_annotations("sym::b::A::a1")
+
+
 def test_find_by_annotation_is_unsupported_on_the_cli(monkeypatch):
     est, _ = _cli_estate(monkeypatch)
     with pytest.raises(NotImplementedError):

--- a/tests/modernize/test_clients.py
+++ b/tests/modernize/test_clients.py
@@ -1,0 +1,235 @@
+"""garden#989 — the CLI-backed un-mock clients (``scripts/modernize/_clients.py``).
+
+The UNIT lane runs with NO binaries present: it monkeypatches the subprocess
+shims to capture the argv the client would run, proving the four mock/CLI
+reconciliations (symbol_id extraction, --symbol+--replace enforcement, semantics
+routing, --db threading) and the resolve precedence. The INTEGRATION lane
+skips-when-absent and exercises the real ``wicked-estate`` + ``wicked-core``.
+
+Disjoint-build discipline: shells the peer binaries (argv lists, no shell string);
+imports NO other-product code.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from modernize import _clients
+
+
+# --- resolve precedence (no binary) ------------------------------------------
+
+def test_env_override_wins_and_empty_is_kill_switch(monkeypatch):
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "/opt/wicked-estate")
+    assert _clients._resolve_bin("WICKED_ESTATE_BIN", "wicked-estate") == ["/opt/wicked-estate"]
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "")  # kill-switch
+    assert _clients._resolve_bin("WICKED_ESTATE_BIN", "wicked-estate") is None
+
+
+def test_config_preference_sits_between_env_and_path(monkeypatch):
+    monkeypatch.delenv("WICKED_ESTATE_BIN", raising=False)
+    monkeypatch.setattr(_clients, "_config_preference",
+                        lambda key: "/cfg/wicked-estate" if key == "wicked-estate" else None)
+    assert _clients._resolve_bin("WICKED_ESTATE_BIN", "wicked-estate") == ["/cfg/wicked-estate"]
+    # Env override still wins over config.
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "/env/wicked-estate")
+    assert _clients._resolve_bin("WICKED_ESTATE_BIN", "wicked-estate") == ["/env/wicked-estate"]
+
+
+def test_config_preference_is_none_on_malformed_config(monkeypatch, tmp_path):
+    # "None on any error" — a non-object JSON (AttributeError) and a non-UTF-8
+    # file (UnicodeDecodeError, a ValueError) must not escape and abort extraction.
+    cfg = tmp_path / "config.json"
+    monkeypatch.setattr(_clients, "_CONFIG_PATH", cfg)
+    cfg.write_text("[1, 2, 3]")  # valid JSON, not an object
+    assert _clients._config_preference("wicked-estate") is None
+    cfg.write_text('"just-a-string"')
+    assert _clients._config_preference("wicked-estate") is None
+    cfg.write_bytes(b"\xff\xfe\x00bad-utf8")  # non-UTF-8
+    assert _clients._config_preference("wicked-estate") is None
+    cfg.write_text('{"tool_preferences": {"wicked-estate": "/x/wicked-estate"}}')
+    assert _clients._config_preference("wicked-estate") == "/x/wicked-estate"
+
+
+def test_invoke_fails_loud_on_unrunnable_binary(monkeypatch):
+    # A resolved-but-unrunnable argv must raise a descriptive RuntimeError, not a
+    # raw FileNotFoundError traceback.
+    with pytest.raises(RuntimeError, match="not found or not executable"):
+        _clients._run(["/nonexistent/wicked-estate-xyz", "resolve", "x"])
+
+
+def test_estate_client_falls_back_to_mock_without_a_binary(monkeypatch):
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "")  # force no binary
+    client = _clients.estate_client(db="/tmp/x.db")
+    from modernize._mocks import EstateClient
+    assert isinstance(client, EstateClient), "no binary -> the fixture-backed mock"
+
+
+def test_estate_client_needs_both_a_binary_and_a_db(monkeypatch):
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "/opt/wicked-estate")
+    # A binary but no db -> still the mock (a CLI op without a store is meaningless).
+    from modernize._mocks import EstateClient
+    assert isinstance(_clients.estate_client(db=None), EstateClient)
+    assert isinstance(_clients.estate_client(db="/tmp/e.db"), _clients.CliEstateClient)
+
+
+def test_core_client_is_none_without_a_binary(monkeypatch):
+    monkeypatch.setenv("WICKED_CORE_BIN", "")
+    assert _clients.core_client() is None
+
+
+# --- CLI argv construction (no binary — monkeypatch the shims) ---------------
+
+class _Capture:
+    def __init__(self, json_return=None):
+        self.calls = []
+        self._json = json_return
+
+    def run(self, argv):
+        self.calls.append(argv)
+        return ""
+
+    def run_json(self, argv):
+        self.calls.append(argv)
+        return self._json
+
+
+def _cli_estate(monkeypatch, json_return=None):
+    cap = _Capture(json_return)
+    monkeypatch.setattr(_clients, "_run", cap.run)
+    monkeypatch.setattr(_clients, "_run_json", cap.run_json)
+    return _clients.CliEstateClient(["wicked-estate"], "/tmp/estate.db"), cap
+
+
+def test_resolve_extracts_symbol_ids_and_threads_db(monkeypatch):
+    est, cap = _cli_estate(monkeypatch, json_return=[
+        {"symbol_id": "sym::billing::A::a1", "name": "A"},
+        {"symbol_id": "sym::billing::B::a2", "name": "B"},
+        {"name": "no-id"},  # ignored
+    ])
+    ids = est.resolve("charge", file="src/billing/charge.py", kind="Function")
+    assert ids == ["sym::billing::A::a1", "sym::billing::B::a2"]
+    argv = cap.calls[0]
+    assert argv[:2] == ["wicked-estate", "resolve"]
+    assert "charge" in argv and "--json" in argv
+    assert argv[argv.index("--file") + 1] == "src/billing/charge.py"  # EXACT path
+    assert argv[argv.index("--kind") + 1] == "Function"
+    assert argv[argv.index("--db") + 1] == "/tmp/estate.db"
+
+
+def test_annotate_forces_symbol_and_replace(monkeypatch):
+    est, cap = _cli_estate(monkeypatch)
+    est.annotate("sym::billing::A::a1", "business_rule", "RULE-001",
+                 "amount must be positive", confidence=0.9, provenance="code-graph")
+    argv = cap.calls[0]
+    assert argv[argv.index("--symbol") + 1] == "sym::billing::A::a1"  # never a bare name
+    assert "--replace" in argv, "must upsert (the CLI defaults to APPEND)"
+    assert argv[argv.index("--type") + 1] == "business_rule"
+    assert argv[argv.index("--key") + 1] == "RULE-001"
+    assert argv[argv.index("--value") + 1] == "amount must be positive"
+    assert argv[argv.index("--db") + 1] == "/tmp/estate.db"
+
+
+def test_annotate_refuses_a_bare_name(monkeypatch):
+    est, _ = _cli_estate(monkeypatch)
+    with pytest.raises(ValueError, match="non-SymbolId"):
+        est.annotate("Charge", "business_rule", "k", "v")
+
+
+def test_set_requirement_routes_to_semantics(monkeypatch):
+    est, cap = _cli_estate(monkeypatch)
+    est.set_requirement("sym::billing::A::a1", "REQ text", validated=True)
+    argv = cap.calls[0]
+    assert argv[:2] == ["wicked-estate", "semantics"], "requirement -> node_semantics, not annotate"
+    assert "sym::billing::A::a1" in argv
+    assert argv[argv.index("--requirement") + 1] == "REQ text"
+    assert argv[argv.index("--validated") + 1] == "true"
+
+
+def test_read_clusters_requests_the_summary_shape(monkeypatch):
+    est, cap = _cli_estate(monkeypatch, json_return=[{"id": 0, "size": 2, "members": []}])
+    est.read_clusters()
+    argv = cap.calls[0]
+    assert "--summary" in argv and "--json" in argv, "the object shape needs --summary"
+    assert argv[argv.index("--db") + 1] == "/tmp/estate.db"
+
+
+def test_read_clusters_threads_the_min_filter(monkeypatch):
+    est, cap = _cli_estate(monkeypatch, json_return=[])
+    est.read_clusters({"min": 5})
+    argv = cap.calls[0]
+    # `[min]` is a positional right after the subcommand, before the flags.
+    assert argv[:3] == ["wicked-estate", "clusters", "5"]
+
+
+def test_read_annotations_uses_symbol_flag_not_positional(monkeypatch):
+    est, cap = _cli_estate(monkeypatch, json_return={"symbol": "sym::b::A::a1",
+                                                     "annotations": [{"key": "RULE-1"}]})
+    anns = est.read_annotations("sym::b::A::a1")
+    assert anns == [{"key": "RULE-1"}]
+    argv = cap.calls[0]
+    # `--symbol` (single-object shape), NOT the positional name-search form.
+    assert argv[argv.index("--symbol") + 1] == "sym::b::A::a1"
+    assert "sym::b::A::a1" not in argv[:argv.index("--symbol")], "id must not also be a positional"
+
+
+def test_read_annotations_refuses_a_bare_name(monkeypatch):
+    est, _ = _cli_estate(monkeypatch)
+    with pytest.raises(ValueError, match="non-SymbolId"):
+        est.read_annotations("Charge")
+
+
+def test_read_annotations_rejects_unexpected_array_shape(monkeypatch):
+    est, _ = _cli_estate(monkeypatch, json_return=[{"symbol": "x", "annotations": []}])
+    with pytest.raises(RuntimeError, match="expected the single-symbol object"):
+        est.read_annotations("sym::b::A::a1")
+
+
+def test_find_by_annotation_is_unsupported_on_the_cli(monkeypatch):
+    est, _ = _cli_estate(monkeypatch)
+    with pytest.raises(NotImplementedError):
+        est.find_by_annotation("business_rule")
+
+
+def test_core_domain_graph_shells_and_returns_the_parsed_doc(monkeypatch, tmp_path):
+    out = tmp_path / "requirements_graph.json"
+    doc = {"metadata": {"schema_version": "1.0.0", "migration_mode": "functional"}, "domains": {}}
+
+    def fake_run(argv):
+        # The CLI would write --out; simulate it.
+        out_path = Path(argv[argv.index("--out") + 1])
+        out_path.write_text(json.dumps(doc))
+        return ""
+
+    monkeypatch.setattr(_clients, "_run", fake_run)
+    core = _clients.CliCoreClient(["wicked-core"])
+    got = core.domain_graph(db="/tmp/e.db", out=str(out))
+    assert got == doc
+
+
+# --- opt-in real-CLI integration (skip when the peers are absent) ------------
+
+def _bin(env, package):
+    import os
+    val = os.environ.get(env, "").strip()
+    return val or shutil.which(package)
+
+
+_ESTATE = _bin("WICKED_ESTATE_BIN", "wicked-estate")
+_CORE = _bin("WICKED_CORE_BIN", "wicked-core")
+
+
+@pytest.mark.skipif(
+    _ESTATE is None or _CORE is None,
+    reason="wicked-estate and/or wicked-core not installed (PATH or WICKED_*_BIN) — real-CLI integration lane",
+)
+def test_real_cli_selection_resolves_the_binaries():
+    # A minimal live assertion that the seam picks the real clients when the peers
+    # are present (the full annotate->coverage==1.0->domain-graph flow additionally
+    # needs an INDEXED + fully-annotated store — a fixture-seeding step tracked for
+    # the end-to-end milestone, core#28).
+    est = _clients.estate_client(db="/tmp/does-not-matter.db")
+    assert isinstance(est, _clients.CliEstateClient)
+    assert _clients.core_client() is not None

--- a/tests/modernize/test_clients.py
+++ b/tests/modernize/test_clients.py
@@ -238,8 +238,11 @@ def test_core_domain_graph_shells_and_returns_the_parsed_doc(monkeypatch, tmp_pa
 
 def _bin(env, package):
     import os
-    val = os.environ.get(env, "").strip()
-    return val or shutil.which(package)
+    # Mirror _resolve_bin's kill-switch: a set-but-empty env var forces "no
+    # binary" (skip the integration lane), NOT a PATH fallback.
+    if env in os.environ:
+        return os.environ[env].strip() or None
+    return shutil.which(package)
 
 
 _ESTATE = _bin("WICKED_ESTATE_BIN", "wicked-estate")


### PR DESCRIPTION
Closes #989.

## What

PHASE-1 ran the modernize workers against canned fixtures (`_mocks.py`). This wires the **real flow**: a selection seam that shells the actual `wicked-estate` + `wicked-core` CLIs, plus the doc corrections the mock-era instructions had drifted from.

### `scripts/modernize/_clients.py` (new)

A `_loom.py`-style selection seam — **shells** the peers (argv lists, never a shell string) and imports **no** other-product code, so the disjoint-build doctrine holds at the letter.

- **`estate_client(db)` / `core_client()`** resolve on the ladder `env → config.json tool_preferences → PATH → node_modules/.bin → mock fallback`. Set-but-empty `WICKED_*_BIN` is the kill-switch.
- **`CliEstateClient`** — the six-method estate surface, reconciling the mock/CLI mismatches **verified against the real Rust CLI source**:
  - `resolve` returns an object array → extract each `.symbol_id`; `--file` is exact `location.file` equality.
  - `annotate` **always** `--symbol` (a bare name fans out over `search()`) and **always** `--replace` (the CLI APPENDs by default → duplicate rows across re-index runs).
  - `set_requirement` → the `semantics` subcommand (not `annotate`).
  - `read_annotations` **must** use `--symbol` (the positional form name-*searches*, so a SymbolId there silently returns `[]`).
  - every op threads `--db`; `find_by_annotation` raises (no reverse-annotation verb).
- **`CliCoreClient`** — the **flow inversion**: `domain_graph(db, out)` shells `wicked-core domain-graph`, which **reads the annotated store and builds `requirements_graph.json` itself** (fail-closed when coverage < 1.0). No `--overlay`, no doc-in/summary-out shape.

### Docs

Corrected `extraction-flow.md` + the three modernize `SKILL.md` files — removed the fictional `wicked-brain domain build --overlay`, the pipe-packed requirement string, and the "translator hands brain the assembled doc" inversion. Honest scope notes the `coverage == 1.0` store-seeding prerequisite is the end-to-end milestone (core#28), not this slice.

## Review

Every argv was cross-checked against the real `wicked-estate`/`wicked-core` arg parsing, and an adversarial review workflow (3 lenses × independent verification) ran over the diff. **4 real findings folded in-phase, each with a test:**

1. **fail-open** — `read_annotations` positional → `--symbol` (a SymbolId was name-searched to `[]` silently).
2. **fail-loud** — `_config_preference` now guards non-object JSON + catches `ValueError` (non-UTF-8), so a malformed user config returns `None` instead of aborting extraction. The identical mirror bug in `scripts/_loom.py` is filed as #990.
3. **bounded** — `_invoke` adds a 120s timeout (matching `_loom`) + descriptive re-raise for an unrunnable/hung binary (no indefinite hang, no raw OS traceback).
4. doc — the resolution ladder in `extraction-flow.md` now includes the config rung.

Refuted findings (correctly): a duplicate of #1 already fixed, and a Windows `node_modules/.bin` concern that doesn't apply (Rust binaries → clean miss → mock fallback, not a crash).

## Test

- 50 modernize tests: argv construction vs the real CLI signatures, the selection ladder, and the fail-loud paths, plus an **opt-in** real-CLI lane that skips when the peers are absent.
- Full garden suite green: **953 passed, 18 skipped**. CI structural validation + registry validator pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)