### PR TITLE
feat(outgov): pattern-conformance engine + per-turn policy advisory (closes #983, #984)

### DIFF
--- a/.claude-plugin/components.json
+++ b/.claude-plugin/components.json
@@ -2,8 +2,8 @@
   "_comment": "Issue #328: Component declarations for wicked-garden plugin. Claude Code plugin.json does not yet support inline component declarations beyond path overrides. This manifest documents all components for tooling, validation, and future schema support. When plugin.json gains a 'components' field, merge this data into plugin.json. The plugin is skills-only: former commands/ became actions of consolidated per-domain skills, and former agents/ became standalone context:fork worker skills (enumerated under fork_skills). Regenerate derived blocks with scripts/ci/sync_components.py.",
   "domains": ["agentic", "crew", "data", "engineering", "jam", "mem", "persona", "platform", "product", "qe", "search", "smaht"],
   "summary": {
-    "skills": 98,
-    "fork_skills": 37,
+    "skills": 99,
+    "fork_skills": 38,
     "hooks": 13,
     "specialists": 7
   },
@@ -27,6 +27,7 @@
     "domain-modeler": ["domain-modeler"],
     "engineering": ["architecture", "backend", "debugging", "docs", "engineering", "frontend", "integration", "large-scale-migration", "patch", "system-design", "unit-test-quality"],
     "engineering-api-documentarian": ["engineering-api-documentarian"],
+    "engineering-conformance-reviewer": ["engineering-conformance-reviewer"],
     "engineering-migration-engineer": ["engineering-migration-engineer"],
     "engineering-solution-architect": ["engineering-solution-architect"],
     "ground": ["ground"],
@@ -57,7 +58,7 @@
     "workflow": ["workflow"],
     "worktrees": ["worktrees"]
   },
-  "fork_skills": ["wicked-garden-agentic-architect", "wicked-garden-agentic-performance-analyst", "wicked-garden-agentic-safety-reviewer", "wicked-garden-archetype", "wicked-garden-classify", "wicked-garden-crew-implementer", "wicked-garden-crew-researcher", "wicked-garden-crew-reviewer", "wicked-garden-data-engineer", "wicked-garden-domain-coverage", "wicked-garden-domain-extractor", "wicked-garden-domain-modeler", "wicked-garden-engineering-api-documentarian", "wicked-garden-engineering-debugging", "wicked-garden-engineering-migration-engineer", "wicked-garden-engineering-solution-architect", "wicked-garden-ground", "wicked-garden-integration-discovery", "wicked-garden-jam-brainstorm-facilitator", "wicked-garden-jam-council", "wicked-garden-multi-model", "wicked-garden-persona-agent", "wicked-garden-platform-compliance-officer", "wicked-garden-platform-privacy-expert", "wicked-garden-platform-security-engineer", "wicked-garden-product-a11y-expert", "wicked-garden-product-requirements-analyst", "wicked-garden-product-ui-reviewer", "wicked-garden-product-ux-designer", "wicked-garden-product-value-strategist", "wicked-garden-qe-semantic-reviewer", "wicked-garden-runtime-exec", "wicked-garden-smaht", "wicked-garden-swarm", "wicked-garden-wickedizer", "wicked-garden-workflow", "wicked-garden-worktrees"],
+  "fork_skills": ["wicked-garden-agentic-architect", "wicked-garden-agentic-performance-analyst", "wicked-garden-agentic-safety-reviewer", "wicked-garden-archetype", "wicked-garden-classify", "wicked-garden-crew-implementer", "wicked-garden-crew-researcher", "wicked-garden-crew-reviewer", "wicked-garden-data-engineer", "wicked-garden-domain-coverage", "wicked-garden-domain-extractor", "wicked-garden-domain-modeler", "wicked-garden-engineering-api-documentarian", "wicked-garden-engineering-conformance-reviewer", "wicked-garden-engineering-debugging", "wicked-garden-engineering-migration-engineer", "wicked-garden-engineering-solution-architect", "wicked-garden-ground", "wicked-garden-integration-discovery", "wicked-garden-jam-brainstorm-facilitator", "wicked-garden-jam-council", "wicked-garden-multi-model", "wicked-garden-persona-agent", "wicked-garden-platform-compliance-officer", "wicked-garden-platform-privacy-expert", "wicked-garden-platform-security-engineer", "wicked-garden-product-a11y-expert", "wicked-garden-product-requirements-analyst", "wicked-garden-product-ui-reviewer", "wicked-garden-product-ux-designer", "wicked-garden-product-value-strategist", "wicked-garden-qe-semantic-reviewer", "wicked-garden-runtime-exec", "wicked-garden-smaht", "wicked-garden-swarm", "wicked-garden-wickedizer", "wicked-garden-workflow", "wicked-garden-worktrees"],
   "hooks": ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure", "TaskCompleted", "SubagentStart", "SubagentStop", "PermissionRequest", "Notification", "PreCompact", "Stop", "SessionEnd"],
   "specialists": [
     {

--- a/WICKED_GARDEN_BUS_EVENTS.md
+++ b/WICKED_GARDEN_BUS_EVENTS.md
@@ -115,6 +115,8 @@ These fields are **stripped automatically** by `_bus.py` before emission:
 | `wicked.garden.compliance.passed` | `platform.compliance` | Compliance check passed for a framework |
 | `wicked.garden.guard.findings` | `platform.guard` | Autonomous session-close guard pipeline surfaced findings (Issue #448) |
 | `wicked.garden.log.rotated` | `platform.log_retention` | Log file rotated by log_retention.rotate_if_needed (audit marker) |
+| `wicked.garden.outgov.pattern_drift_detected` | `platform.outgov` | Pattern-conformance check found drift between session output and a registered conformance rule (garden#983); advisory only. |
+| `wicked.garden.outgov.policy_violation_found` | `platform.outgov` | Per-turn policy compliance check surfaced a violation (garden#984); advisory only — prepended to next session turn, no allow/deny gate. |
 | `wicked.garden.security.finding_raised` | `platform.security` | Security review raised a finding |
 
 ### Qe

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -74,7 +74,7 @@ def _check_outgov_compliance(_input_data: dict) -> list:
     """Per-turn policy compliance advisory when WG_OUTGOV is enabled."""
     try:
         mode = os.environ.get("WG_OUTGOV", "off").strip().lower()
-        if mode == "off":
+        if mode not in ("warn", "strict"):
             return []
         deny_hint = (
             " For CRITICAL severity violations: stop and explain the policy conflict "

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -63,6 +63,37 @@ def _session_dir(subdir: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Output governance — per-turn policy compliance advisory (garden#984)
+# ---------------------------------------------------------------------------
+#
+# When WG_OUTGOV=warn|strict, returns a systemMessage asking Claude to recall
+# Policy-type conformance rules from the estate graph and evaluate this turn's
+# output.  WG_OUTGOV=off (default) → skip silently.  Always fails open.
+
+def _check_outgov_compliance(_input_data: dict) -> list:
+    """Per-turn policy compliance advisory when WG_OUTGOV is enabled."""
+    try:
+        mode = os.environ.get("WG_OUTGOV", "off").strip().lower()
+        if mode == "off":
+            return []
+        deny_hint = (
+            " For CRITICAL severity violations: stop and explain the policy conflict "
+            "before writing or executing the action that would worsen it."
+            if mode == "strict"
+            else ""
+        )
+        return [
+            "[Output Governance] Evaluate this turn's output against applicable policy rules. "
+            "If the estate MCP is connected: use estate tools to list nodes with kind=Rule "
+            "and rule_type=Policy, identify applicable rules, and report any violations with "
+            "rule ID, severity, and a brief explanation. "
+            "If estate is unavailable: skip silently." + deny_hint
+        ]
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Claim sentinel (answer tier) — claim-gated at the Stop boundary.
 # Replaces the old PostToolUse ref-watch that fired on every Bash call. Reads
 # the turn's final assistant message from the transcript; only a real
@@ -600,7 +631,8 @@ def main():
         # _persist_session_state) so its debounce write is the last state write
         # of the turn (avoids clobbering session_ended).
         sentinel_messages = _check_claim_sentinel(input_data)
-        prepend_messages = sentinel_messages + outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages
+        outgov_messages = _check_outgov_compliance(input_data)
+        prepend_messages = sentinel_messages + outgov_messages + outcome_messages + promotion_messages + consolidation_messages + telemetry_messages + guard_messages
         if prepend_messages and reflection:
             final_message = "\n".join(prepend_messages) + "\n\n" + reflection
         elif prepend_messages:

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -265,7 +265,7 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "domain": "wicked-garden",
         "subdomain": "platform.outgov",
         "description": "Per-turn policy compliance check surfaced a violation (garden#984); "
-                       "severity drives allow/deny decision.",
+                       "advisory only — prepended to next session turn, no allow/deny gate.",
     },
     "wicked.garden.compliance.passed": {
         "domain": "wicked-garden",

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -255,6 +255,18 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "platform.guard",
         "description": "Autonomous session-close guard pipeline surfaced findings (Issue #448)",
     },
+    "wicked.garden.outgov.pattern_drift_detected": {
+        "domain": "wicked-garden",
+        "subdomain": "platform.outgov",
+        "description": "Pattern-conformance check found drift between session output and a "
+                       "registered conformance rule (garden#983); advisory only.",
+    },
+    "wicked.garden.outgov.policy_violation_found": {
+        "domain": "wicked-garden",
+        "subdomain": "platform.outgov",
+        "description": "Per-turn policy compliance check surfaced a violation (garden#984); "
+                       "severity drives allow/deny decision.",
+    },
     "wicked.garden.compliance.passed": {
         "domain": "wicked-garden",
         "subdomain": "platform.compliance",

--- a/scripts/_validate_registry.py
+++ b/scripts/_validate_registry.py
@@ -111,6 +111,9 @@ _AUDIT_MARKER_EVENTS: Tuple[str, ...] = (
     "wicked.garden.quality.drift_detected",
     # crew condition resolution — observability only, verdict not mutated.
     "wicked.garden.condition.resolved",
+    # output governance observability signals — no projector state change.
+    "wicked.garden.outgov.pattern_drift_detected",
+    "wicked.garden.outgov.policy_violation_found",
 )
 
 # Reviewer values in gate-policy.json that are NOT subagent identifiers — they

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -1076,7 +1076,10 @@ def check_outgov_pattern(
 
     for rule in pattern_rules:
         if time.monotonic() > deadline:
-            result.note = "budget exhausted; partial rule set surfaced (fail-open)"
+            surfaced = len(result.findings)
+            result.note = (
+                f"budget exhausted; {surfaced} of {len(pattern_rules)} rules surfaced (fail-open)"
+            )
             break
         rid = rule.get("id", "?")
         sev = _OUTGOV_SEV_MAP.get(str(rule.get("severity", "info")).lower(), SEVERITY_INFO)

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -987,11 +987,17 @@ _OUTGOV_SEV_MAP = {
 }
 
 
-def _load_pattern_rules(rules_dir: Path) -> List[Dict[str, Any]]:
-    """Read Pattern-type conformance rules from *.json bundles under rules_dir."""
+def _load_pattern_rules(rules_dir: Path, deadline: float = float("inf")) -> List[Dict[str, Any]]:
+    """Read Pattern-type conformance rules from *.json bundles under rules_dir.
+
+    Stops loading new bundle files once *deadline* (monotonic) is exceeded so
+    the guard pipeline's per-check budget is respected (fail-open: partial results).
+    """
     rules: List[Dict[str, Any]] = []
     seen: set = set()
     for path in sorted(rules_dir.glob("*.json")):
+        if time.monotonic() > deadline:
+            break
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError, ValueError):
@@ -1032,6 +1038,7 @@ def check_outgov_pattern(
     WG_OUTGOV=off (default) → skip.  Always fails open.
     """
     t0 = time.monotonic()
+    deadline = t0 + budget_seconds
     result = CheckResult(name="outgov_pattern", status="ok")
 
     if os.environ.get("WG_OUTGOV", "off").strip().lower() == "off":
@@ -1055,7 +1062,7 @@ def check_outgov_pattern(
         return result
 
     try:
-        pattern_rules = _load_pattern_rules(rules_dir)
+        pattern_rules = _load_pattern_rules(rules_dir, deadline=deadline)
     except Exception as exc:
         result.status = "skip"
         result.note = f"rule load failed (fail-open): {exc}"
@@ -1068,6 +1075,9 @@ def check_outgov_pattern(
         return result
 
     for rule in pattern_rules:
+        if time.monotonic() > deadline:
+            result.note = "budget exhausted; partial rule set surfaced (fail-open)"
+            break
         rid = rule.get("id", "?")
         sev = _OUTGOV_SEV_MAP.get(str(rule.get("severity", "info")).lower(), SEVERITY_INFO)
         statement = str(rule.get("statement", ""))[:200]

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -1057,8 +1057,8 @@ def check_outgov_pattern(
     try:
         pattern_rules = _load_pattern_rules(rules_dir)
     except Exception as exc:
-        result.status = "error"
-        result.note = f"rule load error: {exc}"
+        result.status = "skip"
+        result.note = f"rule load failed (fail-open): {exc}"
         result.duration_ms = int((time.monotonic() - t0) * 1000)
         return result
 

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -16,12 +16,13 @@ Scope limits (important):
       If unavailable we emit a "semantic-review-unavailable" finding with
       severity=info and continue.
 
-The 5 checks:
+The 6 checks:
     1. bulletproof_scan  — R1-R6 surface heuristics on changed files
     2. debug_artifacts   — print/console.log/pdb/breakpoint leftovers
     3. adr_constraints   — ADR MUST/MUST NOT phrases vs the diff
     4. semantic_review   — delegates to scripts.qe.semantic_review (#444)
     5. skip_log          — unresolved skip-reeval entries (audit_skip_log.py)
+    6. outgov_pattern    — pattern-conformance rules from WICKED_OUTGOV_RULES_DIR
 
 Usage (as a module):
     from platform.guard_pipeline import run_pipeline
@@ -1013,6 +1014,8 @@ def _load_pattern_rules(rules_dir: Path, deadline: float = float("inf")) -> List
         if not isinstance(bundle, list):
             continue
         for item in bundle:
+            if time.monotonic() > deadline:
+                return rules
             if not isinstance(item, dict):
                 continue
             if str(item.get("rule_type", "")).lower() != "pattern":
@@ -1041,7 +1044,7 @@ def check_outgov_pattern(
     deadline = t0 + budget_seconds
     result = CheckResult(name="outgov_pattern", status="ok")
 
-    if os.environ.get("WG_OUTGOV", "off").strip().lower() == "off":
+    if os.environ.get("WG_OUTGOV", "off").strip().lower() not in ("warn", "strict"):
         result.status = "skip"
         result.note = "WG_OUTGOV=off"
         result.duration_ms = int((time.monotonic() - t0) * 1000)
@@ -1065,7 +1068,7 @@ def check_outgov_pattern(
         pattern_rules = _load_pattern_rules(rules_dir, deadline=deadline)
     except Exception as exc:
         result.status = "skip"
-        result.note = f"rule load failed (fail-open): {exc}"
+        result.note = f"rule load failed (fail-open): {str(exc)[:200]}"
         result.duration_ms = int((time.monotonic() - t0) * 1000)
         return result
 

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -996,11 +996,14 @@ def _load_pattern_rules(rules_dir: Path) -> List[Dict[str, Any]]:
             raw = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError, ValueError):
             continue
-        if not isinstance(raw, dict):
+        if isinstance(raw, list):
+            bundle = raw
+        elif isinstance(raw, dict):
+            bundle = raw.get("rules", raw)
+            if isinstance(bundle, dict):
+                bundle = [bundle]
+        else:
             continue
-        bundle = raw.get("rules", [])
-        if isinstance(bundle, dict):
-            bundle = [bundle]
         if not isinstance(bundle, list):
             continue
         for item in bundle:
@@ -1073,7 +1076,7 @@ def check_outgov_pattern(
             rule_id=str(rid),
             severity=sev,
             message=f"[{rid}] {statement} — evaluate this session's output for conformance "
-                    f"(invoke wicked-garden-qe-semantic-reviewer with this rule as rubric)",
+                    f"(invoke wicked-garden-engineering-conformance-reviewer with this rule as rubric)",
         ))
 
     result.duration_ms = int((time.monotonic() - t0) * 1000)

--- a/scripts/platform/guard_pipeline.py
+++ b/scripts/platform/guard_pipeline.py
@@ -968,6 +968,119 @@ def check_skip_log(
 
 
 # ---------------------------------------------------------------------------
+# Check 6: Output governance — pattern conformance (garden#983)
+# ---------------------------------------------------------------------------
+#
+# Reads Pattern-type conformance rules from WICKED_OUTGOV_RULES_DIR/rules/*.json
+# and surfaces them as findings so Claude can evaluate the session's output.
+#
+# Requires: WICKED_OUTGOV_RULES_DIR points to a directory containing a rules/
+# subdir with *.json conformance-rule bundles (wicked_governance schema).
+# WG_OUTGOV=off (default) → skip silently.  Always fails open.
+
+_OUTGOV_RULES_DIR_ENV = "WICKED_OUTGOV_RULES_DIR"
+_OUTGOV_SEV_MAP = {
+    "critical": SEVERITY_BLOCK,
+    "error": SEVERITY_WARN,
+    "warn": SEVERITY_WARN,
+    "info": SEVERITY_INFO,
+}
+
+
+def _load_pattern_rules(rules_dir: Path) -> List[Dict[str, Any]]:
+    """Read Pattern-type conformance rules from *.json bundles under rules_dir."""
+    rules: List[Dict[str, Any]] = []
+    seen: set = set()
+    for path in sorted(rules_dir.glob("*.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        bundle = raw.get("rules", [])
+        if isinstance(bundle, dict):
+            bundle = [bundle]
+        if not isinstance(bundle, list):
+            continue
+        for item in bundle:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("rule_type", "")).lower() != "pattern":
+                continue
+            rid = str(item.get("id", "")).strip()
+            if not rid or rid in seen:
+                continue
+            seen.add(rid)
+            rules.append(item)
+    return rules
+
+
+def check_outgov_pattern(
+    files: List[str],
+    *,
+    budget_seconds: float,
+    **_kwargs: Any,
+) -> CheckResult:
+    """Surface applicable pattern-conformance rules from WICKED_OUTGOV_RULES_DIR.
+
+    Reads *.json rule bundles from the rules/ subdirectory and emits one
+    finding per rule so Claude can evaluate the session's output for conformance.
+    WG_OUTGOV=off (default) → skip.  Always fails open.
+    """
+    t0 = time.monotonic()
+    result = CheckResult(name="outgov_pattern", status="ok")
+
+    if os.environ.get("WG_OUTGOV", "off").strip().lower() == "off":
+        result.status = "skip"
+        result.note = "WG_OUTGOV=off"
+        result.duration_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    rules_env = os.environ.get(_OUTGOV_RULES_DIR_ENV, "").strip()
+    if not rules_env:
+        result.status = "skip"
+        result.note = f"{_OUTGOV_RULES_DIR_ENV} not set"
+        result.duration_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    rules_dir = Path(rules_env) / "rules"
+    if not rules_dir.is_dir():
+        result.status = "skip"
+        result.note = f"rules dir not found: {rules_dir}"
+        result.duration_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    try:
+        pattern_rules = _load_pattern_rules(rules_dir)
+    except Exception as exc:
+        result.status = "error"
+        result.note = f"rule load error: {exc}"
+        result.duration_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    if not pattern_rules:
+        result.note = "no pattern rules found"
+        result.duration_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    for rule in pattern_rules:
+        rid = rule.get("id", "?")
+        sev = _OUTGOV_SEV_MAP.get(str(rule.get("severity", "info")).lower(), SEVERITY_INFO)
+        statement = str(rule.get("statement", ""))[:200]
+        result.findings.append(Finding(
+            check="outgov_pattern",
+            rule_id=str(rid),
+            severity=sev,
+            message=f"[{rid}] {statement} — evaluate this session's output for conformance "
+                    f"(invoke wicked-garden-qe-semantic-reviewer with this rule as rubric)",
+        ))
+
+    result.duration_ms = int((time.monotonic() - t0) * 1000)
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Registry + runner
 # ---------------------------------------------------------------------------
 
@@ -977,6 +1090,7 @@ CHECK_REGISTRY: Dict[str, Callable[..., CheckResult]] = {
     "adr_constraints": check_adr_constraints,
     "semantic_review": check_semantic_review,
     "skip_log": check_skip_log,
+    "outgov_pattern": check_outgov_pattern,
 }
 
 

--- a/scripts/platform/guard_profiles.py
+++ b/scripts/platform/guard_profiles.py
@@ -74,6 +74,7 @@ _STANDARD_CHECKS = (
     "adr_constraints",
     "semantic_review",
     "skip_log",
+    "outgov_pattern",
 )
 _DEEP_CHECKS = _STANDARD_CHECKS  # same check set, deeper semantic review
 

--- a/skills/engineering-conformance-reviewer/SKILL.md
+++ b/skills/engineering-conformance-reviewer/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: wicked-garden-engineering-conformance-reviewer
+context: fork
+description: |
+  Pattern-conformance agent-half: evaluates a produced artifact or diff against
+  a set of architectural/design pattern rules from the conformance-rule store
+  (wicked_governance schema). Returns structured findings with rule ID, severity,
+  and rationale — the deterministic half (mechanical rule recall) is done by the
+  guard pipeline; this is the semantic evaluation step.
+
+  Triggered by: the guard_pipeline `outgov_pattern` check (session-close), or
+  explicitly by an engineering review when WICKED_OUTGOV_RULES_DIR is populated.
+
+  NOT a replacement for the full `engineering` review skill — focuses only on
+  conformance to stored Pattern rules; architecture and code-quality checks live
+  in the `engineering` skill.
+phase_relevance: ["build", "review"]
+archetype_relevance: ["build", "review", "modernize"]
+---
+
+# Conformance Reviewer — Pattern-Conformance Agent-Half
+
+You are the **agent-half** of the output-governance pattern-conformance validator.
+The deterministic half has already run: it read Pattern-type rules from the estate
+graph (via `wicked-core rules ingest` → estate NodeKind::Rule) and surfaced them
+as guard-pipeline findings. Your job is the **semantic evaluation** — decide
+whether the artifact or diff actually violates each applicable rule.
+
+## Inputs (provided in the task or session context)
+
+- The artifact or diff to evaluate (from the guard report or explicitly provided)
+- The list of applicable Pattern rules (from the guard `outgov_pattern` findings,
+  or by querying estate with kind=Rule, rule_type=Pattern)
+
+## Process
+
+1. **Load rules**: if rules are not already in context, use estate tools to list
+   NodeKind::Rule nodes filtered to rule_type=Pattern. Each rule has:
+   `id` (PAT-NNN), `statement` (the pattern text), `severity`, `targets`
+   (language/layer/framework facets — absent = wildcard).
+
+2. **Filter by target**: only evaluate rules whose facets match the artifact
+   (language, layer, framework). Absent facets match everything.
+
+3. **Evaluate semantically**: for each applicable rule, judge whether the artifact
+   violates the rule's `statement`. Use the full rule text — not just the finding
+   message from the guard report.
+
+4. **Report findings**: emit structured output per rule:
+   ```
+   RULE <id> [<severity>] <PASS|VIOLATION>
+   Rationale: <1-2 sentences>
+   ```
+   Group: violations first (critical→info), then passes.
+
+5. **Emit bus event**: if any violation is found, emit
+   `wicked.garden.outgov.pattern_drift_detected` via the bus skill with payload
+   `{rule_id, severity, artifact_hint}`.
+
+## Output contract
+
+Return a verdict:
+- `CONFORMANT` — no violations found
+- `DRIFT` — at least one advisory (warn/info) violation
+- `VIOLATION` — at least one error/critical violation (recommend review before merge)
+
+Severity ladder: critical > error > warn > info.
+A single `critical` violation overrides the overall verdict to `VIOLATION`.
+
+## Important
+
+- This is the **semantic** check — do not skip rules because the guard pipeline
+  already flagged them. The guard's findings are reminders; your evaluation is
+  the authoritative result.
+- Do NOT gate or block — report findings only. The crew gate ladder
+  (`wicked-crew` DES-EXEC-001) owns the deny-dominates decision.
+- Fail-open: if rules cannot be loaded, return `CONFORMANT (rules unavailable)`
+  rather than a false `VIOLATION`.

--- a/skills/engineering-conformance-reviewer/SKILL.md
+++ b/skills/engineering-conformance-reviewer/SKILL.md
@@ -16,7 +16,7 @@ description: |
   in the `engineering` skill.
 
   Semantic evaluation reuses `wicked-garden-qe-semantic-reviewer` as the
-  designated agent-half evaluator (per garden#984 spec). This skill is the
+  designated agent-half evaluator (per garden#983 spec). This skill is the
   orchestrating wrapper that loads applicable Pattern rules and delegates the
   per-rule semantic judgment to qe-semantic-reviewer.
 phase_relevance: ["build", "review"]

--- a/skills/engineering-conformance-reviewer/SKILL.md
+++ b/skills/engineering-conformance-reviewer/SKILL.md
@@ -14,6 +14,11 @@ description: |
   NOT a replacement for the full `engineering` review skill — focuses only on
   conformance to stored Pattern rules; architecture and code-quality checks live
   in the `engineering` skill.
+
+  Semantic evaluation reuses `wicked-garden-qe-semantic-reviewer` as the
+  designated agent-half evaluator (per garden#984 spec). This skill is the
+  orchestrating wrapper that loads applicable Pattern rules and delegates the
+  per-rule semantic judgment to qe-semantic-reviewer.
 phase_relevance: ["build", "review"]
 archetype_relevance: ["build", "review", "modernize"]
 ---

--- a/tests/platform/test_outgov_pattern.py
+++ b/tests/platform/test_outgov_pattern.py
@@ -98,6 +98,21 @@ class TestLoadPatternRules:
         rules_dir.mkdir()
         assert _load_pattern_rules(rules_dir) == []
 
+    def test_respects_expired_deadline(self, tmp_path):
+        """An already-expired deadline stops loading after the first file check."""
+        import time
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _make_bundle([_pat("PAT-001", "Would be loaded")], rules_dir / "a.json")
+        _make_bundle([_pat("PAT-002", "Should be skipped")], rules_dir / "b.json")
+        # deadline in the past — sorted glob sees "a.json" first; the deadline check
+        # fires before "b.json", so at most 1 file is loaded.
+        expired = time.monotonic() - 1.0
+        result = _load_pattern_rules(rules_dir, deadline=expired)
+        # With an already-expired deadline the loop breaks before reading any file.
+        assert len(result) == 0
+
 
 # ---------------------------------------------------------------------------
 # check_outgov_pattern
@@ -154,3 +169,18 @@ class TestCheckOutgovPattern:
         result = check_outgov_pattern([], budget_seconds=5.0)
         assert result.status == "ok"
         assert not result.findings
+
+    def test_budget_exhausted_does_not_crash(self, tmp_path, monkeypatch):
+        """check_outgov_pattern is fail-open even with an exhausted budget."""
+        from guard_pipeline import check_outgov_pattern
+        monkeypatch.setenv("WG_OUTGOV", "warn")
+        monkeypatch.setenv("WICKED_OUTGOV_RULES_DIR", str(tmp_path))
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _make_bundle([_pat("PAT-001", "Use DI"), _pat("PAT-002", "No globals")], rules_dir / "a.json")
+        # budget_seconds=0 forces the deadline to fire; result must be ok (fail-open).
+        result = check_outgov_pattern([], budget_seconds=0.0)
+        assert result.status == "ok"
+        # Either "budget exhausted" (deadline fired during emission) or
+        # "no pattern rules found" (deadline fired during load) — both are correct.
+        assert result.duration_ms >= 0

--- a/tests/platform/test_outgov_pattern.py
+++ b/tests/platform/test_outgov_pattern.py
@@ -99,18 +99,17 @@ class TestLoadPatternRules:
         assert _load_pattern_rules(rules_dir) == []
 
     def test_respects_expired_deadline(self, tmp_path):
-        """An already-expired deadline stops loading after the first file check."""
+        """An already-expired deadline stops loading before reading any file."""
         import time
         from guard_pipeline import _load_pattern_rules
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir()
         _make_bundle([_pat("PAT-001", "Would be loaded")], rules_dir / "a.json")
         _make_bundle([_pat("PAT-002", "Should be skipped")], rules_dir / "b.json")
-        # deadline in the past — sorted glob sees "a.json" first; the deadline check
-        # fires before "b.json", so at most 1 file is loaded.
+        # deadline already in the past — the per-file check fires immediately before
+        # any bundle is read, so the result is empty regardless of how many files exist.
         expired = time.monotonic() - 1.0
         result = _load_pattern_rules(rules_dir, deadline=expired)
-        # With an already-expired deadline the loop breaks before reading any file.
         assert len(result) == 0
 
 

--- a/tests/platform/test_outgov_pattern.py
+++ b/tests/platform/test_outgov_pattern.py
@@ -1,0 +1,145 @@
+"""Tests for guard_pipeline.check_outgov_pattern (garden#983)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make guard_pipeline importable.
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_ROOT / "platform"))
+sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+
+def _make_bundle(rules: list, path: Path) -> None:
+    path.write_text(json.dumps({"rules": rules}), encoding="utf-8")
+
+
+def _pat(rid: str, statement: str, severity: str = "warn") -> dict:
+    return {
+        "id": rid,
+        "rule_type": "Pattern",
+        "statement": statement,
+        "severity": severity,
+        "confidence": 0.9,
+        "provenance": {"source": "test", "ref": "test", "source_kinds": ["manual"]},
+    }
+
+
+def _pol(rid: str, statement: str, severity: str = "warn") -> dict:
+    return {
+        "id": rid,
+        "rule_type": "Policy",
+        "statement": statement,
+        "severity": severity,
+        "confidence": 0.9,
+        "provenance": {"source": "test", "ref": "test", "source_kinds": ["manual"]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _load_pattern_rules
+# ---------------------------------------------------------------------------
+
+class TestLoadPatternRules:
+    def test_reads_pattern_rules_from_bundle(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _make_bundle([_pat("PAT-001", "Use dependency injection"), _pol("POL-001", "No secrets")], rules_dir / "a.json")
+        result = _load_pattern_rules(rules_dir)
+        assert len(result) == 1
+        assert result[0]["id"] == "PAT-001"
+
+    def test_deduplicates_by_id(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _make_bundle([_pat("PAT-001", "First"), _pat("PAT-001", "Duplicate")], rules_dir / "a.json")
+        result = _load_pattern_rules(rules_dir)
+        assert len(result) == 1
+
+    def test_skips_malformed_json(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "bad.json").write_text("not-json", encoding="utf-8")
+        _make_bundle([_pat("PAT-001", "Good rule")], rules_dir / "good.json")
+        result = _load_pattern_rules(rules_dir)
+        assert len(result) == 1
+
+    def test_bare_single_rule_object(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "bare.json").write_text(
+            json.dumps({"rules": _pat("PAT-001", "Bare")}), encoding="utf-8"
+        )
+        result = _load_pattern_rules(rules_dir)
+        assert len(result) == 1
+
+    def test_empty_dir(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        assert _load_pattern_rules(rules_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# check_outgov_pattern
+# ---------------------------------------------------------------------------
+
+class TestCheckOutgovPattern:
+    def test_skip_when_wg_outgov_off(self, tmp_path, monkeypatch):
+        from guard_pipeline import check_outgov_pattern
+        monkeypatch.setenv("WG_OUTGOV", "off")
+        result = check_outgov_pattern([], budget_seconds=5.0)
+        assert result.status == "skip"
+        assert "WG_OUTGOV=off" in (result.note or "")
+
+    def test_skip_when_rules_dir_env_not_set(self, tmp_path, monkeypatch):
+        from guard_pipeline import check_outgov_pattern
+        monkeypatch.setenv("WG_OUTGOV", "warn")
+        monkeypatch.delenv("WICKED_OUTGOV_RULES_DIR", raising=False)
+        result = check_outgov_pattern([], budget_seconds=5.0)
+        assert result.status == "skip"
+
+    def test_skip_when_rules_subdir_missing(self, tmp_path, monkeypatch):
+        from guard_pipeline import check_outgov_pattern
+        monkeypatch.setenv("WG_OUTGOV", "warn")
+        monkeypatch.setenv("WICKED_OUTGOV_RULES_DIR", str(tmp_path))
+        result = check_outgov_pattern([], budget_seconds=5.0)
+        assert result.status == "skip"
+        assert "rules dir not found" in (result.note or "")
+
+    def test_emits_findings_for_pattern_rules(self, tmp_path, monkeypatch):
+        from guard_pipeline import check_outgov_pattern, SEVERITY_WARN, SEVERITY_BLOCK
+        monkeypatch.setenv("WG_OUTGOV", "warn")
+        monkeypatch.setenv("WICKED_OUTGOV_RULES_DIR", str(tmp_path))
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _make_bundle([
+            _pat("PAT-001", "Use DI", "warn"),
+            _pat("PAT-002", "No globals", "critical"),
+            _pol("POL-001", "Skipped policy"),
+        ], rules_dir / "a.json")
+        result = check_outgov_pattern([], budget_seconds=5.0)
+        assert result.status == "ok"
+        assert len(result.findings) == 2
+        ids = {f.rule_id for f in result.findings}
+        assert "PAT-001" in ids
+        assert "PAT-002" in ids
+        critical_f = next(f for f in result.findings if f.rule_id == "PAT-002")
+        assert critical_f.severity == SEVERITY_BLOCK
+
+    def test_ok_when_no_pattern_rules(self, tmp_path, monkeypatch):
+        from guard_pipeline import check_outgov_pattern
+        monkeypatch.setenv("WG_OUTGOV", "warn")
+        monkeypatch.setenv("WICKED_OUTGOV_RULES_DIR", str(tmp_path))
+        (tmp_path / "rules").mkdir()
+        result = check_outgov_pattern([], budget_seconds=5.0)
+        assert result.status == "ok"
+        assert not result.findings

--- a/tests/platform/test_outgov_pattern.py
+++ b/tests/platform/test_outgov_pattern.py
@@ -181,6 +181,11 @@ class TestCheckOutgovPattern:
         # budget_seconds=0 forces the deadline to fire; result must be ok (fail-open).
         result = check_outgov_pattern([], budget_seconds=0.0)
         assert result.status == "ok"
-        # Either "budget exhausted" (deadline fired during emission) or
-        # "no pattern rules found" (deadline fired during load) — both are correct.
+        # Either "budget exhausted; N of M rules surfaced" (deadline fired during emission)
+        # or "no pattern rules found" (deadline fired during load) — both are correct.
+        # Either way the note must NOT claim "partial rule set surfaced" without a count.
+        note = result.note or ""
+        assert not note.startswith("budget exhausted; partial"), (
+            "note must include surfaced/total counts, not just 'partial'"
+        )
         assert result.duration_ms >= 0

--- a/tests/platform/test_outgov_pattern.py
+++ b/tests/platform/test_outgov_pattern.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 import pytest
 
-# Make guard_pipeline importable.
-_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent.parent / "scripts"
-sys.path.insert(0, str(_SCRIPTS_ROOT / "platform"))
-sys.path.insert(0, str(_SCRIPTS_ROOT))
+# conftest.py puts scripts/ at sys.path[0]; we only need to append scripts/platform
+# for guard_pipeline. Using append avoids shadowing the conftest-established order.
+sys.path.append(str(Path(__file__).resolve().parents[2] / "scripts" / "platform"))
 
 
 def _make_bundle(rules: list, path: Path) -> None:
@@ -75,11 +74,23 @@ class TestLoadPatternRules:
         from guard_pipeline import _load_pattern_rules
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir()
+        # Rule dict at root with no "rules" key — should be treated as a single rule.
         (rules_dir / "bare.json").write_text(
-            json.dumps({"rules": _pat("PAT-001", "Bare")}), encoding="utf-8"
+            json.dumps(_pat("PAT-001", "Bare")), encoding="utf-8"
         )
         result = _load_pattern_rules(rules_dir)
         assert len(result) == 1
+
+    def test_top_level_list(self, tmp_path):
+        from guard_pipeline import _load_pattern_rules
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "list.json").write_text(
+            json.dumps([_pat("PAT-001", "First"), _pat("PAT-002", "Second")]),
+            encoding="utf-8",
+        )
+        result = _load_pattern_rules(rules_dir)
+        assert len(result) == 2
 
     def test_empty_dir(self, tmp_path):
         from guard_pipeline import _load_pattern_rules
@@ -116,7 +127,7 @@ class TestCheckOutgovPattern:
         assert "rules dir not found" in (result.note or "")
 
     def test_emits_findings_for_pattern_rules(self, tmp_path, monkeypatch):
-        from guard_pipeline import check_outgov_pattern, SEVERITY_WARN, SEVERITY_BLOCK
+        from guard_pipeline import check_outgov_pattern, SEVERITY_BLOCK
         monkeypatch.setenv("WG_OUTGOV", "warn")
         monkeypatch.setenv("WICKED_OUTGOV_RULES_DIR", str(tmp_path))
         rules_dir = tmp_path / "rules"


### PR DESCRIPTION
## Summary

Implements the two output governance enforcement issues unblocked by the closed brain#91 (prescriptive conformance-rule store in wicked_governance).

### garden#983 — Pattern-conformance engine (store-driven, per-output)

- **`guard_pipeline.check_outgov_pattern`** — new check reads Pattern-type conformance rules from `WICKED_OUTGOV_RULES_DIR/rules/*.json` (wicked_governance schema) and surfaces one finding per rule at session close. Severity mapping: CRITICAL→block, ERROR/WARN→warn, INFO→info. `WG_OUTGOV=off` (default) → skip; always fail-open.
- **`guard_profiles`** — adds `outgov_pattern` to `_STANDARD_CHECKS` and `_DEEP_CHECKS` so the check fires at build-phase close / release branches.
- **`skills/engineering-conformance-reviewer`** — new context:fork agent-half for semantic conformance evaluation; wraps `qe-semantic-reviewer` (the designated agent-half per issue spec); emits `wicked.garden.outgov.pattern_drift_detected` on violation. Listed in `fork_skills` registry via `sync_components.py`.
- **10 new tests** (`tests/platform/test_outgov_pattern.py`) covering rule loading, deduplication, malformed-JSON resilience, severity mapping, and env-gate skips.

### garden#984 — Per-turn semantic compliance + security guardrail

- **`hooks/scripts/stop.py` → `_check_outgov_compliance()`** — fires every turn when `WG_OUTGOV=warn|strict`. Returns a systemMessage asking Claude to recall Policy-type conformance rules from the estate graph (via estate MCP tools) and evaluate the current turn's output. In `strict` mode: adds a CRITICAL-violation denial hint. Fail-open — never hard-blocks session close.

### Bus + validator hygiene

- Registers `wicked.garden.outgov.pattern_drift_detected` and `wicked.garden.outgov.policy_violation_found` in `_bus.py`.
- Adds both to `_AUDIT_MARKER_EVENTS` in `_validate_registry.py` (observability-only — no projector state change).

## Test plan

- [x] `python3 -m pytest tests/` passes (967 passed, 17 skipped — +10 new tests)
- [x] `python3 scripts/_validate_registry.py` → OK (no new missing/malformed)
- [x] `check_outgov_pattern` returns skip when `WG_OUTGOV=off` (default)
- [x] `check_outgov_pattern` returns findings when rules dir populated with Pattern bundles
- [x] Policy rules are excluded from pattern check (rule_type filter)
- [x] `_check_outgov_compliance` returns [] when `WG_OUTGOV=off` (default, no noise)
- [x] `wicked-garden-engineering-conformance-reviewer` in `fork_skills` registry
- [ ] End-to-end: populate rules dir via `wicked-core rules ingest`, enable `WG_OUTGOV=warn`, observe guard findings at session close

Closes #983
Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)