### PR TITLE
test(site): baseline Playwright smoke suite for signature widgets

### DIFF
--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -1,0 +1,49 @@
+name: Site E2E
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - ".github/workflows/site-e2e.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: site
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: site
+      - name: Build site
+        run: npm run build
+        working-directory: site
+      - name: Run e2e smoke suite
+        run: npm run test:e2e
+        working-directory: site
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-report
+          path: site/playwright-report/
+          retention-days: 7

--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 22
+          node-version: '24'
           cache: npm
           cache-dependency-path: site/package-lock.json
       - name: Install dependencies

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -5,6 +5,10 @@ dist/
 # dependencies
 node_modules/
 
+# playwright
+playwright-report/
+test-results/
+
 # local screenshots / scratch
 .playwright-mcp/
 *.local.png

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,9 +16,10 @@
         "motion": "^13.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "wicked-web": "github:mikeparcewski/wicked-web"
+        "wicked-web": "github:mikeparcewski/wicked-web#a3c18aabed02dc8c1696c9491f37b6714d002d19"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/vite": "^4.0.0",
         "@types/node": "^25.9.2",
         "@types/react": "^19.0.0",
@@ -1844,6 +1845,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4825,6 +4842,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview --host",
+    "test:e2e": "playwright test",
     "astro": "astro"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
     "wicked-web": "github:mikeparcewski/wicked-web#a3c18aabed02dc8c1696c9491f37b6714d002d19"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^25.9.2",
     "@types/react": "^19.0.0",

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+const PORT = Number(process.env.E2E_PORT ?? 4333);
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Local cap: a saturated dev machine (parallel suites/builds) starves the
+  // single-process preview server and flakes navigations. CI keeps defaults.
+  workers: process.env.CI ? undefined : 4,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: { baseURL: `http://127.0.0.1:${PORT}`, trace: 'on-first-retry' },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `npm run preview -- --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    // Astro 7 auto-daemonizes `astro preview` when it detects an agentic
+    // environment (via am-i-vibing), which makes the spawned process exit
+    // early and breaks Playwright's webServer lifecycle. Setting this env
+    // (the same guard Astro's own daemon child uses) forces foreground mode.
+    env: { ASTRO_PREVIEW_BACKGROUND: '1' },
+  },
+});

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
-const PORT = Number(process.env.E2E_PORT ?? 4333);
+const rawPort = process.env.E2E_PORT ?? '4333';
+const PORT = Number.parseInt(rawPort, 10);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
+  throw new Error(`E2E_PORT must be a port number (1-65535), got "${rawPort}"`);
+}
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 30_000,

--- a/site/tests/e2e/chrome.spec.ts
+++ b/site/tests/e2e/chrome.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Shared wicked-web chrome (node_modules/wicked-web): theme toggle and the
+ * ecosystem dropdown in the fixed topbar.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('theme toggle flips data-theme on <html> and persists across reload', async ({ page }) => {
+  const html = page.locator('html');
+  // The chrome normalizes to a concrete theme on load (default: light).
+  await expect(html).toHaveAttribute('data-theme', /^(light|dark)$/);
+  const initial = await html.getAttribute('data-theme');
+  const flipped = initial === 'dark' ? 'light' : 'dark';
+
+  await page.locator('#themeBtn').click();
+  await expect(html).toHaveAttribute('data-theme', flipped);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('wa-theme')))
+    .toBe(flipped);
+
+  // Persistence: the no-flash init in Base.astro reads 'wa-theme' before paint.
+  await page.reload();
+  await expect(html).toHaveAttribute('data-theme', flipped);
+});
+
+test('ecosystem dropdown opens on click and closes on Escape', async ({ page }) => {
+  const btn = page.locator('#projectsBtn');
+  const menu = page.locator('#projectsMenu');
+  await expect(menu).toBeHidden();
+
+  await btn.click();
+  await expect(menu).toBeVisible();
+  await expect(btn).toHaveAttribute('aria-expanded', 'true');
+  await expect(menu.getByRole('link', { name: /garden/ })).toBeVisible();
+  await expect(menu.getByRole('link', { name: /crew/ })).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  await expect(btn).toHaveAttribute('aria-expanded', 'false');
+});

--- a/site/tests/e2e/islands.spec.ts
+++ b/site/tests/e2e/islands.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import { expectRevealed, clickCopyChip } from './utils';
+
+/**
+ * Smoke coverage for the six React islands mounted on index.astro
+ * (all client:load): HeroStamp, Toolbox, ProveGate, CapabilityGrid,
+ * InstallBench, CopyChip. Each test asserts the island (a) renders and
+ * (b) responds to one representative interaction.
+ */
+
+// Clipboard permissions so CopyChip's navigator.clipboard.writeText resolves
+// (the component swallows clipboard errors, so without this the "copied"
+// feedback never appears).
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('hero renders headline, stats, and install command', async ({ page }) => {
+  await expect(page).toHaveTitle(/wicked-garden/);
+  await expect(page.locator('h1')).toContainText('The tools your coding agent');
+  await expect(page.locator('.gd-hero-stats')).toContainText('94');
+  await expect(
+    page.locator('#hero').getByRole('button', { name: 'Copy command: npx wicked-installer' }),
+  ).toBeVisible();
+});
+
+test('HeroStamp: renders and pinning a claim shows its verdict', async ({ page }) => {
+  const card = page.locator('.hs-card');
+  await card.scrollIntoViewIfNeeded();
+  await expect(card).toBeVisible();
+  await expect(card.getByRole('tab')).toHaveCount(4);
+
+  // Interaction: pick claim 2 ("reviewed — safe to merge" → RE-DERIVED).
+  const pip = card.getByRole('tab', { name: /^claim 2/ });
+  await pip.click();
+  await expect(pip).toHaveAttribute('aria-selected', 'true');
+  await expect(card.locator('.hs-afford')).toContainText('driving');
+  await expect(card.locator('.hs-claim')).toContainText('reviewed');
+  // asserting → stamped after ~1.1s; the pinned claim keeps its stamp.
+  await expect(card.locator('.hs-mark')).toContainText('RE-DERIVED');
+});
+
+test('Toolbox: renders six tools and clicking one pins its demo + command', async ({ page }) => {
+  const box = page.locator('#toolbox');
+  await box.scrollIntoViewIfNeeded();
+  const rail = box.getByRole('tablist', { name: 'garden tools' });
+  await expect(rail.getByRole('tab')).toHaveCount(6);
+
+  // Interaction: pin the "patch" tool — stops auto-play, swaps the stage.
+  const patchTab = rail.getByRole('tab', { name: /patch/ });
+  await patchTab.click();
+  await expect(patchTab).toHaveAttribute('aria-selected', 'true');
+  await expect(box.locator('.tb-afford')).toContainText('driving');
+  await expect(box.locator('.tb-stage-name')).toHaveText('patch');
+  await expect(box.locator('.tb-stage')).toContainText('wicked-garden-engineering');
+
+  // Resume auto-play — affordance flips back.
+  await box.getByRole('button', { name: /resume auto-play/ }).click();
+  await expect(box.locator('.tb-afford')).toContainText('auto-playing');
+});
+
+test('ProveGate: driving the gate re-derives PROVED, breaking the vault FAILS CLOSED', async ({
+  page,
+}) => {
+  const gate = page.locator('#gate');
+  await gate.scrollIntoViewIfNeeded();
+  const machine = gate.getByRole('region', { name: /Evidence gate/ });
+  await expect(machine).toBeVisible();
+  await expect(machine.getByRole('switch')).toHaveCount(4);
+
+  // Take control deterministically: reset stops auto-play and re-arms the bench.
+  await machine.getByRole('button', { name: 'reset the bench' }).click();
+  await expect(gate.locator('.pg-afford')).toContainText('driving the gate');
+
+  // All four conditions hold → PROVED.
+  const lever = machine.getByRole('button', { name: 'Pull the PROVE lever' });
+  await lever.click();
+  await expect(machine.locator('.pg-mark-word')).toHaveText('PROVED');
+
+  // Break the vault condition → the gate FAILS CLOSED (never a vacuous pass).
+  const vault = machine.getByRole('switch', { name: /vault backend present/ });
+  await vault.click();
+  await expect(vault).toHaveAttribute('aria-checked', 'false');
+  await lever.click();
+  await expect(machine.locator('.pg-mark-word')).toHaveText('FAILS CLOSED');
+});
+
+test('CapabilityGrid: 12 domain cards + 4 peers render and reveal on scroll', async ({ page }) => {
+  const grid = page.locator('#toolkit');
+  await grid.scrollIntoViewIfNeeded();
+  await expect(grid.getByRole('heading', { name: /Six tools were the sample/ })).toBeVisible();
+  await expect(grid.locator('.cg-card')).toHaveCount(12);
+  await expect(grid.locator('.cg-peer')).toHaveCount(4);
+  // The island is presentational — its dynamic behavior is the scroll-triggered
+  // reveal. Assert the fade-in actually completed (opacity → 1).
+  await expectRevealed(grid.locator('.cg-grid'));
+  await expect(grid.locator('.cg-card').first()).toContainText('skills');
+});
+
+test('InstallBench: renders both install paths; copy chip gives feedback', async ({ page }) => {
+  const bench = page.locator('#install');
+  await bench.scrollIntoViewIfNeeded();
+  await expect(bench.getByRole('heading', { name: /One command/ })).toBeVisible();
+  await expectRevealed(bench.getByRole('heading', { name: /One command/ }));
+
+  // Interaction: copy the direct-install command.
+  const chip = bench.getByRole('button', {
+    name: 'Copy command: claude plugins install wicked-garden',
+  });
+  await clickCopyChip(chip);
+});
+
+test('CopyChip: click copies the command to the clipboard', async ({ page }) => {
+  const chip = page
+    .locator('#hero')
+    .getByRole('button', { name: 'Copy command: npx wicked-installer' });
+  await clickCopyChip(chip);
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe('npx wicked-installer');
+});

--- a/site/tests/e2e/mobile.spec.ts
+++ b/site/tests/e2e/mobile.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Mobile smoke at iPhone 12 dimensions (390x844). The viewport is set
+ * explicitly instead of spreading devices['iPhone 12'] because that device
+ * descriptor carries defaultBrowserType: 'webkit', which would silently move
+ * the test off the cached Chromium build.
+ */
+test.use({
+  viewport: { width: 390, height: 844 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+test('mobile: page renders, hero island visible, hamburger menu opens', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('h1')).toContainText('The tools your coding agent');
+
+  // The hero island has no mobile fallback — the grid collapses to one column
+  // and the HeroStamp card renders below the pitch (site.css @max-width:1000px).
+  const card = page.locator('.hs-card');
+  await card.scrollIntoViewIfNeeded();
+  await expect(card).toBeVisible();
+  await expect(card.locator('.hs-claim')).not.toBeEmpty();
+
+  // No horizontal overflow — the page must not scroll sideways on a phone.
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(1);
+
+  // Mobile chrome: inline nav collapses behind the hamburger; menu opens.
+  const menuBtn = page.locator('#menuBtn');
+  await expect(menuBtn).toBeVisible();
+  await menuBtn.click();
+  await expect(page.locator('#mobileMenu')).toBeVisible();
+  await expect(page.locator('#mobileMenu').getByRole('link', { name: /garden/ })).toBeVisible();
+});

--- a/site/tests/e2e/reduced-motion.spec.ts
+++ b/site/tests/e2e/reduced-motion.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { expectRevealed } from './utils';
+
+/**
+ * prefers-reduced-motion smoke. The site leans on animation (CSS keyframes,
+ * IntersectionObserver reveals, the motion library in the component library),
+ * and every animated component carries its own reduced-motion branch — this
+ * asserts none of those branches throw and the page still fully renders.
+ */
+test.use({ contextOptions: { reducedMotion: 'reduce' } });
+
+test('reduced motion: zero page errors and every key section visible', async ({ page }) => {
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+
+  await page.goto('/');
+  await expect(page.locator('h1')).toContainText('The tools your coding agent');
+
+  // Walk every section; Reveal short-circuits to visible under reduced motion.
+  const sections: Array<[string, RegExp]> = [
+    ['#toolbox', /Six gaps your agent/],
+    ['#gate', /Play the lying agent/],
+    ['#toolkit', /Six tools were the sample/],
+    ['#install', /One command/],
+  ];
+  for (const [id, heading] of sections) {
+    const section = page.locator(id);
+    await section.scrollIntoViewIfNeeded();
+    const h2 = section.getByRole('heading', { name: heading });
+    await expect(h2).toBeVisible();
+    await expectRevealed(h2);
+  }
+
+  // The hero island still runs its (shortened) verdict loop without throwing.
+  await page.locator('.hs-card').scrollIntoViewIfNeeded();
+  await expect(page.locator('.hs-card .hs-stage')).toBeVisible();
+
+  expect(errors, `pageerror events: ${errors.map((e) => e.message).join('; ')}`).toEqual([]);
+});

--- a/site/tests/e2e/utils.ts
+++ b/site/tests/e2e/utils.ts
@@ -1,0 +1,38 @@
+import { expect, type Locator } from '@playwright/test';
+
+/**
+ * Assert that the nearest <Reveal> wrapper around `target` has finished its
+ * fade-in. Playwright's toBeVisible() ignores opacity, so an element inside a
+ * still-transparent Reveal wrapper would pass a plain visibility check while
+ * being invisible to a human. This walks up to the nearest ancestor carrying
+ * an inline opacity style (the Reveal div) and polls its computed opacity.
+ */
+export async function expectRevealed(target: Locator): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        target.evaluate((el) => {
+          let node: HTMLElement | null = el as HTMLElement;
+          while (node) {
+            if (node.style && node.style.opacity !== '') return getComputedStyle(node).opacity;
+            node = node.parentElement;
+          }
+          return '1'; // no Reveal wrapper — nothing to wait for
+        }),
+      { timeout: 10_000, message: 'Reveal wrapper should reach opacity 1' },
+    )
+    .toBe('1');
+}
+
+/**
+ * Click `chip` (a CopyChip) until its transient "copied" feedback shows.
+ * The feedback auto-clears after 1.4s, so the click + assertion are retried
+ * as a unit instead of racing a fixed observation window.
+ */
+export async function clickCopyChip(chip: Locator): Promise<void> {
+  await chip.scrollIntoViewIfNeeded();
+  await expect(async () => {
+    await chip.click();
+    await expect(chip).toContainText('copied', { timeout: 1_200 });
+  }).toPass({ timeout: 15_000 });
+}


### PR DESCRIPTION
## Summary

Baseline Playwright smoke coverage for the wicked-garden marketing site's signature React islands — the executable "as-good-or-better" bar ahead of the site redesign. The site had zero test coverage.

**11 tests, ~20s runtime, Chromium:**
- HeroStamp: pin a claim pip → verdict shown, RE-DERIVED stamp
- Toolbox: click a tool tab → demo + command pinned, auto-play resume
- ProveGate: drive the gate → PROVED; flip the vault switch → FAILS CLOSED (deny-dominates)
- CapabilityGrid: 12 domain cards + 4 peers render, scroll-reveal completes (computed-opacity poll)
- InstallBench: install-path copy chip gives "copied" feedback
- CopyChip: click → clipboard readback equals the install command
- Universal chrome: theme toggle flips `data-theme` and persists `wa-theme` across reload; ecosystem dropdown opens/closes
- Mobile (390x844): hero island + one-column collapse, no horizontal overflow, hamburger opens
- Reduced motion: zero page errors, all 5 sections visible and Reveal-completed

## CI

New `.github/workflows/site-e2e.yml` runs the suite on PRs touching `site/**` (build + Playwright, Chromium only). Deliberately **not** wired into `pages.yml` deploys yet.

## Notes

- Tests are resilient to IntersectionObserver/setInterval autoplay and async island hydration (polling assertions, no fixed sleeps).
- Astro 7 auto-daemonizes `astro preview` in agentic environments — the Playwright config sets `ASTRO_PREVIEW_BACKGROUND=1` to keep it foreground (no-op in CI).
- CapabilityGrid has no interactive controls in source (presentational) — covered at render + scroll-reveal level; if the redesign adds interactivity the test must grow with it.

Scope: only `site/**` plus the one new workflow file — no non-site code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
