### PR TITLE
fix(domain): batch timeouts retry once before flooring

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -367,6 +367,14 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                 except Exception as e:
                     if _is_infra_failure(e):
                         infra_exc = e
+                    elif "exceeded" in str(e) and attempt == 1:
+                        # A batch timeout is often provider slowness, not batch difficulty
+                        # — one retry before conceding. A repeat floors (termination), it
+                        # does not abort: a genuinely oversized batch must not wedge passes.
+                        print(f"[extract-loop] model batch timeout ({e}) — retrying once "
+                              f"in {int(_RETRY_PAUSE)}s", file=sys.stderr)
+                        time.sleep(_RETRY_PAUSE)
+                        continue
                     else:
                         print(f"[extract-loop] model batch failed ({e}); RISK-flooring the batch",
                               file=sys.stderr)

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -268,13 +268,46 @@ def test_rate_limit_aborts_pass(monkeypatch):
     assert rc == 75 and estate.writes == {}
 
 
-def test_plain_timeout_still_risk_floors(monkeypatch):
-    # a per-batch timeout IS a judgment (batch too hard) — floor and continue
-    rc, estate = _run_with_model_error(monkeypatch, "rule model exceeded 180s")
+def test_persistent_timeout_floors_after_one_retry(monkeypatch):
+    # a timeout retries once (provider slowness); a REPEAT floors — never aborts
+    calls = {"n": 0}
+    def slow(batch, argv):
+        calls["n"] += 1
+        raise RuntimeError("rule model exceeded 180s")
+    ids = ["a::f1", "a::f2"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(extract_loop, "_RETRY_PAUSE", 0.0)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "rule_model_argv", lambda project_dir=None: ["fake-model"])
+    monkeypatch.setattr(_rule_extractor, "extract_rules", slow)
+    rc = extract_loop.run("x.db", time_budget=30, limit=0, batch=12, dry_run=False)
     assert rc == 0
-    for sid in ("a::f1", "a::f2"):
+    assert calls["n"] >= 2  # retried before conceding
+    for sid in ids:
         req, validated = estate.writes[sid]["req"]
         assert req.startswith("[RISK]") and validated is False
+
+
+def test_transient_timeout_recovers_on_retry(monkeypatch):
+    calls = {"n": 0}
+    def flaky(batch, argv):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("rule model exceeded 180s")
+        return [_good("a::f1"), _good("a::f2")]
+    ids = ["a::f1", "a::f2"]
+    estate = _FakeEstate()
+    core = _FakeCore(estate, ids)
+    monkeypatch.setattr(extract_loop, "_RETRY_PAUSE", 0.0)
+    monkeypatch.setattr(_clients, "estate_client", lambda db=None, project_dir=None: estate)
+    monkeypatch.setattr(_clients, "core_client", lambda project_dir=None: core)
+    monkeypatch.setattr(_clients, "rule_model_argv", lambda project_dir=None: ["fake-model"])
+    monkeypatch.setattr(_rule_extractor, "extract_rules", flaky)
+    rc = extract_loop.run("x.db", time_budget=30, limit=0, batch=12, dry_run=False)
+    assert rc == 0
+    assert estate.writes["a::f1"]["req"][1] is True  # recovered rules validate
 
 
 # --- zero-yield abort + floor monotonicity ------------------------------------


### PR DESCRIPTION
## What

Model-batch timeouts clustered during a degraded provider window and each immediately floored its whole batch as `no rule returned` placeholders — ~330 nodes permanently accounted without ever getting a real look (repaired live: placeholders requeued).

A timeout now retries once (same `_RETRY_PAUSE` as the zero-yield path); a **repeat** floors — preserving pass termination (a genuinely oversized batch must not wedge the loop) — and never aborts.

## Evidence

2 new tests: persistent timeout floors after ≥2 attempts; transient timeout recovers and validates on retry. 34/34 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)