### PR TITLE
site: version-free kicker chip

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -29,7 +29,7 @@ const favicon = `${import.meta.env.BASE_URL}/favicon.svg`.replace(/\/{2,}/g, "/"
         <div class="gd-hero-grid">
           <div class="gd-hero-pitch">
             <p class="rise kicker" style="animation-delay:.05s">
-              the toolkit · open-source · MIT · v12.27.0
+              the toolkit · open-source · MIT
             </p>
             <h1 class="gd-hero-h1">
               <span class="rise block" style="animation-delay:.12s">The tools your coding agent</span>


### PR DESCRIPTION
The chip said v12.27.0 while the repo/npm are at 12.29.1 — two releases behind already. Drop the number; npm is the version authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128mG5hv7LYmEdkxtdRUA8b