### PR TITLE
feat(shim): estate reach-shim — garden hooks can reach wicked-estate stdio MCP (Phase 5, S2)

### DIFF
--- a/scripts/_estate_client.py
+++ b/scripts/_estate_client.py
@@ -166,6 +166,13 @@ def _dispatch(requests: list, *, db: Optional[str], timeout: float) -> dict:
             pass
         return {}
 
+    # Fail-open contract: a non-zero exit means the server died mid-batch —
+    # any output it managed to emit is suspect, so degrade to {} rather than
+    # hand back a partial round-trip as success. (A clean stdin-EOF shutdown
+    # exits 0; wicked-estate-mcp's main loop returns Ok(()) on EOF.)
+    if proc.returncode != 0:
+        return {}
+
     responses: dict = {}
     for line in (out or "").splitlines():
         line = line.strip()
@@ -200,6 +207,25 @@ def set_dispatch(fn: Callable[..., dict]) -> None:
 # JSON-RPC — handshake + one tool call, all fail-open
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _initialize_request() -> dict:
+    """The ONE initialize request every handshake uses (id=1).
+
+    Single source of truth so `health()` probes with exactly the same shape a
+    real tool call sends — if the server ever gets stricter about initialize
+    fields, health and the call path cannot diverge.
+    """
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "wicked-garden-estate-shim", "version": "0"},
+        },
+    }
+
+
 def _rpc(method: str, params: dict, *, timeout: float) -> Optional[dict]:
     """Run one MCP method behind the initialize handshake. Return its response.
 
@@ -210,16 +236,7 @@ def _rpc(method: str, params: dict, *, timeout: float) -> Optional[dict]:
     Returns the id=2 response dict, or None if the call did not round-trip.
     """
     requests = [
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "wicked-garden-estate-shim", "version": "0"},
-            },
-        },
+        _initialize_request(),
         {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
         {"jsonrpc": "2.0", "id": 2, "method": method, "params": params},
     ]
@@ -233,8 +250,10 @@ def _unwrap(envelope: Optional[dict]) -> Optional[Any]:
     """Extract a tool's payload from an MCP tools/call envelope.
 
     Estate wraps results as {"result": {"content": [{"type":"text","text": …}],
-    "isError": bool}}. The text is the tool's own JSON string. Returns the
-    parsed payload, or None on error / isError=true / malformed shape.
+    "isError": bool}}. The text is usually the tool's own JSON string, which is
+    parsed and returned; a tool that emits plain (non-JSON) text gets its text
+    handed back verbatim as a str. Returns None on error / isError=true /
+    a malformed envelope shape.
     """
     if not isinstance(envelope, dict):
         return None
@@ -266,14 +285,7 @@ def health(timeout: float = 5.0) -> bool:
     successful `initialize` proves the whole path (resolve → spawn → handshake).
     """
     try:
-        requests = [
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
-            }
-        ]
+        requests = [_initialize_request()]
         responses = _active_dispatch(requests, db=resolve_db(), timeout=timeout)
         resp = responses.get(1)
         return bool(

--- a/scripts/_estate_client.py
+++ b/scripts/_estate_client.py
@@ -1,0 +1,479 @@
+"""
+Reach-shim: let garden's Python hooks (and other non-MCP callers) reach
+wicked-estate's **stdio** MCP server.
+
+Background
+----------
+wicked-estate ships a single stdio JSON-RPC 2.0 MCP binary
+(`wicked-estate-mcp`): newline-delimited requests on stdin, one response per
+request on stdout. There is no HTTP daemon and no port — so the brain-era
+pattern (`_brain_port.resolve_port()` → POST http://localhost:PORT/api) does
+not apply. This module is the estate analogue of `_brain_port.py`: it owns
+binary/DB resolution, a health probe, and a fail-open call surface, so a hook
+never hard-crashes when estate is missing or slow.
+
+Transport
+---------
+**Spawn-per-call** today (simplest correct thing): each call spawns
+`wicked-estate-mcp`, does the `initialize` handshake, issues one `tools/call`,
+parses the result, and lets the process exit on stdin EOF. This is slower than
+a long-lived server but requires zero lifecycle management and cannot leak
+processes.
+
+The spawn-vs-broker choice is an implementation detail behind a single seam:
+`_dispatch()` (installed as `_active_dispatch`). A future persistent stdio
+broker replaces **that one function** via `set_dispatch()` — every public
+function here routes through it, so **no caller changes** when the transport
+does. Callers only ever touch the stable API below (or the `__main__` CLI,
+which is the `wicked-estate-call` entry point).
+
+Fail-open contract
+------------------
+Every public function is fail-open: on a missing binary, spawn failure,
+timeout, non-zero exit, malformed JSON, or a tool `isError`, it returns a safe
+empty value (`False` / `None` / `[]`) and never raises. Hooks degrade; they do
+not crash.
+
+Cross-platform
+--------------
+Pure stdlib. `subprocess` with an argv list (no shell). `shutil.which` resolves
+`.exe`/`.cmd` on Windows. `communicate(timeout=...)` is the portable timeout
+(no Unix-only signals). All paths via `pathlib`; all wire framing via `json`.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolution — binary + graph DB (mirrors the binary's own --db > env > default)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MCP_BIN_NAME = "wicked-estate-mcp"
+_CLI_BIN_NAME = "wicked-estate"
+_DEFAULT_DB_REL = ".wicked-estate/graph.db"
+
+
+def _which_or_local(name: str) -> Optional[str]:
+    """Resolve an executable: PATH first, then the common ~/.local/bin install.
+
+    `shutil.which` already appends the right extensions on Windows; the
+    ~/.local/bin fallback checks the bare name and a `.exe` sibling so a
+    user-local cargo/npm install is found even when it is not on PATH.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    local = Path.home() / ".local" / "bin"
+    for candidate in (local / name, local / f"{name}.exe"):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def resolve_mcp_bin() -> Optional[str]:
+    """Path to the `wicked-estate-mcp` binary, or None if unresolvable.
+
+    Order: WICKED_ESTATE_MCP_BIN env override > PATH > ~/.local/bin.
+    """
+    override = os.environ.get("WICKED_ESTATE_MCP_BIN")
+    if override and Path(override).is_file():
+        return override
+    return _which_or_local(_MCP_BIN_NAME)
+
+
+def resolve_estate_bin() -> Optional[str]:
+    """Path to the `wicked-estate` CLI (used by stats()), or None.
+
+    Order: WICKED_ESTATE_BIN env override > PATH > ~/.local/bin.
+    """
+    override = os.environ.get("WICKED_ESTATE_BIN")
+    if override and Path(override).is_file():
+        return override
+    return _which_or_local(_CLI_BIN_NAME)
+
+
+def resolve_db() -> Optional[str]:
+    """Resolve the graph DB path, mirroring the binary's own resolution.
+
+    Order: WICKED_ESTATE_DB env > <cwd>/.wicked-estate/graph.db (if present) >
+    None. When None, callers omit `--db` and let the binary apply its default,
+    so we never fight the binary's resolution — we only *pin* it when we have a
+    concrete answer. `:memory:` is honoured (passed through) for tests.
+    """
+    env_db = os.environ.get("WICKED_ESTATE_DB")
+    if env_db:
+        return env_db
+    try:
+        candidate = Path.cwd() / _DEFAULT_DB_REL
+        if candidate.is_file():
+            return str(candidate)
+    except OSError:
+        pass
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transport seam — spawn-per-call today; swappable for a broker later
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _dispatch(requests: list, *, db: Optional[str], timeout: float) -> dict:
+    """Spawn-per-call transport. Return {id: response} for id-bearing requests.
+
+    THIS IS THE ONLY FUNCTION A PERSISTENT BROKER NEEDS TO REPLACE (via
+    `set_dispatch`). It receives a fully-formed batch of JSON-RPC requests
+    (the handshake is already included by `_rpc`), writes them to a fresh
+    `wicked-estate-mcp`, closes stdin, and returns every response line keyed by
+    its `id`. Notifications (no `id`) produce no output and are simply absent.
+
+    Fail-open: any failure returns {} — the caller treats a missing id as a
+    dead call and degrades.
+    """
+    exe = resolve_mcp_bin()
+    if not exe:
+        return {}
+    argv = [exe]
+    if db:
+        argv += ["--db", db]
+    payload = "".join(json.dumps(r, separators=(",", ":")) + "\n" for r in requests)
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, ValueError):
+        return {}
+    try:
+        out, _ = proc.communicate(input=payload, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.communicate(timeout=2)
+        except Exception:
+            pass
+        return {}
+    except (OSError, ValueError):
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        return {}
+
+    responses: dict = {}
+    for line in (out or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "id" in obj and obj["id"] is not None:
+            responses[obj["id"]] = obj
+    return responses
+
+
+# Indirection so a broker can install itself without touching any caller.
+_active_dispatch: Callable[..., dict] = _dispatch
+
+
+def set_dispatch(fn: Callable[..., dict]) -> None:
+    """Install an alternative transport (e.g. a persistent stdio broker).
+
+    `fn` must accept `(requests, *, db, timeout)` and return {id: response},
+    exactly like `_dispatch`. This is the single seam that lets the
+    spawn-per-call transport be swapped for a long-lived broker later with no
+    change to any public function or caller.
+    """
+    global _active_dispatch
+    _active_dispatch = fn
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JSON-RPC — handshake + one tool call, all fail-open
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _rpc(method: str, params: dict, *, timeout: float) -> Optional[dict]:
+    """Run one MCP method behind the initialize handshake. Return its response.
+
+    Every spawn-per-call invocation must (re)handshake, so we always send:
+      1. initialize                (id=1)
+      2. notifications/initialized (notification — no id, no response)
+      3. <method>                  (id=2)  ← the response we return
+    Returns the id=2 response dict, or None if the call did not round-trip.
+    """
+    requests = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "wicked-garden-estate-shim", "version": "0"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": method, "params": params},
+    ]
+    responses = _active_dispatch(requests, db=resolve_db(), timeout=timeout)
+    if 1 not in responses:  # handshake never landed → estate unreachable
+        return None
+    return responses.get(2)
+
+
+def _unwrap(envelope: Optional[dict]) -> Optional[Any]:
+    """Extract a tool's payload from an MCP tools/call envelope.
+
+    Estate wraps results as {"result": {"content": [{"type":"text","text": …}],
+    "isError": bool}}. The text is the tool's own JSON string. Returns the
+    parsed payload, or None on error / isError=true / malformed shape.
+    """
+    if not isinstance(envelope, dict):
+        return None
+    result = envelope.get("result")
+    if not isinstance(result, dict) or result.get("isError"):
+        return None
+    content = result.get("content")
+    if not isinstance(content, list) or not content:
+        return None
+    text = content[0].get("text") if isinstance(content[0], dict) else None
+    if text is None:
+        return None
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        # Some tools may return plain text; hand it back verbatim.
+        return text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stable call surface — what the hooks will target (see brain: search/stats/
+# health/context). All fail-open. S4 rewires the hooks onto these.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def health(timeout: float = 5.0) -> bool:
+    """True if estate is reachable: binary resolves + initialize round-trips.
+
+    The estate analogue of `_brain_port._health_ok()`. Spawn-per-call means a
+    successful `initialize` proves the whole path (resolve → spawn → handshake).
+    """
+    try:
+        requests = [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+            }
+        ]
+        responses = _active_dispatch(requests, db=resolve_db(), timeout=timeout)
+        resp = responses.get(1)
+        return bool(
+            isinstance(resp, dict)
+            and isinstance(resp.get("result"), dict)
+            and resp["result"].get("serverInfo", {}).get("name") == "wicked-estate"
+        )
+    except Exception:
+        return False
+
+
+def call(tool: str, arguments: Optional[dict] = None, timeout: float = 8.0) -> Optional[Any]:
+    """Generic seam: call any estate MCP tool, return its parsed payload or None.
+
+    This is the low-level door the convenience wrappers below sit on, and the
+    escape hatch for tools without a wrapper. Fail-open.
+    """
+    try:
+        env = _rpc("tools/call", {"name": tool, "arguments": arguments or {}}, timeout=timeout)
+        return _unwrap(env)
+    except Exception:
+        return None
+
+
+def call_raw(tool: str, arguments: Optional[dict] = None, timeout: float = 8.0) -> Optional[dict]:
+    """Like `call`, but return the full MCP envelope (for callers that need
+    `isError` / staleness diagnostics). Fail-open (None)."""
+    try:
+        return _rpc("tools/call", {"name": tool, "arguments": arguments or {}}, timeout=timeout)
+    except Exception:
+        return None
+
+
+def list_tools(timeout: float = 5.0) -> list:
+    """Names of the tools estate currently advertises (capability probe).
+
+    Also a liveness signal: a non-empty list means the handshake + tools/list
+    round-tripped. Fail-open ([])."""
+    try:
+        env = _rpc("tools/list", {}, timeout=timeout)
+        tools = (env or {}).get("result", {}).get("tools", [])
+        return [t.get("name") for t in tools if isinstance(t, dict) and t.get("name")]
+    except Exception:
+        return []
+
+
+def search(name: str, limit: int = 20, timeout: float = 8.0) -> list:
+    """Symbol search → estate `SearchEntity`. Returns the `matches` list.
+
+    NOTE: estate's SearchEntity is graph-symbol search (name substring), which
+    is narrower than brain's FTS-over-documents. S4 owns the exact semantic
+    mapping for each hook; S2 only guarantees the seam is reachable. Fail-open.
+    """
+    payload = call("SearchEntity", {"name": name, "limit": limit}, timeout=timeout)
+    if isinstance(payload, dict):
+        matches = payload.get("matches")
+        return matches if isinstance(matches, list) else []
+    return []
+
+
+def context(
+    query: Optional[str] = None,
+    symbol: Optional[str] = None,
+    budget: int = 8000,
+    timeout: float = 8.0,
+) -> Optional[Any]:
+    """Packed context bundle → estate `ContextBundle`.
+
+    Provide exactly one seed: `query` (FTS text; top hit is used) or `symbol`
+    (stable SymbolId). Returns the parsed bundle, or None. Fail-open.
+    """
+    args: dict = {"budget": budget}
+    if symbol:
+        args["symbol"] = symbol
+    elif query:
+        args["query"] = query
+    else:
+        return None
+    return call("ContextBundle", args, timeout=timeout)
+
+
+def recall(query: str, scope: str = "", token_budget: int = 2000, timeout: float = 8.0) -> list:
+    """Memory recall → estate `memory.recall`. Returns the `items` list.
+
+    Requires the memory domain store (WICKED_MEMORY_DB / $WICKED_HOME/memory.db)
+    to be present; when it is not, the tool returns an error and this yields [].
+    Fail-open.
+    """
+    payload = call(
+        "memory.recall",
+        {"query": query, "scope": scope, "token_budget": token_budget},
+        timeout=timeout,
+    )
+    if isinstance(payload, dict):
+        items = payload.get("items")
+        return items if isinstance(items, list) else []
+    return []
+
+
+def knowledge_recall(query: str, token_budget: int = 2000, timeout: float = 8.0) -> Optional[Any]:
+    """Knowledge recall → estate `knowledge.recall` (hybrid FTS+vector). Fail-open."""
+    return call("knowledge.recall", {"query": query, "token_budget": token_budget}, timeout=timeout)
+
+
+def stats(timeout: float = 8.0) -> Optional[dict]:
+    """Index summary → the `wicked-estate stats` CLI, parsed to a dict.
+
+    The brain analogue of the `stats` action (used by hooks to detect an empty
+    index). Estate does not expose stats as an MCP *tool* (the MCP surface is
+    read-only graph retrieval), so this shells the estate CLI's `stats`
+    subcommand — the same estate, a different, read-only entrypoint. Returns
+    e.g. {"nodes": N, "edges": N, "files": N} or None. Fail-open.
+    """
+    exe = resolve_estate_bin()
+    if not exe:
+        return None
+    argv = [exe, "stats"]
+    db = resolve_db()
+    if db:
+        argv += ["--db", db]
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = proc.stdout or ""
+    result: dict = {}
+    # First line looks like: "nodes=4 edges=4 files=1 db=0.2MB"
+    for token in out.split():
+        if "=" in token:
+            key, _, val = token.partition("=")
+            if key in ("nodes", "edges", "files"):
+                try:
+                    result[key] = int(val)
+                except ValueError:
+                    pass
+    return result or None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI — the `wicked-estate-call` entry for non-Python / shell / markdown callers
+#   python3 scripts/_estate_client.py <action> [json-args]
+# Prints JSON to stdout; exit 0 always on a clean (even empty) result, 1 only on
+# a usage error. Never crashes a caller.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _emit(obj: Any) -> None:
+    sys.stdout.write(json.dumps(obj))
+    sys.stdout.write("\n")
+
+
+def main(argv: list) -> int:
+    if not argv:
+        _emit({"error": "usage: _estate_client.py <health|search|context|recall|"
+                        "knowledge-recall|stats|list-tools|call> [json-args]"})
+        return 1
+    action = argv[0]
+    raw = argv[1] if len(argv) > 1 else "{}"
+    try:
+        args = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        # Convenience: a bare positional is treated as the primary string arg.
+        args = {"_": raw}
+
+    if action == "health":
+        _emit({"reachable": health()})
+    elif action == "list-tools":
+        _emit({"tools": list_tools()})
+    elif action == "stats":
+        _emit(stats() or {})
+    elif action == "search":
+        name = args.get("name") or args.get("query") or args.get("_", "")
+        _emit({"matches": search(name, int(args.get("limit", 20)))})
+    elif action == "context":
+        _emit(context(query=args.get("query") or args.get("_"),
+                      symbol=args.get("symbol"),
+                      budget=int(args.get("budget", 8000))) or {})
+    elif action == "recall":
+        q = args.get("query") or args.get("_", "")
+        _emit({"items": recall(q, args.get("scope", ""), int(args.get("token_budget", 2000)))})
+    elif action == "knowledge-recall":
+        q = args.get("query") or args.get("_", "")
+        _emit(knowledge_recall(q, int(args.get("token_budget", 2000))) or {})
+    elif action == "call":
+        tool = args.get("tool") or args.get("name")
+        if not tool:
+            _emit({"error": "call requires {\"tool\": \"<ToolName>\", \"arguments\": {...}}"})
+            return 1
+        _emit({"result": call(tool, args.get("arguments", {}))})
+    else:
+        _emit({"error": f"unknown action: {action}"})
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_estate_client.py
+++ b/tests/test_estate_client.py
@@ -79,6 +79,29 @@ def test_fail_open_when_bin_missing(tmp_path, monkeypatch):
     assert _estate_client.stats() is None
 
 
+def test_fail_open_when_server_dies_mid_batch(monkeypatch):
+    """Non-zero exit → {} even if valid JSON-RPC lines landed on stdout.
+
+    Pins the fail-open contract's 'non-zero exit' clause: a server that dies
+    mid-batch may have emitted a partial response set; treating it as success
+    would hand callers a half-round-trip. (A clean stdin-EOF shutdown exits 0.)
+    """
+    init_resp = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "wicked-estate"}}}
+    )
+
+    class _DyingProc:
+        returncode = 1
+
+        def communicate(self, input=None, timeout=None):
+            return (init_resp + "\n", "")
+
+    monkeypatch.setattr(_estate_client, "resolve_mcp_bin", lambda: "fake-estate-mcp")
+    monkeypatch.setattr(_estate_client.subprocess, "Popen", lambda *a, **k: _DyingProc())
+    assert _estate_client._dispatch([json.loads(init_resp)], db=None, timeout=5) == {}
+    assert _estate_client.health() is False
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Envelope unwrapping
 # ─────────────────────────────────────────────────────────────────────────────
@@ -134,17 +157,17 @@ def test_broker_seam_swaps_transport_without_touching_callers():
 # Live round-trip — the S2 proof (spawns a real wicked-estate-mcp)
 # ─────────────────────────────────────────────────────────────────────────────
 
-_MCP_BIN = _estate_client.resolve_mcp_bin()
-_CLI_BIN = _estate_client.resolve_estate_bin()
-
-
 @pytest.mark.slow
-@pytest.mark.skipif(
-    _MCP_BIN is None or _CLI_BIN is None,
-    reason="wicked-estate / wicked-estate-mcp not installed — live round-trip skipped",
-)
 def test_live_roundtrip_to_estate(tmp_path, monkeypatch):
     """Index a tiny fixture, then reach estate through the shim end-to-end."""
+    # Resolve at run time (not collection time) so the skip decision sees the
+    # same environment the test itself runs under.
+    mcp_bin = _estate_client.resolve_mcp_bin()
+    cli_bin = _estate_client.resolve_estate_bin()
+    if mcp_bin is None or cli_bin is None:
+        pytest.skip(
+            "wicked-estate / wicked-estate-mcp not installed — live round-trip skipped"
+        )
     src = tmp_path / "src"
     src.mkdir()
     (src / "lib.py").write_text(
@@ -156,7 +179,7 @@ def test_live_roundtrip_to_estate(tmp_path, monkeypatch):
     )
     db = tmp_path / "graph.db"
     built = subprocess.run(
-        [_CLI_BIN, "index", str(src), "--db", str(db)],
+        [cli_bin, "index", str(src), "--db", str(db)],
         capture_output=True, text=True, timeout=120,
     )
     assert built.returncode == 0, f"index failed: {built.stderr}"

--- a/tests/test_estate_client.py
+++ b/tests/test_estate_client.py
@@ -1,0 +1,181 @@
+"""tests/test_estate_client.py — the estate reach-shim contract.
+
+Pins the seam that lets garden's Python hooks reach wicked-estate's **stdio**
+MCP binary (there is no HTTP port — this is the estate analogue of
+`test_brain_port.py`). Two layers:
+
+  * Hermetic unit tests (always run): binary/DB resolution, fail-open on an
+    unreachable estate, envelope unwrapping, and the transport seam — proving a
+    persistent broker can replace spawn-per-call via `set_dispatch` with no
+    change to any public function.
+
+  * A live round-trip smoke test (`slow`, skipped when the estate binaries are
+    absent): indexes a tiny fixture with `wicked-estate index`, then drives a
+    real `wicked-estate-mcp` through the shim and asserts a `SearchEntity` call
+    returns the known symbol. This is the S2 proof that the seam actually
+    reaches estate.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+import _estate_client
+
+
+@pytest.fixture(autouse=True)
+def _restore_dispatch():
+    """Save/restore the transport seam so a swap in one test cannot leak."""
+    original = _estate_client._active_dispatch
+    yield
+    _estate_client.set_dispatch(original)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_db_prefers_env(monkeypatch):
+    monkeypatch.setenv("WICKED_ESTATE_DB", "/tmp/whatever/graph.db")
+    assert _estate_client.resolve_db() == "/tmp/whatever/graph.db"
+
+
+def test_resolve_db_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("WICKED_ESTATE_DB", raising=False)
+    monkeypatch.chdir(tmp_path)  # no .wicked-estate/graph.db here
+    assert _estate_client.resolve_db() is None
+
+
+def test_resolve_mcp_bin_env_override(tmp_path, monkeypatch):
+    fake = tmp_path / "wicked-estate-mcp"
+    fake.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("WICKED_ESTATE_MCP_BIN", str(fake))
+    assert _estate_client.resolve_mcp_bin() == str(fake)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fail-open — an unreachable estate must degrade, never raise
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_fail_open_when_transport_dead(monkeypatch):
+    """Transport returns {} (nothing round-tripped) → safe empty values."""
+    _estate_client.set_dispatch(lambda requests, *, db, timeout: {})
+    assert _estate_client.health() is False
+    assert _estate_client.search("anything") == []
+    assert _estate_client.recall("anything") == []
+    assert _estate_client.knowledge_recall("anything") is None
+    assert _estate_client.call("SearchEntity", {"name": "x"}) is None
+    assert _estate_client.list_tools() == []
+
+
+def test_fail_open_when_bin_missing(tmp_path, monkeypatch):
+    """No binary anywhere → real _dispatch returns {}, health False, no raise."""
+    monkeypatch.setenv("WICKED_ESTATE_MCP_BIN", "")
+    monkeypatch.setenv("WICKED_ESTATE_BIN", "")
+    monkeypatch.setattr(_estate_client, "_which_or_local", lambda name: None)
+    assert _estate_client.health() is False
+    assert _estate_client.search("x") == []
+    assert _estate_client.stats() is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Envelope unwrapping
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _envelope(payload, is_error=False):
+    return {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": is_error},
+    }
+
+
+def test_unwrap_parses_inner_json():
+    env = _envelope({"matches": [{"name": "Foo"}], "total": 1})
+    assert _estate_client._unwrap(env) == {"matches": [{"name": "Foo"}], "total": 1}
+
+
+def test_unwrap_returns_none_on_iserror():
+    assert _estate_client._unwrap(_envelope({"oops": True}, is_error=True)) is None
+
+
+def test_unwrap_returns_none_on_garbage():
+    assert _estate_client._unwrap(None) is None
+    assert _estate_client._unwrap({"result": {}}) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The transport seam — a broker can replace spawn-per-call transparently
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_broker_seam_swaps_transport_without_touching_callers():
+    """`set_dispatch` installs a fake transport; the public API routes through
+    it unchanged — the exact property that lets a persistent broker replace
+    spawn-per-call later. No subprocess is spawned here."""
+    canned = {"matches": [{"name": "ReachShimProbe", "kind": "class"}], "total": 1}
+
+    def fake_dispatch(requests, *, db, timeout):
+        # Handshake always leads with id=1 initialize; a tool call adds id=2.
+        methods = {r.get("id"): r.get("method") for r in requests if r.get("id") is not None}
+        assert methods.get(1) == "initialize"
+        out = {1: {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "wicked-estate"}}}}
+        if 2 in methods:
+            assert methods[2] == "tools/call"
+            out[2] = _envelope(canned)
+        return out
+
+    _estate_client.set_dispatch(fake_dispatch)
+    assert _estate_client.health() is True                 # initialize-only batch
+    assert _estate_client.search("ReachShimProbe") == canned["matches"]  # +tools/call
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live round-trip — the S2 proof (spawns a real wicked-estate-mcp)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MCP_BIN = _estate_client.resolve_mcp_bin()
+_CLI_BIN = _estate_client.resolve_estate_bin()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    _MCP_BIN is None or _CLI_BIN is None,
+    reason="wicked-estate / wicked-estate-mcp not installed — live round-trip skipped",
+)
+def test_live_roundtrip_to_estate(tmp_path, monkeypatch):
+    """Index a tiny fixture, then reach estate through the shim end-to-end."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lib.py").write_text(
+        "def wicked_estate_ping():\n"
+        "    return 'pong'\n\n\n"
+        "class ReachShimProbe:\n"
+        "    def check(self):\n"
+        "        return wicked_estate_ping()\n"
+    )
+    db = tmp_path / "graph.db"
+    built = subprocess.run(
+        [_CLI_BIN, "index", str(src), "--db", str(db)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert built.returncode == 0, f"index failed: {built.stderr}"
+    assert db.is_file()
+
+    monkeypatch.setenv("WICKED_ESTATE_DB", str(db))
+
+    # 1. health — spawn + initialize handshake round-trips.
+    assert _estate_client.health(timeout=30) is True
+
+    # 2. capability probe — the full read-tool floor is advertised.
+    tools = _estate_client.list_tools(timeout=30)
+    assert "SearchEntity" in tools
+
+    # 3. the S2 proof: a SearchEntity call returns the known symbol.
+    matches = _estate_client.search("ReachShimProbe", limit=5, timeout=30)
+    names = {m.get("name") for m in matches}
+    assert "ReachShimProbe" in names, f"expected ReachShimProbe in {names}"
+
+    # 4. stats CLI analogue reflects the indexed graph.
+    st = _estate_client.stats(timeout=30)
+    assert st and st.get("nodes", 0) >= 1


### PR DESCRIPTION
## What & why

wicked-estate ships a **stdio-only** JSON-RPC 2.0 MCP binary (`wicked-estate-mcp`) — there is no HTTP daemon and no port. When wicked-brain is retired, garden's Python hooks (which today POST to brain's localhost HTTP server via `_brain_port.py`) need a bridge to estate's stdio MCP. This PR delivers that bridge as **Stage S2** of the wicked-brain → wicked-estate consolidation (Phase 5).

**Additive only.** It does not modify wicked-brain and does not rewire any garden hook — hook rewiring is Stage S4. This PR just makes estate *reachable* behind a stable seam, plus a smoke test proving a live round-trip.

## Placement decision

The shim lives **in garden** (`scripts/_estate_client.py`), mirroring `_brain_port.py`. Garden owns the hooks and the fail-open ergonomics they depend on; estate stays a clean stdio MCP binary with zero knowledge of its consumers. Shipping the bridge from estate would couple estate to garden's hook lifecycle and duplicate garden's degrade-gracefully conventions. Least coupling = garden-side client.

(Named `_estate_client.py` rather than the suggested `_estate_port.py`: estate is stdio, not a port — "port" would be a misleading name for future readers.)

## Transport: spawn-per-call behind a swappable seam

Each call spawns `wicked-estate-mcp`, runs the `initialize` handshake, issues one `tools/call`, unwraps the MCP envelope, and lets the process exit on stdin EOF. Simplest correct thing; no lifecycle to manage; cannot leak processes.

The spawn-vs-broker choice is isolated behind a single `_dispatch()` function (installed as `_active_dispatch`, swappable via `set_dispatch()`). A future **persistent stdio broker** replaces that one function — every public API routes through it, so **no caller changes** when the transport does. A test pins this property.

## Stable call surface (what S4 will target)

Ported resolve / health / fail-open ergonomics from `_brain_port.py`:

- `health()` -> bool — reachability (resolve + spawn + handshake)
- `search(name, limit)` — `SearchEntity` (symbol search) -> `matches`
- `context(query|symbol, budget)` — `ContextBundle`
- `recall(query, scope, token_budget)` — `memory.recall` -> `items`
- `knowledge_recall(query, token_budget)` — `knowledge.recall`
- `stats()` — `wicked-estate stats` CLI parsed to `{nodes,edges,files}` (brain-`stats` analogue; estate deliberately does not expose stats as an MCP tool)
- `call(tool, arguments)` / `call_raw(...)` — generic seam for any estate tool
- `list_tools()` — capability/liveness probe
- `__main__` CLI: `python3 scripts/_estate_client.py <action> [json]` — the `wicked-estate-call` entry for shell/markdown callers

**Fail-open throughout:** missing binary / timeout / non-zero exit / malformed JSON / tool `isError` all return a safe empty value (`False`/`None`/`[]`) and never raise. Hooks degrade; they do not crash.

## Cross-platform

Pure stdlib. `subprocess` with an argv list (no shell); `shutil.which` resolves `.exe`/`.cmd` on Windows; `communicate(timeout=...)` is the portable timeout (no Unix-only signals); paths via `pathlib`; framing via `json`.

## Smoke test (the S2 proof)

`tests/test_estate_client.py` — 10 tests, all green:

- Hermetic units: DB/binary resolution, fail-open on a dead transport and a missing binary, envelope unwrapping, and the **broker-seam swap** (proves a transport replacement is caller-transparent).
- **Live round-trip** (`slow`, auto-skips when the estate binaries are absent): indexes a tiny fixture with `wicked-estate index`, then drives a real `wicked-estate-mcp` through the shim — `health()` true, `SearchEntity("ReachShimProbe")` returns the indexed class, `stats()` reflects the graph.

Live result against `wicked-estate-mcp` v0.14.2: handshake returned `serverInfo{name: wicked-estate}`; `SearchEntity` returned the `ReachShimProbe` class node (`{"matches":[{...,"name":"ReachShimProbe",...}],"total":1}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)