### PR TITLE
chore(deps): re-pin site wicked-web (Control-plane chrome)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5690,7 +5690,7 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#f99187a440747eb1d8ad1f71ff6a5fb0a8c2fe69",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#a3c18aabed02dc8c1696c9491f37b6714d002d19",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"


### PR DESCRIPTION
Re-pins the **site** lock (`site/package-lock.json`) to `a3c18aab` so the merged shared-chrome update — crew -> **Control plane**, brain -> **the learning layer** — deploys on this product site. Lockfile-only.