### PR TITLE
feat(mem): rebuild the auto-memorize loop on estate (task #76)

### DIFF
--- a/WICKED_GARDEN_BUS_EVENTS.md
+++ b/WICKED_GARDEN_BUS_EVENTS.md
@@ -89,7 +89,7 @@ These fields are **stripped automatically** by `_bus.py` before emission:
 
 | Event Type | Subdomain | Description |
 |------------|-----------|-------------|
-| `wicked.garden.fact.extracted` | `facts` | Structured fact extracted from conversation (consumed by wicked-brain auto-memorize) |
+| `wicked.garden.fact.extracted` | `facts` | Structured fact extracted from conversation (consumed by the garden-run auto-memorize drain, scripts/mem/auto_memorize.py, which persists to wicked-estate memory) |
 
 ### Gate
 

--- a/hooks/scripts/stop.py
+++ b/hooks/scripts/stop.py
@@ -19,6 +19,7 @@ Runs async so it does NOT block the user on exit.
 
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -263,13 +264,15 @@ _EMITTABLE_FACT_TYPES = frozenset({"decision", "discovery"})
 _MIN_FACT_CONTENT_LENGTH = 15
 
 
-def _run_memory_promotion(session_id: str) -> list:
+def _run_memory_promotion(session_id: str, transcript_path: Optional[str] = None) -> list:
     """Emit high-value session facts as wicked.garden.fact.extracted events on wicked-bus.
 
-    Reads native task records (TaskCreate/TaskUpdate output) via
-    scripts/mem/session_fact_extractor.py, filters to decisions + discoveries
-    over the length threshold, and emits one event per fact. Brain's
-    auto-memorize subscriber handles persistence asynchronously.
+    Reads native task records (TaskCreate/TaskUpdate output) plus the session
+    transcript tail via scripts/_brain_ingest/session_fact_extractor.py,
+    filters to decisions + discoveries over the length threshold, skips facts
+    this session already emitted (per-session ledger — Stop fires every turn),
+    and emits one event per fact. The garden-run auto-memorize consumer
+    (scripts/mem/auto_memorize.py) persists them to wicked-estate memory.
 
     Returns a list of message strings (empty when nothing was emitted or the
     bus is unavailable). Always fails open — exceptions are caught and logged
@@ -279,10 +282,15 @@ def _run_memory_promotion(session_id: str) -> list:
         # scripts/ is on sys.path via the hook bootstrap; _brain_ingest is a
         # package under scripts/ so the qualified import resolves without any
         # additional sys.path manipulation.
-        from _brain_ingest.session_fact_extractor import extract_session_facts
+        from _brain_ingest.session_fact_extractor import (
+            extract_session_facts,
+            filter_unemitted,
+            mark_emitted,
+        )
         from _bus import emit_event
 
-        facts = extract_session_facts(session_id, limit=20)
+        facts = extract_session_facts(session_id, limit=20, transcript_path=transcript_path)
+        facts = filter_unemitted(facts, session_id)
         if not facts:
             if os.environ.get("WICKED_DEBUG"):
                 print(
@@ -292,6 +300,7 @@ def _run_memory_promotion(session_id: str) -> list:
             return []
 
         emitted = 0
+        emitted_facts = []
         for fact in facts:
             if fact.type not in _EMITTABLE_FACT_TYPES:
                 continue
@@ -308,13 +317,55 @@ def _run_memory_promotion(session_id: str) -> list:
                 },
             )
             emitted += 1
+            emitted_facts.append(fact)
 
         if emitted == 0:
             return []
-        return [f"[Memory] Emitted {emitted} fact event(s); wicked-brain will auto-memorize eligible ones."]
+        mark_emitted(emitted_facts, session_id)
+        return [f"[Memory] Emitted {emitted} fact event(s); the auto-memorize drain persists eligible ones to estate."]
 
     except Exception as e:
         print(f"[wicked-garden] fact emit error: {e}", file=sys.stderr)
+        return []
+
+
+def _run_auto_memorize_drain() -> list:
+    """Drain pending fact events into estate memory (garden-run consumer).
+
+    Replaces wicked-brain's server-side auto-memorize subscriber (S7): spawns
+    scripts/mem/auto_memorize.py, which polls the durable wicked-garden-mem
+    cursor, promotes + dedups each fact, and writes via estate memory.capture.
+    A failed estate write leaves the cursor put (at-least-once — next Stop
+    retries; three failed drains dead-letter the event natively). Always fails
+    open and never blocks session end.
+    """
+    try:
+        from _bus import _check_available
+        if not _check_available():
+            return []
+    except Exception:
+        return []
+    try:
+        script = _PLUGIN_ROOT / "scripts" / "mem" / "auto_memorize.py"
+        if not script.is_file():
+            return []
+        proc = subprocess.run(
+            [sys.executable, str(script), "drain", "{}"],
+            capture_output=True, text=True, timeout=25,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return []
+        result = json.loads(proc.stdout.strip().splitlines()[-1])
+        stored = result.get("stored", 0)
+        dead = result.get("dead_lettered", 0)
+        if stored or dead:
+            msg = f"[Memory] Auto-memorized {stored} fact(s) into estate"
+            if dead:
+                msg += f"; {dead} dead-lettered (see `wicked-bus dlq list`)"
+            return [msg + "."]
+        return []
+    except Exception as e:
+        print(f"[wicked-garden] auto-memorize drain error: {e}", file=sys.stderr)
         return []
 
 
@@ -558,7 +609,16 @@ def main():
         # self-reports cleanly, and the next session's bootstrap relies on
         # memories being current. Heavy cadence work (decay/consolidation/
         # telemetry/guard) was extracted in v9.2.15 — see _heavy_cadence.py.
-        promotion_messages = _run_memory_promotion(session_id)
+        promotion_messages = _run_memory_promotion(
+            session_id, input_data.get("transcript_path")
+        )
+
+        # 2c. Auto-memorize drain — the garden-run consumer of the fact events
+        # (brain's server subscriber retired at S7). Durable cursor: events
+        # emitted here (or left over from earlier sessions) land in estate
+        # memory; failures redeliver next Stop.
+        drain_messages = _run_auto_memorize_drain()
+        promotion_messages = promotion_messages + drain_messages
 
         # 4. Persist session state
         _persist_session_state()

--- a/scripts/_brain_ingest/session_fact_extractor.py
+++ b/scripts/_brain_ingest/session_fact_extractor.py
@@ -31,11 +31,13 @@ stdlib-only. Fails open — returns [] on any I/O or parse error.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import sys
 import uuid
+from collections import deque
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -206,6 +208,136 @@ def _iter_task_records(session_id: str) -> Iterable[dict]:
     yield from _iter_task_records_direct(session_id)
 
 
+# --- Transcript source (starvation fix, task #76) ---------------------------
+#
+# Native task records turned out to be a starved source: TaskCreate/TaskUpdate
+# files exist for almost no session, so `wicked.garden.fact.extracted` was
+# never emitted (zero events in a 54MB live bus DB). The transcript the Stop
+# hook already receives on stdin is the real conversation record — run the
+# same patterns over its recent turns.
+
+_TRANSCRIPT_TAIL_LINES = 400   # per-turn Stop scans the recent window; earlier
+                               # turns were scanned by earlier Stops.
+_TRANSCRIPT_MAX_TEXT = 8000    # cap a single message's text (defensive)
+
+
+def _message_text(entry: dict) -> str:
+    """Text of one transcript JSONL entry (user/assistant), '' otherwise."""
+    if not isinstance(entry, dict) or entry.get("type") not in ("user", "assistant"):
+        return ""
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content[:_TRANSCRIPT_MAX_TEXT]
+    if isinstance(content, list):
+        parts = [
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        return "\n".join(p for p in parts if p)[:_TRANSCRIPT_MAX_TEXT]
+    return ""
+
+
+def _iter_transcript_texts(transcript_path: str) -> Iterable[str]:
+    """Yield user/assistant text blocks from the transcript JSONL tail."""
+    try:
+        path = Path(transcript_path)
+        if not path.is_file():
+            return
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            tail = deque(fh, maxlen=_TRANSCRIPT_TAIL_LINES)
+    except OSError:
+        return
+    for line in tail:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        text = _message_text(entry)
+        if text:
+            yield text
+
+
+def extract_transcript_facts(transcript_path: str, limit: int = 10) -> list:
+    """Extract facts from the session transcript's recent turns.
+
+    Same patterns and dedup as the task source; `source` is marked
+    "transcript" so consumers can tell the two apart. Fails open.
+    """
+    if not transcript_path or limit <= 0:
+        return []
+    facts: list = []
+    seen: set = set()
+    try:
+        for text in _iter_transcript_texts(transcript_path):
+            for fact in _extract_from_text(text, task_id="transcript"):
+                fact.source = "transcript"
+                key = fact.content.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                facts.append(fact)
+                if len(facts) >= limit:
+                    return facts
+    except Exception as exc:  # pragma: no cover - defensive fail-open
+        print(f"[wicked-mem] transcript fact extraction error: {exc}", file=sys.stderr)
+    return facts
+
+
+# --- Per-session emitted ledger ----------------------------------------------
+#
+# Stop fires every turn and the transcript is cumulative, so without a ledger
+# the same fact would be re-emitted each turn. One small JSON file per session
+# records the content hashes already emitted; the consumer's global
+# content-hash dedup remains the cross-session guard.
+
+def _emitted_ledger_path(session_id: str) -> Path:
+    override = os.environ.get("WICKED_MEM_LEDGER_DIR")
+    base = Path(override) if override else (
+        Path.home() / ".something-wicked" / "wicked-garden" / "local" / "wicked-mem"
+    )
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_id or "default")[:80]
+    return base / "emitted" / f"{safe}.json"
+
+
+def _fact_hash(content: str) -> str:
+    """Same normalization as scripts/mem/auto_memorize.content_hash."""
+    normalized = re.sub(r"\s+", " ", str(content or "").strip()).lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def filter_unemitted(facts: list, session_id: str) -> list:
+    """Facts whose content this session has not emitted yet. Fails open (all)."""
+    try:
+        raw = _emitted_ledger_path(session_id).read_text(encoding="utf-8")
+        emitted = set(json.loads(raw))
+    except (OSError, ValueError):
+        emitted = set()
+    return [f for f in facts if _fact_hash(f.content) not in emitted]
+
+
+def mark_emitted(facts: list, session_id: str) -> None:
+    """Record facts as emitted for this session. Fails open."""
+    if not facts:
+        return
+    path = _emitted_ledger_path(session_id)
+    try:
+        emitted = set(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError):
+        emitted = set()
+    emitted.update(_fact_hash(f.content) for f in facts)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(sorted(emitted)), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _extract_from_text(text: str, task_id: str) -> list:
     """Extract facts from a text block (task subject + description)."""
     if not text:
@@ -237,8 +369,17 @@ def _extract_from_text(text: str, task_id: str) -> list:
     return facts[:5]
 
 
-def extract_session_facts(session_id: str, limit: int = 10) -> list:
-    """Extract session-level facts from native task records.
+def extract_session_facts(
+    session_id: str,
+    limit: int = 10,
+    transcript_path: Optional[str] = None,
+) -> list:
+    """Extract session-level facts from native task records + the transcript.
+
+    Task records come first (structured, higher precision); the transcript
+    tail (when a path is provided) fills the remaining budget — that source
+    is what actually feeds the pipeline in practice, since native task files
+    exist for almost no session (the auto-memorize starvation, task #76).
 
     Returns a list of SessionFact objects (up to `limit`), deduplicated by
     lowercased content. Fails open — returns [] on any error.
@@ -272,6 +413,14 @@ def extract_session_facts(session_id: str, limit: int = 10) -> list:
     except Exception as exc:  # pragma: no cover - defensive fail-open
         print(f"[wicked-mem] session fact extraction error: {exc}", file=sys.stderr)
         return facts
+
+    if transcript_path and len(facts) < limit:
+        for fact in extract_transcript_facts(transcript_path, limit - len(facts)):
+            key = fact.content.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            facts.append(fact)
 
     return facts
 

--- a/scripts/_brain_ingest/session_fact_extractor.py
+++ b/scripts/_brain_ingest/session_fact_extractor.py
@@ -297,12 +297,20 @@ def extract_transcript_facts(transcript_path: str, limit: int = 10) -> list:
 # content-hash dedup remains the cross-session guard.
 
 def _emitted_ledger_path(session_id: str) -> Path:
-    override = os.environ.get("WICKED_MEM_LEDGER_DIR")
-    base = Path(override) if override else (
-        Path.home() / ".something-wicked" / "wicked-garden" / "local" / "wicked-mem"
-    )
     safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_id or "default")[:80]
-    return base / "emitted" / f"{safe}.json"
+    override = os.environ.get("WICKED_MEM_LEDGER_DIR")  # test seam
+    if override:
+        return Path(override) / "emitted" / f"{safe}.json"
+    try:
+        _scripts = str(Path(__file__).resolve().parents[1])
+        if _scripts not in sys.path:
+            sys.path.insert(0, _scripts)
+        from _paths import get_local_path  # project-scoped storage root
+        return get_local_path("wicked-mem", "emitted") / f"{safe}.json"
+    except Exception:
+        # Fail-open fallback mirroring the _paths layout root.
+        return (Path.home() / ".something-wicked" / "wicked-garden"
+                / "local" / "wicked-mem" / "emitted" / f"{safe}.json")
 
 
 def _fact_hash(content: str) -> str:

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -294,7 +294,7 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
     "wicked.garden.fact.extracted": {
         "domain": "smaht",
         "subdomain": "facts",
-        "description": "Structured fact extracted from conversation (consumed by wicked-brain auto-memorize)",
+        "description": "Structured fact extracted from conversation (consumed by the garden-run auto-memorize drain -> estate memory)",
     },
     # wicked-testing integration — test-lifecycle verdict event (#549, AC-25).
     # Renamed to the wicked-bus SPEC form wicked.test.<noun>.<past-verb>

--- a/scripts/mem/auto_memorize.py
+++ b/scripts/mem/auto_memorize.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""auto_memorize.py — the estate rebuild of brain's auto-memorize loop.
+
+wicked-brain's server ran a wicked-bus subscriber (memory-subscriber.mjs)
+that consumed ``wicked.garden.fact.extracted`` events and wrote memory files.
+Brain retires at S7; this module is the garden-run replacement: the SAME
+promotion policy (promoteFact: decision/discovery only, length floor,
+importance→tier) and the SAME content-hash dedup, but persistence goes to
+**wicked-estate** via ``memory.capture`` through the mem backend plumbing.
+Estate itself stays bus-free by design — garden owns the consumer.
+
+Consumption model — drain-on-invoke
+-----------------------------------
+No daemon. The Stop hook (and anything else that wants to) invokes
+``drain``, which:
+
+  1. runs ``wicked-bus subscribe --once --no-ack`` under the dedicated
+     subscriber identity (plugin ``wicked-garden-mem``, durable cursor,
+     ``cursor_init latest`` on first registration — no historical replay);
+  2. processes each pending event in order: promote → content-hash dedup →
+     ``memory.capture`` via the estate shim;
+  3. advances the durable cursor (CLI ``ack``) only past events that were
+     stored, deduped, skipped, or dead-lettered.
+
+At-least-once is preserved: a failed estate write leaves the cursor put, so
+the event redelivers on the next drain (the retry "backoff" is the next hook
+invocation). Retry bookkeeping and dead-letters use wicked-bus's OWN tables
+(``delivery_attempts``, ``dead_letters``) so ``wicked-bus dlq list|replay``
+sees them exactly as it saw brain's — after ``MAX_ATTEMPTS`` failed drains an
+event is dead-lettered and the cursor moves on (the pipeline never wedges).
+
+Dedup
+-----
+Brain deduped via findByContentHash over its index. Estate has no
+content-hash lookup, so the consumer keeps its own ledger (JSON,
+``~/.something-wicked/wicked-garden/local/wicked-mem/auto_memorize_hashes.json``)
+keyed by the same normalization brain used: trim, collapse whitespace,
+lowercase, sha256.
+
+Fail-open contract: bus or estate absent → ``{"ok": false, "reason": ...}``,
+exit 0; only usage errors exit 1. Stdlib-only; direct sqlite is used ONLY for
+the two native bus tables above plus the cursor lookup (the same pattern
+brain's fastForwardStaleCursor used).
+
+Usage
+-----
+  python3 scripts/mem/auto_memorize.py drain '{}'
+  python3 scripts/mem/auto_memorize.py status '{}'
+"""
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from mem import estate_memory  # noqa: E402
+
+PLUGIN = "wicked-garden-mem"
+FACT_FILTER = "wicked.garden.fact.extracted"
+MAX_ATTEMPTS = 3          # mirrors brain's subscriber (maxRetries: 3)
+_CLI_TIMEOUT = 30.0
+
+# promoteFact policy — ported from brain server/lib/memory-promoter.mjs.
+_ALLOWED_TYPES = frozenset({"decision", "discovery"})
+_MIN_CONTENT_LENGTH = 15
+_IMPORTANCE_BY_TYPE = {"decision": 7, "discovery": 4}
+_MAX_TAGS = 15
+# fact type → estate memory kind (skills/mem/refs/scopes.md mapping).
+_KIND_BY_TYPE = {"decision": "fact", "discovery": "episode"}
+
+
+def _emit(obj):
+    sys.stdout.write(json.dumps(obj))
+    sys.stdout.write("\n")
+
+
+# ── promotion policy (pure) ──────────────────────────────────────────────────
+
+def content_hash(content):
+    """Brain-compatible content hash: trim, collapse whitespace, lowercase."""
+    normalized = re.sub(r"\s+", " ", str(content or "").strip()).lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def promote_fact(event):
+    """Apply brain's auto-memorize promotion policy to a bus event.
+
+    Pure function. Returns ``(memory_args, None)`` where memory_args feeds
+    ``estate_memory._capture_one``, or ``(None, skip_reason)``.
+    """
+    if not isinstance(event, dict) or event.get("event_type") != FACT_FILTER:
+        return None, "wrong event_type"
+    payload = event.get("payload")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None, "malformed payload"
+    if not isinstance(payload, dict):
+        return None, "malformed payload"
+
+    fact_type = payload.get("type")
+    if fact_type not in _ALLOWED_TYPES:
+        return None, f"type {fact_type} not auto-promoted"
+    content = payload.get("content")
+    if not isinstance(content, str):
+        return None, "missing payload.content"
+    trimmed = content.strip()
+    if len(trimmed) < _MIN_CONTENT_LENGTH:
+        return None, "content too short"
+
+    importance = _IMPORTANCE_BY_TYPE[fact_type]
+    tier = "semantic" if importance >= 7 else "episodic"
+    entities = payload.get("entities")
+    about = []
+    if isinstance(entities, list):
+        about = [str(e) for e in entities if e][: _MAX_TAGS - 1]
+    if fact_type not in about:
+        about.append(fact_type)
+
+    return {
+        "content": trimmed,
+        "kind": _KIND_BY_TYPE[fact_type],
+        "tier": tier,
+        "about": about[:_MAX_TAGS],
+        "content_hash": content_hash(trimmed),
+        "session_id": payload.get("session_id") or "",
+    }, None
+
+
+# ── dedup ledger ─────────────────────────────────────────────────────────────
+
+def _ledger_path():
+    override = os.environ.get("WICKED_MEM_LEDGER_DIR")
+    base = Path(override) if override else (
+        Path.home() / ".something-wicked" / "wicked-garden" / "local" / "wicked-mem"
+    )
+    return base / "auto_memorize_hashes.json"
+
+
+def _load_ledger():
+    try:
+        data = json.loads(_ledger_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_ledger(ledger):
+    try:
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(ledger), encoding="utf-8")
+    except OSError:
+        pass  # fail open — worst case is a duplicate memory next drain
+
+
+# ── wicked-bus plumbing (CLI first; direct sqlite only for native tables) ────
+
+def _bus_cmd(*args):
+    return ["npx", "--yes", "wicked-bus", *args]
+
+
+def _run_cli(*args, timeout=_CLI_TIMEOUT):
+    """Run a wicked-bus CLI command. Returns (returncode, stdout) — (-1, "") on spawn failure."""
+    try:
+        proc = subprocess.run(
+            _bus_cmd(*args), capture_output=True, text=True, timeout=timeout,
+        )
+        return proc.returncode, proc.stdout or ""
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return -1, ""
+
+
+def _bus_db_path():
+    """Resolve the bus DB the same way wicked-bus paths.js does (env → home)."""
+    override = os.environ.get("WICKED_BUS_DATA_DIR")
+    base = Path(override) if override else (
+        Path.home() / ".something-wicked" / "wicked-bus"
+    )
+    return base / "bus.db"
+
+
+def _bus_db():
+    path = _bus_db_path()
+    if not path.is_file():
+        return None
+    try:
+        conn = sqlite3.connect(str(path), timeout=3.0)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.Error:
+        return None
+
+
+def _find_cursor(conn):
+    """(cursor_id, subscription_id, last_event_id) for our plugin+filter, or None."""
+    try:
+        row = conn.execute(
+            """SELECT c.cursor_id, c.subscription_id, c.last_event_id
+                 FROM subscriptions s
+                 JOIN cursors c ON c.subscription_id = s.subscription_id
+                WHERE s.plugin = ? AND s.event_type_filter = ?
+                  AND s.role = 'subscriber'
+                  AND s.deregistered_at IS NULL AND c.deregistered_at IS NULL
+                ORDER BY s.registered_at DESC LIMIT 1""",
+            (PLUGIN, FACT_FILTER),
+        ).fetchone()
+        return (row["cursor_id"], row["subscription_id"], row["last_event_id"]) if row else None
+    except sqlite3.Error:
+        return None
+
+
+def _get_attempts(conn, cursor_id, event_id):
+    try:
+        row = conn.execute(
+            "SELECT attempts FROM delivery_attempts WHERE cursor_id = ? AND event_id = ?",
+            (cursor_id, event_id),
+        ).fetchone()
+        return int(row["attempts"]) if row else 0
+    except sqlite3.Error:
+        return 0
+
+
+def _record_attempt(conn, cursor_id, event_id, attempts, error):
+    try:
+        conn.execute(
+            """INSERT INTO delivery_attempts (cursor_id, event_id, attempts, last_attempt_at, last_error)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(cursor_id, event_id) DO UPDATE SET
+                 attempts = excluded.attempts,
+                 last_attempt_at = excluded.last_attempt_at,
+                 last_error = excluded.last_error""",
+            (cursor_id, event_id, attempts, int(time.time() * 1000), str(error)[:500]),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        pass
+
+
+def _clear_attempts(conn, cursor_id, event_id):
+    try:
+        conn.execute(
+            "DELETE FROM delivery_attempts WHERE cursor_id = ? AND event_id = ?",
+            (cursor_id, event_id),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        pass
+
+
+def _dead_letter(conn, cursor_id, subscription_id, event, attempts, reason):
+    """Native dead-letter insert — the same row subscribe()'s moveToDeadLetter
+    writes, so ``wicked-bus dlq list|replay|drop`` operate on it unchanged."""
+    try:
+        payload = event.get("payload")
+        if not isinstance(payload, str):
+            payload = json.dumps(payload)
+        conn.execute(
+            """INSERT INTO dead_letters (
+                 cursor_id, subscription_id, event_id, event_type, domain,
+                 subdomain, payload, emitted_at, attempts, last_error, dead_lettered_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                cursor_id, subscription_id, event.get("event_id"),
+                event.get("event_type", ""), event.get("domain", ""),
+                event.get("subdomain") or "", payload,
+                int(event.get("emitted_at") or time.time() * 1000),
+                attempts, str(reason)[:500], int(time.time() * 1000),
+            ),
+        )
+        conn.commit()
+        return True
+    except sqlite3.Error:
+        return False
+
+
+# ── the drain ────────────────────────────────────────────────────────────────
+
+def _handle_promoted(memory, ledger):
+    """Promote-result → estate write with dedup. Returns (ok, err)."""
+    if memory["content_hash"] in ledger:
+        return True, "dedup"
+    memory_id, err = estate_memory._capture_one({
+        "content": memory["content"],
+        "kind": memory["kind"],
+        "tier": memory["tier"],
+        "about": memory["about"],
+    })
+    if memory_id:
+        ledger[memory["content_hash"]] = memory_id
+        return True, None
+    return False, err
+
+
+def _drain_replays(conn, cursor_id, ledger):
+    """Honor `wicked-bus dlq replay` — mirror subscribe()'s drainReplays():
+    one attempt per replayed row; success deletes the DLQ row, failure clears
+    the replay mark and bumps attempts/last_error so the operator can re-replay
+    after fixing the fault. Returns (replayed, failed)."""
+    replayed = failed = 0
+    while True:
+        try:
+            row = conn.execute(
+                """SELECT dl_id, event_id, event_type, domain, subdomain, payload, emitted_at
+                     FROM dead_letters
+                    WHERE cursor_id = ? AND replay_requested_at IS NOT NULL
+                    ORDER BY dl_id ASC LIMIT 1""",
+                (cursor_id,),
+            ).fetchone()
+        except sqlite3.Error:
+            return replayed, failed
+        if not row:
+            return replayed, failed
+        event = {
+            "event_id": row["event_id"], "event_type": row["event_type"],
+            "domain": row["domain"], "subdomain": row["subdomain"],
+            "payload": row["payload"], "emitted_at": row["emitted_at"],
+        }
+        memory, _skip = promote_fact(event)
+        ok, err = (True, "skip") if memory is None else _handle_promoted(memory, ledger)
+        try:
+            if ok:
+                conn.execute("DELETE FROM dead_letters WHERE dl_id = ?", (row["dl_id"],))
+                conn.commit()
+                replayed += 1
+            else:
+                conn.execute(
+                    """UPDATE dead_letters
+                          SET replay_requested_at = NULL,
+                              attempts = attempts + 1,
+                              last_error = ?
+                        WHERE dl_id = ?""",
+                    (str(err)[:500], row["dl_id"]),
+                )
+                conn.commit()
+                failed += 1
+                return replayed, failed  # stop on failure; operator re-replays
+        except sqlite3.Error:
+            return replayed, failed
+
+
+def do_drain(_args):
+    # 1. Pull pending events without moving the durable cursor.
+    code, out = _run_cli(
+        "subscribe", "--plugin", PLUGIN, "--filter", FACT_FILTER,
+        "--once", "--no-ack",
+    )
+    if code != 0:
+        _emit({"ok": False, "reason": "wicked-bus unavailable or drain failed"})
+        return 0
+    events = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("event_id") is not None:
+            events.append(obj)
+    events.sort(key=lambda e: e["event_id"])
+
+    conn = _bus_db()
+    cursor = _find_cursor(conn) if conn else None
+    if not cursor:
+        # The subscribe call registers the cursor, so this is only reachable
+        # when the DB is unreadable — degrade (events redeliver next drain).
+        if conn:
+            conn.close()
+        if events:
+            _emit({"ok": False, "reason": "subscriber cursor not found in bus db"})
+        else:
+            _emit({"ok": True, "drained": 0, "stored": 0, "deduped": 0,
+                   "skipped": 0, "dead_lettered": 0, "replayed": 0,
+                   "replay_failed": 0, "pending_retry": False})
+        return 0
+    cursor_id, subscription_id, floor = cursor
+
+    ledger = _load_ledger()
+    replayed, replay_failed = _drain_replays(conn, cursor_id, ledger)
+    stored = deduped = skipped = dead = 0
+    advance_to = floor
+    pending_retry = False
+
+    for event in events:
+        event_id = event["event_id"]
+        memory, _skip_reason = promote_fact(event)
+
+        if memory is None:
+            skipped += 1
+            advance_to = event_id
+            continue
+
+        ok, err = _handle_promoted(memory, ledger)
+        if ok:
+            if err == "dedup":
+                deduped += 1
+            else:
+                stored += 1
+                _clear_attempts(conn, cursor_id, event_id)
+            advance_to = event_id
+            continue
+
+        # Estate write failed — retry budget, then native dead-letter.
+        attempts = _get_attempts(conn, cursor_id, event_id) + 1
+        if attempts >= MAX_ATTEMPTS:
+            if _dead_letter(conn, cursor_id, subscription_id, event, attempts, err):
+                _clear_attempts(conn, cursor_id, event_id)
+                dead += 1
+                advance_to = event_id
+                continue
+            # Could not even dead-letter — leave the cursor put and stop.
+            _record_attempt(conn, cursor_id, event_id, attempts, err)
+            pending_retry = True
+            break
+        _record_attempt(conn, cursor_id, event_id, attempts, err)
+        pending_retry = True
+        break  # do not advance past a retryable failure (at-least-once)
+
+    # 2. Advance the durable cursor past everything conclusively handled.
+    if advance_to > floor:
+        _run_cli("ack", "--cursor-id", cursor_id, "--last-event-id", str(advance_to))
+    conn.close()
+    _save_ledger(ledger)
+
+    _emit({"ok": True, "drained": len(events), "stored": stored,
+           "deduped": deduped, "skipped": skipped, "dead_lettered": dead,
+           "replayed": replayed, "replay_failed": replay_failed,
+           "pending_retry": pending_retry})
+    return 0
+
+
+def do_status(_args):
+    out = {"ok": True, "plugin": PLUGIN, "filter": FACT_FILTER,
+           "ledger_size": len(_load_ledger())}
+    conn = _bus_db()
+    if conn:
+        cursor = _find_cursor(conn)
+        if cursor:
+            cursor_id, _, floor = cursor
+            out["cursor_id"] = cursor_id
+            out["cursor_last_event_id"] = floor
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*) AS c FROM dead_letters WHERE cursor_id = ?",
+                    (cursor_id,),
+                ).fetchone()
+                out["dead_letters"] = int(row["c"])
+                row = conn.execute(
+                    "SELECT COUNT(*) AS c FROM events WHERE event_type = ? AND event_id > ?",
+                    (FACT_FILTER, floor),
+                ).fetchone()
+                out["pending"] = int(row["c"])
+            except sqlite3.Error:
+                pass
+        else:
+            out["cursor_id"] = None
+        conn.close()
+    else:
+        out["bus"] = "unavailable"
+    _emit(out)
+    return 0
+
+
+_ACTIONS = {"drain": do_drain, "status": do_status}
+
+
+def main(argv):
+    if not argv or argv[0] not in _ACTIONS:
+        _emit({"error": "usage: auto_memorize.py <drain|status> ['<json-args>']"})
+        return 1
+    raw = argv[1] if len(argv) > 1 else "{}"
+    try:
+        args = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        args = {}
+    return _ACTIONS[argv[0]](args if isinstance(args, dict) else {})
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/mem/auto_memorize.py
+++ b/scripts/mem/auto_memorize.py
@@ -137,11 +137,16 @@ def promote_fact(event):
 # ── dedup ledger ─────────────────────────────────────────────────────────────
 
 def _ledger_path():
-    override = os.environ.get("WICKED_MEM_LEDGER_DIR")
-    base = Path(override) if override else (
-        Path.home() / ".something-wicked" / "wicked-garden" / "local" / "wicked-mem"
-    )
-    return base / "auto_memorize_hashes.json"
+    override = os.environ.get("WICKED_MEM_LEDGER_DIR")  # test seam
+    if override:
+        return Path(override) / "auto_memorize_hashes.json"
+    try:
+        from _paths import get_local_path  # project-scoped storage root
+        return get_local_path("wicked-mem") / "auto_memorize_hashes.json"
+    except Exception:
+        # Fail-open fallback mirroring the _paths layout root.
+        return (Path.home() / ".something-wicked" / "wicked-garden"
+                / "local" / "wicked-mem" / "auto_memorize_hashes.json")
 
 
 def _load_ledger():

--- a/skills/mem/SKILL.md
+++ b/skills/mem/SKILL.md
@@ -128,3 +128,9 @@ capture what we learned", before /clear or exit). It sweeps the conversation
 for decisions, patterns, gotchas, discoveries, and preferences, classifies
 each onto the estate kind/tier vocabulary, and batch-writes them via
 `capture-batch`. Report what it stored.
+
+**Auto-memorize (ambient path)**: independent of this action, the Stop hook
+emits `wicked.garden.fact.extracted` events for decisions/discoveries it
+spots and drains them into estate via `scripts/mem/auto_memorize.py`
+(durable wicked-bus cursor, content-hash dedup, native DLQ — inspect with
+`... auto_memorize.py status '{}'` or `wicked-bus dlq list`).

--- a/tests/mem/test_auto_memorize.py
+++ b/tests/mem/test_auto_memorize.py
@@ -1,0 +1,278 @@
+"""tests/mem/test_auto_memorize.py — the estate auto-memorize loop (task #76).
+
+Brain's server ran the auto-memorize subscriber; garden runs it now:
+``scripts/mem/auto_memorize.py`` drains ``wicked.garden.fact.extracted`` from
+wicked-bus (durable cursor, native delivery_attempts/dead_letters tables) and
+persists promoted facts to wicked-estate via the mem backend. The emitter side
+(``scripts/_brain_ingest/session_fact_extractor.py``) gains the transcript
+source that fixes the starvation (zero fact events ever emitted — native task
+records exist for almost no session).
+
+Layers:
+
+  * Hermetic unit tests (always run): the promoteFact policy port (skip
+    rules, importance→tier, fact-type→estate-kind), brain-compatible content
+    hashing, transcript extraction, and the per-session emitted ledger.
+
+  * Live e2e tests (``slow``; skipped without npx/wicked-bus/estate): the
+    full loop on temp bus + scratch estate stores — emit→drain→estate,
+    dedup (same content twice → ONE memory), retry budget → native DLQ, and
+    operator ``dlq replay`` → estate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import _estate_client  # noqa: E402
+from _brain_ingest import session_fact_extractor as sfe  # noqa: E402
+from mem import auto_memorize  # noqa: E402
+
+_AUTO = _REPO_ROOT / "scripts" / "mem" / "auto_memorize.py"
+_BACKEND = _REPO_ROOT / "scripts" / "mem" / "estate_memory.py"
+
+
+# ── promoteFact policy (pure port of brain's memory-promoter.mjs) ────────────
+
+def _event(payload, event_type="wicked.garden.fact.extracted", **kw):
+    base = {"event_id": 1, "event_type": event_type, "domain": "wicked-garden",
+            "subdomain": "", "payload": json.dumps(payload),
+            "emitted_at": 1700000000000}
+    base.update(kw)
+    return base
+
+
+def test_promote_decision_maps_to_semantic_fact():
+    memory, err = auto_memorize.promote_fact(_event({
+        "type": "decision",
+        "content": "we decided to rebuild auto-memorize on estate",
+        "entities": ["wicked-estate"],
+        "session_id": "s1",
+    }))
+    assert err is None
+    assert memory["kind"] == "fact" and memory["tier"] == "semantic"
+    assert "wicked-estate" in memory["about"] and "decision" in memory["about"]
+    assert memory["content_hash"]
+
+
+def test_promote_discovery_maps_to_episodic_episode():
+    memory, err = auto_memorize.promote_fact(_event({
+        "type": "discovery", "content": "turns out the cursor was never registered",
+    }))
+    assert err is None
+    assert memory["kind"] == "episode" and memory["tier"] == "episodic"
+
+
+@pytest.mark.parametrize("payload,reason_part", [
+    ({"type": "context", "content": "the system uses sqlite everywhere"}, "not auto-promoted"),
+    ({"type": "decision"}, "missing payload.content"),
+    ({"type": "decision", "content": "too short"}, "too short"),
+])
+def test_promote_skip_rules(payload, reason_part):
+    memory, reason = auto_memorize.promote_fact(_event(payload))
+    assert memory is None and reason_part in reason
+
+
+def test_promote_rejects_wrong_event_type():
+    memory, reason = auto_memorize.promote_fact(
+        _event({"type": "decision", "content": "x" * 30}, event_type="wicked.other.thing.done"))
+    assert memory is None and "event_type" in reason
+
+
+def test_content_hash_is_normalization_stable():
+    a = auto_memorize.content_hash("We Decided   to USE\n estate")
+    b = auto_memorize.content_hash("we decided to use estate")
+    assert a == b
+    assert a != auto_memorize.content_hash("we decided to use brain")
+
+
+# ── transcript extraction (the starvation fix) ───────────────────────────────
+
+def _write_transcript(path: Path, texts):
+    lines = []
+    for i, text in enumerate(texts):
+        role = "assistant" if i % 2 else "user"
+        lines.append(json.dumps({
+            "type": role,
+            "message": {"content": [{"type": "text", "text": text}]},
+        }))
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_transcript_facts_extracted(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [
+        "let's think about storage options",
+        "We decided to use the estate memory store for all session facts.",
+        "anything else?",
+        "Turns out the emitter was starved because no task files ever existed.",
+    ])
+    facts = sfe.extract_transcript_facts(str(t), limit=10)
+    types = {f.type for f in facts}
+    assert "decision" in types and "discovery" in types
+    assert all(f.source == "transcript" for f in facts)
+
+
+def test_extract_session_facts_merges_transcript(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))  # no task records
+    t = tmp_path / "tr.jsonl"
+    _write_transcript(t, ["We decided to use transcripts as the fact source."])
+    facts = sfe.extract_session_facts("sess-x", limit=10, transcript_path=str(t))
+    assert facts and facts[0].source == "transcript"
+
+
+def test_transcript_missing_file_fails_open(tmp_path):
+    assert sfe.extract_transcript_facts(str(tmp_path / "nope.jsonl"), 10) == []
+
+
+def test_emitted_ledger_filters_per_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("WICKED_MEM_LEDGER_DIR", str(tmp_path))
+    fact = sfe.SessionFact(id="", type="decision", content="we decided on X for Y reasons")
+    assert sfe.filter_unemitted([fact], "sess-1") == [fact]
+    sfe.mark_emitted([fact], "sess-1")
+    assert sfe.filter_unemitted([fact], "sess-1") == []          # same session: filtered
+    assert sfe.filter_unemitted([fact], "sess-2") == [fact]      # other session: passes
+
+
+# ── dedup ledger ─────────────────────────────────────────────────────────────
+
+def test_dedup_ledger_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("WICKED_MEM_LEDGER_DIR", str(tmp_path))
+    assert auto_memorize._load_ledger() == {}
+    auto_memorize._save_ledger({"abc": "mem-1"})
+    assert auto_memorize._load_ledger() == {"abc": "mem-1"}
+
+
+# ── live e2e (slow) ──────────────────────────────────────────────────────────
+
+_ESTATE_PRESENT = _estate_client.resolve_mcp_bin() is not None
+_NPX_PRESENT = shutil.which("npx") is not None
+
+
+def _env(tmp: Path):
+    env = dict(os.environ)
+    env.update({
+        "WICKED_BUS_DATA_DIR": str(tmp / "bus"),
+        "WICKED_MEM_LEDGER_DIR": str(tmp / "ledger"),
+        "WICKED_MEMORY_DB": str(tmp / "estate" / "memory.db"),
+        "WICKED_KNOWLEDGE_DB": str(tmp / "estate" / "knowledge.db"),
+        "WICKED_XEDGE_DB": str(tmp / "estate" / "xedge.db"),
+        "WICKED_ESTATE_DB": ":memory:",
+        "WICKED_ESTATE_PERSISTENT": "0",
+    })
+    (tmp / "estate").mkdir(parents=True, exist_ok=True)
+    return env
+
+
+def _run_py(env, script, *args):
+    proc = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _emit_fact(env, payload):
+    proc = subprocess.run(
+        ["npx", "--yes", "wicked-bus", "emit",
+         "--type", "wicked.garden.fact.extracted",
+         "--domain", "wicked-garden",
+         "--payload", json.dumps(payload)],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not (_ESTATE_PRESENT and _NPX_PRESENT),
+                    reason="needs wicked-estate-mcp and npx/wicked-bus")
+def test_live_emit_drain_store_and_dedup(tmp_path):
+    env = _env(tmp_path)
+
+    # First drain registers the cursor at 'latest' — no history replay.
+    first = _run_py(env, _AUTO, "drain", "{}")
+    assert first["ok"] is True and first["drained"] == 0
+
+    _emit_fact(env, {"type": "decision",
+                     "content": "we decided to rebuild the auto-memorize loop on estate",
+                     "entities": ["wicked-estate"], "session_id": "e2e"})
+    result = _run_py(env, _AUTO, "drain", "{}")
+    assert result["stored"] == 1 and result["pending_retry"] is False
+
+    recalled = _run_py(env, _BACKEND, "recall",
+                       json.dumps({"query": "rebuild auto-memorize loop"}))
+    assert any("auto-memorize" in i.get("content", "") for i in recalled["items"])
+
+    # Same content again (different whitespace/case) + a non-promotable type.
+    _emit_fact(env, {"type": "decision",
+                     "content": "We DECIDED to rebuild   the auto-memorize loop on estate",
+                     "session_id": "e2e-2"})
+    _emit_fact(env, {"type": "context", "content": "the system uses sqlite everywhere"})
+    result = _run_py(env, _AUTO, "drain", "{}")
+    assert result["deduped"] == 1 and result["skipped"] == 1 and result["stored"] == 0
+
+    # Dedup proven at the store: exactly ONE memory exists.
+    coverage = _run_py(env, _BACKEND, "review", "{}")
+    assert coverage["coverage"]["total"] == 1
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not (_ESTATE_PRESENT and _NPX_PRESENT),
+                    reason="needs wicked-estate-mcp and npx/wicked-bus")
+def test_live_retry_budget_dead_letters_then_operator_replay(tmp_path):
+    env = _env(tmp_path)
+    _run_py(env, _AUTO, "drain", "{}")  # register cursor
+
+    _emit_fact(env, {"type": "discovery",
+                     "content": "turns out estate can be down when the drain runs",
+                     "session_id": "e2e-dlq"})
+
+    # Break estate: a real file that is not an MCP server → handshake fails.
+    broken = dict(env, WICKED_ESTATE_MCP_BIN="/usr/bin/false" if os.name != "nt" else env["COMSPEC"])
+    for attempt in (1, 2):
+        result = _run_py(broken, _AUTO, "drain", "{}")
+        assert result["pending_retry"] is True, f"attempt {attempt} should retry"
+        assert result["dead_lettered"] == 0
+    result = _run_py(broken, _AUTO, "drain", "{}")
+    assert result["dead_lettered"] == 1 and result["pending_retry"] is False
+
+    # Native DLQ visibility: wicked-bus dlq list sees the row.
+    proc = subprocess.run(
+        ["npx", "--yes", "wicked-bus", "dlq", "list", "--json"],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+    dlq = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert dlq["count"] == 1
+    dl = dlq["dead_letters"][0]
+    assert dl["event_type"] == "wicked.garden.fact.extracted"
+    assert dl["attempts"] == 3
+
+    # Operator replay with estate healthy → memory lands, DLQ empties.
+    proc = subprocess.run(
+        ["npx", "--yes", "wicked-bus", "dlq", "replay", "--dl-id", str(dl["dl_id"])],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = _run_py(env, _AUTO, "drain", "{}")
+    assert result["replayed"] == 1 and result["replay_failed"] == 0
+
+    recalled = _run_py(env, _BACKEND, "recall",
+                       json.dumps({"query": "estate can be down when the drain runs"}))
+    assert any("estate can be down" in i.get("content", "") for i in recalled["items"])
+    proc = subprocess.run(
+        ["npx", "--yes", "wicked-bus", "dlq", "list", "--json"],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert json.loads(proc.stdout.strip().splitlines()[-1])["count"] == 0


### PR DESCRIPTION
## What (task #76 — natural extension of the S7 mem-domain folds, #1048)

Brain's server ran the `wicked.garden.fact.extracted` auto-memorize subscriber (`memory-subscriber.mjs`: durable cursor, DLQ, promoteFact, content-hash dedup). Brain retires at S7 — and the loop was **dead anyway**.

### Emitter diagnosis: wired but starved at the source
- **Zero fact events ever emitted** — verified against the live bus DB (54MB, 80k+ events of other types, `count(*)=0` for the fact type).
- The chain itself was intact: `stop.py::_run_memory_promotion` → `session_fact_extractor` → `BUS_EVENT_MAP`-registered type → `emit_event`. The problem is the only input source: native task records under `~/.claude/tasks/{session}/` exist for almost no session (exactly one directory on this machine, ever), and task subjects rarely contain "decided on X" prose.
- **Fix**: the extractor gains a **transcript source** — the Stop hook already receives `transcript_path` on stdin; the transcript tail's user/assistant text runs through the same extraction patterns (`source: "transcript"`). A per-session emitted-hash ledger stops the per-turn Stop from re-emitting the same fact each turn; the consumer's global content-hash dedup remains the cross-session guard.

### Consumer: garden-run (estate stays bus-free by design)
`scripts/mem/auto_memorize.py`, invoked from the Stop hook (drain-on-invoke — no daemon):
- `wicked-bus subscribe --once --no-ack` under a dedicated durable cursor (plugin `wicked-garden-mem`, `cursor_init latest` — no 80k-event history replay on first registration).
- **promoteFact ported** from brain: decision/discovery only, 15-char floor, importance→tier (decision→`fact`/semantic, discovery→`episode`/episodic per the mem scopes mapping), entity tags capped at 15.
- **Brain-compatible dedup**: trim/collapse/lowercase sha256 ledger.
- Writes via estate `memory.capture` through the mem backend plumbing (#1048).
- **At-least-once + native DLQ**: a failed estate write leaves the cursor put (redelivery next drain = the retry backoff); after 3 failed drains the event is dead-lettered into wicked-bus's **own** `dead_letters` table (attempts in its native `delivery_attempts`), so `wicked-bus dlq list|replay|drop` see it exactly as they saw brain's subscriber's. Operator `dlq replay` is honored by the drain (mirrors `subscribe()`'s `drainReplays`: one attempt, success deletes the row, failure clears the mark + bumps attempts).

## Functional proof (live, and codified in `tests/mem/test_auto_memorize.py`)
1. emit → drain → `memory.recall` returns the fact from estate (`fact`/semantic).
2. Same content emitted twice (different whitespace/case) → `deduped: 1`, store total stays **exactly 1** memory.
3. Estate broken (real-file non-MCP binary): drains 1–2 → `pending_retry`, drain 3 → **native DLQ row** (`wicked-bus dlq list` shows it: attempts=3, last_error, plugin attribution).
4. `wicked-bus dlq replay --dl-id N` + healthy drain → memory lands in estate, DLQ empties.
5. First registration drains 0 (no history replay); cursor durability across drains.

## Quality
- `validate.py` PASS, `sync_components.py --check` in sync, fast suite 1013 passed, hooks+mem suites green, both live e2e tests pass locally.
- Direct sqlite is used ONLY for wicked-bus's native `delivery_attempts`/`dead_letters` tables + the cursor lookup (the same pattern brain's `fastForwardStaleCursor` established); everything else rides the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)