### PR TITLE
fix(domain): zero-yield abort distinguishes judgments from outages

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -364,15 +364,17 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                           file=sys.stderr)
                     return 75  # EX_TEMPFAIL
                 print(f"[extract-loop] model batch failed ({e}); RISK-flooring the batch", file=sys.stderr)
-            substantive = sum(1 for r in by_id.values() if (r.get("statement") or "").strip())
-            if substantive == 0 and len(take) >= 4:
-                # Zero substantive yield for a whole real batch is an outage signature,
-                # not a judgment — a limited/degraded CLI can print its notice and exit 0
-                # (parsed as no rules), or emit rule shells with empty statements. Abort
-                # the pass; flooring here would grind the worklist into placeholders.
-                # (Small batches are exempt so one unstatable node can't wedge the loop.)
-                print(f"[extract-loop] ZERO-YIELD batch ({len(take)} framed, {len(by_id)} rules, "
-                      "0 substantive) — treating as infra failure; pass aborted, batch NOT floored",
+            if not by_id and len(take) >= 4:
+                # NO parseable rule objects for a whole real batch is an outage signature
+                # — a limited/degraded CLI prints its notice and exits 0 (parsed as no
+                # rules) or returns a wholesale empty array. Abort the pass; flooring
+                # here would grind the worklist into placeholders. A response with one
+                # object per unit and explicit empty statements is DIFFERENT: that is the
+                # model's per-node judgment (the contract for rule-less helpers), and it
+                # floors those nodes as designed. (Small batches are exempt so one
+                # unstatable node can't wedge the loop.)
+                print(f"[extract-loop] ZERO-YIELD batch ({len(take)} framed, 0 rule objects) — "
+                      "treating as infra failure; pass aborted, batch NOT floored",
                       file=sys.stderr)
                 return 75  # EX_TEMPFAIL
 

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -295,12 +295,22 @@ def test_zero_rules_for_a_real_batch_aborts(monkeypatch):
     assert rc == 75 and estate.writes == {}
 
 
-def test_empty_statement_shells_for_a_real_batch_abort(monkeypatch):
-    # a degraded CLI can emit rule shells with blank statements — same outage signature
-    shells = [{"symbol_id": f"a::f{i}", "statement": "", "confidence": 0.9,
+def test_empty_statement_objects_are_judgments_and_floor(monkeypatch):
+    # one object per unit with an explicit empty statement is the model's per-node
+    # judgment (the contract for rule-less helpers) — floor them, do NOT abort
+    shells = [{"symbol_id": f"a::f{i}", "statement": "", "confidence": 0.1,
                "provenance": {"source": "m", "ref": f"a::f{i}", "source_kinds": ["code-body"]}}
               for i in range(1, 5)]
     rc, estate = _run_with_model_yield(monkeypatch, shells)
+    assert rc == 0
+    for i in range(1, 5):
+        req, validated = estate.writes[f"a::f{i}"]["req"]
+        assert req.startswith("[RISK]") and validated is False
+
+
+def test_wholesale_empty_array_aborts(monkeypatch):
+    # a literal [] for a real batch is the outage signature, not a judgment
+    rc, estate = _run_with_model_yield(monkeypatch, [])
     assert rc == 75 and estate.writes == {}
 
 


### PR DESCRIPTION
## What

Live false positive in #1022's zero-yield guard: clusters headed by CI test-fixture helpers (`write_fixture`, `_assert`, `cleanup_fixtures`) have **no business rule to state**, and the prompt contract tells the model to return one object per unit with `statement: ""` in exactly that case. An honest model (haiku) does precisely this — and the '0 substantive' guard read it as an outage, aborting the pass and wedging two workers in 15-minute back-off loops on those clusters.

The discriminator that matches reality:

- **wholesale `[]` / no parseable objects for a ≥4 batch** → outage signature (limit notice parsed as nothing, empty stdout) → abort with EX_TEMPFAIL, write nothing
- **one object per unit with explicit empty statements** → the model's per-node judgment → RISK-floor those nodes as designed (they're accounted, honestly, as rule-less)

The prior 'empty-statement shells = outage' theory came from the mojibake-frames bug (binary noise in, honest empties out) — fixed separately by the zstd decompression in #1022; with real frames, empty statements are real judgments.

## Evidence

- Reproduced live: raw haiku output on the wedged cluster is 9 well-formed objects, `statement: ""`, confidence 0.1 — the documented honest answer.
- Tests updated to pin both sides (judgment floors, wholesale-[] aborts); 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)