### PR TITLE
fix(peers): bump wicked_testing_version floor ^0.8.0 -> ^0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "wicked-garden",
   "version": "12.29.1",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims \u2014 gates re-derive 'done' through the internal loom engine (fail-closed, independently attested via wicked-vault), so a self-asserted pass can't lie its way green. Relationships grep can't see \u2014 codegraph + injected bus/dispatch/capability edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory (wicked-brain), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (wicked-testing). It reads the shape of your work to apply the right rigor \u2014 steering, not a pipeline \u2014 then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires wicked-vault (installed automatically via wicked-testing); wicked-testing, wicked-brain, and wicked-bus are opt-in layers \u2014 install what you'll use, the toolkit works without the rest.",
-  "wicked_testing_version": "^0.8.0",
+  "wicked_testing_version": "^0.10.0",
   "wicked_vault_version": "^0.4.0",
   "wicked_brain_version": "^0.18.0",
   "wicked_bus_version": "^2.0.0",


### PR DESCRIPTION
## What
Bump the `wicked_testing_version` peer floor in `.claude-plugin/plugin.json` from `^0.8.0` to `^0.10.0`.

## Why
The SessionStart wicked-testing probe (`scripts/_wicked_testing_probe.py`) is failing **now**. Its caret evaluator locks `0.x` pins to the minor version:

- `^0.8.0` => `>=0.8.0 <0.9.0`

The currently published/installed wicked-testing is **0.10.0** (`npm view wicked-testing version` -> `0.10.0`), which falls outside that range. The probe returns `out-of-range`, and because `crew_command_gate()` is fail-closed, crew commands are hard-blocked.

- `^0.10.0` => `>=0.10.0 <0.11.0`, which admits 0.10.0.

## Change
Single-line edit to the peer floor. No probe/gate logic touched.

```diff
-  "wicked_testing_version": "^0.8.0",
+  "wicked_testing_version": "^0.10.0",
```

## Verification
- `npm view wicked-testing version` -> `0.10.0`
- `is_version_in_range("0.10.0", "^0.10.0")` -> True (>=0.10.0 <0.11.0)
