### PR TITLE
feat(domain): structural extraction loop — clusters, blast-radius framing, parallel workers

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -123,7 +123,7 @@ class _DirectStore:
         self.callees = {}
         self.callers = {}
         self.in_deg = {}
-        for r in self._c.execute("SELECT source, target FROM edges WHERE kind = '\"calls\"'"):
+        for r in self._c.execute("SELECT source, target FROM edges WHERE kind IN ('calls', '\"calls\"')"):
             self.callees.setdefault(r["source"], []).append(r["target"])
             self.callers.setdefault(r["target"], []).append(r["source"])
             self.in_deg[r["target"]] = self.in_deg.get(r["target"], 0) + 1
@@ -166,7 +166,9 @@ class _DirectStore:
                     "SELECT c.blob FROM files f JOIN content c ON c.git_sha = f.git_sha WHERE f.path = ?",
                     (file,),
                 ).fetchone()
-                self._file_text[file] = bytes(r["blob"]) if r else b""
+                if len(self._file_text) >= 128:  # bounded FIFO — long runs must not grow without limit
+                    self._file_text.pop(next(iter(self._file_text)))
+                self._file_text[file] = r["blob"] if r else b""
             blob = self._file_text[file]
             if end > start and end <= len(blob):
                 return blob[start:end].decode("utf-8", errors="replace")[:cap]
@@ -251,7 +253,7 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
             # cluster_offset lets parallel workers each own a different leverage-ranked
             # cluster instead of all fighting over the head (offset 0 = head).
             ranked = sorted(clusters_seen.values(), key=_cluster_leverage, reverse=True)
-            head = ranked[min(cluster_offset, len(ranked) - 1)]
+            head = ranked[max(0, cluster_offset) % len(ranked)]
             head.sort(key=lambda n: store.leverage(n["symbol_id"]), reverse=True)
             take = head[: _density_batch(head, store, batch)]
         else:

--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -99,8 +99,95 @@ def _write_node(estate, sid: str, name: str, rule: dict | None, resolved: bool, 
         raise RuntimeError(f"write not durable: {sid} missing annotation {rid} on read-back")
 
 
+class _DirectStore:
+    """READ-ONLY direct sqlite access for structural context (CommandIQ req-engine v3 pattern):
+    the per-node blast radius (1-hop caller/callee names) and source slices come straight from
+    the store instead of one subprocess per node — the prior loop's latency dominator. All
+    queries are reads; every write still goes through the estate CLI client (single surface)."""
+
+    def __init__(self, db: str):
+        import sqlite3
+        self._c = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        self._c.row_factory = sqlite3.Row
+        # symbols: sym string ↔ sid
+        self.sid_of = {}
+        self.sym_of = {}
+        for r in self._c.execute("SELECT sid, sym FROM symbols"):
+            self.sid_of[r["sym"]] = r["sid"]
+            self.sym_of[r["sid"]] = r["sym"]
+        # node names + files + spans (span parsed lazily from data JSON only when sourcing)
+        self.node_row = {}
+        for r in self._c.execute("SELECT symbol, name, file, data FROM nodes"):
+            self.node_row[r["symbol"]] = (r["name"], r["file"], r["data"])
+        # calls adjacency (edge kinds are stored JSON-quoted, e.g. '"calls"')
+        self.callees = {}
+        self.callers = {}
+        self.in_deg = {}
+        for r in self._c.execute("SELECT source, target FROM edges WHERE kind = '\"calls\"'"):
+            self.callees.setdefault(r["source"], []).append(r["target"])
+            self.callers.setdefault(r["target"], []).append(r["source"])
+            self.in_deg[r["target"]] = self.in_deg.get(r["target"], 0) + 1
+        self._file_text = {}
+
+    def name_of_sid(self, sid: int) -> str:
+        row = self.node_row.get(sid)
+        return row[0] if row else self.sym_of.get(sid, "?")
+
+    def blast_neighbors(self, symbol_id: str, cap: int = 8) -> list[str]:
+        """1-hop callers + callees as 'role:name' strings, importance-ranked (callers first)."""
+        sid = self.sid_of.get(symbol_id)
+        if sid is None:
+            return []
+        out = []
+        for other in sorted(self.callers.get(sid, []), key=lambda x: -self.in_deg.get(x, 0))[: cap // 2]:
+            out.append(f"caller:{self.name_of_sid(other)}")
+        for other in sorted(self.callees.get(sid, []), key=lambda x: -self.in_deg.get(x, 0))[: cap - len(out)]:
+            out.append(f"callee:{self.name_of_sid(other)}")
+        return out
+
+    def leverage(self, symbol_id: str) -> int:
+        sid = self.sid_of.get(symbol_id)
+        if sid is None:
+            return 0
+        return self.in_deg.get(sid, 0) + len(self.callees.get(sid, []))
+
+    def source_slice(self, symbol_id: str, cap: int = 4000) -> str:
+        sid = self.sid_of.get(symbol_id)
+        row = self.node_row.get(sid) if sid is not None else None
+        if row is None:
+            return ""
+        _, file, data = row
+        try:
+            import json as _json
+            span = _json.loads(data).get("location", {}).get("span", {})
+            start, end = int(span.get("start_byte", 0)), int(span.get("end_byte", 0))
+            if file not in self._file_text:
+                r = self._c.execute(
+                    "SELECT c.blob FROM files f JOIN content c ON c.git_sha = f.git_sha WHERE f.path = ?",
+                    (file,),
+                ).fetchone()
+                self._file_text[file] = bytes(r["blob"]) if r else b""
+            blob = self._file_text[file]
+            if end > start and end <= len(blob):
+                return blob[start:end].decode("utf-8", errors="replace")[:cap]
+        except Exception:
+            pass
+        return ""
+
+
+def _density_batch(members: list[dict], store, base_batch: int) -> int:
+    """Density-adaptive batch size (planner idea, deterministic form): thin wrappers pack
+    bigger batches, dense logic packs smaller — clamped 4..64."""
+    if not members:
+        return base_batch
+    sample = members[: min(len(members), 12)]
+    avg = sum(len(store.source_slice(m["symbol_id"], cap=2000)) for m in sample) / len(sample)
+    mult = 1.6 if avg < 300 else (0.6 if avg > 1500 else 1.0)
+    return max(4, min(64, int(base_batch * mult)))
+
+
 def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
-        project_dir: Path | None = None) -> int:
+        project_dir: Path | None = None, cluster_offset: int = 0) -> int:
     if not db:
         raise RuntimeError("--db / $WICKED_ESTATE_DB is required but was not provided")
     estate = _clients.estate_client(db=db, project_dir=project_dir)
@@ -127,6 +214,15 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
         print(f"[extract-loop] cohesion framing unavailable ({e}); proceeding singleton-flat", file=sys.stderr)
         node_community, community_sizes = {}, {}
 
+    # STRUCTURAL SUBSTRATE (CommandIQ req-engine v3 pattern): direct read-only store access
+    # for blast-radius context + source slices — no per-node subprocess (the prior loop's
+    # latency dominator). Best-effort: any failure falls back to the flat, context-free path.
+    try:
+        store = _DirectStore(db)
+    except Exception as e:
+        print(f"[extract-loop] direct store unavailable ({e}); flat context-free fallback", file=sys.stderr)
+        store = None
+
     processed = 0
     while True:
         cov = core.coverage(db, cov_out)
@@ -141,21 +237,45 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                   "resume with another pass", file=sys.stderr)
             return 0
 
-        # Take a bounded slice of the worklist for this batch.
-        take = worklist[:batch]
+        # STRUCTURAL ORDER: group the worklist by community, rank clusters by aggregate call
+        # leverage (in+out degree) so high-impact groups extract first, members likewise ranked
+        # within their cluster. Batches then hold RELATED symbols — shared context makes the
+        # model's rules better grounded AND cheaper — with a density-adaptive batch size
+        # (thin wrappers pack bigger batches, dense logic smaller). Flat slice as fallback.
+        if store is not None and node_community:
+            clusters_seen: dict[str, list] = {}
+            for n in worklist:
+                clusters_seen.setdefault(node_community.get(n["symbol_id"], "~singleton"), []).append(n)
+            def _cluster_leverage(members: list) -> int:
+                return sum(store.leverage(m["symbol_id"]) for m in members[:50])
+            # cluster_offset lets parallel workers each own a different leverage-ranked
+            # cluster instead of all fighting over the head (offset 0 = head).
+            ranked = sorted(clusters_seen.values(), key=_cluster_leverage, reverse=True)
+            head = ranked[min(cluster_offset, len(ranked) - 1)]
+            head.sort(key=lambda n: store.leverage(n["symbol_id"]), reverse=True)
+            take = head[: _density_batch(head, store, batch)]
+        else:
+            take = worklist[:batch]
         if limit:
             take = take[:max(0, limit - processed)]
 
-        # Frame each node: source slice + cohesion neighbors (best-effort).
+        # Frame each node: source slice + blast-radius neighbors (direct reads; the old
+        # per-node subprocess path survives only as the fallback).
         framed, ids = [], set()
         for n in take:
             sid, name = n["symbol_id"], n.get("name", "")
-            try:
-                slice_txt = estate.source(sid)[:4000] if not dry_run else ""
-            except Exception:
-                slice_txt = ""
+            slice_txt, neighbors = "", []
+            if not dry_run:
+                if store is not None:
+                    slice_txt = store.source_slice(sid)
+                    neighbors = store.blast_neighbors(sid)
+                if slice_txt == "":
+                    try:
+                        slice_txt = estate.source(sid)[:4000]
+                    except Exception:
+                        slice_txt = ""
             framed.append(_rule_extractor.frame_context(n, slice_txt,
-                          cluster_label=node_community.get(sid), neighbor_names=[]))
+                          cluster_label=node_community.get(sid), neighbor_names=neighbors))
             ids.add(sid)
 
         # THE MODEL BOUNDARY (or the deterministic stub). A model failure over the
@@ -198,11 +318,13 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--limit", type=int, default=0, help="max nodes this pass (0 = unbounded within time budget)")
     ap.add_argument("--batch", type=int, default=12, help="framed nodes per model call")
     ap.add_argument("--dry-run", action="store_true", help="deterministic stub instead of the model (zero cost)")
+    ap.add_argument("--cluster-offset", type=int, default=0,
+                    help="parallel workers: take the Nth leverage-ranked cluster instead of the head")
     args = ap.parse_args(argv)
     if not args.db:
         ap.error("--db is required (or set $WICKED_ESTATE_DB)")
     return run(args.db, time_budget=args.time_budget, limit=args.limit,
-               batch=args.batch, dry_run=args.dry_run)
+               batch=args.batch, dry_run=args.dry_run, cluster_offset=args.cluster_offset)
 
 
 if __name__ == "__main__":

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -123,3 +123,117 @@ def test_loop_dry_run_resolves_every_node(monkeypatch):
     for sid in ids:
         req, validated = estate.writes[sid]["req"]
         assert validated is True  # the deterministic stub is a confident, valid rule
+
+
+# --- structural path (_DirectStore, density batching, cluster offsets) -------
+
+def _fixture_db(tmp_path, n_files=1):
+    """Minimal estate-schema sqlite the structural path reads: two clusters —
+    'hot' (h::a called by h::b, h::c) and 'cold' (c::x → c::y, lower leverage)."""
+    import json as J, sqlite3
+    db = tmp_path / "estate.db"
+    c = sqlite3.connect(db)
+    c.executescript("""
+        CREATE TABLE symbols (sid INTEGER PRIMARY KEY, sym TEXT);
+        CREATE TABLE nodes (symbol INTEGER, name TEXT, file TEXT, data TEXT);
+        CREATE TABLE edges (source INTEGER, target INTEGER, kind TEXT);
+        CREATE TABLE files (path TEXT, git_sha TEXT);
+        CREATE TABLE content (git_sha TEXT, blob BLOB);
+    """)
+    syms = ["h::a", "h::b", "h::c", "c::x", "c::y"]
+    for i, s in enumerate(syms, start=1):
+        c.execute("INSERT INTO symbols VALUES (?, ?)", (i, s))
+        data = J.dumps({"location": {"span": {"start_byte": 0, "end_byte": 9}}})
+        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?)", (i, s.split("::")[-1], f"f{i}.py", data))
+    # both kind spellings must count (stores differ on JSON-quoting)
+    c.execute("INSERT INTO edges VALUES (2, 1, 'calls')")
+    c.execute("INSERT INTO edges VALUES (3, 1, '\"calls\"')")
+    c.execute("INSERT INTO edges VALUES (4, 5, '\"calls\"')")
+    for i in range(1, 6):
+        c.execute("INSERT INTO files VALUES (?, ?)", (f"f{i}.py", f"sha{i}"))
+        c.execute("INSERT INTO content VALUES (?, ?)", (f"sha{i}", b"def body(): pass"))
+    c.commit(); c.close()
+    return str(db)
+
+
+def test_direct_store_reads_both_edge_kind_spellings(tmp_path):
+    store = extract_loop._DirectStore(_fixture_db(tmp_path))
+    assert store.leverage("h::a") == 2          # two callers, both spellings counted
+    names = store.blast_neighbors("h::a")
+    assert "caller:b" in names and "caller:c" in names
+    assert store.leverage("c::y") == 1
+
+
+def test_direct_store_source_slice_uses_byte_span(tmp_path):
+    store = extract_loop._DirectStore(_fixture_db(tmp_path))
+    assert store.source_slice("h::a") == "def body("  # bytes [0, 9)
+
+
+def test_direct_store_file_cache_is_bounded(tmp_path):
+    import json as J, sqlite3
+    db = _fixture_db(tmp_path)
+    c = sqlite3.connect(db)
+    data = J.dumps({"location": {"span": {"start_byte": 0, "end_byte": 5}}})
+    for i in range(140):
+        sid = 100 + i
+        c.execute("INSERT INTO symbols VALUES (?, ?)", (sid, f"m::f{i}"))
+        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?)", (sid, f"f{i}", f"many{i}.py", data))
+        c.execute("INSERT INTO files VALUES (?, ?)", (f"many{i}.py", f"msha{i}"))
+        c.execute("INSERT INTO content VALUES (?, ?)", (f"msha{i}", b"hello world"))
+    c.commit(); c.close()
+    store = extract_loop._DirectStore(db)
+    for i in range(140):
+        assert store.source_slice(f"m::f{i}") == "hello"
+    assert len(store._file_text) <= 128  # eviction happened inside source_slice
+
+
+class _SliceStore:
+    def __init__(self, size):
+        self.size = size
+    def source_slice(self, sid, cap=2000):
+        return "x" * self.size
+
+
+@pytest.mark.parametrize("size,base,expect", [
+    (50, 20, 32),    # sparse → ×1.6
+    (2000, 20, 12),  # dense → ×0.6
+    (800, 20, 20),   # mid → ×1.0
+    (2000, 4, 4),    # clamp floor
+    (50, 60, 64),    # clamp ceiling
+])
+def test_density_batch_adapts_and_clamps(size, base, expect):
+    members = [{"symbol_id": f"s{i}"} for i in range(12)]
+    assert extract_loop._density_batch(members, _SliceStore(size), base) == expect
+
+
+def _run_structural(tmp_path, monkeypatch, cluster_offset):
+    """Full run() through the structural branch against the fixture db; returns
+    the order nodes settled (estate write order)."""
+    db = _fixture_db(tmp_path)
+    ids = ["h::a", "h::b", "h::c", "c::x", "c::y"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "total_node_community",
+                        lambda clusters, nodes: {s: s.split("::")[0] for s in ids})
+    rc = extract_loop.run(db, time_budget=30, limit=2, batch=2, dry_run=True,
+                          cluster_offset=cluster_offset)
+    assert rc == 0
+    return list(estate.writes)
+
+
+def test_offset_zero_takes_highest_leverage_cluster_first(tmp_path, monkeypatch):
+    first = _run_structural(tmp_path, monkeypatch, cluster_offset=0)[0]
+    assert first.startswith("h::")
+
+
+def test_offset_wraps_beyond_cluster_count(tmp_path, monkeypatch):
+    # 2 clusters, offset 5 → 5 % 2 = 1 → the SECOND-ranked cluster, not the tail pile-up
+    first = _run_structural(tmp_path, monkeypatch, cluster_offset=5)[0]
+    assert first.startswith("c::")
+
+
+def test_negative_offset_clamps_to_head(tmp_path, monkeypatch):
+    first = _run_structural(tmp_path, monkeypatch, cluster_offset=-3)[0]
+    assert first.startswith("h::")


### PR DESCRIPTION
## What

Upgrades `extract_loop.py` from a flat per-node slice loop to a structural extraction plan (pattern proven in CommandIQ req-engine v3):

- **`_DirectStore`** — read-only sqlite reads for calls-adjacency, leverage (in+out degree), and source slices via `files.git_sha → content.blob` byte spans. Eliminates the per-node `estate source` subprocess that dominated wall-clock.
- **Cluster-ordered batches** — worklist grouped by `node_community`; the highest-aggregate-leverage cluster extracts first, members leverage-ranked within it. Batches hold *related* symbols, so the model states rules with real context instead of isolated snippets.
- **Blast-radius framing** — each framed node carries its 1-hop caller/callee names (importance-ranked, capped) in `frame_context`.
- **Density-adaptive batch size** — thin wrappers pack ×1.6 bigger batches, dense logic ×0.6 smaller (clamp 4..64); the plan never drops symbols.
- **`--cluster-offset N`** — parallel workers each take the Nth leverage-ranked cluster instead of all fighting over the head.

Flat path survives untouched as the fallback when the store can't open.

## Evidence (live, command_iq store: 15.5k nodes)

- Dry-run smoke: `--dry-run --limit 30` and `--dry-run --limit 8 --cluster-offset 2` both complete cleanly through the structural path (coverage ticks, resume line printed).
- Live rate: flat loop measured **8.7 nodes/min**; structural single worker **14 nodes/min** (114 nodes / 8m09s, batch 24). Three offset workers now running in parallel.
- Statement quality: store now carries 1,324 distinct stated behavioral rules (spot-checked: real MUST-style statements, not ref lists); timeout batches RISK-floor as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)