### PR TITLE
fix(scaffolding): YAML-quote template placeholders — unquoted {{name}} breaks codex entirely

### DIFF
--- a/.claude/skills/scaffolding/templates/agent/agent.md
+++ b/.claude/skills/scaffolding/templates/agent/agent.md
@@ -1,5 +1,5 @@
 ---
-name: {{skill_name}}
+name: "{{skill_name}}"
 description: {{description}}
 context: fork
 allowed-tools: [{{tools}}]

--- a/.claude/skills/scaffolding/templates/skill/SKILL.md
+++ b/.claude/skills/scaffolding/templates/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: {{name}}
+name: "{{name}}"
 description: |
   {{description}}
   Use when {{use_when}}.


### PR DESCRIPTION
## What

codex recursively loads every `SKILL.md` under its skills directory — including the scaffolding skill's **templates**. YAML parses an unquoted `name: {{name}}` placeholder as a nested map, and codex then refuses to boot at all:

```
failed to load skill .../wicked-garden-scaffold/templates/skill/SKILL.md: invalid YAML: name: invalid type: map, expected a string
```

Observed live: a crew coverage-validator seat fail-closed REJECTED healthy evidence (deterministic validator had approved coverage 1.0) because its codex leg exited 1 on this template. Any codex user with the scaffold skill installed is affected.

Quoting the placeholders (`name: "{{name}}"`) parses as a string everywhere, renders identically, and generated skills keep valid frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)