### PR TITLE
docs(adr): ADR 0005 — re-home the code-relationship graph to wicked-estate (supersedes ADR 0004)

### DIFF
--- a/docs/adr/0004-code-graph-moves-to-wicked-brain.md
+++ b/docs/adr/0004-code-graph-moves-to-wicked-brain.md
@@ -1,6 +1,11 @@
 # ADR 0004 — Move the code-relationship graph to wicked-brain (inverts ADR 0001's homing)
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR 0005](0005-code-graph-re-homes-to-wicked-estate.md) (2026-08-11) — the
+  graph's **home moved from wicked-brain to wicked-estate** (which independently built a more capable
+  graph: 75-language tree-sitter extractor, `ExtraEdgeExtractor` TOML injected edges, cross-repo
+  `XedgeStore`, and `BlastRadius`/`Lineage`/`TraverseGraph` MCP tools), and the brain graph
+  implementation this ADR described was stripped from the wicked-brain tree. The injected-edge idea
+  and the knowing/doing split stand; the home and the codegraph engine choice do not. Originally: Accepted.
 - **Date:** 2026-06-10
 - **Supersedes:** the *homing* decision of [ADR 0001](0001-code-relationship-graph-engine.md) (graph lives in garden). **Keeps** ADR 0001's engine choice (codegraph) and the injected-edge concept.
 - **Context owners:** wicked-garden + wicked-brain

--- a/docs/adr/0005-code-graph-re-homes-to-wicked-estate.md
+++ b/docs/adr/0005-code-graph-re-homes-to-wicked-estate.md
@@ -1,0 +1,130 @@
+# ADR 0005 — Re-home the code-relationship graph to wicked-estate (supersedes ADR 0004)
+
+- **Status:** Accepted
+- **Date:** 2026-08-11
+- **Supersedes:** [ADR 0004](0004-code-graph-moves-to-wicked-brain.md) **in full** — the graph's
+  home moves from `wicked-brain` to `wicked-estate`. Also **retires the engine choice** carried
+  forward from [ADR 0001](0001-code-relationship-graph-engine.md): `@colbymchenry/codegraph` is
+  replaced by estate's own 75-language tree-sitter extractor. What ADR 0001/0004 got right — a real
+  relationship graph with **injected edges** as the load-bearing idea — stands; only the home and
+  the engine change.
+- **Context owners:** wicked-garden + wicked-estate
+- **Relates to (estate):** estate [ADR-005 — code-intel as a brain](../../../wicked-estate/docs/adr/ADR-005-code-intel-as-a-brain.md),
+  estate [ADR-001 — graph schema](../../../wicked-estate/docs/adr/ADR-001-graph-schema.md),
+  estate `docs/extractor-sdk.md`, estate `CLAUDE.md`.
+- **Retarget checklist:** [`0005-retarget-inventory.md`](0005-retarget-inventory.md) — the actionable
+  call-site → estate mapping that Stage S5 executes.
+
+## Context
+
+ADR 0004 homed the code-relationship graph in `wicked-brain`: brain shelled `@colbymchenry/codegraph`
+to build a per-repo `.codegraph/codegraph.db`, read it back over `graph-*` server actions + a
+`wicked-brain:graph` skill, and let plugins contribute proprietary injected edges through a drop-in
+registry (`<repo>/.codegraph-extractors/*.mjs`). Garden became a consumer: `skills/search/SKILL.md`,
+`skills/search/refs/hotspots.md`, and `wicked-patch` (`scripts/engineering/patch/codegraph_db.py`)
+all target that brain surface, and garden ships `.codegraph-extractors/archetype.mjs` as its drop-in.
+
+Two facts have since changed the ground under ADR 0004:
+
+1. **The brain graph is gone.** ADR 0004's implementation is stripped from the current wicked-brain
+   working tree — there is no `wicked-brain-graph` skill, no `@colbymchenry/codegraph` dependency,
+   and no `graph-*` server action. Every garden call-site above therefore points at a **surface that
+   no longer exists** — an already-dangling contract, not a live coupling.
+
+2. **wicked-estate already owns a more capable graph.** Per the ecosystem's center-of-gravity
+   decision (root `CLAUDE.md`: *"wicked-estate is the center of gravity — code graph, memory, and
+   knowledge live there; everything else is a consumer"*), estate independently built the exact
+   capability ADR 0004 described, and more:
+   - a **75-language tree-sitter extractor** (`wicked-estate-extract`, `LANG_TABLE` /
+     `languages.toml`) — no external `codegraph` peer, no Node ≥ 22.5 requirement;
+   - an **`ExtraEdgeExtractor`** (`crates/wicked-estate-extract/src/extra_edge.rs`,
+     `docs/extractor-sdk.md` Part 2) that injects event-bus / command-dispatch / framework-hook edges
+     from a **plain TOML rule file** — the same "grep-invisible injected edge" idea as ADR 0001's
+     extractors and archetype.mjs, but as data instead of per-repo JS;
+   - the **`wicked-estate-overlay` `XedgeStore`** (`crates/wicked-estate-overlay/src/xedge.rs`) for
+     injected **cross-store / cross-repo** edges — a capability the brain graph never had;
+   - **`BlastRadius`, `Lineage`, `TraverseGraph`, `RankHotspots`, `SearchEntity`, `RetrieveEntity`**
+     as **live MCP tools** (`crates/wicked-estate-mcp/src/lib.rs`, backed by
+     `crates/wicked-estate-retrieve/src/lib.rs`).
+
+   Estate's own ADR-005 frames this as its through-line — *"make wicked_estate a **brain** — store the
+   actual content, cache expensive results, and run cross-graph queries"* — with blast-radius,
+   lineage, and cross-graph joins as first-class query surfaces. The graph question ADR 0004 was
+   trying to answer ("what breaks / what flows where / who depends on X") is exactly what estate is
+   for.
+
+So the ecosystem no longer has "two half-built code-intelligence stacks" (ADR 0004's framing). It has
+**one mature stack in estate** and a **set of dangling garden pointers at a retired brain surface**.
+
+## Decision
+
+**Re-home the code-relationship graph to `wicked-estate`.** Estate owns the engine (its tree-sitter
+extractor), the injected-edge extraction (`ExtraEdgeExtractor` TOML rules), the cross-repo overlay
+(`XedgeStore`), and every relationship query (`BlastRadius` / `Lineage` / `TraverseGraph` /
+`RankHotspots`) exposed as MCP tools. Garden stays a **consumer** — the *knowing* (estate) vs *doing*
+(garden: deterministic refactor, gates, archetypes) line from ADR 0004 is preserved; only the "knowing"
+provider changes from brain to estate.
+
+This is a **retarget, not a port.** Estate already implements every capability the brain surface
+promised, at higher fidelity (75 languages vs a codegraph peer; TOML rules vs per-repo JS drop-ins;
+cross-repo overlay the brain never had). There is no code to move — only garden call-sites to repoint.
+
+### What ADR 0004 keeps vs changes
+
+| | 0004 (brain) | 0005 (estate) |
+|---|---|---|
+| Home of the graph + queries | wicked-brain | **wicked-estate** |
+| Static engine | `@colbymchenry/codegraph` peer (Node ≥ 22.5) | **estate `wicked-estate-extract`** — 75-language tree-sitter, in-binary |
+| Injected edges | per-repo JS drop-ins `<repo>/.codegraph-extractors/*.mjs` | **`ExtraEdgeExtractor` TOML rules** (`.wicked-estate-extractors/<name>.toml`, `extra_edge.rs`) |
+| Cross-repo / cross-store edges | none | **`wicked-estate-overlay` `XedgeStore`** (`xedge.db`) |
+| blast-radius / lineage owner | brain `graph-*` actions + `wicked-brain:graph` skill | **estate MCP tools `BlastRadius` / `Lineage` / `TraverseGraph` / `RankHotspots`** |
+| Graph DB | `<repo>/.codegraph/codegraph.db` (codegraph-native SQLite) | **estate index DB** (`wicked-estate index <path>`; queried via MCP, not read raw) |
+| wicked-patch symbol source | reads `.codegraph/codegraph.db` directly | **estate graph** (via MCP / an estate export) |
+| Injected-edge direction | `source = dependent, target = producer/playbook`; blast-radius = dependents | **unchanged in spirit** — estate invariant is `source = dependent, target = dependency`, blast-radius = dependents (`xedge.rs` header; estate `CLAUDE.md`). The archetype rule ports **without a direction flip.** |
+
+### What stands from ADR 0001 / 0004
+
+- **Injected relationships are the whole point.** Garden's load-bearing edges (event producer→consumer,
+  command→agent, agent→tool, archetype→playbook) are wired by a shared *string* through a registry,
+  never a literal symbol reference — invisible to grep and to a static call-graph. Estate's
+  `ExtraEdgeExtractor` is the direct, more-capable successor to ADR 0001's `inject_edges.py` and
+  archetype.mjs: same idea (deterministic edge injection per wiring mechanism), expressed as TOML data
+  the estate binary applies, with a shared **`node_scheme` convergence key** so producers and consumers
+  of the same topic land on one synthetic node (`docs/extractor-sdk.md` Part 2, event-bus example).
+- **The knowing/doing split** (brain/estate knows; garden does) is preserved verbatim — only the
+  knowing provider changes.
+
+## Consequences
+
+- **The dangling contracts get a real target.** Every garden call-site that today references a
+  retired brain surface (`graph-index`, `graph-blast-radius`, `graph-lineage`, `wicked-brain:graph`,
+  raw `.codegraph/codegraph.db` reads) maps to a live estate MCP tool or the estate graph. The exact
+  mapping is [`0005-retarget-inventory.md`](0005-retarget-inventory.md).
+- **Any repo** gets relationship-graph knowledge by running the wicked-estate MCP server — no garden
+  required and, unlike ADR 0004, **no external codegraph peer / Node version floor** either.
+- **Garden's archetype extractor is re-authored, not dropped.** `.codegraph-extractors/archetype.mjs`
+  (JS, better-sqlite3, `INSERT INTO edges …`) becomes an estate `ExtraEdgeExtractor` TOML rule set —
+  the archetype→playbook edge that no grep can see is preserved, now as data estate applies at index
+  time. This is the single highest-effort inventory item because estate's regex-per-file rule model
+  differs from archetype.mjs's JSON-catalog-plus-file-existence logic; the inventory records the
+  recommended shared-`node_scheme` modeling.
+- **Cross-repo blast-radius becomes possible** (estate `XedgeStore`) — a capability the brain graph
+  never had. Out of scope for S5's mechanical retarget, but this ADR homes it in estate so it has a
+  place to land.
+- **No consumer code changes in this ADR.** This PR is the decision + the checklist only. The
+  retarget edits (skill rewrites, `codegraph_db.py` repoint, the archetype TOML rule,
+  `.claude/CLAUDE.md` and `.product/*` doc refresh) are executed in **Stage S5** against the inventory.
+
+## Implementation
+
+- **This PR (Stage S0):** ADR 0005 + [`0005-retarget-inventory.md`](0005-retarget-inventory.md); mark
+  ADR 0004 superseded (its Status banner). No consumer code touched.
+- **Stage S5 (later):** execute the retarget inventory — repoint `skills/search/*` to estate MCP
+  tools, repoint `scripts/engineering/patch/codegraph_db.py` to the estate graph, author the archetype
+  `ExtraEdgeExtractor` TOML rule against `crates/wicked-estate-extract/src/extra_edge.rs` /
+  `docs/extractor-sdk.md`, and refresh the doc/spec references (`.claude/CLAUDE.md`, `.product/*`,
+  `README.md`).
+- **Estate side (already built):** MCP tools registered in `crates/wicked-estate-mcp/src/lib.rs`;
+  extractor SDK in `crates/wicked-estate-extract/src/extra_edge.rs` + `docs/extractor-sdk.md`;
+  cross-repo overlay in `crates/wicked-estate-overlay/src/xedge.rs`. Nothing to build in estate for
+  the core retarget.

--- a/docs/adr/0005-code-graph-re-homes-to-wicked-estate.md
+++ b/docs/adr/0005-code-graph-re-homes-to-wicked-estate.md
@@ -9,9 +9,10 @@
   relationship graph with **injected edges** as the load-bearing idea — stands; only the home and
   the engine change.
 - **Context owners:** wicked-garden + wicked-estate
-- **Relates to (estate):** estate [ADR-005 — code-intel as a brain](../../../wicked-estate/docs/adr/ADR-005-code-intel-as-a-brain.md),
-  estate [ADR-001 — graph schema](../../../wicked-estate/docs/adr/ADR-001-graph-schema.md),
-  estate `docs/extractor-sdk.md`, estate `CLAUDE.md`.
+- **Relates to (estate):** estate `docs/adr/ADR-005-code-intel-as-a-brain.md` (code-intel as a brain),
+  estate `docs/adr/ADR-001-graph-schema.md` (graph schema),
+  estate `docs/extractor-sdk.md`, estate `CLAUDE.md`. (Cross-repo references are given as
+  paths, not links — they resolve in the `wicked-estate` repo, not this one.)
 - **Retarget checklist:** [`0005-retarget-inventory.md`](0005-retarget-inventory.md) — the actionable
   call-site → estate mapping that Stage S5 executes.
 

--- a/docs/adr/0005-retarget-inventory.md
+++ b/docs/adr/0005-retarget-inventory.md
@@ -1,0 +1,154 @@
+# ADR 0005 — Retarget inventory (brain graph surface → wicked-estate)
+
+Companion to [ADR 0005](0005-code-graph-re-homes-to-wicked-estate.md). This is the **actionable
+checklist Stage S5 executes.** Every garden call-site that references wicked-brain's (now-retired)
+code-graph surface is listed with: source `file:line`, what it calls today, the estate replacement
+(exact tool / file), and an effort note. **No code is changed in this ADR PR** — S5 does the edits.
+
+All line numbers are against garden `HEAD` at the time of writing; re-confirm before editing.
+
+## Estate replacement surface (the targets)
+
+| Estate capability | Where it lives (estate repo) | Replaces (brain) |
+|---|---|---|
+| `BlastRadius` MCP tool — "what breaks if I change X?" (transitive dependents) | tool registered `crates/wicked-estate-mcp/src/lib.rs:34,69`; impl `crates/wicked-estate-retrieve/src/lib.rs:769` (name `:772`, desc `:776`) | `graph-blast-radius` action |
+| `Lineage` MCP tool — "what does X depend on?" (transitive dependencies; complement of BlastRadius) | registered `.../mcp/src/lib.rs:35,75`; impl `.../retrieve/src/lib.rs:1020` (name `:1023`, desc `:1027`) | `graph-lineage` action |
+| `TraverseGraph` MCP tool — bounded multi-hop walk, forward/reverse/both, `edge_kinds` filter | registered `.../mcp/src/lib.rs:34,68`; impl `.../retrieve/src/lib.rs:609` (name `:633`, desc `:637`) | generic graph walk / `graph-*` BFS |
+| `RankHotspots` MCP tool — most-central symbols by PageRank over Calls+Imports | registered `.../mcp/src/lib.rs`; impl `.../retrieve/src/lib.rs:1223` (name `:1226`, desc `:1230`) | `hotspots` raw-SQLite read |
+| `SearchEntity` / `RetrieveEntity` MCP tools — symbol lookup / node fetch | registered `.../mcp/src/lib.rs:34,66-67`; impl `.../retrieve/src/lib.rs:337`,`:489` | `symbols` / `wicked-brain-call` lookups |
+| `ExtraEdgeExtractor` — injected edges from TOML rules (`.wicked-estate-extractors/<name>.toml`) | `crates/wicked-estate-extract/src/extra_edge.rs`; docs `docs/extractor-sdk.md` Part 2 | `.codegraph-extractors/*.mjs` JS drop-ins |
+| `XedgeStore` / `XedgeReader` — injected cross-store / cross-repo edges (`xedge.db`) | `crates/wicked-estate-overlay/src/xedge.rs` | (no brain equivalent) |
+| Index build (75-lang tree-sitter, in-binary) | `wicked-estate index <path>` (`crates/wicked-estate/src/main.rs:3`); `LANG_TABLE` in `crates/wicked-estate-extract/src/treesitter.rs` | `graph-index` (codegraph shell-out) |
+
+**Edge-direction invariant (unchanged in spirit):** estate uses `source = dependent, target =
+dependency`; `BlastRadius` = dependents (`crates/wicked-estate-overlay/src/xedge.rs:10-14`, estate
+`CLAUDE.md`). This matches archetype.mjs's own convention (`source = archetype`/dependent, `target =
+playbook`/dependency — archetype.mjs:17-19), so the archetype rule ports **without a direction flip.**
+
+---
+
+## A. Active consumer call-sites (S5 must repoint these — they execute)
+
+### A1 — `skills/search/SKILL.md` (the `wicked-garden-search` skill, six actions)
+
+| Line(s) | Calls today | Estate replacement | Effort |
+|---|---|---|---|
+| 7-10, 27-33, 48-52 | Prose: "delegate to wicked-brain… owns the unified static + injected graph (ADR 0004)… `wicked-brain:graph`" | Rewrite framing: delegates to **wicked-estate MCP**; cite ADR 0005 | S — prose |
+| 61, 113, 151 | `npx -y wicked-brain-call graph-index` (build/refresh) | `wicked-estate index <path>` (CLI) — or note the estate MCP server indexes on connect | M — command swap + freshness note |
+| 88 | `npx -y wicked-brain-call symbols --query "<symbol>"` | `SearchEntity` MCP tool (resolve name→node id) | M |
+| 119, 155 | `npx -y wicked-brain-call graph-blast-radius --node "…"` → `dependents` | `BlastRadius` MCP tool (`symbol` arg) | M |
+| 154 | `npx -y wicked-brain-call graph-lineage --node "…"` → `dependencies` | `Lineage` MCP tool (`symbol` arg) | M |
+| 78-80, 92-94 | codegraph-unavailable / `WICKED_CODEGRAPH_BIN` / `@colbymchenry/codegraph` install fallback | Delete — estate needs no external engine; replace with "estate MCP unreachable" fallback | S — remove dead ladder |
+| 84-89 | Node-id scheme (`file:<relpath>`, `function:<hash>`) | Re-document against estate `SymbolId` scheme | S |
+
+Also update the frontmatter `description` (lines 4-24) which advertises "wicked-brain's unified …
+graph (ADR 0004)" and "use wicked-brain:search / wicked-brain:query" — repoint to estate.
+
+### A2 — `skills/search/refs/hotspots.md` (hotspots action)
+
+| Line(s) | Calls today | Estate replacement | Effort |
+|---|---|---|---|
+| 11 | "brain's `graph-index` builds the codegraph graph + injected edges" | `wicked-estate index` | S |
+| 14-35 | **Primary path: raw `sqlite3` read of `.codegraph/codegraph.db`** — `SELECT target, COUNT(*) … FROM edges … GROUP BY target` | `RankHotspots` MCP tool (PageRank ranking — strictly better than incoming-edge count) | M — replace the whole inline Python block with an MCP call |
+| 41-48 | Fallback: `curl` to brain HTTP `localhost:4242` `search` action | Replace with estate MCP fallback (or drop) | S |
+
+### A3 — `scripts/engineering/patch/codegraph_db.py` (wicked-patch symbol DB — the `.codegraph/codegraph.db` reader)
+
+| Line(s) | Does today | Estate replacement | Effort |
+|---|---|---|---|
+| 1-46 | Module: "adapt codegraph's SQLite into the symbol-graph DB wicked-patch expects" (ADR 0001 payoff) | Re-source from the **estate graph**; header/rationale rewrite to ADR 0005 | — |
+| 42-47 | `build_patch_db(codegraph_db, out_db)` opens `.codegraph/codegraph.db` read-only via `sqlite3.connect(file:…?mode=ro)` | Read estate's graph instead — either (a) an **estate graph export** to the patch schema, or (b) query estate MCP (`TraverseGraph`/`RetrieveEntity`) and materialize the patch `--db`. Decide the seam in S5. | **L** — the codegraph↔patch column mapping (lines 34-98) must be re-derived against estate's node/edge shape (`SymbolId`, `EdgeKind`) |
+| 109 | `--codegraph-db` default `.codegraph/codegraph.db` | New default pointing at the estate graph/export path | S |
+| tests: `scripts/engineering/patch/tests/test_codegraph_db.py:22,25,50-52` | Build a codegraph-shaped temp DB and assert the translation | Rewrite fixtures to estate's shape (or the export contract) | M — test rewrite |
+
+> Note: `patch.py` / `propagation_engine.py` / `generators/*` consume the *translated* patch `--db`,
+> not codegraph directly — so once `codegraph_db.py` is repointed, the rest of the patch family is
+> unaffected (only the adapter and its tests change).
+
+### A4 — `.codegraph-extractors/archetype.mjs` (garden's proprietary injected-edge extractor)
+
+| Line(s) | Does today | Estate replacement | Effort |
+|---|---|---|---|
+| 1-67 | JS drop-in run by brain's registry: reads `.claude-plugin/archetypes.json`, and for each archetype key whose `skills/archetype/refs/<name>.md` playbook exists on disk, `INSERT INTO edges` a synthetic `archetype:<name>` → playbook-file edge (`provenance = injected:archetype`), idempotently | Re-author as an estate **`ExtraEdgeExtractor` TOML rule set** (`.wicked-estate-extractors/archetype.toml`) per `crates/wicked-estate-extract/src/extra_edge.rs` + `docs/extractor-sdk.md` Part 2 | **L (highest-effort item)** |
+
+**Why L / modeling note.** archetype.mjs's logic is *JSON-catalog iteration + file-existence guard +
+edge to an existing file node*. Estate's `ExtraEdgeExtractor` is *regex-over-one-file-text, glob-filtered,
+emitting a synthetic node + edge to a synthetic target node*. The port is not 1:1:
+- **Recommended shape (idiomatic to estate, mirrors the event-bus emit/consume example):** two rules
+  sharing one `node_scheme` (the convergence key) so both land on the same synthetic node —
+  1. rule `file_glob = ".claude-plugin/archetypes.json"`, `pattern` capturing each archetype key,
+     `emit_node`/`emit_edge` to `node_scheme = "archetype-playbook"`, `id_template = "playbook:{name}"`;
+  2. rule `file_glob = "skills/archetype/refs/*.md"`, `pattern`/glob capturing `{name}`, `emit_edge`
+     onto the same `node_scheme = "archetype-playbook"`, `id_template = "playbook:{name}"`.
+  Blast-radius on `playbook:{name}` then reaches both the catalog entry and the playbook file.
+- **Two semantic deltas to accept or design around:** (a) archetype.mjs's *"skip if the playbook file
+  is missing — flag, don't fabricate"* guard has no direct regex-rule equivalent (a glob rule only
+  fires on files that exist, which achieves a similar effect but drops the explicit `skipped` count);
+  (b) archetype.mjs targets the playbook's **file node** directly, whereas ExtraEdge targets a
+  **synthetic** node — the shared-`node_scheme` model above co-locates them on a synthetic node
+  rather than pointing at the file node. If S5 needs the edge to land on the literal file node, that
+  is the one case that may warrant a small `extra_edge.rs` affordance (target = file node by path) —
+  raise it with estate before assuming the TOML model suffices.
+- Delete the `.codegraph-extractors/` dir + its packaging/permission refs once ported
+  (`.npmignore:54`, `.claude/settings.local.json:87`).
+
+### A5 — `skills/core/SKILL.md` (top-level skill roster)
+
+| Line(s) | Says today | Estate replacement | Effort |
+|---|---|---|---|
+| 95 | "> `wicked-brain:search` / `wicked-brain:graph` for code search and relationship graphs" | Repoint the relationship-graph half to estate MCP (`BlastRadius`/`Lineage`/`TraverseGraph`) | S |
+| 90, 104 | `wicked-garden-search` blast-radius/lineage examples (thin wrappers over brain) | Unchanged names; they now wrap estate (fixed transitively via A1) | S |
+
+### A6 — `skills/search/codebase-narrator/SKILL.md` + other search sub-refs
+
+`codebase-narrator/SKILL.md:3,131` and `skills/search/refs/service-map.md` describe the search
+skill's `blast-radius`/`lineage` actions. They delegate to `../SKILL.md`, so they're **fixed
+transitively by A1** — audit for any direct `graph-*`/`.codegraph` mention (none found in the sweep)
+and update the ADR-0004 references. Effort: **S**.
+
+---
+
+## B. Documentation / spec references (update for consistency — no executable coupling)
+
+These don't call the brain surface at runtime, but assert the ADR-0004 homing and must be refreshed
+so the narrative matches ADR 0005. Group-edit in S5.
+
+| File:line | Asserts | Fix | Effort |
+|---|---|---|---|
+| `.claude/CLAUDE.md:208` | "Code-relationship graph lives in wicked-brain (ADR 0004)… `graph-*` actions + `wicked-brain:graph`… `.codegraph/codegraph.db`" | Rewrite to estate + ADR 0005 | S |
+| `README.md:77` | Optional peer `npx @colbymchenry/codegraph` "powers blast-radius/lineage/hotspots/wicked-patch" | Estate MCP; drop the codegraph peer | S |
+| `.product/REQ-001-application-overview.md:89` | Patch "reads the codegraph from wicked-brain (`.codegraph/codegraph.db`)" | Estate graph | S |
+| `.product/REQ-002-technology-constraints.md:60` | "wicked-brain builds/maintains `.codegraph/codegraph.db`" | Estate | S |
+| `.product/RAID.md:33,60` | ASS-003 + codegraph dependency row | Estate; drop codegraph external-dep risk | S |
+| `.product/DES-001-technical-design.md:186,206,259,307` | `.codegraph/codegraph.db` "built/maintained by wicked-brain", shared with patch | Estate graph + estate index | M — several diagram/table edits |
+| `docs/required-peers.md` (codegraph peer entry) | codegraph as optional runtime peer | Drop / repoint | S |
+| `.npmignore:54` | ignores `.codegraph-extractors/` | Remove once archetype.mjs is ported (A4) | S |
+| `.claude/settings.local.json:87` | allow `node --check .codegraph-extractors/archetype.mjs` | Remove with A4 | S |
+
+## C. Leave as-is (historical record — do NOT rewrite)
+
+- `docs/adr/0001-code-relationship-graph-engine.md`, `docs/adr/0004-code-graph-moves-to-wicked-brain.md`
+  — historical ADRs. 0004's **Status banner is updated to "Superseded by ADR 0005"** in this PR (the
+  supersede convention); its body stays intact as the record of the prior decision.
+- `CHANGELOG.md:144-145` — changelog entries are an append-only record; don't rewrite history.
+- `docs/plans/2026-06-10-codegraph-to-brain-phase1a-*.md`, `…-phase1b-*.md`,
+  `docs/specs/2026-06-10-codegraph-to-brain-migration.md` — completed migration artifacts for the
+  *brain* move (now superseded). Leave as historical; optionally add a one-line "superseded by ADR
+  0005" pointer at the top in S5 (optional, S).
+
+---
+
+## Effort roll-up
+
+| Bucket | Items | Effort |
+|---|---|---|
+| A1 search skill rewrite | 1 skill, ~10 edits | M |
+| A2 hotspots → `RankHotspots` | 1 ref | M |
+| A3 `codegraph_db.py` → estate graph | 1 adapter + tests | **L** (seam decision: export vs MCP-materialize) |
+| A4 archetype.mjs → ExtraEdge TOML | 1 extractor | **L** (modeling decision; possible estate SDK ask) |
+| A5/A6 skill roster + narrator | 2-3 refs | S |
+| B docs/specs consistency | ~10 files | S–M (bulk) |
+| C historical | leave / optional pointer | — |
+
+**Keystones for S5:** A3 and A4 carry real design decisions (the patch-DB seam; the archetype edge
+model). Everything else is mechanical repointing once those two seams are settled.


### PR DESCRIPTION
## Stage S0 — wicked-brain → wicked-estate consolidation (Phase 5, DESIGN + DOCS track)

ADR + retarget inventory **only**. No consumer code changes — those happen in **Stage S5** against the inventory in this PR. **Do not merge yet** (automated reviewers + CI post asynchronously per the ecosystem protocol).

### Why

ADR 0004 homed the code-relationship graph in **wicked-brain** (codegraph shell-out → `.codegraph/codegraph.db` → `graph-*` server actions + `wicked-brain:graph` skill + `.codegraph-extractors/*.mjs` drop-ins). Two facts retire that decision:

1. **The brain graph is gone.** ADR 0004's implementation is stripped from the current wicked-brain working tree — no `wicked-brain-graph` skill, no `@colbymchenry/codegraph` dep, no `graph-*` action. Every garden call-site (`skills/search/*`, `wicked-patch`, `archetype.mjs`) points at a **surface that no longer exists** — an already-dangling contract.
2. **wicked-estate already owns a more capable graph** and is the ecosystem's center of gravity: a **75-language tree-sitter extractor** (`wicked-estate-extract`), an **`ExtraEdgeExtractor`** injecting event-bus / command-dispatch / hook edges from **TOML rules** (`extra_edge.rs`, `docs/extractor-sdk.md`), a cross-repo **`XedgeStore`** overlay, and **`BlastRadius` / `Lineage` / `TraverseGraph` / `RankHotspots` / `SearchEntity` / `RetrieveEntity`** as **live MCP tools** (`wicked-estate-mcp/src/lib.rs`).

### Decision

**Re-home the graph to wicked-estate. Retarget, not port** — estate already implements every capability the brain surface promised, at higher fidelity (75 languages vs a codegraph peer; TOML rules vs per-repo JS; cross-repo overlay the brain never had). Garden stays a **consumer**; the knowing/doing split is preserved, only the "knowing" provider changes. Consistent with estate **ADR-005 (code-intel-as-a-brain)** and estate `CLAUDE.md`.

### What's in this PR

- **`docs/adr/0005-code-graph-re-homes-to-wicked-estate.md`** — the ADR. Supersedes ADR 0004 in full; retires the codegraph engine choice from ADR 0001; keeps the injected-edge idea and the knowing/doing split.
- **`docs/adr/0005-retarget-inventory.md`** — the **actionable S5 checklist**: every garden call-site (`file:line`) → its estate replacement (exact MCP tool / file) + effort note. Keystones: **A3** (`codegraph_db.py` → estate graph) and **A4** (`archetype.mjs` → `ExtraEdgeExtractor` TOML rule) carry the real design decisions; everything else is mechanical repointing.
- **`docs/adr/0004-*.md`** — Status banner updated to *"Superseded by ADR 0005"* (garden supersede convention, as ADR 0001 was banner-superseded by 0004); body left intact as the historical record.

### Not in scope (Stage S5)

Skill rewrites (`skills/search/*`), the patch-DB repoint, the archetype TOML rule, and the doc/spec refresh (`.claude/CLAUDE.md`, `.product/*`, `README.md`) — all enumerated in the inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)