### PR TITLE
chore(deps): pin wicked-web to an immutable ref (a3c18aa)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -20,7 +20,7 @@
     "motion": "^13.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wicked-web": "github:mikeparcewski/wicked-web"
+    "wicked-web": "github:mikeparcewski/wicked-web#a3c18aabed02dc8c1696c9491f37b6714d002d19"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",


### PR DESCRIPTION
Pins the floating `wicked-web` GitHub dependency to the immutable commit
`a3c18aabed02dc8c1696c9491f37b6714d002d19` (current `wicked-web@main` HEAD).

Previously declared as `github:mikeparcewski/wicked-web` with **no** `#sha`, so a
fresh `npm install` could resolve a different HEAD — a live drift bug.

Changes:
- `package.json` (and `site/package.json` where present): pin the `wicked-web` dep to the immutable ref.
- `package-lock.json` `resolved` git ref updated to the same commit **only where it had drifted**.

Lockfiles edited by text only — no `npm install` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)