### PR TITLE
feat(context): S4 — retarget context assembly from wicked-brain onto wicked-estate

### DIFF
--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -397,8 +397,16 @@ def _brain_api(action, params=None, timeout=3):
 
 
 def _run_memory_decay():
-    """Run memory decay maintenance via brain lint. Returns a summary string or None."""
+    """Run memory decay maintenance via brain lint. Returns a summary string or None.
+
+    S4: brain-era maintenance only — wicked-estate owns its memory lifecycle
+    in-store (tier/reinforcement in the memext sidecar), so under estate
+    routing this is a no-op. The brain path is deleted at S7.
+    """
     try:
+        from _context_backend import route
+        if route() != "brain":
+            return None  # estate manages decay/reinforcement internally
         result = _brain_api("lint", {}, timeout=5)
         if result and (result.get("archived", 0) > 0 or result.get("deleted", 0) > 0):
             return f"Memory: {result.get('archived', 0)} archived, {result.get('deleted', 0)} cleaned"
@@ -408,65 +416,68 @@ def _run_memory_decay():
 
 
 def _check_search_staleness():
-    """Check brain index health. Returns a briefing note or None.
+    """Check the routed context backend's index health. Returns a note or None.
 
-    Brain is the unified knowledge layer — no legacy SQLite fallback.
-    Fails open — any exception returns None so the session always continues.
+    S4: routed via _context_backend — estate coverage totals (cached per
+    session/TTL) under estate/auto, the legacy brain stats + auto-start under
+    WICKED_CONTEXT_BACKEND=brain. Fails open — any exception returns None so
+    the session always continues.
     """
-    stats = _brain_api("stats", {}, timeout=2)
-    if stats is None:
-        # Deterministic auto-start — server lifecycle is a hook job, not a
-        # model directive. ensure_server is lock-safe and fails open.
-        try:
-            from _brain_port import ensure_server
-            if ensure_server():
-                stats = _brain_api("stats", {}, timeout=2)
-        except Exception:
-            pass
-    if stats is None:
-        return (
-            "Brain server unreachable and auto-start failed — run "
-            "`wicked-brain-call --start` to see the cause. Brain skills "
-            "auto-start the server on every call; do NOT skip brain usage."
-        )
-    if stats.get("total", 0) == 0:
-        return "Brain index is empty — run `wicked-brain:ingest` to index your codebase"
-    return None  # Brain is healthy
+    try:
+        from _context_backend import staleness_note
+        return staleness_note()
+    except Exception:
+        return None
 
 
 def _check_onboarding_status():
     """Check if the current project has been onboarded (search index + memories).
 
     Returns (has_index, has_memories, directive_or_none).
-    Fails open when the brain is unreachable: transient API errors must not be
-    interpreted as "this project was never onboarded". Per-install setup state
-    is enforced separately by _check_setup_gate in prompt_submit.py — that
-    flag is user-level (~/.something-wicked/wicked-garden/config.json), not
-    per-project, so it cannot answer the per-project onboarding question here.
+    Fails open when the context backend is unreachable: transient errors must
+    not be interpreted as "this project was never onboarded". Per-install
+    setup state is enforced separately by _check_setup_gate in
+    prompt_submit.py — that flag is user-level
+    (~/.something-wicked/wicked-garden/config.json), not per-project, so it
+    cannot answer the per-project onboarding question here.
+
+    S4: the index/memory signals come from the routed backend — estate
+    coverage totals (knowledge_total/memory_total, cached per session/TTL)
+    under estate/auto, the legacy brain stats + search probe under
+    WICKED_CONTEXT_BACKEND=brain.
     """
     project = os.environ.get("CLAUDE_PROJECT_NAME") or Path.cwd().name
-    cwd = str(Path.cwd())
 
     has_index = False
     has_memories = False  # default: assume not onboarded (fail-closed for new projects)
 
-    # Check search index — brain is the knowledge layer
-    stats = _brain_api("stats", {}, timeout=2)
-    brain_reachable = stats is not None
+    # Check the knowledge layer through the routed backend
+    stats = None
+    try:
+        from _context_backend import stats as _ctx_stats
+        stats = _ctx_stats()
+    except Exception:
+        stats = None
+    backend_reachable = stats is not None
     if stats and stats.get("total", 0) > 0:
         has_index = True
 
-    # If brain is unreachable, we cannot determine onboarding state — fail open.
-    # Brain unavailability is surfaced separately by _check_brain_dependency.
-    if not brain_reachable:
+    # If the backend is unreachable, we cannot determine onboarding state —
+    # fail open. Unavailability is surfaced separately by the dependency
+    # check (7d) in main().
+    if not backend_reachable:
         return False, True, None
 
-    # Check for any stored memories (broad: any brain result, not just /mem- paths).
-    # If brain has an index with content (has_index=True), that alone is sufficient
-    # evidence that the project has been set up — skip the memory search.
+    # Check for any stored memories. If the backend has indexed content
+    # (has_index=True), that alone is sufficient evidence that the project
+    # has been set up — skip the memory probe.
     if has_index:
-        has_memories = True  # indexed brain content ≡ project was onboarded
+        has_memories = True  # indexed content ≡ project was onboarded
+    elif stats.get("backend") == "estate":
+        # Estate answers the memory question directly from coverage totals.
+        has_memories = stats.get("memory_total", 0) > 0
     else:
+        # Brain path: broad memory search (any result counts, not just /mem- paths).
         result = _brain_api("search", {"query": "project memory onboarding", "limit": 5}, timeout=3)
         if result is None:
             # Brain went unreachable between calls — fail open.
@@ -1592,20 +1603,37 @@ def main():
         if registry_note:
             mode_notes.append(registry_note)
 
-        # 7d. Check wicked-brain dependency (opt-in memory/context layer)
-        brain_available, brain_note = _check_brain_dependency()
+        # 7d. Check the context-backend dependency (memory/context layer).
+        #     S4: routed — wicked-estate binary + stores under estate/auto,
+        #     the legacy wicked-brain plugin checks under
+        #     WICKED_CONTEXT_BACKEND=brain. Never blocks the session.
+        try:
+            from _context_backend import route as _ctx_route
+            _ctx_backend = _ctx_route()
+        except Exception:
+            _ctx_backend = "brain"  # router missing → legacy behavior
+        if _ctx_backend == "brain":
+            brain_available, brain_note = _check_brain_dependency()
+        else:
+            try:
+                from _context_backend import estate_dependency
+                brain_available, brain_note = estate_dependency()
+            except Exception:
+                brain_available, brain_note = None, None
         if state is not None and brain_available is not None:
             state.update(brain_available=brain_available)
         if brain_note:
-            # brain is an opt-in toolkit layer, not a hard requirement — surface
-            # the install pointer informationally, never block the session.
+            # the context layer is not a hard requirement — surface the
+            # install pointer informationally, never block the session.
             mode_notes.append(brain_note)
 
-        # 7e. Brain auto-init and auto-ingest
-        #     If brain is installed but has no content for this project, emit
-        #     a directive so the agent auto-runs init + ingest on first use.
-        #     If the server isn't reachable, emit a start directive instead.
-        if brain_available:
+        # 7e. Empty-store directive.
+        #     Brain route: if brain is installed but has no content, emit the
+        #     legacy init→ingest pipeline directive (start directive when the
+        #     server isn't reachable). Estate route: an empty store is already
+        #     surfaced by _check_search_staleness (staleness_note), so only
+        #     the brain path emits here.
+        if brain_available and _ctx_backend == "brain":
             stats = _brain_api("stats", {}, timeout=2)
             if stats is None:
                 # The dependency check above already attempted a deterministic

--- a/hooks/scripts/notification.py
+++ b/hooks/scripts/notification.py
@@ -106,6 +106,14 @@ def _handle_context_limit(payload: dict) -> str:
     except Exception:
         pass
 
+    # S4: name the memory surface for the routed context backend (brain while
+    # the bridge is alive, estate memory.capture afterwards). Fail-open.
+    try:
+        from _context_backend import memory_directive_target
+        _mem_target = memory_directive_target()
+    except Exception:
+        _mem_target = "wicked-brain:memory"
+
     return json.dumps({
         "systemMessage": (
             "[Context Pressure] Context limit is approaching. Adapting behavior:\n"
@@ -113,7 +121,7 @@ def _handle_context_limit(payload: dict) -> str:
             "2. Prefer delegation to subagents via Task() over inline execution\n"
             "3. Keep responses concise — avoid large code dumps\n"
             "4. If in a crew project, consider completing the current phase before starting new work\n"
-            "5. Use wicked-brain:memory to save critical context before compaction"
+            f"5. Use {_mem_target} to save critical context before compaction"
         ),
         "continue": True,
     })

--- a/hooks/scripts/post_tool.py
+++ b/hooks/scripts/post_tool.py
@@ -220,7 +220,18 @@ def _brain_reindex_file(file_path: str) -> None:
     Reads the file content and POSTs it to the brain index API so the brain
     stays current as files are edited during the session. Async-safe: uses
     stdlib urllib with a short timeout.
+
+    S4: brain-route only. wicked-estate keeps its own stores fresh through
+    its indexer — a per-edit knowledge.write from a hook would append a new
+    node per edit (no stable id on that surface), so under estate routing
+    this is deliberately a no-op (same net effect as brain-absent today).
     """
+    try:
+        from _context_backend import route
+        if route() != "brain":
+            return
+    except Exception:
+        return  # fail open — never block the hook on router import
     try:
         import urllib.request
         p = Path(file_path)

--- a/hooks/scripts/pre_compact.py
+++ b/hooks/scripts/pre_compact.py
@@ -5,8 +5,9 @@ PreCompact hook — wicked-garden WIP snapshot before context compression.
 v6: the v5 ticket-rail preservation path (HistoryCondenser + PressureTracker)
 was removed with smaht/v2 in #428. The remaining jobs are:
 1. Stamp SessionState.last_compact_ts (dedup guard)
-2. Save a lightweight WIP memory to wicked-brain using SessionState + native
-   in-progress task subjects as the input
+2. Save a lightweight WIP memory to the routed context backend (S4: estate
+   memory.capture by default, legacy brain under WICKED_CONTEXT_BACKEND=brain)
+   using SessionState + native in-progress task subjects as the input
 3. Prompt Claude to store any additional memories before context is lost
 
 Always fails open — any unhandled exception returns {"continue": true}.
@@ -24,13 +25,6 @@ from pathlib import Path
 _PLUGIN_ROOT = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(_PLUGIN_ROOT / "scripts"))
 
-def _resolve_brain_port():
-    try:
-        from _brain_port import resolve_port
-        return resolve_port()
-    except Exception:
-        return int(os.environ.get("WICKED_BRAIN_PORT", "4242"))
-
 # ---------------------------------------------------------------------------
 # Ops logger wrapper — fail-silent, never crashes the hook
 # ---------------------------------------------------------------------------
@@ -42,71 +36,6 @@ def _log(domain, level, event, ok=True, ms=None, detail=None):
         log(domain, level, event, ok=ok, ms=ms, detail=detail)
     except Exception:
         pass
-
-
-# ---------------------------------------------------------------------------
-# Brain API helpers
-# ---------------------------------------------------------------------------
-
-def _brain_api(action, params=None, timeout=3):
-    """Call brain API. Returns parsed JSON or None."""
-    try:
-        import urllib.request
-        port = _resolve_brain_port()
-        payload = json.dumps({"action": action, "params": params or {}}).encode("utf-8")
-        req = urllib.request.Request(
-            f"http://localhost:{port}/api",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except Exception:
-        return None
-
-
-def _write_brain_memory(title, content, tier="episodic", tags=None, mem_type="episodic", importance=5):
-    """Write a memory chunk to brain. Returns chunk_id or None."""
-    try:
-        mem_id = str(_uuid_mod.uuid4())
-        chunk_id = f"memories/{tier}/mem-{mem_id}"
-        chunk_path = Path.home() / ".wicked-brain" / f"{chunk_id}.md"
-        chunk_path.parent.mkdir(parents=True, exist_ok=True)
-
-        tags_list = tags or []
-        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-
-        lines = ["---"]
-        lines.append("source: wicked-brain:memory")
-        lines.append(f"memory_type: {mem_type}")
-        lines.append(f"memory_tier: {tier}")
-        lines.append(f"title: {title}")
-        lines.append(f"importance: {importance}")
-        lines.append("contains:")
-        for t in tags_list:
-            lines.append(f"  - {t}")
-        lines.append(f'indexed_at: "{now}"')
-        lines.append("---")
-        lines.append("")
-        lines.append(f"# {title}")
-        lines.append("")
-        lines.append(content)
-
-        chunk_path.write_text("\n".join(lines), encoding="utf-8")
-
-        # Index in brain FTS5 — auto-start the server first so a stopped
-        # server doesn't silently drop the index entry (fail-open).
-        try:
-            from _brain_port import ensure_server
-            ensure_server(wait_secs=2.0)
-        except Exception:
-            pass
-        search_text = f"{title} {content} {' '.join(tags_list)}"
-        _brain_api("index", {"id": f"{chunk_id}.md", "path": f"{chunk_id}.md", "content": search_text, "brain_id": "wicked-brain"})
-        return chunk_id
-    except Exception:
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -156,11 +85,12 @@ def _build_wip_markdown(session_state_dict, in_progress):
 
 
 def _save_wip_state(session_id, project):
-    """Save a lightweight WIP memory to wicked-brain.
+    """Save a lightweight WIP memory to the routed context backend.
 
     v6: no HistoryCondenser ticket rail. Input is SessionState + native
     in-progress task subjects. The richer v5 snapshot (decisions, file scope,
-    open questions) is gone.
+    open questions) is gone. S4: the write routes through
+    _context_backend.capture_memory (estate primary).
     """
     try:
         from _session import SessionState
@@ -190,13 +120,14 @@ def _save_wip_state(session_id, project):
     title = f"WIP: {active_project or 'Session work'} — pre-compaction snapshot"
 
     try:
-        chunk_id = _write_brain_memory(
+        # S4: routed capture — estate memory.capture by default, the legacy
+        # brain file+index path under WICKED_CONTEXT_BACKEND=brain.
+        from _context_backend import capture_memory
+        chunk_id = capture_memory(
             title=title,
             content=content,
             tier="working",
             tags=["wip", "pre-compact", "auto-saved"],
-            mem_type="working",
-            importance=5,
         )
         if chunk_id:
             _log("context", "verbose", "pre_compact.wip_saved", ok=True,
@@ -257,13 +188,22 @@ def main():
         except Exception:
             pass  # fail open
 
+    # S4: name the memory surface for the routed backend (brain while the
+    # bridge is alive; estate memory.capture after retirement). Fail-open to
+    # the legacy wording.
+    try:
+        from _context_backend import memory_directive_target
+        _mem_target = memory_directive_target()
+    except Exception:
+        _mem_target = "wicked-brain:memory"
+
     _log("context", "debug", "hook.end", ms=int((time.monotonic() - _t0) * 1000))
     print(json.dumps({
         "continue": True,
         "systemMessage": (
             "[Memory] Context compression imminent. WIP state has been auto-saved. "
             "After compaction, your WIP will be automatically restored on the next prompt. "
-            "Store any additional decisions or patterns NOW with wicked-brain:memory."
+            f"Store any additional decisions or patterns NOW with {_mem_target}."
         ),
     }))
 

--- a/hooks/scripts/pre_tool.py
+++ b/hooks/scripts/pre_tool.py
@@ -280,10 +280,17 @@ def _handle_write_guard(tool_input: dict) -> str:
     is_auto_memory = _AUTO_MEMORY_MARKER in file_path and "/memory/" in file_path
 
     if is_memory_md or is_auto_memory:
+        # S4: name the memory surface for the routed context backend (brain
+        # while the bridge is alive, estate memory.capture afterwards).
+        try:
+            from _context_backend import memory_directive_target
+            _mem_target = memory_directive_target()
+        except Exception:
+            _mem_target = "wicked-brain:memory"
         return _deny(
             "Do not write to MEMORY.md or the auto memory directory. "
             "This project uses wicked-garden memory for persistence. "
-            "Use wicked-brain:memory to save decisions, patterns, and gotchas instead."
+            f"Use {_mem_target} to save decisions, patterns, and gotchas instead."
         )
 
     # Issue #442: challenge-artifacts gate for build-phase writes

--- a/hooks/scripts/prompt_submit.py
+++ b/hooks/scripts/prompt_submit.py
@@ -40,14 +40,6 @@ _PLUGIN_ROOT = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", Path(__file__).resolve(
 _SCRIPTS_DIR = _PLUGIN_ROOT / "scripts"
 sys.path.insert(0, str(_SCRIPTS_DIR))
 
-def _resolve_brain_port():
-    try:
-        from _brain_port import resolve_port
-        return resolve_port()
-    except Exception:
-        return int(os.environ.get("WICKED_BRAIN_PORT", "4242"))
-
-
 # ---------------------------------------------------------------------------
 # Ops logger wrapper — fail-silent, never crashes the hook
 # ---------------------------------------------------------------------------
@@ -65,76 +57,24 @@ def _log(domain, level, event, ok=True, ms=None, detail=None):
 # Session goal capture (turns 1-2)
 # ---------------------------------------------------------------------------
 
-def _brain_api(action, params=None, timeout=3):
-    """Call brain API. Returns parsed JSON or None."""
-    try:
-        import urllib.request
-        port = _resolve_brain_port()
-        payload = json.dumps({"action": action, "params": params or {}}).encode("utf-8")
-        req = urllib.request.Request(
-            f"http://localhost:{port}/api",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except Exception:
-        return None
-
-
-def _write_brain_memory(title, content, tier="episodic", tags=None, mem_type="episodic", importance=5):
-    """Write a memory chunk to brain. Returns chunk_id or None."""
-    try:
-        import uuid
-        mem_id = str(uuid.uuid4())
-        chunk_id = f"memories/{tier}/mem-{mem_id}"
-        chunk_path = Path.home() / ".wicked-brain" / f"{chunk_id}.md"
-        chunk_path.parent.mkdir(parents=True, exist_ok=True)
-
-        tags_list = tags or []
-        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-
-        lines = ["---"]
-        lines.append("source: wicked-brain:memory")
-        lines.append(f"memory_type: {mem_type}")
-        lines.append(f"memory_tier: {tier}")
-        lines.append(f"title: {title}")
-        lines.append(f"importance: {importance}")
-        lines.append("contains:")
-        for t in tags_list:
-            lines.append(f"  - {t}")
-        lines.append(f'indexed_at: "{now}"')
-        lines.append("---")
-        lines.append("")
-        lines.append(f"# {title}")
-        lines.append("")
-        lines.append(content)
-
-        chunk_path.write_text("\n".join(lines), encoding="utf-8")
-
-        # Index in brain FTS5
-        search_text = f"{title} {content} {' '.join(tags_list)}"
-        _brain_api("index", {"id": f"{chunk_id}.md", "path": f"{chunk_id}.md", "content": search_text, "brain_id": "wicked-brain"})
-        return chunk_id
-    except Exception:
-        return None
-
-
 def _capture_session_goal(prompt: str, turn_count: int, project: str, session_id: str):
-    """On turns 1-2, save the session goal as WORKING memory via brain API."""
+    """On turns 1-2, save the session goal as WORKING memory.
+
+    S4: routed through _context_backend.capture_memory — estate
+    ``memory.capture`` by default, the legacy brain file+index path under
+    WICKED_CONTEXT_BACKEND=brain. Fail-open, never blocks the prompt.
+    """
     if turn_count > 2:
         return
     if len(prompt.strip()) < 20:
         return
     try:
-        _write_brain_memory(
+        from _context_backend import capture_memory
+        capture_memory(
             title=f"Session goal (turn {turn_count})",
             content=prompt[:500],
             tier="working",
             tags=["session-goal", "auto-captured"],
-            mem_type="working",
-            importance=5,
         )
     except Exception:
         pass
@@ -588,51 +528,28 @@ def _check_setup_gate(prompt: str) -> str | None:
     return None
 
 
-def _check_brain_gate(prompt: str) -> None:
-    """Warn if wicked-brain server is not reachable.
+def _check_context_gate(prompt: str) -> None:
+    """Warn if the routed context backend is not reachable.
 
-    Probes the brain API with a 1s timeout. If unreachable, prints a directive
-    to stderr — this feeds back to the model via the hook error channel but does
-    NOT hard-block (sys.exit(2)) since brain is a server process that may be
-    starting up or temporarily unavailable.
+    S4: probes the backend selected by WICKED_CONTEXT_BACKEND (estate primary
+    in ``auto``; brain under ``brain``, including its deterministic
+    auto-start). If unreachable, prints a note to stderr — this feeds back to
+    the model via the hook error channel but does NOT hard-block (sys.exit(2)).
+    The estate probe is cached per session/TTL so this stays cheap per prompt.
 
-    Exempted on setup/help commands (brain not needed before setup completes).
+    Exempted on setup/help commands (context layer not needed before setup).
     """
     stripped = prompt.strip().lower()
     if stripped.startswith(_GUARD_PASS_PREFIXES):
         return
 
     try:
-        port = _resolve_brain_port()
-        payload = json.dumps({"action": "stats", "params": {}}).encode("utf-8")
-        import urllib.request
-        req = urllib.request.Request(
-            f"http://localhost:{port}/api",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=1) as _resp:
-            pass  # Brain is running — no action needed
+        from _context_backend import gate_note
+        note = gate_note()
+        if note:
+            print(note, file=sys.stderr)
     except Exception:
-        # Deterministic auto-start before nagging: a stopped server is a
-        # hook-fixable condition, not something to delegate to the model.
-        started = False
-        try:
-            from _brain_port import ensure_server
-            started = ensure_server(wait_secs=2.0)
-        except Exception:
-            pass
-        if not started:
-            print(
-                "[wicked-brain] Brain server is not running on port "
-                f"{_resolve_brain_port()} and auto-start failed.\n"
-                "wicked-garden requires wicked-brain for context assembly and memory.\n"
-                "Brain skills auto-start the server on every call — do NOT skip "
-                "brain usage. Diagnose with: wicked-brain-call --start. "
-                "If not installed: claude plugin install wicked-brain --scope project",
-                file=sys.stderr,
-            )
+        pass  # fail open — a broken router must never block a prompt
 
 
 # v11: _assemble_current_chain, _consume_facilitator_reeval, and
@@ -805,14 +722,24 @@ def _build_intent_directive(intent: str, turn_count: int, explicit: bool, state=
     if intent == "simple-edit":
         return label  # empty when auto-detected
 
-    # synthesis directive shared by feature / research / rigor
+    # synthesis directive shared by feature / research / rigor.
+    # S4: grounding steps are backend-aware — brain wording while the bridge
+    # is installed and answering, estate wording otherwise (fail-open to the
+    # legacy brain wording if the router cannot be imported).
+    try:
+        from _context_backend import grounding_directive_lines
+        grounding = grounding_directive_lines()
+    except Exception:
+        grounding = [
+            "1. Call wicked-brain:query for conceptual grounding ('how does X work', "
+            "'what are the constraints around Y').",
+            "2. Call wicked-brain:search for specific symbols, files, or past decisions. "
+            "Drill into wiki hits with wicked-brain:read depth=2.",
+        ]
     directive_lines = [
         f"[Context Assembly — intent={intent}] Deep context needed before answering.",
         "BEFORE drafting a response:",
-        "1. Call wicked-brain:query for conceptual grounding ('how does X work', "
-        "'what are the constraints around Y').",
-        "2. Call wicked-brain:search for specific symbols, files, or past decisions. "
-        "Drill into wiki hits with wicked-brain:read depth=2.",
+        *grounding,
     ]
     if intent == "rigor":
         directive_lines.append(
@@ -912,10 +839,11 @@ def main():
     # MUST run before HOT continuations so setup can never be bypassed.
     _check_setup_gate(prompt)
 
-    # Brain gate — soft directive if brain server is not reachable.
-    # Runs after setup gate (brain irrelevant before setup completes).
-    # Does NOT hard-block — brain server may be starting up; user can start it.
-    _check_brain_gate(prompt)
+    # Context gate — soft directive if the routed context backend (estate
+    # primary; brain under WICKED_CONTEXT_BACKEND=brain) is not reachable.
+    # Runs after setup gate (context layer irrelevant before setup completes).
+    # Does NOT hard-block — hooks fail open, retrieval degrades to empty.
+    _check_context_gate(prompt)
 
     # Onboarding gate — inject directive if project hasn't been onboarded.
     # Checked after setup gate but before HOT path so continuations during

--- a/hooks/scripts/session_end.py
+++ b/hooks/scripts/session_end.py
@@ -69,7 +69,7 @@ def main() -> None:
         messages = []
 
     # Claim sentinel — info-tier session-close lines (never blocking): a
-    # significant session that captured zero brain memories, or repo playbooks
+    # significant session that captured zero memory-layer memories, or repo playbooks
     # (wicked-understanding) that have drifted well behind HEAD. Observed state
     # only; each check is fail-open and silent when its layer is absent.
     try:

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -392,9 +392,16 @@ def _brain_api(action, params=None, timeout=3):
 
 
 def _run_memory_decay() -> list:
-    """Run decay maintenance via brain lint API. Return list of result message strings."""
+    """Run decay maintenance via brain lint API. Return list of result message strings.
+
+    S4: brain-route only — wicked-estate owns its memory lifecycle in-store,
+    so under estate routing this is a no-op. Deleted with the brain path at S7.
+    """
     messages = []
     try:
+        from _context_backend import route
+        if route() != "brain":
+            return messages  # estate manages decay/reinforcement internally
         # Session-end maintenance writes — auto-start the server so a stopped
         # server doesn't silently skip decay (fail-open, lock-safe, one
         # spawn attempt per process).
@@ -417,9 +424,14 @@ def _run_working_consolidation() -> list:
     """Consolidate working-tier memories via brain compile + lint.
 
     Returns a list of message strings. Fails open — never blocks session end.
+    S4: brain-route only — estate consolidation is in-store (memory.reflect
+    owns that surface); no-op under estate routing. Deleted at S7.
     """
     messages = []
     try:
+        from _context_backend import route
+        if route() != "brain":
+            return messages  # estate consolidates in-store
         try:
             from _brain_port import ensure_server
             ensure_server(wait_secs=2.0)

--- a/hooks/scripts/task_completed.py
+++ b/hooks/scripts/task_completed.py
@@ -251,13 +251,20 @@ def main():
                 _mem_target = memory_directive_target()
             except Exception:
                 _mem_target = "wicked-brain:memory"
+            # `type=` is wicked-brain:memory vocabulary; estate's memory.capture
+            # takes kind/tier/scope/content instead. Suffix the hint only when
+            # the directive targets the brain skill, so the instruction stays
+            # valid under either routed backend (Copilot review, #1044).
+            _type_clause = (
+                f" with type={mem_type}" if "wicked-brain" in _mem_target else ""
+            )
             if compliance_required:
                 escalation_prefix = (
                     "[ESCALATION] " if escalations >= _ESCALATION_THRESHOLD else ""
                 )
                 system_message = (
                     f"{escalation_prefix}[Memory] Task {task_label} completed. "
-                    f"REQUIRED: Call {_mem_target} with type={mem_type} "
+                    f"REQUIRED: Call {_mem_target}{_type_clause} "
                     "to capture any decision, gotcha, or pattern from this work. "
                     "If genuinely nothing is worth storing, respond with 'No memory stored: <reason>'."
                 )
@@ -265,7 +272,7 @@ def main():
                 system_message = (
                     f"[Memory] Task {task_label} completed. "
                     "If this produced a decision, gotcha, or reusable pattern, "
-                    f"store it with {_mem_target} (type={mem_type})."
+                    f"store it with {_mem_target}{_type_clause}."
                 )
 
         # Evidence nudge for crew tasks (Issue #253).

--- a/hooks/scripts/task_completed.py
+++ b/hooks/scripts/task_completed.py
@@ -244,13 +244,20 @@ def main():
         if subject and _is_deliverable_task(subject):
             mem_type = _infer_mem_type(subject)
             task_label = f'"{subject}"' if subject else f"task {task_id}"
+            # S4: name the memory surface for the routed context backend
+            # (brain while the bridge is alive, estate memory.capture after).
+            try:
+                from _context_backend import memory_directive_target
+                _mem_target = memory_directive_target()
+            except Exception:
+                _mem_target = "wicked-brain:memory"
             if compliance_required:
                 escalation_prefix = (
                     "[ESCALATION] " if escalations >= _ESCALATION_THRESHOLD else ""
                 )
                 system_message = (
                     f"{escalation_prefix}[Memory] Task {task_label} completed. "
-                    f"REQUIRED: Call wicked-brain:memory with type={mem_type} "
+                    f"REQUIRED: Call {_mem_target} with type={mem_type} "
                     "to capture any decision, gotcha, or pattern from this work. "
                     "If genuinely nothing is worth storing, respond with 'No memory stored: <reason>'."
                 )
@@ -258,7 +265,7 @@ def main():
                 system_message = (
                     f"[Memory] Task {task_label} completed. "
                     "If this produced a decision, gotcha, or reusable pattern, "
-                    f"store it with wicked-brain:memory (type={mem_type})."
+                    f"store it with {_mem_target} (type={mem_type})."
                 )
 
         # Evidence nudge for crew tasks (Issue #253).

--- a/scripts/_context_backend.py
+++ b/scripts/_context_backend.py
@@ -201,6 +201,28 @@ def _memory_scope() -> str:
     return os.environ.get("WICKED_ESTATE_MEMORY_SCOPE", "")
 
 
+def _memory_scope_prefix() -> Optional[str]:
+    """Subtree filter for estate memory recall (estate #98 ``scope_prefix``).
+
+    The ancestor-visible ``scope`` filter alone cannot see leaf-scoped
+    memories — the 205 migrated brain memories live at scopes like
+    ``brain:wicked-garden/doc:<id>`` and were invisible to root recalls.
+    ``scope_prefix`` REPLACES that filter with subtree matching; the default
+    ``""`` (root subtree) sees ALL memories: root + every migrated subtree.
+
+    When the operator pinned a custom recall scope via
+    WICKED_ESTATE_MEMORY_SCOPE, honor it — return None (param omitted,
+    inheritance semantics) so the pin keeps meaning what it meant.
+    Explicit override: WICKED_ESTATE_MEMORY_SCOPE_PREFIX.
+    """
+    prefix = os.environ.get("WICKED_ESTATE_MEMORY_SCOPE_PREFIX")
+    if prefix is not None:
+        return prefix
+    if os.environ.get("WICKED_ESTATE_MEMORY_SCOPE"):
+        return None  # custom scope pinned — keep ancestor-visible semantics
+    return ""
+
+
 def _f(value: Any) -> float:
     try:
         return float(value)
@@ -278,8 +300,12 @@ def _estate_search(query: str, limit: int = 10, timeout: float = 5.0) -> Optiona
     """Two-call estate retrieval. None = estate unreachable (caller may fall back).
 
     knowledge.recall is the primary signal (bench r@10 0.703); memory.recall
-    is fused in when it has anything to say. An empty-but-reachable answer is
-    a valid [] — only a dead estate returns None.
+    is fused in when it has anything to say — with ``scope_prefix`` (estate
+    #98) so the fusion sees ALL memories, migrated ``brain:…`` subtrees
+    included. An empty-but-reachable answer is a valid [] — only a dead
+    estate returns None. A memory-leg failure (e.g. an older binary
+    rejecting ``scope_prefix``) degrades the fusion to knowledge-only —
+    knowledge already answered, so it is not treated as estate-down.
     """
     try:
         import _estate_client
@@ -291,9 +317,16 @@ def _estate_search(query: str, limit: int = 10, timeout: float = 5.0) -> Optiona
         if payload is None:
             return None  # unreachable / tool error — fail toward the caller
         k_items = payload.get("items", []) if isinstance(payload, dict) else []
-        m_items = _estate_client.recall(
-            query, scope=_memory_scope(), token_budget=800, timeout=timeout
-        )
+        try:
+            m_items = _estate_client.recall(
+                query,
+                scope=_memory_scope(),
+                scope_prefix=_memory_scope_prefix(),
+                token_budget=800,
+                timeout=timeout,
+            )
+        except Exception:
+            m_items = []  # memory leg failed — knowledge-only fusion, as before
         k_norm = [_norm_knowledge(i) for i in k_items if isinstance(i, dict)]
         m_norm = [_norm_memory(i) for i in m_items if isinstance(i, dict)]
         return _rrf_fuse([k_norm, m_norm], limit)
@@ -355,7 +388,11 @@ def search(query: str, limit: int = 10, timeout: float = 5.0) -> List[dict]:
 
 
 def recall_memories(query: str, limit: int = 10, timeout: float = 5.0) -> List[dict]:
-    """Memory-only recall (estate memory.recall; brain search under brain mode)."""
+    """Memory-only recall (estate memory.recall; brain search under brain mode).
+
+    Same subtree visibility as the fusion: ``scope_prefix`` (estate #98) so
+    migrated ``brain:…`` leaf memories are recallable here too.
+    """
     if not query or not str(query).strip():
         return []
     try:
@@ -365,7 +402,11 @@ def recall_memories(query: str, limit: int = 10, timeout: float = 5.0) -> List[d
         import _estate_client
 
         items = _estate_client.recall(
-            query, scope=_memory_scope(), token_budget=max(800, limit * 200), timeout=timeout
+            query,
+            scope=_memory_scope(),
+            scope_prefix=_memory_scope_prefix(),
+            token_budget=max(800, limit * 200),
+            timeout=timeout,
         )
         return [_norm_memory(i) for i in items if isinstance(i, dict)][:limit]
     except Exception:

--- a/scripts/_context_backend.py
+++ b/scripts/_context_backend.py
@@ -1,0 +1,708 @@
+"""
+Context-backend router — the single seam between garden's hooks/adapters and
+the knowledge layer (Stage S4 of the brain→estate consolidation).
+
+Backends
+--------
+* **estate** — wicked-estate's stdio MCP binary, reached through the
+  persistent-broker shim (``scripts/_estate_client.py``). Retrieval is a
+  two-call fusion: ``knowledge.recall`` (hybrid FTS+vector over the migrated
+  chunks/wiki) + ``memory.recall``, merged with reciprocal-rank fusion. The
+  S3 parity bench scored the knowledge side alone at r@10 0.703 vs brain
+  0.437 — estate wins the general class outright.
+* **brain** — the legacy wicked-brain HTTP server (``scripts/_brain_port.py``).
+  Kept for the bridge period because "symbolish" queries (identifiers,
+  dotted/snake_case/CamelCase code tokens, import-like strings) still score
+  better on brain (r@10 0.786 vs estate 0.494 per the same bench).
+
+Routing flag
+------------
+``WICKED_CONTEXT_BACKEND = estate | brain | auto`` (default ``auto``).
+
+* ``estate`` — estate only; brain is never consulted.
+* ``brain``  — brain only; legacy behavior, byte-for-byte directives.
+* ``auto``   — estate primary, with two bridge-period exceptions:
+    - symbolish queries route to brain **while brain is alive**;
+    - when estate is unreachable, brain covers (when alive).
+  When brain is retired (S7), every brain probe fails open, so ``auto``
+  silently degrades to estate-only: hooks behave exactly as they do today
+  when the brain server is absent — empty results plus a stderr marker,
+  never a crash.
+
+Writes (``capture_memory``) route estate-first in ``auto`` so fresh memories
+land in the store that survives retirement; ``brain`` mode keeps the legacy
+file-write + FTS-index path.
+
+Fail-open contract
+------------------
+Every public function is fail-open: missing module, missing binary, dead
+broker, dead brain server, malformed payload — all degrade to a safe empty
+value (``None`` / ``[]`` / ``False``). No exception ever escapes to a hook.
+Pure stdlib; cross-platform (no shell, no Unix-only calls).
+"""
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, List, Optional
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Flag + routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+_FLAG_ENV = "WICKED_CONTEXT_BACKEND"
+_VALID_MODES = ("estate", "brain", "auto")
+
+# "Symbolish" query classifier — identifier-shaped tokens route to brain
+# during the bridge (S3 bench: brain r@10 0.786 vs estate 0.494 on this
+# class). Regex is deliberately simple; precision over cleverness.
+_SNAKE = re.compile(r"\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b")
+_DOTTED = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]+\.[A-Za-z_][A-Za-z0-9_]+(?:\.[A-Za-z_][A-Za-z0-9_]+)*\b"
+)
+_CAMEL = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b")
+_UNDERSCORE_ID = re.compile(r"(?:^|[\s'\"`(])_[A-Za-z][A-Za-z0-9_]*")
+_PATHY = re.compile(r"(?:[\w.\-]+[/\\])+[\w.\-]+")
+# import-like: real import statements, require()/include<...>, and Rust/C++
+# path or arrow tokens. Bare English "require"/"from" must NOT trip this.
+_IMPORTISH = re.compile(
+    r"\bfrom\s+[\w.]+\s+import\b|\bimport\s+[A-Za-z_][\w.]*"
+    r"|\brequire\s*\(|\binclude\s*[<\"']|::\w|->\s*\w"
+)
+_FILEEXT = re.compile(
+    r"\b[\w\-]{2,}\.(?:py|rs|ts|tsx|js|jsx|mjs|go|java|kt|rb|json|yaml|yml|toml|md|sh|sql|c|h|hpp|cpp|cs)\b",
+    re.IGNORECASE,
+)
+_SYMBOLISH_PATTERNS = (
+    _SNAKE, _DOTTED, _CAMEL, _UNDERSCORE_ID, _PATHY, _IMPORTISH, _FILEEXT,
+)
+
+
+def backend_mode() -> str:
+    """The configured routing mode. Unknown values fall back to ``auto``."""
+    mode = os.environ.get(_FLAG_ENV, "auto").strip().lower()
+    return mode if mode in _VALID_MODES else "auto"
+
+
+def is_symbolish(query: str) -> bool:
+    """True when the query contains an identifier-shaped token.
+
+    Matches snake_case, dotted paths (min 2 chars/segment, so "e.g." and
+    version numbers don't trip it), CamelCase (two+ humps), path-like tokens,
+    import-like phrases, and bare code filenames.
+    """
+    if not query:
+        return False
+    text = str(query)
+    return any(p.search(text) for p in _SYMBOLISH_PATTERNS)
+
+
+def route(query: Optional[str] = None) -> str:
+    """Resolve the backend for one operation. Returns "estate" or "brain".
+
+    ``estate``/``brain`` modes are absolute. ``auto`` routes symbolish
+    queries to brain while brain is alive (per-class bench fallback) and
+    everything else — including writes and query-less operations — to estate.
+    """
+    mode = backend_mode()
+    if mode in ("estate", "brain"):
+        return mode
+    if query and is_symbolish(query) and brain_alive():
+        return "brain"
+    return "estate"
+
+
+def _bridge_active() -> bool:
+    """True while directives should still name brain surfaces.
+
+    The model-facing memory/grounding skills stay brain-worded while the
+    brain bridge is installed and answering (they still work, and the estate
+    MCP surface may not be attached to the session). Once brain is gone the
+    wording degrades to the estate surfaces silently.
+    """
+    mode = backend_mode()
+    if mode == "brain":
+        return True
+    if mode == "estate":
+        return False
+    return brain_alive()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Liveness probes — memoized per process (a hook run is one short process)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_PROBE_CACHE: dict = {}
+
+
+def _reset_probe_cache() -> None:
+    """Test seam: forget memoized liveness probes."""
+    _PROBE_CACHE.clear()
+
+
+def _brain_api(action: str, params: Optional[dict] = None, timeout: float = 3.0) -> Optional[dict]:
+    """POST one action to the brain HTTP API. None on any failure (fail-open)."""
+    try:
+        import urllib.request
+
+        from _brain_port import resolve_port
+
+        payload = json.dumps({"action": action, "params": params or {}}).encode("utf-8")
+        req = urllib.request.Request(
+            f"http://localhost:{resolve_port()}/api",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosem: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is localhost with int port from resolve_port()
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def brain_alive(timeout: float = 1.0) -> bool:
+    """True if the brain server answers a health call. Memoized per process."""
+    if "brain" in _PROBE_CACHE:
+        return _PROBE_CACHE["brain"]
+    alive = _brain_api("health", {}, timeout=timeout) is not None
+    _PROBE_CACHE["brain"] = alive
+    return alive
+
+
+def _ensure_brain(wait_secs: float = 2.0) -> bool:
+    """Deterministic brain auto-start (bridge only). Fail-open."""
+    try:
+        from _brain_port import ensure_server
+
+        if ensure_server(wait_secs=wait_secs):
+            _PROBE_CACHE["brain"] = True
+            return True
+        return False
+    except Exception:
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Estate retrieval — knowledge.recall + memory.recall, RRF-fused
+# ─────────────────────────────────────────────────────────────────────────────
+
+_RRF_K = 60  # standard reciprocal-rank-fusion constant
+
+
+def _memory_scope() -> str:
+    """Scope for estate memory capture/recall.
+
+    Default is the root scope (""): estate visibility is ancestor-visible,
+    so root-scope memories are recallable from every scoped query — and the
+    hooks' own captures round-trip. Override via WICKED_ESTATE_MEMORY_SCOPE.
+    """
+    return os.environ.get("WICKED_ESTATE_MEMORY_SCOPE", "")
+
+
+def _f(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _norm_knowledge(item: dict) -> dict:
+    """Estate knowledge.recall item → normalized result dict."""
+    return {
+        "id": str(item.get("node_id", "")),
+        "kind": str(item.get("class", "chunk")),
+        "title": str(item.get("label", "")).strip()[:80],
+        "snippet": str(item.get("body_snippet", "")),
+        "raw_score": _f(item.get("score")),
+        "source": str(item.get("source", "")),
+        "scope": "",
+        "backend": "estate",
+    }
+
+
+def _norm_memory(item: dict) -> dict:
+    """Estate memory.recall item → normalized result dict.
+
+    The memory's scope doubles as its source attribution (migrated brain
+    memories carry ``brain:wicked-garden/...`` scopes).
+    """
+    content = str(item.get("content", ""))
+    first_line = content.strip().splitlines()[0][:80] if content.strip() else ""
+    scope = str(item.get("scope", ""))
+    return {
+        "id": str(item.get("memory_id", "")),
+        "kind": "memory",
+        "title": first_line,
+        "snippet": content[:400],
+        "raw_score": _f(item.get("score")),
+        "source": scope or "estate://memory",
+        "scope": scope,
+        "tier": str(item.get("tier", "")),
+        "backend": "estate",
+    }
+
+
+def _norm_brain(item: dict) -> dict:
+    """Brain FTS search result → normalized result dict."""
+    path = str(item.get("path", "") or item.get("id", ""))
+    return {
+        "id": path,
+        "kind": "chunk",
+        "title": "",
+        "snippet": str(item.get("snippet", "")),
+        "raw_score": _f(item.get("score")),
+        "source": f"wicked-brain://{path}" if path else "wicked-brain://",
+        "scope": "",
+        "backend": "brain",
+    }
+
+
+def _rrf_fuse(ranked_lists: List[List[dict]], limit: int) -> List[dict]:
+    """Reciprocal-rank fusion across result lists. Dedupes by id."""
+    fused: dict = {}
+    for items in ranked_lists:
+        for rank, item in enumerate(items):
+            key = item.get("id") or item.get("source") or item.get("snippet", "")[:80]
+            entry = fused.get(key)
+            if entry is None:
+                entry = dict(item)
+                entry["score"] = 0.0
+                fused[key] = entry
+            entry["score"] += 1.0 / (_RRF_K + rank + 1)
+    return sorted(fused.values(), key=lambda d: d["score"], reverse=True)[:limit]
+
+
+def _estate_search(query: str, limit: int = 10, timeout: float = 5.0) -> Optional[List[dict]]:
+    """Two-call estate retrieval. None = estate unreachable (caller may fall back).
+
+    knowledge.recall is the primary signal (bench r@10 0.703); memory.recall
+    is fused in when it has anything to say. An empty-but-reachable answer is
+    a valid [] — only a dead estate returns None.
+    """
+    try:
+        import _estate_client
+    except Exception:
+        return None
+    try:
+        k_budget = max(1600, int(limit) * 300)
+        payload = _estate_client.knowledge_recall(query, token_budget=k_budget, timeout=timeout)
+        if payload is None:
+            return None  # unreachable / tool error — fail toward the caller
+        k_items = payload.get("items", []) if isinstance(payload, dict) else []
+        m_items = _estate_client.recall(
+            query, scope=_memory_scope(), token_budget=800, timeout=timeout
+        )
+        k_norm = [_norm_knowledge(i) for i in k_items if isinstance(i, dict)]
+        m_norm = [_norm_memory(i) for i in m_items if isinstance(i, dict)]
+        return _rrf_fuse([k_norm, m_norm], limit)
+    except Exception:
+        return None
+
+
+def _brain_search(query: str, limit: int = 10) -> Optional[List[dict]]:
+    """Brain FTS search with the legacy 3-term→2-term recall retry.
+
+    None = brain unreachable. FTS5 uses AND, so fewer terms = wider recall:
+    when the full query lands < 2 hits, retry first+third (drop the middle,
+    often the most generic term) and first+second, keeping the wider set.
+    """
+    tokens = [t for t in str(query).split() if t]
+    if not tokens:
+        return []
+    raw = _brain_api("search", {"query": " ".join(tokens), "limit": limit}, timeout=3)
+    if raw is None:
+        return None
+    results = raw.get("results", []) if isinstance(raw, dict) else []
+    if len(results) < 2 and len(tokens) >= 3:
+        ra = _brain_api("search", {"query": f"{tokens[0]} {tokens[2]}", "limit": limit}, timeout=3)
+        rb = _brain_api("search", {"query": f"{tokens[0]} {tokens[1]}", "limit": limit}, timeout=3)
+        la = ra.get("results", []) if isinstance(ra, dict) else []
+        lb = rb.get("results", []) if isinstance(rb, dict) else []
+        results = la if len(la) >= len(lb) else lb
+    return [_norm_brain(r) for r in results if isinstance(r, dict)]
+
+
+def search(query: str, limit: int = 10, timeout: float = 5.0) -> List[dict]:
+    """Routed context search. Always returns a list (fail-open []).
+
+    Result dicts: {id, kind, title, snippet, score, raw_score, source, scope,
+    backend} — ``source`` carries estate's #96 attribution (or a
+    wicked-brain:// URI), ``scope`` the memory scope where applicable.
+    """
+    if not query or not str(query).strip():
+        return []
+    try:
+        backend = route(query)
+        if backend == "brain":
+            results = _brain_search(query, limit=limit)
+            if results is not None:
+                return results
+            if backend_mode() == "auto":  # brain died mid-route — estate covers
+                est = _estate_search(query, limit=limit, timeout=timeout)
+                return est if est is not None else []
+            return []
+        est = _estate_search(query, limit=limit, timeout=timeout)
+        if est is not None:
+            return est
+        if backend_mode() == "auto" and brain_alive():  # estate dead — bridge covers
+            results = _brain_search(query, limit=limit)
+            return results if results is not None else []
+        return []
+    except Exception:
+        return []
+
+
+def recall_memories(query: str, limit: int = 10, timeout: float = 5.0) -> List[dict]:
+    """Memory-only recall (estate memory.recall; brain search under brain mode)."""
+    if not query or not str(query).strip():
+        return []
+    try:
+        if route(query) == "brain":
+            results = _brain_search(query, limit=limit)
+            return results if results is not None else []
+        import _estate_client
+
+        items = _estate_client.recall(
+            query, scope=_memory_scope(), token_budget=max(800, limit * 200), timeout=timeout
+        )
+        return [_norm_memory(i) for i in items if isinstance(i, dict)][:limit]
+    except Exception:
+        return []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Memory capture — estate memory.capture; legacy brain file+index under brain
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ESTATE_TIERS = ("working", "episodic", "semantic", "procedural", "archival")
+
+
+def _brain_capture(title, content, tier="episodic", tags=None, mem_type=None, importance=5):
+    """Legacy brain memory write: chunk file under ~/.wicked-brain + FTS index.
+
+    Single surviving copy of the _write_brain_memory helper that used to be
+    duplicated in prompt_submit.py and pre_compact.py. Bridge-only; deleted
+    with the rest of the brain path at S7.
+    """
+    try:
+        import uuid
+        from datetime import datetime, timezone
+
+        mem_id = str(uuid.uuid4())
+        chunk_id = f"memories/{tier}/mem-{mem_id}"
+        chunk_path = Path.home() / ".wicked-brain" / f"{chunk_id}.md"
+        chunk_path.parent.mkdir(parents=True, exist_ok=True)
+
+        tags_list = list(tags or [])
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+        lines = ["---"]
+        lines.append("source: wicked-brain:memory")
+        lines.append(f"memory_type: {mem_type or tier}")
+        lines.append(f"memory_tier: {tier}")
+        lines.append(f"title: {title}")
+        lines.append(f"importance: {importance}")
+        lines.append("contains:")
+        for t in tags_list:
+            lines.append(f"  - {t}")
+        lines.append(f'indexed_at: "{now}"')
+        lines.append("---")
+        lines.append("")
+        lines.append(f"# {title}")
+        lines.append("")
+        lines.append(content)
+
+        chunk_path.write_text("\n".join(lines), encoding="utf-8")
+
+        _ensure_brain(wait_secs=2.0)
+        search_text = f"{title} {content} {' '.join(tags_list)}"
+        _brain_api(
+            "index",
+            {
+                "id": f"{chunk_id}.md",
+                "path": f"{chunk_id}.md",
+                "content": search_text,
+                "brain_id": "wicked-brain",
+            },
+        )
+        return chunk_id
+    except Exception:
+        return None
+
+
+def capture_memory(title, content, tier="working", tags=None, timeout: float = 5.0):
+    """Store a memory in the routed backend. Returns an id string or None.
+
+    Writes route estate-first in ``auto`` (fresh memories must land in the
+    store that survives brain retirement); ``brain`` mode keeps the legacy
+    path. On an estate write failure in ``auto``, the brain bridge covers
+    while it is alive. Fail-open (None) — never raises.
+    """
+    try:
+        text = f"{title}\n\n{content}" if title else str(content or "")
+        if not text.strip():
+            return None
+        if route() == "brain":
+            return _brain_capture(title, content, tier=tier, tags=tags)
+        try:
+            import _estate_client
+
+            payload = _estate_client.call(
+                "memory.capture",
+                {
+                    "content": text,
+                    "kind": "working" if tier == "working" else "episode",
+                    "tier": tier if tier in _ESTATE_TIERS else "working",
+                    "scope": _memory_scope(),
+                    "about": list(tags or []),
+                },
+                timeout=timeout,
+            )
+            if isinstance(payload, dict):
+                mem_id = payload.get("memory_id") or payload.get("id")
+                if mem_id:
+                    return str(mem_id)
+        except Exception:
+            pass
+        if backend_mode() == "auto" and brain_alive():
+            return _brain_capture(title, content, tier=tier, tags=tags)
+        return None
+    except Exception:
+        return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stats — cached per session/TTL (never per-prompt; the estate probes cost
+# a broker spawn + ~200-500ms cold, which is fine once per TTL, not per turn)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_STATS_TTL_ENV = "WICKED_CONTEXT_STATS_TTL_SECS"
+_STATS_TTL_DEFAULT = 300.0
+_STATS_FAIL_TTL = 60.0  # cached failure re-probes sooner than cached success
+
+
+def _stats_cache_path() -> Path:
+    """Project-scoped cache file; tempdir fallback when _paths is unavailable."""
+    try:
+        from _paths import get_local_file
+
+        return get_local_file("smaht", "context-backend-stats.json")
+    except Exception:
+        import hashlib
+        import tempfile
+
+        cwd_hash = hashlib.sha256(str(Path.cwd()).encode()).hexdigest()[:8]
+        return Path(tempfile.gettempdir()) / f"wicked-garden-ctx-stats-{cwd_hash}.json"
+
+
+def _read_stats_cache() -> Optional[dict]:
+    """The cached record {ok, stats, ts} if fresh, else None."""
+    try:
+        raw = json.loads(_stats_cache_path().read_text(encoding="utf-8"))
+        ts = float(raw.get("ts", 0))
+        ttl = float(os.environ.get(_STATS_TTL_ENV, _STATS_TTL_DEFAULT))
+        if not raw.get("ok"):
+            ttl = min(ttl, _STATS_FAIL_TTL)
+        if time.time() - ts <= ttl:
+            return raw
+        return None
+    except Exception:
+        return None
+
+
+def _write_stats_cache(stats_result: Optional[dict]) -> None:
+    try:
+        record = {"ok": stats_result is not None, "stats": stats_result, "ts": time.time()}
+        _stats_cache_path().write_text(json.dumps(record), encoding="utf-8")
+    except Exception:
+        pass  # cache is an optimization, never a requirement
+
+
+def _estate_stats(timeout: float = 6.0) -> Optional[dict]:
+    """Coverage totals for the context layer's estate stores. None = unreachable."""
+    try:
+        import _estate_client
+    except Exception:
+        return None
+    try:
+        kc = _estate_client.call("knowledge.coverage", {}, timeout=timeout)
+        mc = _estate_client.call("memory.coverage", {}, timeout=timeout)
+        if not isinstance(kc, dict) and not isinstance(mc, dict):
+            return None
+        k_total = int(kc.get("total", 0)) if isinstance(kc, dict) else 0
+        m_total = int(mc.get("total", 0)) if isinstance(mc, dict) else 0
+        return {
+            "backend": "estate",
+            "knowledge_total": k_total,
+            "memory_total": m_total,
+            "total": k_total + m_total,
+        }
+    except Exception:
+        return None
+
+
+def stats() -> Optional[dict]:
+    """Routed index stats. Estate results are TTL-cached across hook processes.
+
+    Estate shape: {backend, knowledge_total, memory_total, total}. Brain shape:
+    the brain server's own stats payload + backend="brain". Both expose
+    ``total`` so emptiness checks port unchanged. None = backend unreachable.
+    """
+    try:
+        mode = backend_mode()
+        if mode == "brain":
+            s = _brain_api("stats", {}, timeout=2)
+            return dict(s, backend="brain") if isinstance(s, dict) else None
+
+        cached = _read_stats_cache()
+        if cached is not None and cached.get("ok"):
+            return cached.get("stats")
+        if cached is not None:
+            estate_result = None  # fresh failure record — skip the re-probe
+        else:
+            estate_result = _estate_stats()
+            _write_stats_cache(estate_result)
+        if estate_result is not None:
+            return estate_result
+        if mode == "auto" and brain_alive():
+            s = _brain_api("stats", {}, timeout=2)
+            if isinstance(s, dict):
+                return dict(s, backend="brain")
+        return None
+    except Exception:
+        return None
+
+
+def health() -> bool:
+    """True if the routed context backend is answering (cached via stats)."""
+    return stats() is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hook-facing note/directive builders — all Optional[str], None = silence
+# ─────────────────────────────────────────────────────────────────────────────
+
+def memory_directive_target() -> str:
+    """Skill/tool name that hooks should reference in memory-capture directives.
+
+    Brain wording while the bridge is installed and answering (the skill still
+    works and is what the model has today); estate wording once brain is gone.
+    """
+    if _bridge_active():
+        return "wicked-brain:memory"
+    return "the wicked-estate `memory.capture` tool"
+
+
+def grounding_directive_lines() -> List[str]:
+    """Numbered grounding steps for the Context Assembly directive."""
+    if _bridge_active():
+        return [
+            "1. Call wicked-brain:query for conceptual grounding ('how does X work', "
+            "'what are the constraints around Y').",
+            "2. Call wicked-brain:search for specific symbols, files, or past decisions. "
+            "Drill into wiki hits with wicked-brain:read depth=2.",
+        ]
+    return [
+        "1. Ground in the knowledge layer via the wicked-garden-search skill "
+        "(wicked-estate knowledge + memory recall) — concepts, symbols, files, "
+        "and past decisions, with source attribution.",
+        "2. Open the cited sources with Read before answering; do not answer "
+        "from recall snippets alone.",
+    ]
+
+
+def gate_note() -> Optional[str]:
+    """Per-prompt reachability note (prompt_submit). None = healthy/silent."""
+    try:
+        mode = backend_mode()
+        if mode == "brain":
+            if brain_alive() or _ensure_brain(wait_secs=2.0):
+                return None
+            return (
+                "[wicked-brain] Brain server is not running and auto-start failed.\n"
+                "WICKED_CONTEXT_BACKEND=brain requires wicked-brain for context "
+                "assembly and memory. Diagnose with: wicked-brain-call --start. "
+                "If not installed: claude plugin install wicked-brain --scope project"
+            )
+        if stats() is not None:
+            return None
+        if mode == "auto" and (brain_alive() or _ensure_brain(wait_secs=2.0)):
+            return (
+                "[wicked-context] wicked-estate is unreachable — the wicked-brain "
+                "bridge is covering context assembly for this session (fail-open)."
+            )
+        return (
+            "[wicked-context] Context backend (wicked-estate) is unreachable and no "
+            "fallback answered. Context assembly is degraded for this session — hooks "
+            "fail open, nothing is blocked. Check the wicked-estate install "
+            "(`wicked-estate-mcp` on PATH or ~/.local/bin) and the stores under ~/.wicked/."
+        )
+    except Exception:
+        return None
+
+
+def staleness_note() -> Optional[str]:
+    """SessionStart index-health note (bootstrap). None = healthy/silent."""
+    try:
+        mode = backend_mode()
+        if mode == "brain":
+            s = _brain_api("stats", {}, timeout=2)
+            if s is None and _ensure_brain():
+                s = _brain_api("stats", {}, timeout=2)
+            if s is None:
+                return (
+                    "Brain server unreachable and auto-start failed — run "
+                    "`wicked-brain-call --start` to see the cause. Brain skills "
+                    "auto-start the server on every call; do NOT skip brain usage."
+                )
+            if s.get("total", 0) == 0:
+                return "Brain index is empty — run `wicked-brain:ingest` to index your codebase"
+            return None
+        s = stats()
+        if s is None:
+            return (
+                "Context backend (wicked-estate) unreachable — knowledge/memory recall "
+                "is degraded this session (fail-open). Check the wicked-estate install."
+            )
+        if s.get("total", 0) == 0:
+            if s.get("backend") == "brain":
+                return "Brain index is empty — run `wicked-brain:ingest` to index your codebase"
+            return (
+                "wicked-estate knowledge/memory stores are empty — run the brain→estate "
+                "migration or ingest content (knowledge.ingest) so context assembly has "
+                "something to recall."
+            )
+        return None
+    except Exception:
+        return None
+
+
+def estate_dependency() -> tuple:
+    """(available, note) for bootstrap's dependency check under estate/auto.
+
+    available: True when the estate MCP binary resolves, False when missing,
+    None on internal error (caller treats as unknown, fail-open). note is an
+    informational string or None.
+    """
+    try:
+        from _estate_client import resolve_mcp_bin
+
+        if resolve_mcp_bin() is None:
+            note = (
+                "[wicked-estate] context-backend binary not found.\n"
+                "Install wicked-estate so hooks can reach the knowledge layer "
+                "(binary `wicked-estate-mcp` on PATH or ~/.local/bin)."
+            )
+            if backend_mode() == "auto" and brain_alive():
+                note += " The wicked-brain bridge is covering context assembly meanwhile."
+            return False, note
+        if stats() is None:
+            return True, (
+                "[wicked-estate] binary present but the MCP server did not answer — "
+                "context assembly degraded for this session (fail-open)."
+            )
+        return True, None
+    except Exception:
+        return None, None

--- a/scripts/_estate_client.py
+++ b/scripts/_estate_client.py
@@ -656,18 +656,31 @@ def context(
     return call("ContextBundle", args, timeout=timeout)
 
 
-def recall(query: str, scope: str = "", token_budget: int = 2000, timeout: float = 8.0) -> list:
+def recall(
+    query: str,
+    scope: str = "",
+    token_budget: int = 2000,
+    timeout: float = 8.0,
+    scope_prefix: Optional[str] = None,
+) -> list:
     """Memory recall → estate `memory.recall`. Returns the `items` list.
+
+    ``scope_prefix`` (estate #98): when not None it is sent on the wire and
+    REPLACES the ancestor-visible ``scope`` filter with subtree matching —
+    ``""`` means the root subtree, i.e. every memory including migrated
+    leaf scopes like ``brain:wicked-garden/doc:<id>``. None omits the param
+    (inheritance behavior, and the only shape pre-#98 binaries understand).
+    An older binary that rejects the param surfaces as a tool error → [] —
+    the same fail-open degrade as any other recall failure.
 
     Requires the memory domain store (WICKED_MEMORY_DB / $WICKED_HOME/memory.db)
     to be present; when it is not, the tool returns an error and this yields [].
     Fail-open.
     """
-    payload = call(
-        "memory.recall",
-        {"query": query, "scope": scope, "token_budget": token_budget},
-        timeout=timeout,
-    )
+    arguments: dict = {"query": query, "scope": scope, "token_budget": token_budget}
+    if scope_prefix is not None:
+        arguments["scope_prefix"] = scope_prefix
+    payload = call("memory.recall", arguments, timeout=timeout)
     if isinstance(payload, dict):
         items = payload.get("items")
         return items if isinstance(items, list) else []
@@ -760,7 +773,8 @@ def main(argv: list) -> int:
                       budget=int(args.get("budget", 8000))) or {})
     elif action == "recall":
         q = args.get("query") or args.get("_", "")
-        _emit({"items": recall(q, args.get("scope", ""), int(args.get("token_budget", 2000)))})
+        _emit({"items": recall(q, args.get("scope", ""), int(args.get("token_budget", 2000)),
+                               scope_prefix=args.get("scope_prefix"))})
     elif action == "knowledge-recall":
         q = args.get("query") or args.get("_", "")
         _emit(knowledge_recall(q, int(args.get("token_budget", 2000))) or {})

--- a/scripts/_heavy_cadence.py
+++ b/scripts/_heavy_cadence.py
@@ -307,6 +307,17 @@ def run_heavy_cadence(trigger: str, session_id: Optional[str] = None,
 # Brain APIs called identically; what changed is only WHEN they fire.
 # ---------------------------------------------------------------------------
 
+def _context_route() -> str:
+    """Resolve the context-backend route (S4). Fail-open to "brain" so the
+    legacy maintenance path keeps running when the router is unavailable."""
+    try:
+        from _context_backend import route
+
+        return route()
+    except Exception:
+        return "brain"
+
+
 def _brain_api_call(plugin_root: Path, action: str, params: dict, timeout: int = 5):
     """Lightweight brain HTTP wrapper — same shape as stop.py::_brain_api but
     importable without pulling in stop.py's hook-specific dependencies.
@@ -330,9 +341,15 @@ def _brain_api_call(plugin_root: Path, action: str, params: dict, timeout: int =
 
 
 def _run_memory_decay(plugin_root: Path) -> List[str]:
-    """Run decay maintenance via brain lint API. Idempotent."""
+    """Run decay maintenance via brain lint API. Idempotent.
+
+    S4: brain-route only — wicked-estate owns its memory lifecycle in-store,
+    so under estate routing this is a no-op. Deleted with the brain path at S7.
+    """
     messages: List[str] = []
     try:
+        if _context_route() != "brain":
+            return messages  # estate manages decay/reinforcement internally
         result = _brain_api_call(plugin_root, "lint", {}, timeout=5)
         if result and (result.get("archived", 0) > 0 or result.get("deleted", 0) > 0):
             messages.append(
@@ -348,9 +365,14 @@ def _run_memory_consolidation(plugin_root: Path) -> List[str]:
 
     Heaviest call in the cadence (10s timeout on compile). Idempotent —
     same chunks won't re-synthesize the same wiki article.
+
+    S4: brain-route only — estate consolidation is in-store (memory.reflect
+    owns that surface); no-op under estate routing. Deleted at S7.
     """
     messages: List[str] = []
     try:
+        if _context_route() != "brain":
+            return messages  # estate consolidates in-store
         compile_result = _brain_api_call(plugin_root, "compile", {}, timeout=10)
         lint_result = _brain_api_call(plugin_root, "lint", {}, timeout=5)
         compiled = compile_result.get("compiled", 0) if compile_result else 0

--- a/scripts/smaht/adapters/brain_adapter.py
+++ b/scripts/smaht/adapters/brain_adapter.py
@@ -1,20 +1,18 @@
 """
-Brain adapter for wicked-smaht context assembly.
+Knowledge-layer adapter for wicked-smaht context assembly (S4: brain→estate).
 
-Queries the wicked-brain FTS5 index for code and document context
-relevant to the current prompt. Returns ContextItems tagged with
-source="brain" so the slow path briefing formatter labels them correctly.
+Queries the routed context backend (wicked-estate recall fusion by default;
+the legacy wicked-brain FTS5 index for symbolish queries while the bridge is
+alive — see scripts/_context_backend.py) for code and document context
+relevant to the current prompt. Returns ContextItems whose ``source`` names
+the answering backend ("estate" / "brain") and whose metadata carries the
+store-level source attribution (estate #96) and memory scope.
 
-wicked-brain is a required dependency — context assembly is degraded without it.
-When brain is unreachable, this adapter logs a warning to stderr and returns empty.
+The knowledge layer degrades gracefully: when no backend is reachable, this
+adapter logs a warning to stderr and returns empty — never raises.
 """
 
-import json
-import os
 import sys
-import urllib.error
-import urllib.request
-from pathlib import Path
 from typing import List
 
 from . import ContextItem, run_in_thread
@@ -38,7 +36,7 @@ _STOP_WORDS = frozenset({
 
 
 def _extract_keywords(prompt: str, limit: int = 3) -> str:
-    """Extract up to `limit` keywords for FTS5 AND query.
+    """Extract up to `limit` keywords for the backend query.
 
     Position-order preserves the prompt's intent; the first non-stop words
     are almost always the topic. Callers pass limit=2 for retry fallback.
@@ -54,55 +52,24 @@ def _extract_keywords(prompt: str, limit: int = 3) -> str:
     return " ".join(unique[:limit]) if unique else ""
 
 
-def _query_brain(prompt: str) -> list:
-    """Query brain FTS5 index with automatic recall fallback.
+def _query_backend(prompt: str) -> list:
+    """Query the routed context backend with extracted keywords.
 
-    FTS5 uses AND — more terms = fewer results. Try 3 terms first (higher
-    precision); if < 2 results, try two 2-term combinations and pick the
-    one with more results:
-      - first + third (drop middle — often the most generic term)
-      - first + second (standard narrowing)
+    Routing, the estate two-call recall fusion, and the brain-side FTS5
+    3-term→2-term retry all live in _context_backend.search(). Returns
+    normalized result dicts, or [] when no backend answers (fail-open).
     """
-    keywords = _extract_keywords(prompt, limit=3).split()
+    keywords = _extract_keywords(prompt, limit=3)
     if not keywords:
         return []
 
-    query = " ".join(keywords)
-
     try:
-        from _brain_port import resolve_port as _resolve_port
-        port = _resolve_port()
+        from _context_backend import search as _ctx_search
 
-        def _search(q: str) -> list:
-            payload = json.dumps({
-                "action": "search",
-                "params": {"query": q, "limit": 10},
-            }).encode("utf-8")
-            req = urllib.request.Request(
-                f"http://localhost:{port}/api",
-                data=payload,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=3) as resp:
-                return json.loads(resp.read().decode("utf-8")).get("results", [])
-
-        results = _search(query)
-        if len(results) < 2 and len(keywords) >= 3:
-            # Try dropping the middle keyword (often the least specific)
-            alt_a = f"{keywords[0]} {keywords[2]}"  # first + third
-            alt_b = f"{keywords[0]} {keywords[1]}"  # first + second
-            ra = _search(alt_a)
-            rb = _search(alt_b)
-            # Prefer whichever returns more results (wider recall)
-            results = ra if len(ra) >= len(rb) else rb
-        elif len(results) < 2 and len(keywords) == 2:
-            # Already at 2 terms; nothing further to try
-            pass  # intentional: no-op
-        return results
+        return _ctx_search(keywords, limit=10)
     except Exception as _e:
         print(
-            f"smaht: brain adapter unreachable (port {port})"
+            "smaht: context backend unreachable"
             f" — context assembly degraded: {type(_e).__name__}",
             file=sys.stderr,
         )
@@ -147,9 +114,10 @@ def _readable_title(source_file: str) -> str:
 def _clean_snippet(raw: str) -> str:
     """Strip YAML frontmatter lines and FTS highlight tags from snippet.
 
-    FTS5 snippets contain frontmatter when the brain server re-indexes full
-    chunk files. Strip aggressively: snake_case keys, floats, timestamps,
-    list tags, and separator markers.
+    Both backends can surface frontmatter (the brain server re-indexes full
+    chunk files; estate's migrated chunks kept those bodies). Strip
+    aggressively: snake_case keys, floats, timestamps, list tags, and
+    separator markers.
     """
     import re as _re
 
@@ -192,13 +160,28 @@ def _clean_snippet(raw: str) -> str:
     return result[:160] if result else ""
 
 
+def _source_file_of(item: dict) -> str:
+    """Derive the originating source file from a normalized backend item.
+
+    Estate items carry a ``source`` attribution URI like
+    ``wicked-brain://wicked-garden/chunks/extracted/<slug>/chunk-001.md``;
+    brain items carry ``wicked-brain://<chunk path>``. Memories have no
+    source file — group them by their own id so each stays distinct.
+    """
+    if item.get("kind") == "memory":
+        return item.get("id", "") or "memory"
+    ref = item.get("source", "") or item.get("id", "")
+    if "chunks/extracted/" in ref:
+        return ref.split("chunks/extracted/", 1)[1].split("/chunk-")[0]
+    return ref
+
+
 async def query(prompt: str) -> List[ContextItem]:
-    """Query brain for code and document context relevant to the prompt."""
-    results = await run_in_thread(_query_brain, prompt)
+    """Query the knowledge layer for context relevant to the prompt."""
+    results = await run_in_thread(_query_backend, prompt)
     if not results:
         return []
 
-    import re
     # Score against extracted keywords only (not full prompt) so incidental
     # words in the prompt (e.g. "crew" in "without going through the crew
     # workflow") don't boost unrelated documents that happen to mention them.
@@ -208,18 +191,10 @@ async def query(prompt: str) -> List[ContextItem]:
     best_by_source: dict[str, dict] = {}
 
     for r in results:
-        path = r.get("path", "") or r.get("id", "")
-        snippet = r.get("snippet", "")
-
-        # Determine source file from chunk path
-        source_file = ""
-        if "chunks/extracted/" in path:
-            part = path.replace("chunks/extracted/", "").split("/chunk-")[0]
-            source_file = part
-        else:
-            source_file = path
-
-        clean_snippet = _clean_snippet(snippet)
+        if not isinstance(r, dict):
+            continue
+        source_file = _source_file_of(r)
+        clean_snippet = _clean_snippet(r.get("snippet", ""))
         kw_score = _keyword_score(score_against, f"{source_file} {clean_snippet}")
         # Items with no readable snippet get a relevance floor of 0.2 so they
         # rank below items that survived cleaning and only appear if budget allows.
@@ -230,7 +205,7 @@ async def query(prompt: str) -> List[ContextItem]:
         existing = best_by_source.get(source_file)
         if existing is None or relevance > existing["relevance"]:
             best_by_source[source_file] = {
-                "path": path,
+                "item": r,
                 "source_file": source_file,
                 "snippet": clean_snippet,
                 "relevance": relevance,
@@ -239,15 +214,26 @@ async def query(prompt: str) -> List[ContextItem]:
     # Second pass: convert to ContextItems
     items: List[ContextItem] = []
     for source_file, entry in best_by_source.items():
-        title = _readable_title(source_file)
+        r = entry["item"]
+        if r.get("kind") == "memory":
+            # A memory's first content line is its natural title.
+            title = r.get("title") or "memory"
+        else:
+            title = _readable_title(source_file)
         items.append(ContextItem(
-            id=entry["path"],
-            source="brain",
+            id=r.get("id", ""),
+            source=r.get("backend", "estate"),
             title=title,
             summary=entry["snippet"],
             excerpt=entry["snippet"][:100],
             relevance=entry["relevance"],
-            metadata={"brain_path": entry["path"]},
+            metadata={
+                # Store-level attribution (estate #96) + scope for memories.
+                "source": r.get("source", ""),
+                "scope": r.get("scope", ""),
+                "type": r.get("kind", ""),
+                "backend": r.get("backend", ""),
+            },
         ))
 
     items.sort(key=lambda x: x.relevance, reverse=True)

--- a/tests/smaht/test_brain_adapter.py
+++ b/tests/smaht/test_brain_adapter.py
@@ -23,7 +23,10 @@ import pytest
 _REPO = Path(__file__).resolve().parents[2]
 _SMAHT = str(_REPO / "scripts" / "smaht")
 if _SMAHT not in sys.path:
-    sys.path.insert(0, _SMAHT)
+    # APPEND — never insert(0): tests/conftest.py keeps scripts/ at sys.path[0]
+    # so scripts/-level modules can't be shadowed (the crew.py scar). Same
+    # pattern conftest uses for scripts/crew.
+    sys.path.append(_SMAHT)
 
 import _context_backend  # noqa: E402  (scripts/ is on sys.path via conftest)
 from adapters import brain_adapter  # noqa: E402

--- a/tests/smaht/test_brain_adapter.py
+++ b/tests/smaht/test_brain_adapter.py
@@ -1,0 +1,139 @@
+"""tests/smaht/test_brain_adapter.py — S4 adapter contract.
+
+The smaht knowledge-layer adapter now queries the routed context backend
+(scripts/_context_backend.py) instead of the brain HTTP API directly. This
+suite pins:
+
+  * ContextItem mapping from the router's normalized result dicts, including
+    the #96 source/scope attribution in metadata and the answering backend in
+    ContextItem.source;
+  * per-source-file deduplication (many chunks → one item per source);
+  * memory items titled by their first content line;
+  * fail-open: router returns [] ⇒ adapter returns [] (no raise).
+
+Hermetic: the router is monkeypatched — no estate binary, no brain server.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SMAHT = str(_REPO / "scripts" / "smaht")
+if _SMAHT not in sys.path:
+    sys.path.insert(0, _SMAHT)
+
+import _context_backend  # noqa: E402  (scripts/ is on sys.path via conftest)
+from adapters import brain_adapter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _fake_results():
+    return [
+        {
+            "id": "kchunk 1",
+            "kind": "chunk",
+            "title": "specialist routing",
+            "snippet": "the crew workflow routes specialists by archetype",
+            "score": 0.03,
+            "raw_score": 0.7,
+            "source": "wicked-brain://wicked-garden/chunks/extracted/"
+                      "skills-crew-workflow-refs-specialist-routing-rules.md/chunk-001.md",
+            "scope": "",
+            "backend": "estate",
+        },
+        {
+            "id": "kchunk 2",
+            "kind": "chunk",
+            "title": "specialist routing (cont)",
+            "snippet": "crew workflow specialist routing continued",
+            "score": 0.02,
+            "raw_score": 0.5,
+            "source": "wicked-brain://wicked-garden/chunks/extracted/"
+                      "skills-crew-workflow-refs-specialist-routing-rules.md/chunk-002.md",
+            "scope": "",
+            "backend": "estate",
+        },
+        {
+            "id": "mem 9",
+            "kind": "memory",
+            "title": "Decision: crew workflow gates are fail-closed",
+            "snippet": "Decision: crew workflow gates are fail-closed\n\ndetails",
+            "score": 0.01,
+            "raw_score": 0.4,
+            "source": "brain:wicked-garden/doc:mem-abc.md",
+            "scope": "brain:wicked-garden/doc:mem-abc.md",
+            "backend": "estate",
+        },
+    ]
+
+
+def test_query_maps_router_results_to_context_items(monkeypatch):
+    monkeypatch.setattr(_context_backend, "search", lambda q, limit=10: _fake_results())
+    items = _run(brain_adapter.query("explain the crew workflow specialist routing"))
+    assert items, "expected ContextItems from fake router results"
+    assert all(i.source == "estate" for i in items)
+    # #96 attribution survives into metadata
+    chunk_items = [i for i in items if i.metadata.get("type") == "chunk"]
+    assert chunk_items
+    assert chunk_items[0].metadata["source"].startswith("wicked-brain://wicked-garden/chunks/")
+    assert chunk_items[0].metadata["backend"] == "estate"
+
+
+def test_query_dedupes_chunks_by_source_file(monkeypatch):
+    """Two chunks of the same source file collapse to one ContextItem."""
+    monkeypatch.setattr(_context_backend, "search", lambda q, limit=10: _fake_results())
+    items = _run(brain_adapter.query("crew workflow specialist routing"))
+    chunk_items = [i for i in items if i.metadata.get("type") == "chunk"]
+    assert len(chunk_items) == 1
+
+
+def test_query_titles_memories_by_first_content_line(monkeypatch):
+    monkeypatch.setattr(_context_backend, "search", lambda q, limit=10: _fake_results())
+    items = _run(brain_adapter.query("crew workflow specialist routing"))
+    memory_items = [i for i in items if i.metadata.get("type") == "memory"]
+    assert len(memory_items) == 1
+    assert memory_items[0].title.startswith("Decision: crew workflow gates")
+    assert memory_items[0].metadata["scope"] == "brain:wicked-garden/doc:mem-abc.md"
+
+
+def test_query_titles_chunks_from_source_file(monkeypatch):
+    monkeypatch.setattr(_context_backend, "search", lambda q, limit=10: _fake_results())
+    items = _run(brain_adapter.query("crew workflow specialist routing"))
+    chunk_items = [i for i in items if i.metadata.get("type") == "chunk"]
+    assert chunk_items[0].title == "crew / workflow-specialist-routing-rules"
+
+
+def test_query_returns_empty_when_router_is_empty(monkeypatch):
+    monkeypatch.setattr(_context_backend, "search", lambda q, limit=10: [])
+    assert _run(brain_adapter.query("anything")) == []
+
+
+def test_query_fails_open_when_router_raises(monkeypatch):
+    def boom(q, limit=10):
+        raise RuntimeError("router exploded")
+
+    monkeypatch.setattr(_context_backend, "search", boom)
+    assert _run(brain_adapter.query("anything")) == []
+
+
+def test_query_skips_stop_word_only_prompts(monkeypatch):
+    called = {"n": 0}
+
+    def spy(q, limit=10):
+        called["n"] += 1
+        return []
+
+    monkeypatch.setattr(_context_backend, "search", spy)
+    assert _run(brain_adapter.query("the a an is to")) == []
+    assert called["n"] == 0  # no keywords → no backend call
+
+
+def test_extract_keywords_preserves_prompt_order():
+    kw = brain_adapter._extract_keywords("explain the crew workflow specialist routing")
+    assert kw == "explain crew workflow"

--- a/tests/test_context_backend.py
+++ b/tests/test_context_backend.py
@@ -34,6 +34,7 @@ def _clean_router(monkeypatch, tmp_path):
     """Isolate every test: default flag, cold probe memo, tmp stats cache."""
     monkeypatch.delenv("WICKED_CONTEXT_BACKEND", raising=False)
     monkeypatch.delenv("WICKED_ESTATE_MEMORY_SCOPE", raising=False)
+    monkeypatch.delenv("WICKED_ESTATE_MEMORY_SCOPE_PREFIX", raising=False)
     monkeypatch.delenv("WICKED_CONTEXT_STATS_TTL_SECS", raising=False)
     cb._reset_probe_cache()
     cache_file = tmp_path / "ctx-stats.json"
@@ -52,8 +53,8 @@ def _plant_fake_estate(monkeypatch, **overrides):
         fake.calls.append(("knowledge_recall", query))
         return {"items": []}
 
-    def recall(query, scope="", token_budget=2000, timeout=8.0):
-        fake.calls.append(("recall", query, scope))
+    def recall(query, scope="", token_budget=2000, timeout=8.0, scope_prefix=None):
+        fake.calls.append(("recall", query, scope, scope_prefix))
         return []
 
     def call(tool, arguments=None, timeout=8.0):
@@ -181,7 +182,7 @@ def test_estate_search_fuses_knowledge_and_memory(monkeypatch):
     _plant_fake_estate(
         monkeypatch,
         knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
-        recall=lambda q, scope="", token_budget=2000, timeout=8.0: [_M_ITEM],
+        recall=lambda q, scope="", token_budget=2000, timeout=8.0, scope_prefix=None: [_M_ITEM],
     )
     results = cb.search("how does gate policy work", limit=10)
     assert len(results) == 2
@@ -191,12 +192,62 @@ def test_estate_search_fuses_knowledge_and_memory(monkeypatch):
     assert results[0]["score"] == pytest.approx(results[1]["score"])
 
 
+def test_estate_search_recalls_the_full_memory_subtree(monkeypatch):
+    """estate #98: the memory leg sends scope_prefix="" (root subtree) so
+    migrated leaf-scoped memories (brain:…/doc:…) are fused in — they were
+    invisible under the ancestor-only `scope` filter."""
+    fake = _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": []},
+    )
+    cb.search("gh account switch 403", limit=10)
+    recall_calls = [c for c in fake.calls if c[0] == "recall"]
+    assert recall_calls == [("recall", "gh account switch 403", "", "")]
+
+
+def test_memory_scope_prefix_defaults_and_overrides(monkeypatch):
+    # Default: root subtree — every memory, migrated subtrees included.
+    assert cb._memory_scope_prefix() == ""
+    # A pinned custom scope keeps its ancestor-visible meaning (param omitted).
+    monkeypatch.setenv("WICKED_ESTATE_MEMORY_SCOPE", "org:acme")
+    assert cb._memory_scope_prefix() is None
+    # The explicit prefix override wins over both.
+    monkeypatch.setenv("WICKED_ESTATE_MEMORY_SCOPE_PREFIX", "brain:wicked-garden")
+    assert cb._memory_scope_prefix() == "brain:wicked-garden"
+
+
+def test_estate_search_degrades_to_knowledge_only_when_memory_leg_fails(monkeypatch):
+    """An older binary rejecting scope_prefix (or any memory-leg blowup) must
+    degrade the fusion to knowledge-only — never estate-down, never a raise."""
+
+    def recall_pre_98(query, scope="", token_budget=2000, timeout=8.0):
+        raise TypeError("recall() got an unexpected keyword argument 'scope_prefix'")
+
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
+        recall=recall_pre_98,
+    )
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    results = cb.search("how does gate policy work", limit=10)
+    assert [r["kind"] for r in results] == ["chunk"]
+    assert results[0]["backend"] == "estate"  # knowledge answered — no brain bounce
+
+
+def test_recall_memories_uses_the_subtree_prefix_too(monkeypatch):
+    """Memory-only recall gets the same #98 subtree visibility as the fusion."""
+    fake = _plant_fake_estate(monkeypatch)
+    assert cb.recall_memories("gate policy decisions") == []
+    recall_calls = [c for c in fake.calls if c[0] == "recall"]
+    assert recall_calls == [("recall", "gate policy decisions", "", "")]
+
+
 def test_estate_search_surfaces_source_attribution(monkeypatch):
     """#96: estate `source` (knowledge) and scope (memory) survive normalization."""
     _plant_fake_estate(
         monkeypatch,
         knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
-        recall=lambda q, scope="", token_budget=2000, timeout=8.0: [_M_ITEM],
+        recall=lambda q, scope="", token_budget=2000, timeout=8.0, scope_prefix=None: [_M_ITEM],
     )
     results = cb.search("gate policy", limit=10)
     by_kind = {r["kind"]: r for r in results}

--- a/tests/test_context_backend.py
+++ b/tests/test_context_backend.py
@@ -1,0 +1,537 @@
+"""tests/test_context_backend.py — the S4 context-backend router contract.
+
+Pins the seam that retargets garden's context-assembly layer from
+wicked-brain onto wicked-estate (scripts/_context_backend.py):
+
+  * the symbolish classifier (identifier-shaped queries route to brain
+    while the bridge is alive — per the S3 parity bench);
+  * WICKED_CONTEXT_BACKEND flag semantics (estate | brain | auto);
+  * the estate two-call recall fusion (knowledge.recall + memory.recall,
+    RRF-merged) including normalization and #96 source attribution;
+  * fail-open degradation: estate dead + brain dead ⇒ empty results, never
+    an exception (the exact brain-absent behavior hooks rely on today);
+  * capture_memory routing (estate memory.capture primary; legacy brain
+    path under the flag);
+  * stats TTL caching (per-session file cache — never re-probed per prompt).
+
+Hermetic: the estate side is faked by planting a fake ``_estate_client``
+module in sys.modules; the brain side by monkeypatching ``_brain_api`` /
+``brain_alive``. No subprocess, no network.
+"""
+
+import json
+import sys
+import time
+import types
+
+import pytest
+
+import _context_backend as cb
+
+
+@pytest.fixture(autouse=True)
+def _clean_router(monkeypatch, tmp_path):
+    """Isolate every test: default flag, cold probe memo, tmp stats cache."""
+    monkeypatch.delenv("WICKED_CONTEXT_BACKEND", raising=False)
+    monkeypatch.delenv("WICKED_ESTATE_MEMORY_SCOPE", raising=False)
+    monkeypatch.delenv("WICKED_CONTEXT_STATS_TTL_SECS", raising=False)
+    cb._reset_probe_cache()
+    cache_file = tmp_path / "ctx-stats.json"
+    monkeypatch.setattr(cb, "_stats_cache_path", lambda: cache_file)
+    yield
+    cb._reset_probe_cache()
+    sys.modules.pop("_fake_estate_marker", None)
+
+
+def _plant_fake_estate(monkeypatch, **overrides):
+    """Install a fake _estate_client module; returns it for call inspection."""
+    fake = types.ModuleType("_estate_client")
+    fake.calls = []
+
+    def knowledge_recall(query, token_budget=2000, timeout=8.0):
+        fake.calls.append(("knowledge_recall", query))
+        return {"items": []}
+
+    def recall(query, scope="", token_budget=2000, timeout=8.0):
+        fake.calls.append(("recall", query, scope))
+        return []
+
+    def call(tool, arguments=None, timeout=8.0):
+        fake.calls.append(("call", tool, arguments))
+        return None
+
+    def resolve_mcp_bin():
+        return "/fake/wicked-estate-mcp"
+
+    fake.knowledge_recall = knowledge_recall
+    fake.recall = recall
+    fake.call = call
+    fake.resolve_mcp_bin = resolve_mcp_bin
+    for name, fn in overrides.items():
+        setattr(fake, name, fn)
+    monkeypatch.setitem(sys.modules, "_estate_client", fake)
+    return fake
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Classifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("query", [
+    "where is resolve_port used",                # snake_case
+    "explain SessionState.load behavior",        # dotted + CamelCase
+    "fix the bug in prompt_submit.py",           # bare code filename
+    "from _brain_port import resolve_port",      # import-like
+    "hooks/scripts/bootstrap.py brain gate",     # path-like
+    "what does _PersistentBroker do",            # CamelCase-ish snake mix
+    "wicked_estate::GraphStore lifetime",        # rust path
+])
+def test_is_symbolish_positives(query):
+    assert cb.is_symbolish(query) is True
+
+
+@pytest.mark.parametrize("query", [
+    "how does the acceptance pipeline decide a verdict",
+    "what are the constraints around memory decay",
+    "explain the crew workflow phases",
+    "why does onboarding require a wizard",
+    "e.g. the general case, i.e. plain English",  # 1-char dotted segments
+    "",
+])
+def test_is_symbolish_negatives(query):
+    assert cb.is_symbolish(query) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Flag semantics + routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_backend_mode_defaults_to_auto():
+    assert cb.backend_mode() == "auto"
+
+
+def test_backend_mode_honors_flag(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "estate")
+    assert cb.backend_mode() == "estate"
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "brain")
+    assert cb.backend_mode() == "brain"
+
+
+def test_backend_mode_unknown_value_falls_back_to_auto(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "banana")
+    assert cb.backend_mode() == "auto"
+
+
+def test_route_estate_flag_is_absolute(monkeypatch):
+    """estate mode never consults brain, even for symbolish queries."""
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "estate")
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.route("resolve_port usage") == "estate"
+
+
+def test_route_brain_flag_is_absolute(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "brain")
+    assert cb.route("plain english question") == "brain"
+
+
+def test_route_auto_symbolish_goes_to_brain_while_alive(monkeypatch):
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.route("where is resolve_port used") == "brain"
+
+
+def test_route_auto_symbolish_degrades_to_estate_when_brain_gone(monkeypatch):
+    """The incremental-retire property: brain absent ⇒ auto is estate-only."""
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert cb.route("where is resolve_port used") == "estate"
+
+
+def test_route_auto_nonsymbolish_goes_to_estate_even_with_brain_alive(monkeypatch):
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.route("how does the crew workflow decide phases") == "estate"
+
+
+def test_route_queryless_operations_default_to_estate(monkeypatch):
+    """Writes and stats (no query) route estate-first in auto."""
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.route() == "estate"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Estate search — fusion + normalization + attribution
+# ─────────────────────────────────────────────────────────────────────────────
+
+_K_ITEM = {
+    "node_id": "kchunk 1",
+    "class": "chunk",
+    "label": "archetype detection",
+    "body_snippet": "the v11 archetype detector routes prompts",
+    "score": 0.7,
+    "source": "wicked-brain://wicked-garden/chunks/extracted/scripts-crew-archetypes.md/chunk-001.md",
+}
+_M_ITEM = {
+    "memory_id": "mem 9",
+    "scope": "brain:wicked-garden/doc:mem-abc.md",
+    "content": "Decision: gate policy lives in gate-policy.json\n\nbody text",
+    "tier": "semantic",
+    "score": 0.4,
+}
+
+
+def test_estate_search_fuses_knowledge_and_memory(monkeypatch):
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
+        recall=lambda q, scope="", token_budget=2000, timeout=8.0: [_M_ITEM],
+    )
+    results = cb.search("how does gate policy work", limit=10)
+    assert len(results) == 2
+    kinds = {r["kind"] for r in results}
+    assert kinds == {"chunk", "memory"}
+    # RRF: both are rank-0 in their lists → equal fused scores
+    assert results[0]["score"] == pytest.approx(results[1]["score"])
+
+
+def test_estate_search_surfaces_source_attribution(monkeypatch):
+    """#96: estate `source` (knowledge) and scope (memory) survive normalization."""
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
+        recall=lambda q, scope="", token_budget=2000, timeout=8.0: [_M_ITEM],
+    )
+    results = cb.search("gate policy", limit=10)
+    by_kind = {r["kind"]: r for r in results}
+    assert by_kind["chunk"]["source"].startswith("wicked-brain://wicked-garden/chunks/")
+    assert by_kind["memory"]["scope"] == "brain:wicked-garden/doc:mem-abc.md"
+    assert by_kind["memory"]["source"] == "brain:wicked-garden/doc:mem-abc.md"
+    assert by_kind["memory"]["title"].startswith("Decision: gate policy")
+    assert all(r["backend"] == "estate" for r in results)
+
+
+def test_rrf_fusion_ranks_earlier_items_higher():
+    a = [{"id": f"a{i}", "snippet": ""} for i in range(3)]
+    fused = cb._rrf_fuse([a], limit=10)
+    assert [r["id"] for r in fused] == ["a0", "a1", "a2"]
+    assert fused[0]["score"] > fused[1]["score"] > fused[2]["score"]
+
+
+def test_rrf_fusion_dedupes_by_id_and_sums_scores():
+    a = [{"id": "x", "snippet": "s"}]
+    b = [{"id": "x", "snippet": "s"}]
+    fused = cb._rrf_fuse([a, b], limit=10)
+    assert len(fused) == 1
+    assert fused[0]["score"] == pytest.approx(2.0 / (cb._RRF_K + 1))
+
+
+def test_estate_search_empty_is_a_valid_answer_no_brain_bounce(monkeypatch):
+    """A reachable-but-empty estate answer stays [] — no bounce to brain."""
+    _plant_fake_estate(monkeypatch)  # both recalls return empty
+    called = {"brain": False}
+
+    def brain_search(q, limit=10):
+        called["brain"] = True
+        return []
+
+    monkeypatch.setattr(cb, "_brain_search", brain_search)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.search("plain english question") == []
+    assert called["brain"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fallback routing — auto mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_auto_falls_back_to_brain_when_estate_unreachable(monkeypatch):
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: None,  # dead
+    )
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    monkeypatch.setattr(
+        cb, "_brain_api",
+        lambda action, params=None, timeout=3.0: (
+            {"results": [{"id": "c1", "path": "chunks/extracted/x.md/chunk-001.md",
+                          "snippet": "hit"}]}
+            if action == "search" else {"status": "ok"}
+        ),
+    )
+    results = cb.search("plain english question")
+    assert len(results) == 1
+    assert results[0]["backend"] == "brain"
+    assert results[0]["source"].startswith("wicked-brain://")
+
+
+def test_auto_symbolish_falls_back_to_estate_when_brain_dies_midway(monkeypatch):
+    """brain_alive said yes but the search call failed → estate covers."""
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    monkeypatch.setattr(cb, "_brain_search", lambda q, limit=10: None)  # dead
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: {"items": [_K_ITEM]},
+    )
+    results = cb.search("where is resolve_port used")
+    assert len(results) == 1
+    assert results[0]["backend"] == "estate"
+
+
+def test_search_fails_open_when_both_backends_dead(monkeypatch):
+    """The keystone guarantee: estate dead + brain dead ⇒ [] — never a raise."""
+    _plant_fake_estate(
+        monkeypatch,
+        knowledge_recall=lambda q, token_budget=2000, timeout=8.0: None,
+    )
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert cb.search("anything at all") == []
+
+
+def test_search_fails_open_when_estate_module_is_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "_estate_client", None)  # import → error
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert cb.search("anything at all") == []
+
+
+def test_brain_mode_does_not_touch_estate(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "brain")
+    fake = _plant_fake_estate(monkeypatch)
+    monkeypatch.setattr(
+        cb, "_brain_api",
+        lambda action, params=None, timeout=3.0: {"results": []},
+    )
+    assert cb.search("query") == []
+    assert fake.calls == []
+
+
+def test_brain_search_retries_with_two_term_combinations(monkeypatch):
+    """The legacy FTS5 AND-narrowing retry moved here from brain_adapter."""
+    queries = []
+
+    def brain_api(action, params=None, timeout=3.0):
+        queries.append(params["query"])
+        if params["query"] == "alpha gamma":
+            return {"results": [{"id": "1", "path": "p1", "snippet": "s"},
+                                {"id": "2", "path": "p2", "snippet": "s"}]}
+        return {"results": []}
+
+    monkeypatch.setattr(cb, "_brain_api", brain_api)
+    results = cb._brain_search("alpha beta gamma", limit=10)
+    assert queries == ["alpha beta gamma", "alpha gamma", "alpha beta"]
+    assert len(results) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# capture_memory
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_capture_memory_estate_path_calls_memory_capture(monkeypatch):
+    captured = {}
+
+    def call(tool, arguments=None, timeout=8.0):
+        captured["tool"] = tool
+        captured["args"] = arguments
+        return {"memory_id": "mem xyz"}
+
+    _plant_fake_estate(monkeypatch, call=call)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    mem_id = cb.capture_memory(
+        "Session goal (turn 1)", "do the thing", tier="working",
+        tags=["session-goal", "auto-captured"],
+    )
+    assert mem_id == "mem xyz"
+    assert captured["tool"] == "memory.capture"
+    assert captured["args"]["kind"] == "working"
+    assert captured["args"]["tier"] == "working"
+    assert captured["args"]["about"] == ["session-goal", "auto-captured"]
+    assert captured["args"]["content"].startswith("Session goal (turn 1)")
+
+
+def test_capture_memory_brain_mode_uses_legacy_path(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "brain")
+    fake = _plant_fake_estate(monkeypatch)
+    monkeypatch.setattr(
+        cb, "_brain_capture",
+        lambda title, content, tier="episodic", tags=None, **kw: "memories/working/mem-1",
+    )
+    assert cb.capture_memory("t", "c", tier="working") == "memories/working/mem-1"
+    assert fake.calls == []  # estate never touched
+
+
+def test_capture_memory_auto_falls_back_to_brain_on_estate_write_failure(monkeypatch):
+    _plant_fake_estate(monkeypatch)  # call() returns None → write failed
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    monkeypatch.setattr(
+        cb, "_brain_capture",
+        lambda title, content, tier="episodic", tags=None, **kw: "memories/working/mem-2",
+    )
+    assert cb.capture_memory("t", "c", tier="working") == "memories/working/mem-2"
+
+
+def test_capture_memory_fails_open_when_everything_is_dead(monkeypatch):
+    _plant_fake_estate(monkeypatch)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert cb.capture_memory("t", "c") is None
+
+
+def test_capture_memory_rejects_empty_content(monkeypatch):
+    fake = _plant_fake_estate(monkeypatch)
+    assert cb.capture_memory("", "") is None
+    assert fake.calls == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# stats — TTL cache, never per-prompt
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _coverage_call(counter):
+    def call(tool, arguments=None, timeout=8.0):
+        counter["n"] += 1
+        if tool == "knowledge.coverage":
+            return {"total": 11719}
+        if tool == "memory.coverage":
+            return {"total": 205}
+        return None
+    return call
+
+
+def test_stats_estate_shape_and_totals(monkeypatch):
+    _plant_fake_estate(monkeypatch, call=_coverage_call({"n": 0}))
+    s = cb.stats()
+    assert s == {
+        "backend": "estate",
+        "knowledge_total": 11719,
+        "memory_total": 205,
+        "total": 11924,
+    }
+
+
+def test_stats_second_call_is_served_from_cache(monkeypatch):
+    counter = {"n": 0}
+    _plant_fake_estate(monkeypatch, call=_coverage_call(counter))
+    first = cb.stats()
+    probes_after_first = counter["n"]
+    second = cb.stats()
+    assert counter["n"] == probes_after_first  # no re-probe within TTL
+    assert second == first
+
+
+def test_stats_cache_expires_after_ttl(monkeypatch):
+    counter = {"n": 0}
+    _plant_fake_estate(monkeypatch, call=_coverage_call(counter))
+    monkeypatch.setenv("WICKED_CONTEXT_STATS_TTL_SECS", "0")
+    cb.stats()
+    probes_after_first = counter["n"]
+    time.sleep(0.01)
+    cb.stats()
+    assert counter["n"] > probes_after_first
+
+
+def test_stats_failure_is_cached_with_short_ttl(monkeypatch, tmp_path):
+    """A dead estate is not re-probed on every prompt — the failure record
+    short-circuits until its (shorter) TTL lapses."""
+    counter = {"n": 0}
+
+    def dead_call(tool, arguments=None, timeout=8.0):
+        counter["n"] += 1
+        return None
+
+    _plant_fake_estate(monkeypatch, call=dead_call)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert cb.stats() is None
+    probes_after_first = counter["n"]
+    assert cb.stats() is None
+    assert counter["n"] == probes_after_first  # served from failure record
+
+
+def test_stats_brain_mode_passes_through_brain_payload(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "brain")
+    monkeypatch.setattr(
+        cb, "_brain_api",
+        lambda action, params=None, timeout=3.0: {"total": 42} if action == "stats" else None,
+    )
+    assert cb.stats() == {"total": 42, "backend": "brain"}
+
+
+def test_stats_auto_falls_back_to_brain_when_estate_dead(monkeypatch):
+    _plant_fake_estate(monkeypatch)  # coverage → None
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    monkeypatch.setattr(
+        cb, "_brain_api",
+        lambda action, params=None, timeout=3.0: {"total": 7} if action == "stats" else {"status": "ok"},
+    )
+    assert cb.stats() == {"total": 7, "backend": "brain"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hook-facing notes + directive targets
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_gate_note_silent_when_estate_healthy(monkeypatch):
+    _plant_fake_estate(monkeypatch, call=_coverage_call({"n": 0}))
+    assert cb.gate_note() is None
+
+
+def test_gate_note_degraded_when_everything_is_dead(monkeypatch):
+    _plant_fake_estate(monkeypatch)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    monkeypatch.setattr(cb, "_ensure_brain", lambda wait_secs=2.0: False)
+    note = cb.gate_note()
+    assert note is not None
+    assert "fail open" in note or "degraded" in note
+
+
+def test_gate_note_brain_covers_when_estate_dead_in_auto(monkeypatch):
+    _plant_fake_estate(monkeypatch)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    # brain stats also answers, so stats() falls back to brain → healthy
+    monkeypatch.setattr(
+        cb, "_brain_api",
+        lambda action, params=None, timeout=3.0: {"total": 5},
+    )
+    assert cb.gate_note() is None  # brain fallback made stats() healthy
+
+
+def test_staleness_note_empty_estate_store_points_at_migration(monkeypatch):
+    def empty_call(tool, arguments=None, timeout=8.0):
+        return {"total": 0}
+
+    _plant_fake_estate(monkeypatch, call=empty_call)
+    note = cb.staleness_note()
+    assert note is not None and "empty" in note
+
+
+def test_memory_directive_target_brain_while_bridge_alive(monkeypatch):
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert cb.memory_directive_target() == "wicked-brain:memory"
+
+
+def test_memory_directive_target_estate_after_retirement(monkeypatch):
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    assert "memory.capture" in cb.memory_directive_target()
+
+
+def test_memory_directive_target_estate_mode_ignores_brain(monkeypatch):
+    monkeypatch.setenv("WICKED_CONTEXT_BACKEND", "estate")
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert "memory.capture" in cb.memory_directive_target()
+
+
+def test_grounding_lines_follow_the_bridge(monkeypatch):
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: True)
+    assert any("wicked-brain:query" in line for line in cb.grounding_directive_lines())
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    cb._reset_probe_cache()
+    assert any("wicked-garden-search" in line for line in cb.grounding_directive_lines())
+
+
+def test_estate_dependency_missing_binary(monkeypatch):
+    _plant_fake_estate(monkeypatch, resolve_mcp_bin=lambda: None)
+    monkeypatch.setattr(cb, "brain_alive", lambda timeout=1.0: False)
+    available, note = cb.estate_dependency()
+    assert available is False
+    assert "wicked-estate" in note
+
+
+def test_estate_dependency_healthy(monkeypatch):
+    _plant_fake_estate(monkeypatch, call=_coverage_call({"n": 0}))
+    available, note = cb.estate_dependency()
+    assert available is True
+    assert note is None

--- a/tests/test_estate_client.py
+++ b/tests/test_estate_client.py
@@ -206,6 +206,34 @@ def test_unwrap_returns_none_on_garbage():
     assert _estate_client._unwrap({"result": {}}) is None
 
 
+def test_recall_scope_prefix_on_the_wire():
+    """estate #98: recall(scope_prefix=…) sends the param — "" included, since
+    "" means the root subtree (every memory); None omits it entirely (the only
+    shape pre-#98 binaries understand)."""
+    seen = []
+
+    def fake_dispatch(requests, *, db, timeout):
+        out = {1: {"jsonrpc": "2.0", "id": 1,
+                   "result": {"serverInfo": {"name": "wicked-estate"}}}}
+        for r in requests:
+            if r.get("method") == "tools/call":
+                seen.append(r["params"]["arguments"])
+                env = _envelope({"items": []})
+                env["id"] = r["id"]
+                out[r["id"]] = env
+        return out
+
+    _estate_client.set_dispatch(fake_dispatch)
+    assert _estate_client.recall("q") == []
+    assert _estate_client.recall("q", scope_prefix="") == []
+    assert _estate_client.recall("q", scope_prefix="brain:wicked-garden") == []
+    assert len(seen) == 3
+    assert "scope_prefix" not in seen[0]
+    assert seen[1]["scope_prefix"] == ""
+    assert seen[2]["scope_prefix"] == "brain:wicked-garden"
+    assert all(a["query"] == "q" and a["scope"] == "" for a in seen)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # The transport seam — a broker can replace spawn-per-call transparently
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Stage S4 — brain→estate consolidation

Retargets wicked-garden's context-assembly layer (the 9 hooks + the smaht adapter) from the wicked-brain HTTP server onto wicked-estate's stdio MCP, through one new routed seam: **`scripts/_context_backend.py`**. Built on the persistent-broker shim (#1043). Last major code wave before brain retirement (S7).

## Router

**Flag: `WICKED_CONTEXT_BACKEND = estate | brain | auto`** (default `auto`)

| Mode | Behavior |
|---|---|
| `estate` | estate only — brain never consulted |
| `brain` | legacy behavior, byte-for-byte directives (incl. brain auto-start) |
| `auto` | estate primary; **symbolish** queries → brain while the bridge is alive; estate-unreachable → brain covers while alive; **brain retired ⇒ silently estate-only** (fail-open, hooks never crash) |

**Per-class routing (S3 parity bench):** "symbolish" queries — snake_case, dotted paths (≥2 chars/segment), CamelCase (2+ humps), leading-underscore identifiers, path-like tokens, real import statements / `require(` / `::` / `->`, bare code filenames — score better on brain (r@10 **0.786 vs 0.494**), so they keep routing there during the bridge. Everything else goes straight to estate (knowledge side alone: **0.703 vs brain 0.437**).

**Estate retrieval** = `knowledge.recall` + `memory.recall` (root/ancestor-visible scope), fused with RRF (k=60), normalized to `{id, kind, title, snippet, score, source, scope, backend}` — `source` carries estate's #96 attribution, `scope` the memory scope.

**Stats** = `knowledge.coverage` + `memory.coverage`, cached per session/TTL (`WICKED_CONTEXT_STATS_TTL_SECS`, default 300s; failure records re-probe at 60s) — never per prompt.

**Writes** (`capture_memory`) = estate `memory.capture` at the root scope (ancestor-visible, so the hooks' own captures round-trip through unscoped recall); the legacy brain file+index path survives under the flag and as the auto-mode fallback while estate is unreachable.

## Per-consumer mapping

| File | Old brain call | New call |
|---|---|---|
| `scripts/smaht/adapters/brain_adapter.py` | HTTP `search` + retry | `_context_backend.search()` (routed fusion; retry lives in the router's brain path) |
| `hooks/scripts/prompt_submit.py` | `_check_brain_gate` HTTP probe + `ensure_server` | `gate_note()` (routed, stats-cache-backed) |
| `hooks/scripts/prompt_submit.py` | `_write_brain_memory` (session goal) | `capture_memory()` → estate `memory.capture` |
| `hooks/scripts/prompt_submit.py` | brain-worded grounding directive | `grounding_directive_lines()` (backend-aware) |
| `hooks/scripts/bootstrap.py` | `_brain_api("stats")` ×3 (staleness/onboarding/7e) | `staleness_note()` / `stats()` (coverage totals, cached) |
| `hooks/scripts/bootstrap.py` | `_brain_api("lint")` decay | brain-route only (estate owns memory lifecycle in-store) |
| `hooks/scripts/bootstrap.py` | `_check_brain_dependency` (7d) | route-aware: `estate_dependency()` under estate/auto |
| `hooks/scripts/post_tool.py` | `_brain_reindex_file` HTTP `index` | brain-route only (estate keeps its own stores fresh; per-edit `knowledge.write` would duplicate nodes) |
| `hooks/scripts/stop.py` + `scripts/_heavy_cadence.py` | `lint`/`compile` maintenance | brain-route only; fact-emit message backend-neutral |
| `hooks/scripts/pre_compact.py` | `_write_brain_memory` (WIP snapshot) | `capture_memory()`; duplicated brain-write helper deleted (single copy in router) |
| `pre_tool.py` / `task_completed.py` / `notification.py` / `session_end.py` | hardcoded `wicked-brain:memory` directives | `memory_directive_target()` (brain while bridge alive; estate `memory.capture` after) |

## Fail-open guarantees kept

Estate binary missing / broker dead / brain absent ⇒ empty results + a stderr marker, exactly like brain-absent degrades today. Every router entry point catches everything; no hook can crash on a backend outage. `brain` flag mode preserves the legacy nag texts and deterministic brain auto-start verbatim.

## Tests

- `tests/test_context_backend.py` — classifier (pos/neg), flag semantics, RRF fusion + dedupe, fallback routing (estate-dead→brain, brain-dead→estate, both-dead→[]), capture routing, stats TTL cache incl. cached-failure short-circuit, gate/staleness notes, directive targets. Hermetic (fake `_estate_client` in `sys.modules`, monkeypatched brain probes).
- `tests/smaht/test_brain_adapter.py` — ContextItem mapping, per-source dedupe, #96 attribution in metadata, memory titling, fail-open.
- **Full suite: 1079 passed, 13 skipped.**

## Live smoke (real stores, ~/.wicked: 11,719 knowledge nodes + 205 memories)

```
backend_mode: auto            brain_alive: False (bridge down → auto = estate-only)
stats: {'backend': 'estate', 'knowledge_total': 11719, 'memory_total': 205, 'total': 11924}
gate_note: None               staleness_note: None
search("how does the crew workflow decide phases") → 3 results, 191ms
  - chunk | # decide — pick between options with an ADR ... | src: wicked-brain://wicked-garden/chunks/extracted/...
adapter query("crew workflow specialist routing rules") → 9 ContextItems, source=estate, attribution present
```

## Out of scope (later stages)

S5: `skills/search`, wicked-patch, `.codegraph-extractors`. S7: deletion of `_brain_port.py` and every brain-route path added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)