### PR TITLE
ci: notify wicked-installer on release tags

### DIFF
--- a/.github/workflows/notify-installer.yml
+++ b/.github/workflows/notify-installer.yml
@@ -8,6 +8,9 @@ on:
   push:
     tags: ['v*', '*-v*']
 
+# The job only calls the GitHub API with its own PAT — GITHUB_TOKEN needs nothing.
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-installer.yml
+++ b/.github/workflows/notify-installer.yml
@@ -1,0 +1,27 @@
+# Fire the wicked-installer registry-conformance check whenever a release tag
+# lands, so a rename/retire/typo in this package surfaces there immediately
+# instead of on the daily schedule. Requires the INSTALLER_DISPATCH_TOKEN
+# secret (a fine-grained PAT with wicked-installer repo scope) — GITHUB_TOKEN
+# cannot dispatch cross-repo. Without the secret the job no-ops loudly.
+name: notify installer
+on:
+  push:
+    tags: ['v*', '*-v*']
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository_dispatch package-released
+        env:
+          TOKEN: ${{ secrets.INSTALLER_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::INSTALLER_DISPATCH_TOKEN not set — installer conformance will only run on its daily schedule"
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/mikeparcewski/wicked-installer/dispatches \
+            -d "{\"event_type\":\"package-released\",\"client_payload\":{\"repo\":\"${{ github.repository }}\",\"tag\":\"${{ github.ref_name }}\"}}"


### PR DESCRIPTION
Fires `repository_dispatch: package-released` at wicked-installer's new registry-conformance workflow (wicked-installer#9) on every release tag, so package renames/retirements surface in the installer immediately instead of on the daily schedule. No-ops with a loud warning until the `INSTALLER_DISPATCH_TOKEN` fine-grained PAT secret is added (GITHUB_TOKEN cannot dispatch cross-repo). Same hook shipping in estate#76 and crew#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)