### PR TITLE
fix(domain): trailing-dot-tolerant symbol-id matching

### DIFF
--- a/scripts/domain/extract_loop.py
+++ b/scripts/domain/extract_loop.py
@@ -360,9 +360,20 @@ def run(db: str, *, time_budget: float, limit: int, batch: int, dry_run: bool,
                 by_id = {}
                 floor_batch = False
                 infra_exc = None
+                # Models normalize punctuation-bearing ids (a trailing '.' in the symbol
+                # grammar came back stripped, dropping EVERY rule of certain batches as a
+                # "mismatch" and mimicking an outage). Exact match first; else re-canonize
+                # by trailing-dot-insensitive lookup. Anything else stays a hallucination.
+                canon = {sid.rstrip("."): sid for sid in ids}
                 try:
                     for r in _rule_extractor.extract_rules(framed, model_argv):
-                        if isinstance(r, dict) and r.get("symbol_id") in ids:
+                        if not isinstance(r, dict):
+                            continue
+                        rid = r.get("symbol_id")
+                        if rid in ids:
+                            by_id[rid] = r
+                        elif isinstance(rid, str) and rid.strip().rstrip(".") in canon:
+                            r["symbol_id"] = canon[rid.strip().rstrip(".")]
                             by_id[r["symbol_id"]] = r
                 except Exception as e:
                     if _is_infra_failure(e):

--- a/tests/domain/test_extract_loop.py
+++ b/tests/domain/test_extract_loop.py
@@ -411,3 +411,16 @@ def test_source_slice_decompresses_zstd_blobs(tmp_path):
 
 def test_maybe_decompress_passes_plain_bytes_through():
     assert extract_loop._maybe_decompress(b"plain text") == b"plain text"
+
+
+def test_trailing_dot_symbol_ids_recanonize(monkeypatch):
+    # canonical ids can carry a trailing '.'; models strip it — rules must still land
+    ids = ["m::helper().", "m::other()."]
+    returned = [
+        {**_good("m::helper()."), "symbol_id": "m::helper()"},
+        {**_good("m::other()."), "symbol_id": "m::other()."},
+    ]
+    rc, estate = _run_with_model_yield(monkeypatch, returned, ids=ids)
+    assert rc == 0
+    assert estate.writes["m::helper()."]["req"][1] is True  # normalized match validated
+    assert estate.writes["m::other()."]["req"][1] is True


### PR DESCRIPTION
## What

The last ~200 unaccounted nodes wedged the fleet in abort/back-off loops: every pass hit `zero-yield (16 framed, 0 rule objects)` while the raw model responses were **perfect JSON arrays of rules**. Root cause: those symbols' canonical ids end with a trailing period (`config/skills/xlsx/.../merge_runs/_next_element_sibling().` — note the final dot), and models normalize it away. Exact-match dropped every returned rule as a mismatch — a content-shaped failure mimicking an outage signature.

Matching is now exact-first, then trailing-dot-insensitive re-canonization (writes always use the canonical id). Genuinely wrong ids still reject as hallucinations.

## Evidence

- Reproduced live: raw haiku output on the wedged batch is a clean fenced JSON array with statements and correct ids minus the trailing dot.
- New test pins recanonization (returned id without the dot lands on the dotted canonical id, validates). 35/35 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)