### PR TITLE
fix(domain): infra failures abort the extraction pass instead of RISK-flooring

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -49,6 +49,21 @@ def _cohesion(sid: str, node_community: dict[str, str], community_sizes: dict[st
     return min(1.1, 0.95 + 0.03 * size)
 
 
+_INFRA_MARKERS = ("session limit", "rate limit", "rate_limit", "overloaded", "quota",
+                  "credit balance", "billing", "unauthorized", "authentication",
+                  "connection refused", "connection reset", "network", "econnrefused",
+                  "usage limit", "insufficient")
+
+
+def _is_infra_failure(exc: Exception) -> bool:
+    """True when the model boundary failed for infrastructure reasons (quota, auth,
+    network) rather than judgment. A per-batch timeout stays a judgment failure —
+    THAT batch was too hard — but an account-level outage would fail every future
+    batch identically, so it must stop the pass, not floor the worklist."""
+    msg = str(exc).lower()
+    return any(m in msg for m in _INFRA_MARKERS)
+
+
 def _stub_rule(node: dict) -> dict:
     """Deterministic no-model rule: a valid, confident business rule per node so a
     `--dry-run` pass drives coverage to 1.0 (proves the loop + gate, zero model cost)."""
@@ -291,6 +306,13 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                     if isinstance(r, dict) and r.get("symbol_id") in ids:
                         by_id[r["symbol_id"]] = r
             except Exception as e:
+                if _is_infra_failure(e):
+                    # An outage is not a judgment. Flooring here would burn the whole
+                    # remaining worklist into placeholders — stop the pass instead;
+                    # nothing from this batch is written, resume re-derives it.
+                    print(f"[extract-loop] INFRA FAILURE — pass aborted, batch NOT floored ({e})",
+                          file=sys.stderr)
+                    return 75  # EX_TEMPFAIL
                 print(f"[extract-loop] model batch failed ({e}); RISK-flooring the batch", file=sys.stderr)
 
         # Deterministic decision + write per node — RISK-FLOOR: every node terminates.

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -237,3 +237,40 @@ def test_offset_wraps_beyond_cluster_count(tmp_path, monkeypatch):
 def test_negative_offset_clamps_to_head(tmp_path, monkeypatch):
     first = _run_structural(tmp_path, monkeypatch, cluster_offset=-3)[0]
     assert first.startswith("h::")
+
+
+# --- infra failures abort the pass (outage ≠ judgment) ------------------------
+
+def _run_with_model_error(monkeypatch, message):
+    ids = ["a::f1", "a::f2"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "rule_model_argv", lambda project_dir=None: ["fake-model"])
+    def boom(batch, argv):
+        raise RuntimeError(message)
+    monkeypatch.setattr(_rule_extractor, "extract_rules", boom)
+    rc = extract_loop.run("x.db", time_budget=30, limit=0, batch=12, dry_run=False)
+    return rc, estate
+
+
+def test_session_limit_aborts_pass_and_floors_nothing(monkeypatch):
+    rc, estate = _run_with_model_error(
+        monkeypatch, "rule model exited 1: You've hit your session limit · resets 9:30pm")
+    assert rc == 75          # EX_TEMPFAIL — resume later, don't gate on it
+    assert estate.writes == {}  # the outage burned NOTHING into the store
+
+
+def test_rate_limit_aborts_pass(monkeypatch):
+    rc, estate = _run_with_model_error(monkeypatch, "429 rate limit exceeded")
+    assert rc == 75 and estate.writes == {}
+
+
+def test_plain_timeout_still_risk_floors(monkeypatch):
+    # a per-batch timeout IS a judgment (batch too hard) — floor and continue
+    rc, estate = _run_with_model_error(monkeypatch, "rule model exceeded 180s")
+    assert rc == 0
+    for sid in ("a::f1", "a::f2"):
+        req, validated = estate.writes[sid]["req"]
+        assert req.startswith("[RISK]") and validated is False


### PR DESCRIPTION
## What

The extraction harness treated every model-boundary failure as a judgment failure and RISK-floored the batch. That's correct for a per-batch timeout (that batch was too hard) but catastrophic for infrastructure failures: a session limit, rate limit, or auth outage fails every subsequent batch identically, so the loop grinds the entire remaining worklist into `[RISK] <name>: empty statement` placeholders — which are then ACCOUNTED and never revisited.

**Observed live** during the command_iq extraction: the claude CLI session limit tripped mid-run and three workers converted **2,590 nodes** into permanent placeholders in under an hour before the anomaly was caught (90% of new coverage was placeholder). The store had to be surgically repaired.

## Fix

- `_is_infra_failure()` classifies the failure by message (session/rate/usage limit, quota, billing, auth, connection markers)
- infra → **abort the pass with EX_TEMPFAIL (75), write nothing** — the resume loop re-derives the worklist; a supervisor can back off and retry
- timeout/malformed-output → unchanged: RISK-floor that batch only

## Evidence

3 new hermetic tests pin the distinction (session-limit aborts + floors nothing; 429 aborts; plain 180s timeout still floors). 26/26 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)