### PR TITLE
feat(packs): third-party extension contract — drop-in packs, shipped conformance gate, crew routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ Optional, lights up the code graph: **wicked-estate** (single binary; `wicked-es
 
 ---
 
+## Build on it
+
+The catalog is open: ship your own domain pack — a `wicked-pack.json`
+manifest plus `{vendor}-{domain}` router / `{vendor}-{domain}-{role}` fork
+workers — and the runtime discovers it without a garden PR: catalog listing,
+crew specialist routing, peer-floor probing, same evidence discipline.
+
+```bash
+npx wicked-garden pack check ./acme-seo-pack   # the shipped conformance gate
+npx wicked-installer pack add acme-seo-pack    # acquire + validate + install + register
+npx wicked-garden pack list                    # what the runtime sees
+```
+
+Full author guide: [`docs/extending.md`](docs/extending.md).
+
+---
+
 ## Principles
 
 - **Don't fight the harness.** Fill the gaps; never re-implement what it already does well.
@@ -106,7 +123,7 @@ Optional, lights up the code graph: **wicked-estate** (single binary; `wicked-es
 
 ## More
 
-[`ETHOS.md`](ETHOS.md) · [`docs/getting-started.md`](docs/getting-started.md) · [`docs/domains.md`](docs/domains.md) · [`docs/required-peers.md`](docs/required-peers.md) · [`docs/compiler.md`](docs/compiler.md)
+[`ETHOS.md`](ETHOS.md) · [`docs/getting-started.md`](docs/getting-started.md) · [`docs/domains.md`](docs/domains.md) · [`docs/required-peers.md`](docs/required-peers.md) · [`docs/compiler.md`](docs/compiler.md) · [`docs/extending.md`](docs/extending.md)
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Work in wicked-garden is organized around **9 work-shape archetypes** — not a 
 | [Domains](domains.md) | The 10 domain skills archetypes invoke for expertise |
 | [Required Peers](required-peers.md) | The five required peer plugins and the install/runtime stance |
 | [The Compiler](compiler.md) | `/wicked-garden-prove compile` — emit a self-contained vault-backed gate into any repo |
+| [Extending the Catalog](extending.md) | Ship a third-party pack — `{vendor}-{domain}-{role}` skills, the `wicked-pack.json` manifest, the shipped conformance gate, install + crew routing |
 | [Brain Chunk Format](brain-chunk-format.md) | Historical: how content was chunked for the retired wicked-brain index (the migrated chunks in wicked-estate keep this shape) |
 
 ## Quick Links
@@ -22,6 +23,7 @@ Work in wicked-garden is organized around **9 work-shape archetypes** — not a 
 - **Setting up?** The [Required Peers](required-peers.md) — wicked-vault, wicked-estate, wicked-bus — are verified by `/wicked-garden-core setup` (the loom engine ships in-package; the qe domain is in-catalog).
 - **Looking for domain expertise or a specific action?** Browse [Domains](domains.md).
 - **Want a build gate that runs without wicked-garden present?** See [The Compiler](compiler.md).
+- **Shipping your own domain pack?** Follow [Extending the Catalog](extending.md) — `npx wicked-garden pack check` validates it against the same rules the built-ins follow.
 
 ## Need Help?
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,191 @@
+# Extending the catalog — shipping a third-party pack
+
+Garden is **the** catalog, not a closed product: the built-in domains follow a
+naming contract anyone can follow, and the runtime discovers conformant
+third-party **packs** without a garden PR. Your fintech-risk domain, your
+games-QA fleet, your compliance cast — they sit beside the built-ins, under
+the same evidence discipline.
+
+This is the complete pack-author guide. Everything here is executable today;
+the sections at the end state plainly which parts of the contract are still
+minimal.
+
+## What a pack is
+
+A directory (npm package, git checkout, or plain folder) with:
+
+```
+acme-seo-pack/
+├── wicked-pack.json                      # the manifest (see schema)
+└── skills/
+    ├── acme-seo/SKILL.md                 # ONE router per domain (user-invocable)
+    ├── acme-seo-keyword-analyst/SKILL.md # fork worker (context: fork)
+    ├── acme-seo-content-auditor/SKILL.md # fork worker (context: fork)
+    └── acme-seo-content-auditor/refs/…   # tier-3 refs (optional)
+```
+
+Schema: [`schemas/wicked-pack.schema.json`](../schemas/wicked-pack.schema.json).
+A complete working example (used as garden's own e2e fixture):
+[`tests/fixtures/packs/acme-seo/`](../tests/fixtures/packs/acme-seo/).
+
+### The manifest
+
+```json
+{
+  "spec": 1,
+  "name": "acme-seo",
+  "vendor": "acme",
+  "version": "0.1.0",
+  "description": "ACME's SEO domain pack.",
+  "skills_dir": "skills",
+  "domains": [
+    {
+      "name": "seo",
+      "specialist": {
+        "role": "seo-engineering",
+        "description": "SEO specialist — keyword strategy and evidence-backed audits.",
+        "enhances": ["design", "build", "review"]
+      },
+      "produces": [
+        { "archetype": "review", "produces": ["seo-audit"], "gate": "vault" }
+      ]
+    }
+  ],
+  "peers": { "wicked-garden": ">=12.0.0", "wicked-vault": ">=0.5.0" },
+  "provenance": { "source": "https://github.com/acme/acme-seo-pack", "publisher": "acme" }
+}
+```
+
+## The rules (the same ones the built-ins follow)
+
+1. **One router per domain.** A single user-invocable skill named
+   `{vendor}-{domain}` fronts the domain; sub-capabilities are *actions* of
+   the router, never sibling top-level skills. ≤ 200-line body.
+2. **Workers are `{vendor}-{domain}-{role}`** with `context: fork` in
+   frontmatter — isolated subagent contexts with their own tool boundaries.
+3. **Your prefix is your vendor name.** `wicked-*` (and `wicked-garden-*`)
+   is reserved for the first-party catalog; the conformance gate rejects
+   squatting, and the resolver indexes garden first so a pack can never
+   shadow a first-party name.
+4. **kebab-case, ≤ 64 chars; three-tier disclosure** — frontmatter ~100
+   words, SKILL.md ≤ 200 lines (fork workers exempt — they load into an
+   isolated context), refs/ 200–300 lines each.
+5. **NOT-THIS-WHEN reciprocity.** If two of your skills are twins
+   (executor vs advisor), each names the other in a `NOT THIS WHEN:` block —
+   the gate enforces reciprocity inside your pack.
+6. **Evidence via vault.** Your pack's "done" goes through the same gate:
+   record evidence with `wicked-vault record … --actor <doer>` and let the
+   produces-gate re-derive it. A pack never ships its own gate logic
+   (`"gate": "vault"` is the only backend).
+7. **Events** (if you emit them): 4-segment
+   `wicked.<domain>.<noun>.<past-verb>` — bus SPEC.md is the authority.
+
+## Validate: the shipped conformance gate
+
+```bash
+npx wicked-garden pack check ./acme-seo-pack          # human output
+npx wicked-garden pack check ./acme-seo-pack --json   # CI
+```
+
+Exit 0 = conformant (warnings allowed), 1 = errors. The gate checks the
+manifest, router/worker shape, naming, disclosure tiers, NOT-THIS-WHEN
+reciprocity, produces contracts (archetype names must exist in garden's
+catalog), and peer-floor syntax — rule codes PK001–PK050, each with an
+actionable message. It runs anywhere Python ≥ 3.10 exists; no garden install
+required (`scripts/pack/check.py` ships in the npm package).
+
+## Install + register
+
+Registration is what makes the runtime *see* the pack. Any of:
+
+```bash
+# acquire + install + validate + register in one step (wicked-installer —
+# the same code path garden's own `pack install` delegates to):
+npx wicked-installer pack add acme-seo-pack          # npm package name
+npx wicked-installer pack add ./acme-seo-pack        # local directory
+
+# or register an on-disk pack directly with garden:
+npx wicked-garden pack register ./acme-seo-pack --source https://github.com/acme/acme-seo-pack
+
+# see what the runtime sees:
+npx wicked-garden pack list --json
+npx wicked-garden pack unregister acme-seo
+```
+
+Registration is **fail-closed**: a pack that fails the conformance gate does
+not register (`--force` exists, on your own head). Discovery itself also
+picks packs up from, in priority order:
+
+1. `WICKED_PACK_PATH` (pathsep-separated pack roots or dirs of packs),
+2. the registered-pack file (`~/.something-wicked/wicked-garden/packs/registered.json`),
+3. Claude Code plugin dirs (`~/.claude/plugins/*`, `~/.claude/plugins/cache/*/*`)
+   containing a `wicked-pack.json`,
+4. `<project>/.wicked/packs/*`.
+
+So a pack shipped **as a Claude Code plugin** is discovered automatically —
+the harness loads your skills, garden registers your routing. A pack that is
+not a plugin needs its skills visible to the harness some other way
+(`~/.claude/skills/`, which `wicked-installer pack add` handles for Claude
+Code today).
+
+## What registration gets you
+
+- **Catalog**: `pack list` surfaces the pack, its domains, specialists,
+  produces contracts, and provenance. No garden file is edited — 
+  `components.json`/`specialist.json` stay first-party-only and the sync
+  tooling ignores packs by design.
+- **Crew routing** (the specialist seam): workers resolve through
+  `scripts/crew/specialist_resolver.py` by full name
+  (`acme-seo-keyword-analyst`), bare role (`keyword-analyst`), with the
+  specialist domain `{vendor}-{domain}` (`acme-seo`). Specialist-engagement
+  tracking (the SubagentStop hook) accepts pack domains that declare a
+  `specialist` block.
+- **Steering data**: declared `produces` contracts are validated and exposed
+  (`_pack_registry.pack_produces()`); see honesty notes below.
+- **Peer floors**: checked at SessionStart (cheap, fail-open) and on demand
+  via `npx wicked-garden pack floors`.
+
+## Honesty notes — where the contract is still minimal
+
+The parts above are implemented and e2e-tested
+(`tests/packs/test_e2e_toy_pack.py`). Three parts are deliberately minimal;
+their current state, plainly:
+
+**Trust & provenance (minimal).** Packs *declare* provenance; registration
+*records* it plus a sha256 of the manifest and a content hash of the skills
+tree. That detects post-registration drift — it does **not** prove
+authorship. There is no signing, no central marketplace listing, and no
+review process. Skills carry shell: **install packs only from sources you
+trust**, exactly as you would an npm dependency. A signed/marketplace model
+is future work (wicked-installer's `registry.json` is the named seam).
+
+**Produces-contracts (data layer implemented; steering attach designed).**
+Your declared produces are validated (PK040/PK041), surfaced in the catalog,
+and the gate engine consumes a produces id directly — running
+`loom gate <produces-id>` (i.e. `wicked-vault cross-check --phase seo-audit`)
+against evidence your workers record works today, and your router should
+instruct exactly that (see the fixture router). What does *not* happen yet:
+the archetype steering engine (`scripts/crew/archetypes_v11.py`) does not
+automatically append pack produces to an archetype's gate set when your
+domain is engaged. That attach point is the named seam:
+`archetypes_v11.steering_directives()` merging
+`_pack_registry.pack_produces()` into each matched archetype's
+`produces` list — filtered by *engaged* specialist domains (the
+specialist-engagement ledger), because attaching unconditionally would
+gate every `review` on every installed pack's contract. Until that
+lands, pack gates are explicit-invocation, not auto-steered.
+
+**Peer floors (implemented, deliberately fail-open).** Floors are syntax-
+checked by the gate, compared at SessionStart against garden's own version
+(zero subprocesses), and fully probed by `pack floors` (`--version` probes
+for binary peers like `wicked-vault`). Violations *warn*; nothing blocks.
+An unprobeable peer reports `unknown`, never a violation.
+
+## Checklist before you publish
+
+- [ ] `npx wicked-garden pack check .` exits 0
+- [ ] every worker declares `context: fork`; the router does not
+- [ ] evidence-writing workers record via `wicked-vault record … --actor <worker-name>`
+- [ ] `peers` floors reflect what you actually tested against
+- [ ] `provenance.source` points at the canonical repo
+- [ ] ship `wicked-pack.json` at the package root (npm: include it in `files`)

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -553,6 +553,40 @@ def _check_vault_dependency():
         return None  # Fail open — never block session start
 
 
+def _check_pack_floors():
+    """Return a briefing note when an installed pack's peer floor is violated.
+
+    Extension-contract gap 6: third-party packs declare peer version floors
+    in wicked-pack.json (``peers``). SessionStart runs the CHEAP check only
+    (probe=False — garden's own version, zero subprocesses); the full probe
+    lives in ``npx wicked-garden pack floors``. Strictly fail-open: unknown
+    versions are never reported, and any error returns None.
+    """
+    try:
+        import _pack_registry
+
+        packs, _errors = _pack_registry.discover_packs()
+        if not packs:
+            return None
+        findings = _pack_registry.check_peer_floors(packs, probe=False)
+        violations = [f for f in findings if f.get("status") in ("below-floor", "bad-range")]
+        if not violations:
+            return None
+        lines = [
+            f"  - {v['pack']}: needs {v['peer']} {v['floor']}, installed "
+            f"{v.get('installed') or 'unparseable floor'}"
+            for v in violations[:5]
+        ]
+        return (
+            "[Packs] peer version floor violation(s) — pack capabilities may "
+            "misbehave until peers are updated (informational, nothing is blocked):\n"
+            + "\n".join(lines)
+            + "\n  Full probe: npx wicked-garden pack floors"
+        )
+    except Exception:
+        return None  # fail open — packs never block session start
+
+
 def _check_loom_dependency():
     """Return a briefing note if loom peer-resolution is unavailable, else None.
 
@@ -1257,6 +1291,10 @@ def main():
         _loom_note = _check_loom_dependency()
         if _loom_note:
             mode_notes.append(_loom_note)
+        # Third-party pack peer floors (extension contract, fail-open).
+        _pack_note = _check_pack_floors()
+        if _pack_note:
+            mode_notes.append(_pack_note)
         if onedrive_path:
             mode_notes.append(
                 f"[Path] OneDrive directory detected. Resolved base: {onedrive_path}. "

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -572,11 +572,18 @@ def _check_pack_floors():
         violations = [f for f in findings if f.get("status") in ("below-floor", "bad-range")]
         if not violations:
             return None
-        lines = [
-            f"  - {v['pack']}: needs {v['peer']} {v['floor']}, installed "
-            f"{v.get('installed') or 'unparseable floor'}"
-            for v in violations[:5]
-        ]
+        lines = []
+        for v in violations[:5]:
+            if v.get("status") == "bad-range":
+                lines.append(
+                    f"  - {v['pack']}: peer {v['peer']} declares a malformed "
+                    f"floor {v['floor']!r} (expected \">=X.Y.Z\" or \"^X.Y.Z\")"
+                )
+            else:
+                lines.append(
+                    f"  - {v['pack']}: needs {v['peer']} {v['floor']}, "
+                    f"installed {v.get('installed') or 'unknown'}"
+                )
         return (
             "[Packs] peer version floor violation(s) — pack capabilities may "
             "misbehave until peers are updated (informational, nothing is blocked):\n"

--- a/hooks/scripts/subagent_lifecycle.py
+++ b/hooks/scripts/subagent_lifecycle.py
@@ -145,15 +145,25 @@ def _write_trace(entry: dict) -> None:
 def _load_specialist_domains() -> set:
     """Return the set of specialist domain names from specialist.json.
 
-    Reads .claude-plugin/specialist.json relative to CLAUDE_PLUGIN_ROOT.
+    Reads .claude-plugin/specialist.json relative to CLAUDE_PLUGIN_ROOT,
+    then merges specialist domains contributed by installed third-party
+    packs (extension-contract gap 2 — ``{vendor}-{domain}`` entries from
+    wicked-pack.json manifests, via scripts/_pack_registry.py).
     Returns an empty set on any error so the hook stays fail-open.
     """
+    domains: set = set()
     try:
         specialist_path = _PLUGIN_ROOT / ".claude-plugin" / "specialist.json"
         data = json.loads(specialist_path.read_text(encoding="utf-8"))
-        return {s["name"] for s in data.get("specialists", []) if "name" in s}
+        domains = {s["name"] for s in data.get("specialists", []) if "name" in s}
     except Exception:
         return set()
+    try:
+        import _pack_registry
+        domains.update(_pack_registry.specialist_domains())
+    except Exception:
+        pass  # packs are optional — fail open to first-party domains only
+    return domains
 
 
 def _parse_specialist_from_agent_type(agent_type: str, specialist_domains: set):

--- a/install.mjs
+++ b/install.mjs
@@ -4,21 +4,22 @@
  * Copies plugin files to ~/.claude/plugins/wicked-garden/ and optionally syncs Python deps.
  *
  * Usage:
- *   npx wicked-garden install    Install or update the plugin
- *   npx wicked-garden update     Same as install
- *   npx wicked-garden status     Show current install state
- *   npx wicked-garden --version  Print version
+ *   npx wicked-garden install         Install or update the plugin
+ *   npx wicked-garden update          Same as install
+ *   npx wicked-garden status          Show current install state
+ *   npx wicked-garden pack <verb>     Third-party pack tooling (check/register/list/…)
+ *   npx wicked-garden --version       Print version
  */
 import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
 
-const PLUGIN_DIRS  = [".claude-plugin", "hooks", "scripts", "skills"];
+const PLUGIN_DIRS  = [".claude-plugin", "hooks", "scripts", "skills", "schemas"];
 const PLUGIN_FILES = ["ETHOS.md", "CHANGELOG.md", "README.md", "WICKED_GARDEN_BUS_EVENTS.md", "pyproject.toml"];
 const SKIP         = [/__pycache__/, /\.pyc$/, /\.pyo$/, /\.DS_Store$/];
 // Dev-only subdirs within scripts/ — not needed at runtime
@@ -102,6 +103,84 @@ function cmdStatus() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Pack tooling (extension contract). One implementation rule:
+//   * validation + registration = the shipped Python (scripts/pack/check.py,
+//     scripts/_pack_registry.py) — invoked here so `npx wicked-garden pack
+//     check` works without installing anything else;
+//   * acquisition + cross-CLI staging = wicked-installer (`pack install`
+//     DELEGATES — garden never grows a second installer code path).
+// ---------------------------------------------------------------------------
+
+function findPython() {
+  for (const candidate of ["python3", "python"]) {
+    const bin = findBin(candidate);
+    if (bin) return bin;
+  }
+  return undefined;
+}
+
+function runPython(scriptRel, args) {
+  const python = findPython();
+  if (!python) {
+    console.error("Error: python3 (or python) is required for pack tooling — install Python >= 3.10.");
+    return 1;
+  }
+  const script = join(__dirname, ...scriptRel);
+  if (!existsSync(script)) {
+    console.error(`Error: bundled script missing: ${script}`);
+    return 1;
+  }
+  const res = spawnSync(python, [script, ...args], { stdio: "inherit" });
+  return res.status ?? 1;
+}
+
+function delegateToInstaller(args) {
+  // WICKED_INSTALLER_BIN → PATH → npx (the loom/vault resolution pattern).
+  const override = process.env.WICKED_INSTALLER_BIN;
+  let argv;
+  if (override) argv = [override, ...args];
+  else if (findBin("wicked-installer")) argv = ["wicked-installer", ...args];
+  else argv = [findBin("npx") ?? "npx", "-y", "wicked-installer@latest", ...args];
+  const res = spawnSync(argv[0], argv.slice(1), {
+    stdio: "inherit",
+    shell: process.platform === "win32", // npx/.cmd shims need a shell on Windows
+  });
+  return res.status ?? 1;
+}
+
+function cmdPack(argv) {
+  const verb = argv[0];
+  const rest = argv.slice(1);
+  switch (verb) {
+    case "check":
+      return runPython(["scripts", "pack", "check.py"], rest);
+    case "register":
+    case "unregister":
+    case "list":
+    case "floors":
+      return runPython(["scripts", "_pack_registry.py"], [verb, ...rest]);
+    case "install":
+      // Acquisition/staging is wicked-installer's job — same code path
+      // third parties use directly (`npx wicked-installer pack add …`).
+      return delegateToInstaller(["pack", "add", ...rest]);
+    default:
+      console.log([
+        "Usage: npx wicked-garden pack <verb>",
+        "",
+        "  pack check <dir>                  Conformance-check a pack (the shipped gate)",
+        "  pack register <dir> [--source u]  Register an on-disk pack with the runtime",
+        "  pack unregister <name>            Remove a registered pack",
+        "  pack list [--json]                Show discovered packs (the catalog view)",
+        "  pack floors [--json]              Check declared peer version floors (fail-open)",
+        "  pack install <source>             Acquire + install a pack (delegates to wicked-installer)",
+        "",
+        "Pack authoring guide: docs/extending.md (schema: schemas/wicked-pack.schema.json)",
+      ].join("\n"));
+      return verb ? 1 : 0;
+  }
+}
+
 const cmd = process.argv[2];
 switch (cmd) {
   case "install":
@@ -112,6 +191,9 @@ switch (cmd) {
   case "status":
     cmdStatus();
     break;
+  case "pack":
+    process.exit(cmdPack(process.argv.slice(3)));
+    break;
   case "--version":
   case "-v":
     console.log(pkg.version);
@@ -121,8 +203,9 @@ switch (cmd) {
       `wicked-garden v${pkg.version}`,
       "",
       "Usage:",
-      "  npx wicked-garden install    Install or update the plugin",
-      "  npx wicked-garden status     Show current install state",
-      "  npx wicked-garden --version  Show version",
+      "  npx wicked-garden install         Install or update the plugin",
+      "  npx wicked-garden status          Show current install state",
+      "  npx wicked-garden pack <verb>     Third-party pack tooling (check/register/list/floors/install)",
+      "  npx wicked-garden --version       Show version",
     ].join("\n"));
 }

--- a/schemas/wicked-pack.schema.json
+++ b/schemas/wicked-pack.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/mikeparcewski/wicked-garden/blob/main/schemas/wicked-pack.schema.json",
+  "title": "wicked-pack.json — third-party skill-pack manifest",
+  "description": "Drop-in registration manifest for a third-party pack (extension contract, SKILL-RATIONALIZATION §5). Placed at the pack root next to its skills/ tree. Garden discovers it at runtime from WICKED_PACK_PATH, the registered-pack file, Claude Code plugin dirs, and <project>/.wicked/packs/ — no garden PR required. Executable validation: `npx wicked-garden pack check <dir>` (scripts/pack/check.py).",
+  "type": "object",
+  "required": ["spec", "name", "vendor", "version", "domains"],
+  "additionalProperties": false,
+  "properties": {
+    "spec": {
+      "const": 1,
+      "description": "Manifest spec version. Currently 1."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 64,
+      "description": "Pack name, kebab-case, must start with the vendor prefix (e.g. acme-seo). The wicked* prefix is reserved for the first-party catalog."
+    },
+    "vendor": {
+      "type": "string",
+      "pattern": "^(?!wicked)[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 64,
+      "description": "Vendor prefix all skill names in the pack must carry ({vendor}-{domain}[-{role}]). 'wicked' and 'wicked-*' are reserved."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+",
+      "description": "Pack semver."
+    },
+    "description": {
+      "type": "string",
+      "description": "One-paragraph pack summary (shown by `pack list`)."
+    },
+    "skills_dir": {
+      "type": "string",
+      "default": "skills",
+      "description": "Relative path to the skills tree (skills/<skill-name>/SKILL.md). Must stay inside the pack."
+    },
+    "domains": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The domains this pack contributes. Each declared domain must have exactly one router skill named {vendor}-{domain}; its workers are {vendor}-{domain}-{role} fork skills.",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+            "description": "Bare domain name (e.g. seo). The crew-facing specialist domain becomes {vendor}-{name}."
+          },
+          "description": { "type": "string" },
+          "specialist": {
+            "type": "object",
+            "description": "Present iff this domain should be crew-routable (the pack equivalent of a specialist.json entry). Registered as {vendor}-{domain}; first-party names always win a collision.",
+            "required": ["role"],
+            "additionalProperties": false,
+            "properties": {
+              "role": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                "description": "Human-facing discipline label (e.g. seo-engineering)."
+              },
+              "description": { "type": "string" },
+              "enhances": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Crew phases this specialist enhances: clarify | design | qe | build | review | operate | *"
+              }
+            }
+          },
+          "produces": {
+            "type": "array",
+            "description": "Produces-contract declarations (extension-contract gap 5). Each names an archetype and the produces ids the domain's work yields; gates re-derive them via wicked-vault (`loom gate` consumes the produces id directly). Steering attach is documented in docs/extending.md — declared data today, auto-steering is the named seam.",
+            "items": {
+              "type": "object",
+              "required": ["archetype", "produces"],
+              "additionalProperties": false,
+              "properties": {
+                "archetype": {
+                  "type": "string",
+                  "description": "One of garden's work-shape archetypes (.claude-plugin/archetypes.json): triage, explore, specify, decide, ship, review, incident, build, migrate, modernize."
+                },
+                "produces": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" },
+                  "description": "Kebab-case produces ids (the vault cross-check --phase values)."
+                },
+                "gate": {
+                  "type": "string",
+                  "enum": ["vault"],
+                  "default": "vault",
+                  "description": "Gate backend. Only the vault re-derivation gate exists; a pack never ships its own gate logic."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "peers": {
+      "type": "object",
+      "description": "Peer version floors (extension-contract gap 6), e.g. {\"wicked-garden\": \">=12.29.0\", \"wicked-vault\": \">=0.5.0\"}. Checked FAIL-OPEN: violations are surfaced at SessionStart and by `pack floors`, never blocked on.",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^(>=|\\^)\\s*\\d+\\.\\d+\\.\\d+$"
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Declared provenance (extension-contract gap 4 — minimal + honest). Registration additionally records a sha256 of this manifest and a content hash of the skills tree. There is NO signing: hashes detect post-registration drift, they do not prove authorship. Install packs only from sources you trust — skills carry shell.",
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string", "description": "Canonical origin URL (git repo or npm page)." },
+        "publisher": { "type": "string", "description": "Vendor / maintainer identity as published." },
+        "license": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/wicked-pack.schema.json
+++ b/schemas/wicked-pack.schema.json
@@ -19,9 +19,9 @@
     },
     "vendor": {
       "type": "string",
-      "pattern": "^(?!wicked)[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^(?!wicked($|-))[a-z0-9]+(-[a-z0-9]+)*$",
       "maxLength": 64,
-      "description": "Vendor prefix all skill names in the pack must carry ({vendor}-{domain}[-{role}]). 'wicked' and 'wicked-*' are reserved."
+      "description": "Vendor prefix all skill names in the pack must carry ({vendor}-{domain}[-{role}]). Exactly 'wicked' and 'wicked-*' are reserved (matching the runtime validator); other vendors that merely start with the letters 'wicked' are allowed."
     },
     "version": {
       "type": "string",

--- a/scripts/_pack_registry.py
+++ b/scripts/_pack_registry.py
@@ -154,7 +154,18 @@ def structural_errors(manifest: dict, root: Path) -> list:
         errors.append(f"version must be semver (got {version!r})")
 
     skills_rel = manifest.get("skills_dir", "skills")
-    if not isinstance(skills_rel, str) or ".." in skills_rel.replace("\\", "/").split("/"):
+    # Reject anything that could escape the pack root: parent segments AND
+    # absolute paths (POSIX or Windows — checked textually so validation is
+    # host-independent). Discovery, hashing, and the checker all walk this.
+    escapes_root = True
+    if isinstance(skills_rel, str) and skills_rel:
+        normalized = skills_rel.replace("\\", "/")
+        escapes_root = (
+            ".." in normalized.split("/")
+            or normalized.startswith("/")
+            or bool(re.match(r"^[A-Za-z]:", skills_rel))
+        )
+    if escapes_root:
         errors.append(f"skills_dir must be a relative path inside the pack (got {skills_rel!r})")
     else:
         skills_dir = Path(root) / skills_rel

--- a/scripts/_pack_registry.py
+++ b/scripts/_pack_registry.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""_pack_registry.py — discovery + registration of third-party skill packs.
+
+The extension contract (SKILL-RATIONALIZATION §5, gaps 1/2/4/6): a third
+party ships a **pack** — a directory with a ``wicked-pack.json`` manifest and
+a ``skills/`` tree following the catalog naming rules
+(``{vendor}-{domain}`` router + ``{vendor}-{domain}-{role}`` fork workers).
+Garden's runtime discovers installed packs WITHOUT a garden PR: no edit to
+components.json / specialist.json is ever required for a pack to register.
+
+Discovery sources, in priority order (first occurrence of a pack name wins):
+
+  1. ``WICKED_PACK_PATH`` env — ``os.pathsep``-separated dirs; each entry is
+     either a pack root (contains wicked-pack.json) or a directory of pack
+     roots. Explicit operator intent — highest priority.
+  2. The registered-pack file (``pack register`` / wicked-installer writes
+     it): ``~/.something-wicked/wicked-garden/packs/registered.json``
+     (override with ``WICKED_PACK_REGISTRY``). This is how npm-installed
+     packs surface — the installer registers the resolved package dir.
+  3. Claude Code plugin dirs: ``~/.claude/plugins/<name>/`` (direct
+     installs) and ``~/.claude/plugins/cache/<marketplace>/<plugin>/``
+     (marketplace cache) that contain a wicked-pack.json.
+  4. Project-local packs: ``<cwd>/.wicked/packs/<name>/``.
+
+Provenance (gap 4, minimal + honest): registration records the declared
+``provenance`` block plus a sha256 of the manifest and a content hash of the
+skills tree. There is NO signing — the hashes detect post-registration drift,
+they do not prove authorship. See docs/extending.md "Trust model".
+
+Peer floors (gap 6, fail-open): a pack may declare ``peers`` —
+``{"wicked-garden": ">=12.29.0", "wicked-vault": ">=0.5.0"}``.
+``check_peer_floors()`` compares floors against what is actually installed
+and returns violations as data. It NEVER raises and never blocks: an
+unprobeable peer reports status "unknown", not a violation.
+
+stdlib-only — importable from hooks. Fail-open everywhere: a malformed pack
+is skipped (collected under ``errors``), never a crash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+MANIFEST_NAME = "wicked-pack.json"
+SPEC_VERSION = 1
+
+# ``wicked`` is the reserved first-party vendor prefix — third-party packs
+# must never claim it (ruling naming rule #3).
+RESERVED_VENDOR_PREFIXES = ("wicked",)
+
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_MAX_NAME_LEN = 64
+# Accepted peer-floor range shapes. Both are treated as an inclusive
+# MAJOR.MINOR.PATCH floor (documented in docs/extending.md).
+_FLOOR_RE = re.compile(r"^(>=|\^)\s*(\d+)\.(\d+)\.(\d+)$")
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+
+_DEFAULT_REGISTRY = (
+    Path.home() / ".something-wicked" / "wicked-garden" / "packs" / "registered.json"
+)
+
+_PROBE_TIMEOUT_S = 5  # bound for optional peer --version subprocess probes
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Pack:
+    """A discovered, structurally-valid pack."""
+
+    name: str
+    vendor: str
+    version: str
+    root: Path
+    source: str                       # env | registered | plugin-dir | project
+    skills_dir: Path
+    description: str = ""
+    domains: list = field(default_factory=list)   # manifest "domains" entries
+    peers: dict = field(default_factory=dict)     # {package: floor-range}
+    provenance: dict = field(default_factory=dict)
+    manifest_sha256: str = ""
+
+    def domain_names(self) -> list:
+        return [d.get("name") for d in self.domains if isinstance(d, dict) and d.get("name")]
+
+    def specialist_domain(self, domain: str) -> str:
+        """The crew-facing specialist domain name: ``{vendor}-{domain}``."""
+        return f"{self.vendor}-{domain}"
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading + structural validation (the discovery-time light check;
+# scripts/pack/check.py is the full conformance gate)
+# ---------------------------------------------------------------------------
+
+def load_manifest(root: Path) -> tuple:
+    """Return ``(manifest_dict | None, [error strings])`` for a pack root."""
+    manifest_path = Path(root) / MANIFEST_NAME
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, [f"{manifest_path}: unreadable ({exc})"]
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, [f"{manifest_path}: invalid JSON ({exc})"]
+    if not isinstance(manifest, dict):
+        return None, [f"{manifest_path}: manifest must be a JSON object"]
+    return manifest, []
+
+
+def structural_errors(manifest: dict, root: Path) -> list:
+    """The minimum a pack must get right to be *discovered* at all."""
+    errors: list = []
+
+    spec = manifest.get("spec")
+    if spec != SPEC_VERSION:
+        errors.append(f"spec must be {SPEC_VERSION} (got {spec!r})")
+
+    name = manifest.get("name")
+    vendor = manifest.get("vendor")
+    version = manifest.get("version")
+
+    for label, value in (("name", name), ("vendor", vendor)):
+        if not isinstance(value, str) or not _KEBAB_RE.match(value or ""):
+            errors.append(f"{label} must be kebab-case (got {value!r})")
+        elif len(value) > _MAX_NAME_LEN:
+            errors.append(f"{label} exceeds {_MAX_NAME_LEN} chars: {value!r}")
+
+    if isinstance(vendor, str):
+        for reserved in RESERVED_VENDOR_PREFIXES:
+            if vendor == reserved or vendor.startswith(reserved + "-"):
+                errors.append(
+                    f"vendor {vendor!r} uses the reserved prefix {reserved!r} "
+                    "(wicked-* names belong to the first-party catalog)"
+                )
+    if isinstance(name, str) and isinstance(vendor, str) and _KEBAB_RE.match(vendor or ""):
+        if name != vendor and not name.startswith(vendor + "-"):
+            errors.append(f"name {name!r} must start with vendor prefix {vendor!r}")
+
+    if not isinstance(version, str) or not _SEMVER_RE.match(version or ""):
+        errors.append(f"version must be semver (got {version!r})")
+
+    skills_rel = manifest.get("skills_dir", "skills")
+    if not isinstance(skills_rel, str) or ".." in skills_rel.replace("\\", "/").split("/"):
+        errors.append(f"skills_dir must be a relative path inside the pack (got {skills_rel!r})")
+    else:
+        skills_dir = Path(root) / skills_rel
+        if not skills_dir.is_dir():
+            errors.append(f"skills dir not found: {skills_dir}")
+
+    domains = manifest.get("domains")
+    if not isinstance(domains, list) or not domains:
+        errors.append("domains must be a non-empty array")
+
+    return errors
+
+
+def _pack_from_manifest(manifest: dict, root: Path, source: str) -> Pack:
+    skills_rel = manifest.get("skills_dir", "skills")
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    return Pack(
+        name=manifest["name"],
+        vendor=manifest["vendor"],
+        version=manifest["version"],
+        root=Path(root).resolve(),
+        source=source,
+        skills_dir=(Path(root) / skills_rel).resolve(),
+        description=str(manifest.get("description", "")),
+        domains=[d for d in manifest.get("domains", []) if isinstance(d, dict)],
+        peers=manifest.get("peers", {}) if isinstance(manifest.get("peers"), dict) else {},
+        provenance=manifest.get("provenance", {}) if isinstance(manifest.get("provenance"), dict) else {},
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def registry_path() -> Path:
+    override = os.environ.get("WICKED_PACK_REGISTRY")
+    return Path(override) if override else _DEFAULT_REGISTRY
+
+
+def _read_registry_file() -> dict:
+    try:
+        data = json.loads(registry_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _candidate_roots(cwd: Path) -> list:
+    """Yield ``(root, source)`` candidates in priority order (may repeat)."""
+    candidates: list = []
+
+    # 1. WICKED_PACK_PATH — pack roots or directories of pack roots.
+    for entry in filter(None, os.environ.get("WICKED_PACK_PATH", "").split(os.pathsep)):
+        p = Path(entry).expanduser()
+        if (p / MANIFEST_NAME).is_file():
+            candidates.append((p, "env"))
+        elif p.is_dir():
+            try:
+                for child in sorted(p.iterdir()):
+                    if (child / MANIFEST_NAME).is_file():
+                        candidates.append((child, "env"))
+            except OSError:
+                pass
+
+    # 2. Registered packs (pack register / wicked-installer).
+    for record in _read_registry_file().get("packs", []):
+        if isinstance(record, dict) and record.get("path"):
+            p = Path(record["path"]).expanduser()
+            if (p / MANIFEST_NAME).is_file():
+                candidates.append((p, "registered"))
+
+    # 3. Claude Code plugin dirs (direct installs + marketplace cache).
+    plugins_root = Path.home() / ".claude" / "plugins"
+    scan_dirs = [plugins_root]
+    cache_root = plugins_root / "cache"
+    try:
+        if cache_root.is_dir():
+            scan_dirs.extend(sorted(d for d in cache_root.iterdir() if d.is_dir()))
+    except OSError:
+        pass
+    for base in scan_dirs:
+        try:
+            if not base.is_dir():
+                continue
+            for child in sorted(base.iterdir()):
+                if (child / MANIFEST_NAME).is_file():
+                    candidates.append((child, "plugin-dir"))
+        except OSError:
+            continue
+
+    # 4. Project-local packs.
+    local = cwd / ".wicked" / "packs"
+    try:
+        if local.is_dir():
+            for child in sorted(local.iterdir()):
+                if (child / MANIFEST_NAME).is_file():
+                    candidates.append((child, "project"))
+    except OSError:
+        pass
+
+    return candidates
+
+
+def discover_packs(cwd: "Path | None" = None) -> tuple:
+    """Return ``(packs, errors)`` — structurally-valid packs, deduped by name.
+
+    Never raises. A candidate with structural errors is skipped and its
+    errors reported; a later duplicate of an already-seen pack name is
+    silently ignored (priority order above is the tiebreak).
+    """
+    cwd = Path(cwd) if cwd else Path(os.environ.get("CLAUDE_CWD", os.getcwd()))
+    packs: list = []
+    errors: list = []
+    seen: set = set()
+
+    try:
+        candidates = _candidate_roots(cwd)
+    except Exception as exc:  # noqa: BLE001 — discovery is strictly fail-open
+        return [], [f"pack discovery failed: {exc}"]
+
+    for root, source in candidates:
+        try:
+            resolved = Path(root).resolve()
+            manifest, load_errs = load_manifest(resolved)
+            if load_errs or manifest is None:
+                errors.extend(load_errs)
+                continue
+            struct_errs = structural_errors(manifest, resolved)
+            if struct_errs:
+                errors.extend(f"{resolved}: {e}" for e in struct_errs)
+                continue
+            if manifest["name"] in seen:
+                continue
+            seen.add(manifest["name"])
+            packs.append(_pack_from_manifest(manifest, resolved, source))
+        except Exception as exc:  # noqa: BLE001 — skip broken candidates
+            errors.append(f"{root}: {exc}")
+
+    return packs, errors
+
+
+# ---------------------------------------------------------------------------
+# Registration (gap 1 install seam + gap 4 provenance record)
+# ---------------------------------------------------------------------------
+
+def _tree_sha256(skills_dir: Path) -> str:
+    """Content hash over the skills tree (sorted relpath + bytes)."""
+    digest = hashlib.sha256()
+    try:
+        for path in sorted(skills_dir.rglob("*")):
+            if path.is_file():
+                digest.update(str(path.relative_to(skills_dir)).replace("\\", "/").encode())
+                digest.update(path.read_bytes())
+    except OSError:
+        return ""
+    return digest.hexdigest()
+
+
+def register_pack(path: Path, source_url: "str | None" = None,
+                  *, force: bool = False) -> dict:
+    """Run the full conformance gate, then record the pack in registered.json.
+
+    Returns the written record. Raises ValueError on a non-conformant pack
+    (registration is the one deliberately fail-CLOSED door: installing a
+    broken pack should fail loudly, not half-register). ``force=True``
+    downgrades conformance errors to a skipped gate — structural validity
+    is still required.
+    """
+    root = Path(path).expanduser().resolve()
+    manifest, errs = load_manifest(root)
+    if manifest is None:
+        raise ValueError("; ".join(errs))
+    errs = structural_errors(manifest, root)
+    if errs:
+        raise ValueError(f"pack at {root} failed structural validation: " + "; ".join(errs))
+
+    if not force:
+        try:
+            from pack.check import check_pack  # lazy — avoids a module cycle
+            conformance_errors = [f for f in check_pack(root) if f.level == "error"]
+        except Exception as exc:  # noqa: BLE001 — registration is fail-closed
+            raise ValueError(
+                f"conformance gate could not run ({exc}); refusing to register "
+                f"unverified pack (use --force to override)"
+            ) from exc
+        if conformance_errors:
+            rendered = "; ".join(f.render() for f in conformance_errors[:10])
+            raise ValueError(
+                f"pack at {root} failed conformance ({len(conformance_errors)} "
+                f"errors — run `pack check` for the full list; --force to "
+                f"register anyway): {rendered}"
+            )
+
+    pack = _pack_from_manifest(manifest, root, "registered")
+    record = {
+        "name": pack.name,
+        "vendor": pack.vendor,
+        "version": pack.version,
+        "path": str(root),
+        "source_url": source_url or pack.provenance.get("source", ""),
+        "publisher": pack.provenance.get("publisher", ""),
+        "manifest_sha256": pack.manifest_sha256,
+        "skills_tree_sha256": _tree_sha256(pack.skills_dir),
+        "registered_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+    reg_file = registry_path()
+    data = _read_registry_file()
+    packs = [p for p in data.get("packs", []) if isinstance(p, dict) and p.get("name") != pack.name]
+    packs.append(record)
+    reg_file.parent.mkdir(parents=True, exist_ok=True)
+    reg_file.write_text(
+        json.dumps({"spec": SPEC_VERSION, "packs": packs}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return record
+
+
+def unregister_pack(name: str) -> bool:
+    """Remove ``name`` from registered.json. True if it was present."""
+    data = _read_registry_file()
+    packs = data.get("packs", [])
+    kept = [p for p in packs if not (isinstance(p, dict) and p.get("name") == name)]
+    if len(kept) == len(packs):
+        return False
+    reg_file = registry_path()
+    reg_file.parent.mkdir(parents=True, exist_ok=True)
+    reg_file.write_text(
+        json.dumps({"spec": SPEC_VERSION, "packs": kept}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def registered_records() -> list:
+    return [p for p in _read_registry_file().get("packs", []) if isinstance(p, dict)]
+
+
+# ---------------------------------------------------------------------------
+# Crew-routing + steering views (gaps 2 and 5)
+# ---------------------------------------------------------------------------
+
+def specialist_entries(packs: "list | None" = None) -> list:
+    """specialist.json-shaped entries contributed by packs.
+
+    Each pack domain that declares a ``specialist`` block yields
+    ``{name: "{vendor}-{domain}", role, description, enhances, pack}``.
+    Merged by consumers AFTER garden's own specialist.json (first-party
+    entries always win a name collision).
+    """
+    if packs is None:
+        packs, _ = discover_packs()
+    entries: list = []
+    for pack in packs:
+        for domain in pack.domains:
+            spec = domain.get("specialist")
+            if not isinstance(spec, dict):
+                continue
+            name = pack.specialist_domain(domain.get("name", ""))
+            entries.append({
+                "name": name,
+                "role": spec.get("role", domain.get("name", "")),
+                "description": spec.get("description", pack.description),
+                "enhances": spec.get("enhances", []),
+                "pack": pack.name,
+            })
+    return entries
+
+
+def specialist_domains(packs: "list | None" = None) -> list:
+    """The crew-facing specialist domain names contributed by packs."""
+    return [e["name"] for e in specialist_entries(packs)]
+
+
+def pack_produces(packs: "list | None" = None) -> list:
+    """Produces-contract declarations contributed by packs (gap 5 data layer).
+
+    Shape: ``{pack, domain, archetype, produces: [ids], gate}`` per entry.
+    The loom gate consumes a produces id directly (``loom.gate.run_gate``);
+    steering attach is the documented seam (docs/extending.md §produces).
+    """
+    if packs is None:
+        packs, _ = discover_packs()
+    out: list = []
+    for pack in packs:
+        for domain in pack.domains:
+            for contract in domain.get("produces", []) or []:
+                if not isinstance(contract, dict):
+                    continue
+                out.append({
+                    "pack": pack.name,
+                    "domain": pack.specialist_domain(domain.get("name", "")),
+                    "archetype": contract.get("archetype", ""),
+                    "produces": list(contract.get("produces", []) or []),
+                    "gate": contract.get("gate", "vault"),
+                })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Peer version floors (gap 6 — fail-open probe)
+# ---------------------------------------------------------------------------
+
+def _parse_floor(range_str: str) -> "tuple | None":
+    m = _FLOOR_RE.match((range_str or "").strip())
+    if not m:
+        return None
+    return int(m.group(2)), int(m.group(3)), int(m.group(4))
+
+
+def _parse_version(version_str: str) -> "tuple | None":
+    m = _SEMVER_RE.match((version_str or "").strip().lstrip("v"))
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def _garden_version(plugin_root: "Path | None") -> "str | None":
+    roots = []
+    if plugin_root:
+        roots.append(Path(plugin_root))
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        roots.append(Path(env_root))
+    roots.append(Path(__file__).resolve().parents[1])
+    for root in roots:
+        try:
+            data = json.loads((root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+            if data.get("version"):
+                return str(data["version"])
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return None
+
+
+def _probe_binary_version(binary: str) -> "str | None":
+    """``<binary> --version`` with a tight timeout. None = unknown."""
+    resolved = shutil.which(binary)
+    if not resolved:
+        return None
+    try:
+        out = subprocess.run(
+            [resolved, "--version"], capture_output=True, text=True,
+            timeout=_PROBE_TIMEOUT_S, check=False,
+        )
+        text = (out.stdout or "") + (out.stderr or "")
+        m = re.search(r"(\d+\.\d+\.\d+)", text)
+        return m.group(1) if m else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def check_peer_floors(packs: "list | None" = None, *,
+                      plugin_root: "Path | None" = None,
+                      probe: bool = True) -> list:
+    """Compare each pack's declared peer floors to installed versions.
+
+    Returns a list of finding dicts:
+      {pack, peer, floor, installed, status}
+    status ∈ ok | below-floor | unknown | bad-range.
+
+    Fail-open by design: only ``below-floor`` (and ``bad-range``) are
+    actionable; ``unknown`` means the peer could not be probed and MUST be
+    treated as informational, never a block. With ``probe=False`` only the
+    zero-subprocess checks run (garden's own version) — the cheap mode for
+    SessionStart.
+    """
+    if packs is None:
+        packs, _ = discover_packs()
+    findings: list = []
+
+    garden_version = _garden_version(plugin_root)
+    probed: dict = {}
+
+    for pack in packs:
+        for peer, range_str in sorted((pack.peers or {}).items()):
+            floor = _parse_floor(str(range_str))
+            if floor is None:
+                findings.append({"pack": pack.name, "peer": peer, "floor": str(range_str),
+                                 "installed": None, "status": "bad-range"})
+                continue
+
+            installed: "str | None"
+            if peer == "wicked-garden":
+                installed = garden_version
+            elif probe:
+                if peer not in probed:
+                    probed[peer] = _probe_binary_version(peer)
+                installed = probed[peer]
+            else:
+                installed = None
+
+            if installed is None:
+                findings.append({"pack": pack.name, "peer": peer, "floor": str(range_str),
+                                 "installed": None, "status": "unknown"})
+                continue
+
+            parsed = _parse_version(installed)
+            status = "unknown" if parsed is None else ("ok" if parsed >= floor else "below-floor")
+            findings.append({"pack": pack.name, "peer": peer, "floor": str(range_str),
+                             "installed": installed, "status": status})
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# CLI — the catalog surface (`pack list`) + registration verbs
+# ---------------------------------------------------------------------------
+
+def _cmd_list(as_json: bool) -> int:
+    packs, errors = discover_packs()
+    if as_json:
+        payload = {
+            "packs": [{
+                "name": p.name, "vendor": p.vendor, "version": p.version,
+                "root": str(p.root), "source": p.source,
+                "description": p.description,
+                "domains": p.domain_names(),
+                "specialists": specialist_domains([p]),
+                "produces": pack_produces([p]),
+                "peers": p.peers,
+                "provenance": p.provenance,
+                "manifest_sha256": p.manifest_sha256,
+            } for p in packs],
+            "errors": errors,
+            "registered": registered_records(),
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+    if not packs:
+        print("no packs discovered")
+    for p in packs:
+        print(f"{p.name} v{p.version}  [{p.source}]  {p.root}")
+        print(f"  domains: {', '.join(p.domain_names())}")
+        specs = specialist_domains([p])
+        if specs:
+            print(f"  crew specialists: {', '.join(specs)}")
+        if p.provenance:
+            print(f"  provenance: {p.provenance.get('publisher', '?')} "
+                  f"<{p.provenance.get('source', 'no source url')}>")
+    for err in errors:
+        print(f"WARN: {err}", file=sys.stderr)
+    return 0
+
+
+def _cmd_floors(as_json: bool) -> int:
+    findings = check_peer_floors()
+    if as_json:
+        print(json.dumps({"findings": findings}, indent=2))
+    else:
+        if not findings:
+            print("no pack peer floors declared")
+        for f in findings:
+            print(f"{f['pack']}: {f['peer']} {f['floor']} — installed "
+                  f"{f['installed'] or '?'} [{f['status']}]")
+    # Fail-open: floors never fail the command; violations are data.
+    return 0
+
+
+def main(argv: "list | None" = None) -> int:
+    parser = argparse.ArgumentParser(prog="wicked-garden pack",
+                                     description="Third-party pack registry")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="discovered packs (the catalog view)")
+    p_list.add_argument("--json", action="store_true")
+
+    p_reg = sub.add_parser("register", help="register a pack directory")
+    p_reg.add_argument("path")
+    p_reg.add_argument("--source", default=None, help="origin URL (npm/git) for provenance")
+    p_reg.add_argument("--force", action="store_true",
+                       help="register even when the conformance gate fails (structural validity still required)")
+
+    p_unreg = sub.add_parser("unregister", help="remove a registered pack")
+    p_unreg.add_argument("name")
+
+    p_floors = sub.add_parser("floors", help="check declared peer version floors")
+    p_floors.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "list":
+        return _cmd_list(args.json)
+    if args.cmd == "register":
+        try:
+            record = register_pack(Path(args.path), source_url=args.source,
+                                   force=args.force)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(record, indent=2))
+        return 0
+    if args.cmd == "unregister":
+        removed = unregister_pack(args.name)
+        print(f"{args.name}: {'unregistered' if removed else 'not registered'}")
+        return 0 if removed else 1
+    if args.cmd == "floors":
+        return _cmd_floors(args.json)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crew/specialist_resolver.py
+++ b/scripts/crew/specialist_resolver.py
@@ -32,6 +32,14 @@ is the dispatchable fork-skill name (``wicked-garden-{domain}-{role}``).
 
 The builder is cached per ``plugin_root`` string so repeated calls from
 hooks or scripts do not re-walk the skills tree.
+
+Third-party packs (extension-contract gap 2): after walking garden's own
+skills tree, the builder discovers installed packs via
+``scripts/_pack_registry.py`` (wicked-pack.json manifests) and indexes
+their ``context: fork`` workers under the same maps — so crew dispatch of
+``{vendor}-{domain}-{role}`` (e.g. ``acme-seo-keyword-analyst``) resolves
+exactly like a first-party worker. Garden walks FIRST, so a pack can never
+shadow a first-party role name; pack discovery is strictly fail-open.
 """
 
 from __future__ import annotations
@@ -124,6 +132,66 @@ def _load_domains(plugin_root: Path) -> list:
     return names
 
 
+def _discover_packs_safe() -> list:
+    """Discovered third-party packs, or [] — never raises (fail-open)."""
+    try:
+        import sys
+        scripts_dir = str(Path(__file__).resolve().parents[1])
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+        import _pack_registry
+        packs, _errors = _pack_registry.discover_packs()
+        return packs
+    except Exception:
+        return []
+
+
+def _index_pack_workers(pack, maps: dict, warnings: list) -> None:
+    """Index one pack's ``context: fork`` workers into the resolver maps.
+
+    Pack workers are named ``{vendor}-{domain}-{role}``; their specialist
+    domain is the qualified ``{vendor}-{domain}`` (so pack domains can never
+    collide with garden's bare domain names). Both the bare role tail and
+    the full skill name resolve. First match wins — garden is indexed
+    before any pack, and packs are iterated in discovery priority order.
+    """
+    try:
+        skills_dir = Path(pack.skills_dir)
+        if not skills_dir.is_dir():
+            return
+        pack_domains = sorted(pack.domain_names(), key=len, reverse=True)
+        for skill_path in sorted(skills_dir.rglob("SKILL.md")):
+            meta = _parse_skill_frontmatter(skill_path)
+            if meta.get("context") != "fork":
+                continue
+            skill_name = meta.get("name")
+            if not skill_name or not skill_name.startswith(pack.vendor + "-"):
+                continue
+            tail = skill_name[len(pack.vendor) + 1:]
+            domain = next((d for d in pack_domains if tail.startswith(d + "-")), None)
+            if domain is None:
+                continue  # not a {vendor}-{domain}-{role} worker — pack check flags it
+            role = tail[len(domain) + 1:]
+            qualified_domain = pack.specialist_domain(domain)
+
+            if role in maps["role_to_skill"]:
+                if maps["role_to_skill"][role] != skill_name:
+                    warnings.append(
+                        f"role collision: '{role}' maps to both "
+                        f"'{maps['role_to_skill'][role]}' and '{skill_name}' "
+                        f"(pack {pack.name}) — keeping first"
+                    )
+            else:
+                maps["role_to_skill"][role] = skill_name
+                maps["role_to_domain"][role] = qualified_domain
+            # The full skill name ALWAYS resolves (even when the bare role
+            # lost a collision) — crew dispatches pack workers by full name.
+            maps["skill_to_role"].setdefault(skill_name, role)
+            maps["skill_to_domain"].setdefault(skill_name, qualified_domain)
+    except Exception:
+        pass  # fail-open — a broken pack never breaks first-party resolution
+
+
 def _split_domain_role(skill_name: str, legacy_subagent_type: str) -> Tuple[str, str]:
     """Derive ``(domain, bare_role)`` for a fork skill.
 
@@ -158,6 +226,7 @@ def _build_resolver_cached(plugin_root_str: str) -> dict:
     role_to_skill: dict = {}
     role_to_domain: dict = {}
     skill_to_role: dict = {}
+    skill_to_domain: dict = {}
     subagent_to_role: dict = {}
     warnings: list = []
 
@@ -190,8 +259,24 @@ def _build_resolver_cached(plugin_root_str: str) -> dict:
             role_to_skill[role] = skill_name
             role_to_domain[role] = domain
             skill_to_role[skill_name] = role
+            skill_to_domain[skill_name] = domain
             if legacy_subagent_type:
                 subagent_to_role.setdefault(legacy_subagent_type, role)
+
+    # Third-party packs (gap 2): indexed AFTER garden so first-party names
+    # always win collisions. Strictly fail-open.
+    maps = {
+        "role_to_skill": role_to_skill,
+        "role_to_domain": role_to_domain,
+        "skill_to_role": skill_to_role,
+        "skill_to_domain": skill_to_domain,
+    }
+    packs = _discover_packs_safe()
+    pack_domains: list = []
+    for pack in packs:
+        _index_pack_workers(pack, maps, warnings)
+        for domain_name in pack.domain_names():
+            pack_domains.append(pack.specialist_domain(domain_name))
 
     return {
         # role -> dispatchable fork-skill name (dash form). The key keeps
@@ -201,10 +286,14 @@ def _build_resolver_cached(plugin_root_str: str) -> dict:
         "role_to_skill": role_to_skill,
         "role_to_domain": role_to_domain,
         "skill_to_role": skill_to_role,
+        # skill name -> owning specialist domain (garden bare domains;
+        # packs use the qualified "{vendor}-{domain}" form).
+        "skill_to_domain": skill_to_domain,
         # legacy colon subagent_type -> role (only where a fork skill kept
         # the legacy frontmatter key), plus skill name -> role.
         "subagent_to_role": {**subagent_to_role, **skill_to_role},
-        "domains": _load_domains(plugin_root),
+        "domains": _load_domains(plugin_root) + pack_domains,
+        "packs": [pack.name for pack in packs],
         "warnings": warnings,
     }
 
@@ -237,9 +326,10 @@ def resolve_role(
     """Return ``(domain, skill_name)`` for a role, or ``(None, None)``.
 
     Accepts a bare role (``requirements-analyst``), a fork-skill name
-    (``wicked-garden-product-requirements-analyst``), or a legacy colon
-    subagent_type (``wicked-garden:product:requirements-analyst``) —
-    all resolve to the dispatchable fork-skill name.
+    (``wicked-garden-product-requirements-analyst`` — or a pack worker
+    like ``acme-seo-keyword-analyst``), or a legacy colon subagent_type
+    (``wicked-garden:product:requirements-analyst``) — all resolve to
+    the dispatchable fork-skill name.
 
     Unknown roles return ``(None, None)`` without raising. Callers that
     want close-match suggestions should drive ``difflib.get_close_matches``
@@ -251,9 +341,14 @@ def resolve_role(
     if not role_name:
         return None, None
 
-    # Qualified identifiers (legacy colon form or dash skill name): map
-    # back to the bare role via the reverse map, then use the forward
-    # maps so the return shape is consistent for every input form.
+    # Exact fork-skill name (first-party OR pack worker): the direct map
+    # is authoritative — immune to bare-role collisions.
+    direct_domain = resolver.get("skill_to_domain", {}).get(role_name)
+    if direct_domain is not None:
+        return direct_domain, role_name
+
+    # Legacy colon identifiers: map back to the bare role via the reverse
+    # map, then fall through to the forward maps below.
     if role_name.startswith(_SUBAGENT_PREFIX) or role_name.startswith(_SKILL_PREFIX):
         bare = resolver.get("subagent_to_role", {}).get(role_name)
         if bare is None:

--- a/scripts/pack/check.py
+++ b/scripts/pack/check.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""check.py — the shipped pack conformance gate (extension-contract gap 3).
+
+Validates a third-party pack against the catalog rules the ruling codified
+(SKILL-RATIONALIZATION §4 naming rules + SKILLS-GUIDELINES disclosure tiers),
+executable OUTSIDE garden's dev tree: this file ships in the npm package and
+the installed plugin, so pack authors run it as
+
+    npx wicked-garden pack check <pack-dir>
+    # or directly:
+    python3 scripts/pack/check.py <pack-dir> [--json] [--garden-root DIR]
+
+Exit code 0 = conformant (warnings allowed), 1 = errors found, 2 = usage.
+
+Rule codes
+----------
+  PK001  wicked-pack.json missing or unparseable
+  PK002  manifest structural error (spec/name/vendor/version/skills_dir/domains)
+  PK010  skills tree empty
+  PK011  SKILL.md missing frontmatter, name, or description
+  PK012  skill name not kebab-case or > 64 chars
+  PK013  skill name not prefixed with "{vendor}-"
+  PK014  declared domain has no router skill "{vendor}-{domain}"
+  PK015  router skill must not declare context: fork
+  PK016  worker skill "{vendor}-{domain}-{role}" must declare context: fork
+  PK017  skill directory name must match frontmatter name
+  PK018  skill does not belong to any declared domain
+  PK020  non-fork SKILL.md exceeds 200 lines (tier-2 disclosure cap)
+  PK021  frontmatter description exceeds ~120 words (tier-1 cap) [warn]
+  PK022  refs/ file exceeds 350 lines (tier-3 band is 200-300) [warn]
+  PK030  NOT-THIS-WHEN reciprocity: same-pack twin does not point back
+  PK031  NOT-THIS-WHEN target skill not found [warn]
+  PK040  produces contract names an unknown archetype
+  PK041  produces id not kebab-case
+  PK042  specialist "enhances" phase not a known crew phase [warn]
+  PK050  peer floor range malformed (expected ">=X.Y.Z" or "^X.Y.Z")
+
+stdlib-only. Imports the manifest loader from scripts/_pack_registry.py
+(same package layout in the repo, the npm tarball, and the installed
+plugin), so validation and discovery can never drift apart.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# scripts/ on sys.path so _pack_registry resolves in-repo, in the npm
+# tarball, and in the installed plugin (all share the scripts/ layout).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from _pack_registry import (  # noqa: E402
+    MANIFEST_NAME,
+    _KEBAB_RE,
+    _FLOOR_RE,
+    _MAX_NAME_LEN,
+    load_manifest,
+    structural_errors,
+)
+
+# Fallback archetype catalog — kept in sync with .claude-plugin/archetypes.json;
+# when a garden root is locatable the live file wins (see _known_archetypes).
+_FALLBACK_ARCHETYPES = (
+    "triage", "explore", "specify", "decide", "ship",
+    "review", "incident", "build", "migrate", "modernize",
+)
+
+# Crew phases a specialist may declare in "enhances" (specialist.json usage).
+_KNOWN_PHASES = {"clarify", "design", "qe", "build", "review", "operate", "*"}
+
+_FRONTMATTER_FENCE = "---"
+_MAX_BODY_LINES = 200
+_MAX_DESC_WORDS = 120
+_MAX_REF_LINES = 350
+_NOT_THIS_WHEN_RE = re.compile(r"NOT[ -]THIS[ -]WHEN", re.IGNORECASE)
+_BACKTICK_NAME_RE = re.compile(r"`([a-z0-9][a-z0-9-]*)`")
+
+
+class Finding:
+    __slots__ = ("code", "level", "where", "message")
+
+    def __init__(self, code: str, level: str, where: str, message: str):
+        self.code = code
+        self.level = level  # "error" | "warn"
+        self.where = where
+        self.message = message
+
+    def as_dict(self) -> dict:
+        return {"code": self.code, "level": self.level,
+                "where": self.where, "message": self.message}
+
+    def render(self) -> str:
+        return f"{self.code} [{self.level.upper()}] {self.where}: {self.message}"
+
+
+def _parse_frontmatter(text: str) -> tuple:
+    """Return ``(frontmatter_dict, fm_line_count)``.
+
+    Scalar top-level keys only, plus multi-line ``description: |`` blocks
+    captured verbatim — mirrors the resolver's line-scan (no YAML lib).
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
+        return {}, 0
+    fm: dict = {}
+    desc_lines: list = []
+    in_desc = False
+    end = 0
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == _FRONTMATTER_FENCE:
+            end = i
+            break
+        if in_desc:
+            if line.startswith((" ", "\t")) or not line.strip():
+                desc_lines.append(line.strip())
+                continue
+            in_desc = False
+        if ":" in line and not line.startswith((" ", "\t", "-")):
+            key, _, val = line.partition(":")
+            key, val = key.strip(), val.strip()
+            if key == "description" and val in ("|", ">", "|-", ">-"):
+                in_desc = True
+                continue
+            fm.setdefault(key, val)
+    if desc_lines:
+        fm["description"] = " ".join(l for l in desc_lines if l)
+    return fm, end
+
+
+def _known_archetypes(garden_root: "Path | None") -> set:
+    roots = [garden_root] if garden_root else []
+    import os
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        roots.append(Path(env_root))
+    roots.append(_SCRIPTS_DIR.parent)  # in-repo / installed-plugin layout
+    for root in roots:
+        try:
+            data = json.loads(
+                (Path(root) / ".claude-plugin" / "archetypes.json").read_text(encoding="utf-8"))
+            names = set(data.get("archetypes", {}).keys())
+            if names:
+                return names
+        except (OSError, json.JSONDecodeError, AttributeError):
+            continue
+    return set(_FALLBACK_ARCHETYPES)
+
+
+def _garden_skill_exists(name: str, garden_root: "Path | None") -> "bool | None":
+    """True/False when a garden skills tree is locatable; None when unknown."""
+    import os
+    roots = [garden_root] if garden_root else []
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        roots.append(Path(env_root))
+    roots.append(_SCRIPTS_DIR.parent)
+    for root in roots:
+        skills = Path(root) / "skills"
+        if skills.is_dir():
+            return (skills / name / "SKILL.md").is_file()
+    return None
+
+
+def check_pack(pack_root: Path, *, garden_root: "Path | None" = None) -> list:
+    """Run every rule; return the full findings list (errors + warnings)."""
+    findings: list = []
+    err = lambda code, where, msg: findings.append(Finding(code, "error", where, msg))  # noqa: E731
+    warn = lambda code, where, msg: findings.append(Finding(code, "warn", where, msg))  # noqa: E731
+
+    pack_root = Path(pack_root).resolve()
+    manifest, load_errs = load_manifest(pack_root)
+    if manifest is None:
+        for e in load_errs:
+            err("PK001", MANIFEST_NAME, e)
+        return findings
+
+    for e in structural_errors(manifest, pack_root):
+        err("PK002", MANIFEST_NAME, e)
+    if any(f.code == "PK002" and "skills dir" in f.message for f in findings):
+        return findings  # cannot walk a missing tree
+
+    vendor = str(manifest.get("vendor", ""))
+    skills_dir = pack_root / str(manifest.get("skills_dir", "skills"))
+    domain_names = [d.get("name", "") for d in manifest.get("domains", [])
+                    if isinstance(d, dict)]
+
+    # ---- walk the skills tree -------------------------------------------
+    skill_files = sorted(skills_dir.rglob("SKILL.md")) if skills_dir.is_dir() else []
+    if not skill_files:
+        err("PK010", str(skills_dir), "no SKILL.md files found")
+        return findings
+
+    skills: dict = {}   # name -> {fm, path, text, is_fork}
+    for skill_md in skill_files:
+        rel = str(skill_md.relative_to(pack_root))
+        try:
+            text = skill_md.read_text(encoding="utf-8")
+        except OSError as exc:
+            err("PK011", rel, f"unreadable: {exc}")
+            continue
+        fm, _ = _parse_frontmatter(text)
+        name = fm.get("name", "")
+        if not fm or not name or not fm.get("description"):
+            err("PK011", rel, "frontmatter must declare name + description")
+            continue
+        if not _KEBAB_RE.match(name) or len(name) > _MAX_NAME_LEN:
+            err("PK012", rel, f"skill name {name!r} must be kebab-case, <= {_MAX_NAME_LEN} chars")
+        if vendor and not (name == vendor or name.startswith(vendor + "-")):
+            err("PK013", rel, f"skill name {name!r} must be prefixed with vendor {vendor!r}")
+        if skill_md.parent.name != name:
+            err("PK017", rel, f"directory {skill_md.parent.name!r} must match skill name {name!r}")
+        skills[name] = {
+            "fm": fm, "path": rel, "text": text,
+            "is_fork": fm.get("context", "") == "fork",
+        }
+
+    # ---- router / worker shape per declared domain ----------------------
+    router_names = {f"{vendor}-{d}" for d in domain_names}
+    for d in domain_names:
+        router = f"{vendor}-{d}"
+        if router not in skills:
+            err("PK014", MANIFEST_NAME,
+                f"domain {d!r} has no router skill {router!r} (one router per domain)")
+        elif skills[router]["is_fork"]:
+            err("PK015", skills[router]["path"],
+                f"router {router!r} must be user-invocable, not context: fork")
+
+    for name, info in skills.items():
+        if name in router_names:
+            continue
+        owner = next((d for d in sorted(domain_names, key=len, reverse=True)
+                      if name.startswith(f"{vendor}-{d}-")), None)
+        if owner is None:
+            err("PK018", info["path"],
+                f"skill {name!r} does not belong to any declared domain "
+                f"(expected {vendor}-{{domain}}-{{role}} with domain in {domain_names})")
+            continue
+        if not info["is_fork"]:
+            err("PK016", info["path"],
+                f"worker {name!r} must declare context: fork (isolated subagent)")
+
+    # ---- disclosure tiers ------------------------------------------------
+    for name, info in skills.items():
+        line_count = len(info["text"].splitlines())
+        if not info["is_fork"] and line_count > _MAX_BODY_LINES:
+            err("PK020", info["path"],
+                f"{line_count} lines (tier-2 cap is {_MAX_BODY_LINES}; "
+                "move detail into refs/)")
+        desc_words = len(str(info["fm"].get("description", "")).split())
+        if desc_words > _MAX_DESC_WORDS:
+            warn("PK021", info["path"],
+                 f"frontmatter description is {desc_words} words "
+                 f"(tier-1 guidance is ~100, cap {_MAX_DESC_WORDS})")
+    if skills_dir.is_dir():
+        for ref in sorted(skills_dir.rglob("refs/*.md")):
+            try:
+                ref_lines = len(ref.read_text(encoding="utf-8").splitlines())
+            except OSError:
+                continue
+            if ref_lines > _MAX_REF_LINES:
+                warn("PK022", str(ref.relative_to(pack_root)),
+                     f"{ref_lines} lines (tier-3 band is 200-300)")
+
+    # ---- NOT-THIS-WHEN reciprocity ---------------------------------------
+    ntw: dict = {}
+    for name, info in skills.items():
+        refs = set()
+        for chunk in (str(info["fm"].get("description", "")), info["text"]):
+            for block in _NOT_THIS_WHEN_RE.split(chunk)[1:]:
+                # names referenced in the sentence(s) after the marker
+                refs.update(_BACKTICK_NAME_RE.findall(block[:400]))
+        ntw[name] = {r for r in refs if r != name}
+    for name, targets in ntw.items():
+        for target in sorted(targets):
+            if target in skills:
+                if name not in ntw.get(target, set()):
+                    err("PK030", skills[name]["path"],
+                        f"NOT-THIS-WHEN names `{target}` but `{target}` does not "
+                        f"point back at `{name}` (twins must be reciprocal)")
+            elif target.startswith("wicked-garden-"):
+                exists = _garden_skill_exists(target, garden_root)
+                if exists is False:
+                    warn("PK031", skills[name]["path"],
+                         f"NOT-THIS-WHEN target `{target}` not found in the garden catalog")
+            elif target.startswith(vendor + "-") or target in router_names:
+                warn("PK031", skills[name]["path"],
+                     f"NOT-THIS-WHEN target `{target}` not found in this pack")
+
+    # ---- produces contracts + specialist blocks ---------------------------
+    archetypes = _known_archetypes(garden_root)
+    for domain in manifest.get("domains", []):
+        if not isinstance(domain, dict):
+            continue
+        d = domain.get("name", "?")
+        for contract in domain.get("produces", []) or []:
+            if not isinstance(contract, dict):
+                err("PK040", MANIFEST_NAME, f"domain {d!r}: produces entry must be an object")
+                continue
+            archetype = contract.get("archetype", "")
+            if archetype not in archetypes:
+                err("PK040", MANIFEST_NAME,
+                    f"domain {d!r}: unknown archetype {archetype!r} "
+                    f"(known: {', '.join(sorted(archetypes))})")
+            for pid in contract.get("produces", []) or []:
+                if not isinstance(pid, str) or not _KEBAB_RE.match(pid):
+                    err("PK041", MANIFEST_NAME,
+                        f"domain {d!r}: produces id {pid!r} must be kebab-case")
+        spec = domain.get("specialist")
+        if isinstance(spec, dict):
+            for phase in spec.get("enhances", []) or []:
+                if phase not in _KNOWN_PHASES:
+                    warn("PK042", MANIFEST_NAME,
+                         f"domain {d!r}: enhances phase {phase!r} is not a known "
+                         f"crew phase ({', '.join(sorted(_KNOWN_PHASES))})")
+
+    # ---- peer floors -------------------------------------------------------
+    peers = manifest.get("peers", {})
+    if isinstance(peers, dict):
+        for peer, range_str in sorted(peers.items()):
+            if not _FLOOR_RE.match(str(range_str).strip()):
+                err("PK050", MANIFEST_NAME,
+                    f"peer {peer!r} floor {range_str!r} malformed "
+                    "(expected \">=X.Y.Z\" or \"^X.Y.Z\")")
+
+    return findings
+
+
+def main(argv: "list | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="pack check", description="wicked-garden pack conformance gate")
+    parser.add_argument("pack_root", help="pack directory (contains wicked-pack.json)")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--garden-root", default=None,
+                        help="garden plugin root for cross-catalog checks (optional)")
+    args = parser.parse_args(argv)
+
+    pack_root = Path(args.pack_root)
+    if not pack_root.is_dir():
+        print(f"ERROR: not a directory: {pack_root}", file=sys.stderr)
+        return 2
+
+    findings = check_pack(pack_root,
+                          garden_root=Path(args.garden_root) if args.garden_root else None)
+    errors = [f for f in findings if f.level == "error"]
+    warnings = [f for f in findings if f.level == "warn"]
+
+    if args.json:
+        print(json.dumps({
+            "pack_root": str(pack_root.resolve()),
+            "ok": not errors,
+            "errors": [f.as_dict() for f in errors],
+            "warnings": [f.as_dict() for f in warnings],
+        }, indent=2))
+    else:
+        for f in findings:
+            print(f.render())
+        verdict = "PASS" if not errors else "FAIL"
+        print(f"\npack check: {verdict} ({len(errors)} errors, {len(warnings)} warnings)")
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pack/check.py
+++ b/scripts/pack/check.py
@@ -103,6 +103,8 @@ def _parse_frontmatter(text: str) -> tuple:
 
     Scalar top-level keys only, plus multi-line ``description: |`` blocks
     captured verbatim — mirrors the resolver's line-scan (no YAML lib).
+    Frontmatter without a CLOSING fence is malformed and yields ``({}, 0)``
+    so the caller reports PK011 instead of trusting a half-open block.
     """
     lines = text.splitlines()
     if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
@@ -110,9 +112,11 @@ def _parse_frontmatter(text: str) -> tuple:
     fm: dict = {}
     desc_lines: list = []
     in_desc = False
+    closed = False
     end = 0
     for i, line in enumerate(lines[1:], start=1):
         if line.strip() == _FRONTMATTER_FENCE:
+            closed = True
             end = i
             break
         if in_desc:
@@ -127,6 +131,8 @@ def _parse_frontmatter(text: str) -> tuple:
                 in_desc = True
                 continue
             fm.setdefault(key, val)
+    if not closed:
+        return {}, 0
     if desc_lines:
         fm["description"] = " ".join(l for l in desc_lines if l)
     return fm, end
@@ -181,8 +187,9 @@ def check_pack(pack_root: Path, *, garden_root: "Path | None" = None) -> list:
 
     for e in structural_errors(manifest, pack_root):
         err("PK002", MANIFEST_NAME, e)
-    if any(f.code == "PK002" and "skills dir" in f.message for f in findings):
-        return findings  # cannot walk a missing tree
+    if any(f.code == "PK002" and ("skills dir" in f.message or "skills_dir" in f.message)
+           for f in findings):
+        return findings  # cannot walk a missing/escaping tree
 
     vendor = str(manifest.get("vendor", ""))
     skills_dir = pack_root / str(manifest.get("skills_dir", "skills"))

--- a/tests/fixtures/packs/acme-broken/skills/acme-seo-ranker/SKILL.md
+++ b/tests/fixtures/packs/acme-broken/skills/acme-seo-ranker/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: acme-seo-ranker
+context: fork
+description: |
+  Ranking analyst. Part of the broken fixture: it is referenced by the
+  scraper's NOT-THIS-WHEN but deliberately does not point back.
+---
+
+# Ranker (broken fixture)
+
+A conformant worker on its own — exists so the scraper's one-way
+NOT-THIS-WHEN reference is detectable as non-reciprocal (PK030).

--- a/tests/fixtures/packs/acme-broken/skills/acme-seo-scraper/SKILL.md
+++ b/tests/fixtures/packs/acme-broken/skills/acme-seo-scraper/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: acme-seo-scraper
+description: |
+  Scrapes SERPs. Deliberately BROKEN: this is a worker
+  ({vendor}-{domain}-{role}) but it does not declare context: fork.
+
+  NOT THIS WHEN: ranking analysis — use `acme-seo-ranker`
+  (which deliberately does NOT point back, breaking reciprocity).
+---
+
+# Scraper (broken fixture)
+
+Worker without `context: fork` — must trip PK016. Its NOT-THIS-WHEN
+reference above must trip PK030 because the ranker does not reciprocate.

--- a/tests/fixtures/packs/acme-broken/skills/wicked-garden-seo-thief/SKILL.md
+++ b/tests/fixtures/packs/acme-broken/skills/wicked-garden-seo-thief/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: wicked-garden-seo-thief
+context: fork
+description: |
+  Deliberately BROKEN: claims the reserved wicked-garden prefix from a
+  third-party pack. Must trip PK013 (vendor prefix) — the wicked-* namespace
+  belongs to the first-party catalog.
+---
+
+# Thief (broken fixture)
+
+A pack skill squatting on the first-party namespace.

--- a/tests/fixtures/packs/acme-broken/wicked-pack.json
+++ b/tests/fixtures/packs/acme-broken/wicked-pack.json
@@ -1,0 +1,30 @@
+{
+  "spec": 1,
+  "name": "acme-broken",
+  "vendor": "acme",
+  "version": "0.1.0",
+  "description": "Deliberately non-conformant pack — exercises the pack check failure modes. Every defect here is intentional.",
+  "skills_dir": "skills",
+  "domains": [
+    {
+      "name": "seo",
+      "specialist": {
+        "role": "seo-engineering",
+        "enhances": ["design", "sorcery"]
+      },
+      "produces": [
+        {
+          "archetype": "seo-magic",
+          "produces": ["Audit_Report"]
+        }
+      ]
+    }
+  ],
+  "peers": {
+    "wicked-vault": "latest"
+  },
+  "provenance": {
+    "source": "https://github.com/acme/acme-broken-pack",
+    "publisher": "acme"
+  }
+}

--- a/tests/fixtures/packs/acme-seo/skills/acme-seo-content-auditor/SKILL.md
+++ b/tests/fixtures/packs/acme-seo/skills/acme-seo-content-auditor/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: acme-seo-content-auditor
+context: fork
+model: sonnet
+effort: medium
+max-turns: 10
+allowed-tools: Read, Write, Bash, Grep, Glob, WebFetch
+description: |
+  On-page SEO auditor — crawls the given pages, checks title/meta/heading
+  structure, internal linking, and content-keyword alignment, then records
+  an evidence-backed seo-audit verdict via wicked-vault (never self-asserted).
+
+  Use when: "audit this page", "SEO review", "why does this page not rank",
+  "meta description review", "content audit with a verdict".
+
+  NOT THIS WHEN: greenfield keyword strategy with no page to audit — use
+  `acme-seo-keyword-analyst` (the strategy twin); this skill judges
+  existing content and writes evidence.
+phase_relevance: ["review"]
+archetype_relevance: ["review"]
+---
+
+# Content Auditor
+
+You audit existing pages and record a verdict the gate can re-derive.
+
+## Method
+
+1. Fetch each target page; extract title, meta description, headings,
+   internal links, and body text.
+2. Check: one h1; title <= 60 chars containing the primary keyword; meta
+   description 120-160 chars; heading hierarchy without skips; primary
+   keyword in the first paragraph; at least two contextual internal links.
+3. Score each page PASS / CONDITIONAL / FAIL with the failing checks named.
+4. Record the evidence BEFORE reporting:
+
+   ```bash
+   wicked-vault record --scope "$SCOPE" --phase seo-audit \
+     --actor acme-seo-content-auditor --run -- <verifier-command>
+   ```
+
+5. Report the per-page table + remediation list. The review archetype's
+   produces-gate re-derives `seo-audit` through the vault — a verdict you
+   did not record does not exist.
+
+## Boundaries
+
+- Judge and record; never rewrite the page in the same run (evaluator ≠
+  creator).
+- Keyword strategy questions go to `acme-seo-keyword-analyst`.

--- a/tests/fixtures/packs/acme-seo/skills/acme-seo-keyword-analyst/SKILL.md
+++ b/tests/fixtures/packs/acme-seo/skills/acme-seo-keyword-analyst/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: acme-seo-keyword-analyst
+context: fork
+model: sonnet
+effort: medium
+max-turns: 8
+allowed-tools: Read, Write, Bash, Grep, Glob, WebFetch
+description: |
+  Keyword research specialist — builds a keyword map with intent clusters
+  (informational / navigational / transactional), estimates difficulty from
+  SERP snapshots, and proposes a target-page mapping.
+
+  Use when: "keyword research", "what should we rank for", "search intent",
+  "keyword gap vs competitor".
+
+  NOT THIS WHEN: an existing page needs an on-page audit with a recorded
+  verdict — use `acme-seo-content-auditor` (it writes evidence and its
+  verdict is gate-checkable); this skill produces strategy, not evidence.
+phase_relevance: ["design", "build"]
+archetype_relevance: ["build", "explore"]
+---
+
+# Keyword Analyst
+
+You research what the audience actually searches for and map it to pages.
+
+## Method
+
+1. Collect the seed terms from the brief (product names, problems solved).
+2. Expand: variants, question forms, long-tail modifiers.
+3. Cluster by intent: informational / navigational / transactional.
+4. For each cluster, propose one target page and a primary/secondary
+   keyword split. Never assign two clusters to one page.
+5. Output a keyword map table + the top-5 quick wins.
+
+## Boundaries
+
+- Strategy only — you do not edit pages. Hand findings to the router.
+- If asked to *judge* an existing page, decline and point the caller at
+  `acme-seo-content-auditor` (the evidence-writing twin).

--- a/tests/fixtures/packs/acme-seo/skills/acme-seo/SKILL.md
+++ b/tests/fixtures/packs/acme-seo/skills/acme-seo/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: acme-seo
+user-invocable: true
+description: |
+  ACME SEO domain router: keyword research, content audits, and ranking
+  verdicts with recorded evidence. Two actions — keywords (dispatch the
+  keyword analyst) and audit (dispatch the content auditor; its verdict is
+  recorded via wicked-vault so "done" is re-derived, never asserted).
+
+  Use when: "keyword research", "SEO audit", "why don't we rank",
+  "content optimization", "meta description review".
+phase_relevance: ["design", "build", "review"]
+archetype_relevance: ["review", "build"]
+---
+
+# ACME SEO
+
+One router per domain — this skill fronts the `acme-seo` domain and routes
+its actions to fork workers. It never does the analysis itself.
+
+## Actions
+
+| Action     | Worker                      | What you get                        |
+|------------|-----------------------------|-------------------------------------|
+| `keywords` | `acme-seo-keyword-analyst`  | keyword map + intent clusters       |
+| `audit`    | `acme-seo-content-auditor`  | seo-audit verdict, evidence-recorded|
+
+## Routing
+
+1. Classify the ask. Keyword strategy → `keywords`. Existing-content
+   review → `audit`.
+2. Dispatch the worker with the target URLs / content paths.
+3. For `audit`, the worker records its findings via
+   `wicked-vault record --phase seo-audit --actor acme-seo-content-auditor`
+   so the review archetype's produces-gate can re-derive the verdict.
+
+Never self-assert an audit passed — the gate re-derives `seo-audit`
+through the vault.

--- a/tests/fixtures/packs/acme-seo/wicked-pack.json
+++ b/tests/fixtures/packs/acme-seo/wicked-pack.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://github.com/mikeparcewski/wicked-garden/blob/main/schemas/wicked-pack.schema.json",
+  "spec": 1,
+  "name": "acme-seo",
+  "vendor": "acme",
+  "version": "0.1.0",
+  "description": "ACME's SEO domain pack — a router plus two fork workers, used as the extension-contract e2e fixture.",
+  "skills_dir": "skills",
+  "domains": [
+    {
+      "name": "seo",
+      "description": "Search-engine optimization: keyword research, content audits, ranking verdicts.",
+      "specialist": {
+        "role": "seo-engineering",
+        "description": "SEO specialist — keyword strategy, content audits, and crawlability review with recorded evidence.",
+        "enhances": ["design", "build", "review"]
+      },
+      "produces": [
+        {
+          "archetype": "review",
+          "produces": ["seo-audit"],
+          "gate": "vault"
+        }
+      ]
+    }
+  ],
+  "peers": {
+    "wicked-garden": ">=12.0.0",
+    "wicked-vault": ">=0.5.0"
+  },
+  "provenance": {
+    "source": "https://github.com/acme/acme-seo-pack",
+    "publisher": "acme",
+    "license": "MIT"
+  }
+}

--- a/tests/packs/test_e2e_toy_pack.py
+++ b/tests/packs/test_e2e_toy_pack.py
@@ -1,0 +1,153 @@
+"""E2E: the toy pack travels the REAL third-party path (acceptance evidence).
+
+The scenario the extension contract sells (site #extend): a vendor ships
+``acme-seo`` — one router + two ``context: fork`` workers, one
+produces-contract, peer floors, provenance — and WITHOUT any garden PR:
+
+  1. the conformance gate passes it (`node install.mjs pack check` — the
+     exact command a pack author runs via ``npx wicked-garden pack check``),
+  2. and FAILS the deliberately-broken variant with actionable errors,
+  3. registration through the real CLI records provenance hashes,
+  4. runtime discovery surfaces it in the catalog (`pack list --json`),
+  5. crew's specialist resolution finds ``acme-seo-*`` workers,
+  6. the SubagentStop engagement tracker accepts the pack's specialist
+     domain (the crew routing seam end-to-end),
+  7. the router fronts exactly the workers the resolver dispatches,
+  8. declared peer floors are checked fail-open.
+
+Runs the shipped entry points as subprocesses — not library shortcuts —
+wherever a real user-facing command exists.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+FIXTURES = _REPO / "tests" / "fixtures" / "packs"
+VALID = FIXTURES / "acme-seo"
+BROKEN = FIXTURES / "acme-broken"
+
+_NODE = shutil.which("node")
+_PY = sys.executable
+
+
+@pytest.fixture()
+def pack_home(monkeypatch, tmp_path):
+    """Isolated pack registry + no ambient pack env."""
+    reg = tmp_path / "registered.json"
+    monkeypatch.setenv("WICKED_PACK_REGISTRY", str(reg))
+    monkeypatch.delenv("WICKED_PACK_PATH", raising=False)
+    from crew.specialist_resolver import clear_cache
+    clear_cache()
+    yield reg
+    clear_cache()
+
+
+def _run(argv, env_extra=None):
+    import os
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(argv, capture_output=True, text=True,
+                          timeout=180, env=env, cwd=str(_REPO))
+
+
+def test_toy_pack_end_to_end(pack_home):
+    if _NODE is None:
+        pytest.skip("node not available (CI installs it)")
+
+    # 1. conformance gate PASSES the valid pack — the author's command
+    check = _run([_NODE, str(_REPO / "install.mjs"), "pack", "check", str(VALID)])
+    assert check.returncode == 0, check.stdout + check.stderr
+    assert "PASS" in check.stdout
+
+    # 2. the broken variant FAILS with actionable errors
+    broken = _run([_NODE, str(_REPO / "install.mjs"), "pack", "check", str(BROKEN)])
+    assert broken.returncode == 1
+    for expected in ("PK014", "PK016", "PK030", "context: fork", "one router per domain"):
+        assert expected in broken.stdout, f"missing {expected!r} in:\n{broken.stdout}"
+
+    # 3. registration through the real CLI (the same code path
+    #    wicked-installer's `pack add` invokes) records provenance
+    reg = _run([_NODE, str(_REPO / "install.mjs"), "pack", "register", str(VALID),
+                "--source", "https://github.com/acme/acme-seo-pack"])
+    assert reg.returncode == 0, reg.stdout + reg.stderr
+    record = json.loads(reg.stdout)
+    assert record["name"] == "acme-seo"
+    assert len(record["manifest_sha256"]) == 64
+    assert len(record["skills_tree_sha256"]) == 64
+    assert record["source_url"] == "https://github.com/acme/acme-seo-pack"
+
+    # ...and the broken variant CANNOT register (fail-closed door)
+    reg_broken = _run([_NODE, str(_REPO / "install.mjs"), "pack", "register", str(BROKEN)])
+    assert reg_broken.returncode != 0
+    assert "failed conformance" in reg_broken.stderr
+
+    # 4. the catalog surfaces the pack — discovery, no garden file edited
+    listing = _run([_NODE, str(_REPO / "install.mjs"), "pack", "list", "--json"])
+    assert listing.returncode == 0, listing.stdout + listing.stderr
+    catalog = json.loads(listing.stdout)
+    entry = next(p for p in catalog["packs"] if p["name"] == "acme-seo")
+    assert entry["domains"] == ["seo"]
+    assert entry["specialists"] == ["acme-seo"]
+    assert entry["produces"] == [{"pack": "acme-seo", "domain": "acme-seo",
+                                  "archetype": "review", "produces": ["seo-audit"],
+                                  "gate": "vault"}]
+    assert entry["provenance"]["publisher"] == "acme"
+
+    # 5. crew specialist resolution finds acme-seo-* (gap 2)
+    from crew.specialist_resolver import build_resolver, clear_cache, resolve_role
+    clear_cache()
+    resolver = build_resolver(_REPO)
+    assert resolve_role("acme-seo-keyword-analyst", resolver) == \
+        ("acme-seo", "acme-seo-keyword-analyst")
+    assert resolve_role("acme-seo-content-auditor", resolver) == \
+        ("acme-seo", "acme-seo-content-auditor")
+    assert "acme-seo" in resolver["domains"]
+
+    # 6. the SubagentStop engagement tracker accepts the pack domain —
+    #    the same functions the hook runs (crew routing seam end-to-end)
+    import importlib
+    import os
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(_REPO)
+    hooks_dir = _REPO / "hooks" / "scripts"
+    sys.path.insert(0, str(hooks_dir))
+    try:
+        lifecycle = importlib.import_module("subagent_lifecycle")
+        domains = lifecycle._load_specialist_domains()
+        assert "acme-seo" in domains
+        parsed = lifecycle._parse_specialist_from_agent_type(
+            "acme-seo-content-auditor", domains)
+        assert parsed == ("acme-seo", "content-auditor")
+    finally:
+        sys.path.remove(str(hooks_dir))
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+    # 7. the router fronts exactly the workers crew can dispatch
+    router_body = (VALID / "skills" / "acme-seo" / "SKILL.md").read_text(encoding="utf-8")
+    for worker in ("acme-seo-keyword-analyst", "acme-seo-content-auditor"):
+        assert worker in router_body
+        domain, skill = resolve_role(worker, resolver)
+        assert skill == worker and domain == "acme-seo"
+
+    # 8. peer floors surface fail-open (gap 6)
+    floors = _run([_NODE, str(_REPO / "install.mjs"), "pack", "floors", "--json"])
+    assert floors.returncode == 0, floors.stdout + floors.stderr
+    findings = json.loads(floors.stdout)["findings"]
+    garden_floor = next(f for f in findings
+                        if f["pack"] == "acme-seo" and f["peer"] == "wicked-garden")
+    assert garden_floor["status"] == "ok"
+
+    # 9. unregister removes it from the catalog
+    unreg = _run([_NODE, str(_REPO / "install.mjs"), "pack", "unregister", "acme-seo"])
+    assert unreg.returncode == 0
+    listing2 = _run([_NODE, str(_REPO / "install.mjs"), "pack", "list", "--json"])
+    assert all(p["name"] != "acme-seo"
+               for p in json.loads(listing2.stdout)["packs"])

--- a/tests/packs/test_pack_check.py
+++ b/tests/packs/test_pack_check.py
@@ -1,0 +1,138 @@
+"""The shipped pack conformance gate (extension-contract gap 3).
+
+The valid fixture must PASS clean; the deliberately-broken fixture must
+FAIL with the specific rule codes its defects were built to trip — and
+with messages useful enough to fix from.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+from pack.check import check_pack  # noqa: E402
+
+FIXTURES = _REPO / "tests" / "fixtures" / "packs"
+VALID = FIXTURES / "acme-seo"
+BROKEN = FIXTURES / "acme-broken"
+
+
+def _codes(findings, level=None):
+    return {f.code for f in findings if level is None or f.level == level}
+
+
+def test_valid_pack_passes_clean():
+    findings = check_pack(VALID, garden_root=_REPO)
+    assert _codes(findings, "error") == set(), [f.render() for f in findings]
+
+
+def test_broken_pack_fails_with_expected_codes():
+    findings = check_pack(BROKEN, garden_root=_REPO)
+    errors = _codes(findings, "error")
+    assert {"PK013",   # wicked-garden-* namespace squat
+            "PK014",   # missing router for declared domain
+            "PK016",   # worker without context: fork
+            "PK030",   # non-reciprocal NOT-THIS-WHEN
+            "PK040",   # unknown archetype in produces contract
+            "PK041",   # non-kebab produces id
+            "PK050",   # malformed peer floor
+            } <= errors
+    assert "PK042" in _codes(findings, "warn")  # unknown enhances phase
+
+
+def test_broken_pack_messages_name_the_fix():
+    findings = check_pack(BROKEN, garden_root=_REPO)
+    rendered = "\n".join(f.render() for f in findings)
+    # messages must be actionable, not just codes
+    assert "must declare context: fork" in rendered
+    assert "one router per domain" in rendered
+    assert "must be reciprocal" in rendered
+    assert '">=X.Y.Z"' in rendered
+
+
+def test_missing_manifest_is_pk001(tmp_path):
+    findings = check_pack(tmp_path)
+    assert _codes(findings, "error") == {"PK001"}
+
+
+def test_oversize_router_trips_pk020(tmp_path):
+    root = tmp_path / "acme-big"
+    (root / "skills" / "acme-big").mkdir(parents=True)
+    (root / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-big", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "big"}],
+    }), encoding="utf-8")
+    body = "---\nname: acme-big\ndescription: router\n---\n" + ("filler\n" * 250)
+    (root / "skills" / "acme-big" / "SKILL.md").write_text(body, encoding="utf-8")
+    findings = check_pack(root)
+    assert "PK020" in _codes(findings, "error")
+
+
+def test_fork_worker_exempt_from_line_cap(tmp_path):
+    root = tmp_path / "acme-work"
+    for d in ("acme-work", "acme-work-deep-thinker"):
+        (root / "skills" / d).mkdir(parents=True)
+    (root / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-work", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "work"}],
+    }), encoding="utf-8")
+    (root / "skills" / "acme-work" / "SKILL.md").write_text(
+        "---\nname: acme-work\ndescription: router\n---\n# r\n", encoding="utf-8")
+    (root / "skills" / "acme-work-deep-thinker" / "SKILL.md").write_text(
+        "---\nname: acme-work-deep-thinker\ncontext: fork\ndescription: w\n---\n"
+        + ("long system prompt line\n" * 400), encoding="utf-8")
+    findings = check_pack(root)
+    assert "PK020" not in _codes(findings)
+
+
+def test_dir_name_mismatch_trips_pk017(tmp_path):
+    root = tmp_path / "acme-mix"
+    (root / "skills" / "acme-mix").mkdir(parents=True)
+    (root / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-mix", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "mix"}],
+    }), encoding="utf-8")
+    (root / "skills" / "acme-mix" / "SKILL.md").write_text(
+        "---\nname: acme-mix-other\ncontext: fork\ndescription: x\n---\n# x\n",
+        encoding="utf-8")
+    findings = check_pack(root)
+    assert "PK017" in _codes(findings, "error")
+
+
+# ---------------------------------------------------------------------------
+# The command pack authors actually run: `npx wicked-garden pack check <dir>`
+# (node install.mjs pack check — same file the npm bin points at).
+# ---------------------------------------------------------------------------
+
+def _node():
+    import shutil
+    return shutil.which("node")
+
+
+def test_cli_pack_check_valid_exits_zero():
+    node = _node()
+    if node is None:
+        import pytest
+        pytest.skip("node not available")
+    proc = subprocess.run(
+        [node, str(_REPO / "install.mjs"), "pack", "check", str(VALID)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "PASS" in proc.stdout
+
+
+def test_cli_pack_check_broken_exits_nonzero_with_useful_errors():
+    node = _node()
+    if node is None:
+        import pytest
+        pytest.skip("node not available")
+    proc = subprocess.run(
+        [node, str(_REPO / "install.mjs"), "pack", "check", str(BROKEN)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "PK016" in proc.stdout and "context: fork" in proc.stdout

--- a/tests/packs/test_pack_check.py
+++ b/tests/packs/test_pack_check.py
@@ -88,6 +88,37 @@ def test_fork_worker_exempt_from_line_cap(tmp_path):
     assert "PK020" not in _codes(findings)
 
 
+def test_unterminated_frontmatter_is_pk011(tmp_path):
+    """A SKILL.md whose frontmatter never closes must be malformed (PK011),
+    not half-parsed as valid (Copilot review, PR #1057)."""
+    root = tmp_path / "acme-open"
+    (root / "skills" / "acme-open").mkdir(parents=True)
+    (root / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-open", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "open"}],
+    }), encoding="utf-8")
+    (root / "skills" / "acme-open" / "SKILL.md").write_text(
+        "---\nname: acme-open\ndescription: no closing fence\n# body\n",
+        encoding="utf-8")
+    findings = check_pack(root)
+    assert "PK011" in _codes(findings, "error")
+
+
+def test_absolute_skills_dir_rejected(tmp_path):
+    """skills_dir must not escape the pack root — absolute paths (POSIX or
+    Windows drive-letter) fail structural validation (Copilot review, PR #1057)."""
+    for bad in ("/etc", "C:\\evil", "..\\up"):
+        root = tmp_path / f"acme-esc-{abs(hash(bad)) % 1000}"
+        root.mkdir()
+        (root / "wicked-pack.json").write_text(json.dumps({
+            "spec": 1, "name": "acme-esc", "vendor": "acme", "version": "1.0.0",
+            "skills_dir": bad, "domains": [{"name": "esc"}],
+        }), encoding="utf-8")
+        findings = check_pack(root)
+        rendered = "\n".join(f.render() for f in findings)
+        assert "relative path inside the pack" in rendered, f"{bad!r} was not rejected"
+
+
 def test_dir_name_mismatch_trips_pk017(tmp_path):
     root = tmp_path / "acme-mix"
     (root / "skills" / "acme-mix").mkdir(parents=True)

--- a/tests/packs/test_pack_registry.py
+++ b/tests/packs/test_pack_registry.py
@@ -1,0 +1,184 @@
+"""Pack discovery + registration (extension-contract gaps 1 and 4).
+
+Covers: WICKED_PACK_PATH discovery (pack root + directory-of-packs),
+registered.json discovery, dedupe priority, provenance hash recording,
+registration fail-closed on non-conformant packs, and peer-floor checks
+(gap 6) staying fail-open.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+import _pack_registry as preg  # noqa: E402
+
+FIXTURES = _REPO / "tests" / "fixtures" / "packs"
+VALID = FIXTURES / "acme-seo"
+BROKEN = FIXTURES / "acme-broken"
+
+
+@pytest.fixture()
+def isolated_registry(tmp_path, monkeypatch):
+    """Point the registered-pack file at a temp location; no env packs."""
+    reg = tmp_path / "registered.json"
+    monkeypatch.setenv("WICKED_PACK_REGISTRY", str(reg))
+    monkeypatch.delenv("WICKED_PACK_PATH", raising=False)
+    return reg
+
+
+def _discover_names(cwd=None):
+    packs, errors = preg.discover_packs(cwd=cwd or Path.cwd())
+    return {p.name for p in packs}, errors
+
+
+def test_env_path_discovers_pack_root(isolated_registry, monkeypatch):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    names, _ = _discover_names()
+    assert "acme-seo" in names
+
+
+def test_env_path_discovers_directory_of_packs(isolated_registry, monkeypatch):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(FIXTURES))
+    names, _ = _discover_names()
+    # Both fixtures are STRUCTURALLY valid (the broken one fails only the
+    # conformance gate), so a directory-of-packs surfaces both.
+    assert {"acme-seo", "acme-broken"} <= names
+
+
+def test_registered_pack_is_discovered(isolated_registry):
+    preg.register_pack(VALID, source_url="https://example.test/acme-seo")
+    names, _ = _discover_names()
+    assert "acme-seo" in names
+    packs, _ = preg.discover_packs()
+    pack = next(p for p in packs if p.name == "acme-seo")
+    assert pack.source == "registered"
+
+
+def test_register_records_provenance_hashes(isolated_registry):
+    record = preg.register_pack(VALID, source_url="https://example.test/acme-seo")
+    assert record["source_url"] == "https://example.test/acme-seo"
+    assert record["publisher"] == "acme"
+    assert len(record["manifest_sha256"]) == 64
+    assert len(record["skills_tree_sha256"]) == 64
+    on_disk = json.loads(isolated_registry.read_text(encoding="utf-8"))
+    assert on_disk["packs"][0]["manifest_sha256"] == record["manifest_sha256"]
+
+
+def test_register_refuses_nonconformant_pack(isolated_registry):
+    with pytest.raises(ValueError, match="failed conformance"):
+        preg.register_pack(BROKEN)
+    # fail-closed: nothing half-registered
+    assert not preg.registered_records()
+
+
+def test_register_force_overrides_conformance_gate(isolated_registry):
+    record = preg.register_pack(BROKEN, force=True)
+    assert record["name"] == "acme-broken"
+
+
+def test_unregister_roundtrip(isolated_registry):
+    preg.register_pack(VALID)
+    assert preg.unregister_pack("acme-seo") is True
+    assert preg.unregister_pack("acme-seo") is False
+    names, _ = _discover_names()
+    assert "acme-seo" not in names
+
+
+def test_duplicate_name_first_source_wins(isolated_registry, monkeypatch, tmp_path):
+    # env (priority 1) vs registered (priority 2) — env wins the dedupe.
+    preg.register_pack(VALID)
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    packs, _ = preg.discover_packs()
+    matches = [p for p in packs if p.name == "acme-seo"]
+    assert len(matches) == 1
+    assert matches[0].source == "env"
+
+
+def test_structurally_invalid_pack_reported_not_raised(isolated_registry, monkeypatch, tmp_path):
+    bad = tmp_path / "bad-pack"
+    bad.mkdir()
+    (bad / "wicked-pack.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("WICKED_PACK_PATH", str(bad))
+    packs, errors = preg.discover_packs()
+    assert all(p.name != "bad-pack" for p in packs)
+    assert any("invalid JSON" in e for e in errors)
+
+
+def test_reserved_vendor_prefix_rejected(isolated_registry, monkeypatch, tmp_path):
+    squatter = tmp_path / "wicked-fake"
+    (squatter / "skills").mkdir(parents=True)
+    (squatter / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "wicked-fake", "vendor": "wicked-fake",
+        "version": "1.0.0", "domains": [{"name": "fake"}],
+    }), encoding="utf-8")
+    monkeypatch.setenv("WICKED_PACK_PATH", str(squatter))
+    packs, errors = preg.discover_packs()
+    assert all(p.name != "wicked-fake" for p in packs)
+    assert any("reserved prefix" in e for e in errors)
+
+
+def test_specialist_entries_shape(isolated_registry, monkeypatch):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    packs, _ = preg.discover_packs()
+    entries = preg.specialist_entries(packs)
+    assert entries == [{
+        "name": "acme-seo",
+        "role": "seo-engineering",
+        "description": ("SEO specialist — keyword strategy, content audits, "
+                        "and crawlability review with recorded evidence."),
+        "enhances": ["design", "build", "review"],
+        "pack": "acme-seo",
+    }]
+
+
+def test_pack_produces_exposed(isolated_registry, monkeypatch):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    packs, _ = preg.discover_packs()
+    produces = preg.pack_produces(packs)
+    assert produces == [{
+        "pack": "acme-seo", "domain": "acme-seo", "archetype": "review",
+        "produces": ["seo-audit"], "gate": "vault",
+    }]
+
+
+# ---------------------------------------------------------------------------
+# Peer floors (gap 6) — fail-open by contract
+# ---------------------------------------------------------------------------
+
+def test_peer_floors_garden_ok_without_probe(isolated_registry, monkeypatch):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    packs, _ = preg.discover_packs()
+    findings = preg.check_peer_floors(packs, plugin_root=_REPO, probe=False)
+    by_peer = {f["peer"]: f for f in findings}
+    # garden's own version is comparable without any subprocess
+    assert by_peer["wicked-garden"]["status"] == "ok"
+    # probe=False leaves binary peers unknown — informational, never a block
+    assert by_peer["wicked-vault"]["status"] == "unknown"
+
+
+def test_peer_floor_violation_detected(isolated_registry, monkeypatch, tmp_path):
+    demanding = tmp_path / "acme-future"
+    (demanding / "skills" / "acme-future").mkdir(parents=True)
+    (demanding / "skills" / "acme-future" / "SKILL.md").write_text(
+        "---\nname: acme-future\ndescription: r\n---\n# r\n", encoding="utf-8")
+    (demanding / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-future", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "future"}],
+        "peers": {"wicked-garden": ">=99999.0.0", "wicked-vault": "banana"},
+    }), encoding="utf-8")
+    monkeypatch.setenv("WICKED_PACK_PATH", str(demanding))
+    packs, _ = preg.discover_packs()
+    findings = preg.check_peer_floors(packs, plugin_root=_REPO, probe=False)
+    statuses = {f["peer"]: f["status"] for f in findings}
+    assert statuses["wicked-garden"] == "below-floor"
+    assert statuses["wicked-vault"] == "bad-range"
+
+
+def test_peer_floors_never_raise(isolated_registry):
+    # No packs at all — empty findings, no exception.
+    assert preg.check_peer_floors([], probe=False) == []

--- a/tests/packs/test_pack_registry.py
+++ b/tests/packs/test_pack_registry.py
@@ -122,6 +122,22 @@ def test_reserved_vendor_prefix_rejected(isolated_registry, monkeypatch, tmp_pat
     assert any("reserved prefix" in e for e in errors)
 
 
+def test_vendor_merely_starting_with_wicked_letters_allowed(isolated_registry, monkeypatch, tmp_path):
+    """Only exactly 'wicked' and 'wicked-*' are reserved — 'wickedx' is an
+    (ugly but) legal vendor, matching the JSON schema (Copilot review, PR #1057)."""
+    pack = tmp_path / "wickedx-tools"
+    (pack / "skills" / "wickedx-tools").mkdir(parents=True)
+    (pack / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "wickedx-tools", "vendor": "wickedx",
+        "version": "1.0.0", "domains": [{"name": "tools"}],
+    }), encoding="utf-8")
+    (pack / "skills" / "wickedx-tools" / "SKILL.md").write_text(
+        "---\nname: wickedx-tools\ndescription: router\n---\n# r\n", encoding="utf-8")
+    monkeypatch.setenv("WICKED_PACK_PATH", str(pack))
+    packs, errors = preg.discover_packs()
+    assert any(p.name == "wickedx-tools" for p in packs), errors
+
+
 def test_specialist_entries_shape(isolated_registry, monkeypatch):
     monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
     packs, _ = preg.discover_packs()

--- a/tests/packs/test_specialist_resolver_packs.py
+++ b/tests/packs/test_specialist_resolver_packs.py
@@ -1,0 +1,124 @@
+"""specialist_resolver resolves pack workers (extension-contract gap 2).
+
+Crew dispatch by ``{vendor}-{domain}-{role}`` must resolve a pack worker
+exactly like a first-party one; garden always wins name collisions; a
+broken pack can never break first-party resolution.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+from crew.specialist_resolver import build_resolver, clear_cache, resolve_role  # noqa: E402
+
+FIXTURES = _REPO / "tests" / "fixtures" / "packs"
+VALID = FIXTURES / "acme-seo"
+
+
+@pytest.fixture()
+def pack_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("WICKED_PACK_PATH", str(VALID))
+    monkeypatch.setenv("WICKED_PACK_REGISTRY", str(tmp_path / "registered.json"))
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture()
+def no_pack_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("WICKED_PACK_PATH", raising=False)
+    monkeypatch.setenv("WICKED_PACK_REGISTRY", str(tmp_path / "registered.json"))
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def test_pack_worker_resolves_by_full_skill_name(pack_env):
+    resolver = build_resolver(_REPO)
+    assert resolve_role("acme-seo-keyword-analyst", resolver) == \
+        ("acme-seo", "acme-seo-keyword-analyst")
+    assert resolve_role("acme-seo-content-auditor", resolver) == \
+        ("acme-seo", "acme-seo-content-auditor")
+
+
+def test_pack_worker_resolves_by_bare_role(pack_env):
+    resolver = build_resolver(_REPO)
+    domain, skill = resolve_role("keyword-analyst", resolver)
+    assert (domain, skill) == ("acme-seo", "acme-seo-keyword-analyst")
+
+
+def test_pack_router_is_not_a_dispatchable_worker(pack_env):
+    resolver = build_resolver(_REPO)
+    # the router is user-invocable, not context:fork — it must NOT resolve
+    assert resolve_role("acme-seo", resolver) == (None, None)
+
+
+def test_pack_specialist_domain_listed(pack_env):
+    resolver = build_resolver(_REPO)
+    assert "acme-seo" in resolver["domains"]
+    assert "acme-seo" in resolver["packs"]
+    # first-party domains still present
+    assert "engineering" in resolver["domains"]
+
+
+def test_first_party_resolution_unchanged_by_pack(pack_env):
+    resolver = build_resolver(_REPO)
+    domain, skill = resolve_role("wicked-garden-crew-reviewer", resolver)
+    assert (domain, skill) == ("crew", "wicked-garden-crew-reviewer")
+
+
+def test_garden_wins_role_collision(monkeypatch, tmp_path):
+    """A pack shipping a worker whose bare role collides with a first-party
+    role (``reviewer`` = wicked-garden-crew-reviewer's bare role) must lose
+    the bare-role slot (garden indexed first) but still be dispatchable by
+    its full name."""
+    import json
+    pack = tmp_path / "acme-rivals"
+    (pack / "skills" / "acme-rivals").mkdir(parents=True)
+    (pack / "skills" / "acme-rivals-reviewer").mkdir(parents=True)
+    (pack / "wicked-pack.json").write_text(json.dumps({
+        "spec": 1, "name": "acme-rivals", "vendor": "acme", "version": "1.0.0",
+        "domains": [{"name": "rivals"}],
+    }), encoding="utf-8")
+    (pack / "skills" / "acme-rivals" / "SKILL.md").write_text(
+        "---\nname: acme-rivals\ndescription: router\n---\n# r\n", encoding="utf-8")
+    (pack / "skills" / "acme-rivals-reviewer" / "SKILL.md").write_text(
+        "---\nname: acme-rivals-reviewer\ncontext: fork\ndescription: w\n---\n# w\n",
+        encoding="utf-8")
+    monkeypatch.setenv("WICKED_PACK_PATH", str(pack))
+    monkeypatch.setenv("WICKED_PACK_REGISTRY", str(tmp_path / "registered.json"))
+    clear_cache()
+    try:
+        resolver = build_resolver(_REPO)
+        # bare role: first-party keeps it
+        assert resolve_role("reviewer", resolver) == \
+            ("crew", "wicked-garden-crew-reviewer")
+        # full name: the pack worker still resolves, to ITSELF
+        assert resolve_role("acme-rivals-reviewer", resolver) == \
+            ("acme-rivals", "acme-rivals-reviewer")
+        assert any("collision" in w for w in resolver["warnings"])
+    finally:
+        clear_cache()
+
+
+def test_no_packs_resolver_shape_intact(no_pack_env):
+    resolver = build_resolver(_REPO)
+    assert resolver["packs"] == []
+    assert resolve_role("reviewer", resolver) == \
+        ("crew", "wicked-garden-crew-reviewer")
+
+
+def test_broken_discovery_fails_open(monkeypatch, tmp_path, no_pack_env):
+    """A garbage WICKED_PACK_PATH must not break first-party resolution."""
+    monkeypatch.setenv("WICKED_PACK_PATH", str(tmp_path / "does-not-exist"))
+    clear_cache()
+    try:
+        resolver = build_resolver(_REPO)
+        assert resolve_role("wicked-garden-crew-implementer", resolver) == \
+            ("crew", "wicked-garden-crew-implementer")
+    finally:
+        clear_cache()


### PR DESCRIPTION
## What

Closes the 7 extension-contract gaps from the SKILL-RATIONALIZATION ruling (§5) so garden is **the** catalog people build on: the site's #extend pitch — `{vendor}-{domain}-{role}` + one-router-per-domain + evidence-via-vault — is now fully executable by a third party without a garden PR.

## Per-gap disposition

| # | Gap | Disposition |
|---|-----|-------------|
| 1 | Drop-in pack registration | **Built.** `wicked-pack.json` manifest (`schemas/wicked-pack.schema.json`) + runtime discovery in `scripts/_pack_registry.py`: `WICKED_PACK_PATH` → registered-pack file → Claude plugin dirs (`~/.claude/plugins/*`, `cache/*/*`) → `<project>/.wicked/packs/*`. `components.json`/`specialist.json` stay first-party-only; sync tooling ignores packs by design. |
| 2 | specialist_resolver resolves packs | **Built.** Pack `context: fork` workers index after garden (first-party wins bare-role collisions; full names are collision-immune via the new `skill_to_domain` map). Specialist domain = `{vendor}-{domain}`. SubagentStop engagement tracking accepts pack domains. |
| 3 | Shipped pack spec + conformance gate | **Built.** `npx wicked-garden pack check <dir>` → `scripts/pack/check.py` (ships in the npm package + installed plugin). Rules PK001–PK050: naming/reserved prefix, router/worker shape, `context: fork`, 3-tier disclosure caps, NOT-THIS-WHEN reciprocity, produces archetypes, peer-floor syntax. |
| 4 | Trust/provenance | **Minimal, honest.** Declared `provenance` + recorded manifest sha256 + skills-tree content hash at registration. No signing — stated plainly in docs; wicked-installer `registry.json` named as the future marketplace seam. |
| 5 | Pack produces-contracts | **Data layer built; steering attach designed.** Declared contracts are validated (PK040/41), surfaced in the catalog, and gate-runnable explicitly via loom (`--phase <produces-id>`). Auto-steering attach seam named in docs: `archetypes_v11.steering_directives()` × engaged-specialist filter. |
| 6 | Peer-version floors | **Built, fail-open.** `peers` block; SessionStart cheap check (garden version only, zero subprocesses) surfaces violations as a briefing note; `pack floors` does full `--version` probes. `unknown` is never a violation; nothing blocks. |
| 7 | Installer consolidation | **Built (garden side).** `install.mjs pack install` **delegates** acquisition to `wicked-installer pack add` (see companion PR mikeparcewski/wicked-installer#10); validation+registration stay the shipped Python here — one implementation each way. |

## The proof (e2e acceptance)

`tests/packs/test_e2e_toy_pack.py` drives the **real commands** over the `acme-seo` toy pack (router + 2 fork workers, one produces-contract, peer floors, provenance):

1. `node install.mjs pack check` PASSes the valid pack, FAILs `acme-broken` with actionable PK-codes
2. `pack register` records provenance hashes; the broken variant is refused (fail-closed)
3. `pack list --json` surfaces the pack, its specialists (`acme-seo`), produces, provenance
4. `specialist_resolver` resolves `acme-seo-keyword-analyst` / bare `keyword-analyst`
5. the SubagentStop tracker accepts the `acme-seo` specialist domain
6. `pack floors` reports the declared floors (`wicked-garden >= 12.0.0` → ok)
7. unregister removes it from the catalog

## Docs

`docs/extending.md` — the complete pack-author guide, honest about gaps 4–6 status. README "Build on it" section + docs index entry.

## Verification

- `python -m pytest tests/ -q` → 1193 passed, 13 skipped (33 new pack tests incl. the e2e)
- `scripts/ci/validate.py` → PASS; `sync_components.py --check` → in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
