### PR TITLE
fix(domain): zero-yield batches abort as infra-suspect; floors never overwrite content

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -130,6 +130,30 @@ def _write_node(estate, sid: str, name: str, rule: dict | None, resolved: bool, 
         raise RuntimeError(f"write not durable: {sid} missing annotation {rid} on read-back")
 
 
+_ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+def _maybe_decompress(blob) -> bytes:
+    """Estate stores content zstd-compressed; node spans are byte offsets into the
+    DECOMPRESSED text. Slicing the raw blob feeds the model binary noise — observed
+    live as whole batches of 'cannot state a rule'. Returns b'' when the blob is
+    compressed but no decompressor is available, which routes framing to the
+    subprocess fallback instead of producing garbage."""
+    b = blob if isinstance(blob, bytes) else bytes(blob)
+    if not b.startswith(_ZSTD_MAGIC):
+        return b
+    try:
+        from compression import zstd  # stdlib, Python 3.14+
+        return zstd.decompress(b)
+    except ImportError:
+        pass
+    try:
+        import zstandard
+        return zstandard.ZstdDecompressor().decompress(b)
+    except ImportError:
+        return b""
+
+
 class _DirectStore:
     """READ-ONLY direct sqlite access for structural context (CommandIQ req-engine v3 pattern):
     the per-node blast radius (1-hop caller/callee names) and source slices come straight from
@@ -209,7 +233,7 @@ class _DirectStore:
                 ).fetchone()
                 if len(self._file_text) >= 128:  # bounded FIFO — long runs must not grow without limit
                     self._file_text.pop(next(iter(self._file_text)))
-                self._file_text[file] = r["blob"] if r else b""
+                self._file_text[file] = _maybe_decompress(r["blob"]) if r else b""
             blob = self._file_text[file]
             if end > start and end <= len(blob):
                 return blob[start:end].decode("utf-8", errors="replace")[:cap]

--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -77,6 +77,22 @@ def _stub_rule(node: dict) -> dict:
     }
 
 
+_FLOOR_MARKERS = ("no rule returned for this node", "empty statement (model could not state a rule)")
+
+
+def _has_statement(store, symbol_id: str) -> bool:
+    """True when the node already carries a substantive statement (not a floor
+    placeholder) — the signal that a failed retry must not degrade it. Reads the
+    store snapshot; without a direct store the answer is unknowable cheaply, so
+    the guard stays inactive (flat-path behavior unchanged)."""
+    if store is None:
+        return False
+    req = (store.requirement_of(symbol_id) or "").strip()
+    if not req:
+        return False
+    return not any(m in req for m in _FLOOR_MARKERS)
+
+
 def _write_node(estate, sid: str, name: str, rule: dict | None, resolved: bool, reason: str) -> None:
     """The two coordinated writes + read-back (vault record+verify). RESOLVED ⇒ a
     validated requirement + business_rule annotation; RISK ⇒ a non-blank requirement
@@ -132,8 +148,14 @@ class _DirectStore:
             self.sym_of[r["sid"]] = r["sym"]
         # node names + files + spans (span parsed lazily from data JSON only when sourcing)
         self.node_row = {}
-        for r in self._c.execute("SELECT symbol, name, file, data FROM nodes"):
+        self._req = {}
+        try:
+            rows = self._c.execute("SELECT symbol, name, file, data, requirement FROM nodes")
+        except sqlite3.OperationalError:  # older stores predate the requirement column
+            rows = self._c.execute("SELECT symbol, name, file, data, NULL FROM nodes")
+        for r in rows:
             self.node_row[r["symbol"]] = (r["name"], r["file"], r["data"])
+            self._req[r["symbol"]] = r[4] or ""
         # calls adjacency (edge kinds are stored JSON-quoted, e.g. '"calls"')
         self.callees = {}
         self.callers = {}
@@ -143,6 +165,10 @@ class _DirectStore:
             self.callers.setdefault(r["target"], []).append(r["source"])
             self.in_deg[r["target"]] = self.in_deg.get(r["target"], 0) + 1
         self._file_text = {}
+
+    def requirement_of(self, symbol_id: str) -> str:
+        sid = self.sid_of.get(symbol_id)
+        return self._req.get(sid, "") if sid is not None else ""
 
     def name_of_sid(self, sid: int) -> str:
         row = self.node_row.get(sid)
@@ -314,6 +340,17 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                           file=sys.stderr)
                     return 75  # EX_TEMPFAIL
                 print(f"[extract-loop] model batch failed ({e}); RISK-flooring the batch", file=sys.stderr)
+            substantive = sum(1 for r in by_id.values() if (r.get("statement") or "").strip())
+            if substantive == 0 and len(take) >= 4:
+                # Zero substantive yield for a whole real batch is an outage signature,
+                # not a judgment — a limited/degraded CLI can print its notice and exit 0
+                # (parsed as no rules), or emit rule shells with empty statements. Abort
+                # the pass; flooring here would grind the worklist into placeholders.
+                # (Small batches are exempt so one unstatable node can't wedge the loop.)
+                print(f"[extract-loop] ZERO-YIELD batch ({len(take)} framed, {len(by_id)} rules, "
+                      "0 substantive) — treating as infra failure; pass aborted, batch NOT floored",
+                      file=sys.stderr)
+                return 75  # EX_TEMPFAIL
 
         # Deterministic decision + write per node — RISK-FLOOR: every node terminates.
         for n in take:
@@ -326,6 +363,14 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                 resolved = adjusted >= RESOLVE_THRESHOLD
                 _write_node(estate, sid, name, rule, resolved,
                             "below confidence threshold" if not resolved else "")
+            elif (rule or {}).get("statement"):
+                _write_node(estate, sid, name, rule, False, reason)
+            elif _has_statement(store, sid):
+                # Statement-less floor over existing content would DEGRADE the store —
+                # a re-queued node keeps its prior statement instead. Floors only ever
+                # fill blanks; content is monotonic.
+                print(f"[extract-loop] floor skipped for {sid} (existing statement kept)",
+                      file=sys.stderr)
             else:
                 _write_node(estate, sid, name, rule, False, reason)
             processed += 1

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -337,3 +337,32 @@ def test_floor_never_overwrites_existing_statement(tmp_path, monkeypatch):
     assert "h::a" not in estate.writes          # kept its existing statement — no floor write
     assert estate.writes["h::b"]["req"][1] is True
     assert estate.writes["h::c"]["req"][0].startswith("[RISK]")  # blank node still floors
+
+
+# --- compressed content blobs -------------------------------------------------
+
+def test_source_slice_decompresses_zstd_blobs(tmp_path):
+    import json as J, sqlite3
+    from compression import zstd
+    db = tmp_path / "estate-z.db"
+    c = sqlite3.connect(db)
+    c.executescript("""
+        CREATE TABLE symbols (sid INTEGER PRIMARY KEY, sym TEXT);
+        CREATE TABLE nodes (symbol INTEGER, name TEXT, file TEXT, data TEXT, requirement TEXT);
+        CREATE TABLE edges (source INTEGER, target INTEGER, kind TEXT);
+        CREATE TABLE files (path TEXT, git_sha TEXT);
+        CREATE TABLE content (git_sha TEXT, blob BLOB);
+    """)
+    src = b"def guarded(x):\n    return x > 0\n"
+    data = J.dumps({"location": {"span": {"start_byte": 0, "end_byte": len(src)}}})
+    c.execute("INSERT INTO symbols VALUES (1, 'z::guarded')")
+    c.execute("INSERT INTO nodes VALUES (1, 'guarded', 'z.py', ?, NULL)", (data,))
+    c.execute("INSERT INTO files VALUES ('z.py', 'zsha')")
+    c.execute("INSERT INTO content VALUES ('zsha', ?)", (zstd.compress(src),))
+    c.commit(); c.close()
+    store = extract_loop._DirectStore(str(db))
+    assert store.source_slice("z::guarded") == src.decode()
+
+
+def test_maybe_decompress_passes_plain_bytes_through():
+    assert extract_loop._maybe_decompress(b"plain text") == b"plain text"

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -135,7 +135,7 @@ def _fixture_db(tmp_path, n_files=1):
     c = sqlite3.connect(db)
     c.executescript("""
         CREATE TABLE symbols (sid INTEGER PRIMARY KEY, sym TEXT);
-        CREATE TABLE nodes (symbol INTEGER, name TEXT, file TEXT, data TEXT);
+        CREATE TABLE nodes (symbol INTEGER, name TEXT, file TEXT, data TEXT, requirement TEXT);
         CREATE TABLE edges (source INTEGER, target INTEGER, kind TEXT);
         CREATE TABLE files (path TEXT, git_sha TEXT);
         CREATE TABLE content (git_sha TEXT, blob BLOB);
@@ -144,7 +144,7 @@ def _fixture_db(tmp_path, n_files=1):
     for i, s in enumerate(syms, start=1):
         c.execute("INSERT INTO symbols VALUES (?, ?)", (i, s))
         data = J.dumps({"location": {"span": {"start_byte": 0, "end_byte": 9}}})
-        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?)", (i, s.split("::")[-1], f"f{i}.py", data))
+        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?, NULL)", (i, s.split("::")[-1], f"f{i}.py", data))
     # both kind spellings must count (stores differ on JSON-quoting)
     c.execute("INSERT INTO edges VALUES (2, 1, 'calls')")
     c.execute("INSERT INTO edges VALUES (3, 1, '\"calls\"')")
@@ -177,7 +177,7 @@ def test_direct_store_file_cache_is_bounded(tmp_path):
     for i in range(140):
         sid = 100 + i
         c.execute("INSERT INTO symbols VALUES (?, ?)", (sid, f"m::f{i}"))
-        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?)", (sid, f"f{i}", f"many{i}.py", data))
+        c.execute("INSERT INTO nodes VALUES (?, ?, ?, ?, NULL)", (sid, f"f{i}", f"many{i}.py", data))
         c.execute("INSERT INTO files VALUES (?, ?)", (f"many{i}.py", f"msha{i}"))
         c.execute("INSERT INTO content VALUES (?, ?)", (f"msha{i}", b"hello world"))
     c.commit(); c.close()
@@ -274,3 +274,66 @@ def test_plain_timeout_still_risk_floors(monkeypatch):
     for sid in ("a::f1", "a::f2"):
         req, validated = estate.writes[sid]["req"]
         assert req.startswith("[RISK]") and validated is False
+
+
+# --- zero-yield abort + floor monotonicity ------------------------------------
+
+def _run_with_model_yield(monkeypatch, rules, ids=None, db="x.db"):
+    ids = ids or ["a::f1", "a::f2", "a::f3", "a::f4"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "rule_model_argv", lambda project_dir=None: ["fake-model"])
+    monkeypatch.setattr(_rule_extractor, "extract_rules", lambda batch, argv: rules)
+    rc = extract_loop.run(db, time_budget=30, limit=0, batch=12, dry_run=False)
+    return rc, estate
+
+
+def test_zero_rules_for_a_real_batch_aborts(monkeypatch):
+    rc, estate = _run_with_model_yield(monkeypatch, [])
+    assert rc == 75 and estate.writes == {}
+
+
+def test_empty_statement_shells_for_a_real_batch_abort(monkeypatch):
+    # a degraded CLI can emit rule shells with blank statements — same outage signature
+    shells = [{"symbol_id": f"a::f{i}", "statement": "", "confidence": 0.9,
+               "provenance": {"source": "m", "ref": f"a::f{i}", "source_kinds": ["code-body"]}}
+              for i in range(1, 5)]
+    rc, estate = _run_with_model_yield(monkeypatch, shells)
+    assert rc == 75 and estate.writes == {}
+
+
+def test_partial_yield_still_floors_the_misses(monkeypatch):
+    # one substantive rule → the batch is judged normally: hit resolves, misses floor
+    rules = [_good("a::f1")]
+    rc, estate = _run_with_model_yield(monkeypatch, rules)
+    assert rc == 0
+    assert estate.writes["a::f1"]["req"][1] is True
+    for sid in ("a::f2", "a::f3", "a::f4"):
+        req, validated = estate.writes[sid]["req"]
+        assert req.startswith("[RISK]") and validated is False
+
+
+def test_floor_never_overwrites_existing_statement(tmp_path, monkeypatch):
+    # fixture store: give h::a an existing substantive statement, then run a pass whose
+    # model yields ONE substantive rule (so the batch isn't zero-yield) but nothing for
+    # h::a — its floor must be SKIPPED, content is monotonic.
+    import json as J, sqlite3
+    db = _fixture_db(tmp_path)
+    c = sqlite3.connect(db)
+    c.execute("UPDATE nodes SET requirement = 'callers must pass a validated payload' WHERE name = 'a'")
+    c.commit(); c.close()
+    ids = ["h::a", "h::b", "h::c", "c::x"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "rule_model_argv", lambda project_dir=None: ["fake-model"])
+    monkeypatch.setattr(_clients, "total_node_community", lambda clusters, nodes: {s: "one" for s in ids})
+    monkeypatch.setattr(_rule_extractor, "extract_rules", lambda batch, argv: [_good("h::b")])
+    rc = extract_loop.run(db, time_budget=30, limit=0, batch=12, dry_run=False)
+    assert rc == 0
+    assert "h::a" not in estate.writes          # kept its existing statement — no floor write
+    assert estate.writes["h::b"]["req"][1] is True
+    assert estate.writes["h::c"]["req"][0].startswith("[RISK]")  # blank node still floors


### PR DESCRIPTION
## What

Follow-up to #1021 — the same live outage (session-limited claude CLI) exposed two more damage vectors the exception-based infra abort can't see, because the CLI can fail while 'succeeding':

1. **Zero-yield abort.** Exit 0 with the limit notice as output parses as zero rules; a degraded CLI can also emit rule shells with **empty statements**. Both floored entire batches at full speed (observed: 539 placeholder floors written in ~15 minutes with zero validated rules). A real batch (≥4 framed) with zero *substantive* yield now aborts the pass with EX_TEMPFAIL — same contract as #1021, so a back-off supervisor retries later. Batches <4 are exempt so a single genuinely-unstatable node can't wedge the loop; partial yield (≥1 substantive rule) still floors the misses normally.

2. **Floor monotonicity.** The RISK floor could replace an existing substantive statement with a placeholder when a node got re-queued and the retry missed. Floors now only ever fill blanks — a failed retry keeps the prior statement. The direct store snapshot loads the `requirement` column (tolerant of older stores without it).

## Evidence

- 4 new hermetic tests: zero-rules abort, empty-statement-shells abort, partial-yield floors misses, floor-skip keeps existing content (fixture store). 30/30 pass.
- Live store repaired: 539 junk floors nulled, 3,323 coverage-inflating junk annotations deleted; honest baseline re-measured at 0.0773 coverage before relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)