### PR TITLE
fix(domain): rule statements in product-functional terms; config trivia floors honestly

### DIFF
--- a/scripts/domain/_rule_extractor.py
+++ b/scripts/domain/_rule_extractor.py
@@ -38,6 +38,13 @@ _PROMPT_HEADER = (
     '"source_kinds": ["code-body"|"type-def"|"comment"|"doc", ...]}}\n'
     "If a unit’s behavior is unclear, set statement to \"\" and confidence low — do "
     "NOT guess. Ground trusted rules in code-body/type-def, not comment/doc alone.\n"
+    "State each rule in PRODUCT-FUNCTIONAL terms: what the business requires, not the "
+    "implementation. Name a specific tool, library, or technology ONLY when the source "
+    "makes that tool itself the requirement — otherwise state the capability (e.g. "
+    "'adversarial prompt-injection testing', not a vendor suite). For configuration or "
+    "data-fixture units (lockfiles, manifests, data JSON/YAML), state a rule only when "
+    "it encodes a genuine business constraint; format trivia and tool settings take "
+    "statement \"\".\n"
 )
 
 


### PR DESCRIPTION
## What

Two statement-quality defects observed on the live command_iq corpus:

1. Rules extracted from data-fixture units embedded **vendor tool names as requirements** ("adversarial testing via <specific suite>") — a functional requirement should state the capability unless the tool itself is the mandated thing.
2. Lockfile/manifest units yielded **format trivia stated as business rules** ("lock file must conform to format version 9.0").

The prompt contract now instructs: product-functional terms; name a tool only when the source makes that tool the requirement; config/data-fixture units without a genuine business constraint return an empty statement (which the harness floors honestly as RISK).

Complements wicked-crew#160, which classifies existing statements by source (functional vs config-data) so the UI defaults to product requirements.

## Evidence

Harness suite 34/34 (prompt header is data to the tests). The header is static — extending it rotates provider prompt-cache prefixes exactly once on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)