### PR TITLE
chore(site): re-pin wicked-web chrome to cf770de (studio first-class)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,7 +16,7 @@
         "motion": "^13.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "wicked-web": "github:mikeparcewski/wicked-web#61396e428846e67e081e4ac529ec045b15931ab8"
+        "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1",
@@ -5818,8 +5818,8 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#61396e428846e67e081e4ac529ec045b15931ab8",
-      "integrity": "sha512-Jo+ygnqvGf5W4hZRmkIvgQbM1Bo121IEaqGBpLikFUaE637BMpni2K1afAw5RH4jreNMcoaMpac0vhfy/5KW/g==",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#cf770de0a151d46837ae8b3369606b005bb8473c",
+      "integrity": "sha512-uc0gE4B6fQPztbCF+Ix4X6yhR9DnS8eKjAD5F+JquDXRe7B1LHixr5HdyKZFr8pibbtSZod283yMCVvxPEfp/A==",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
     "motion": "^13.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wicked-web": "github:mikeparcewski/wicked-web#61396e428846e67e081e4ac529ec045b15931ab8"
+    "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
Pulls in [wicked-web#24](https://github.com/mikeparcewski/wicked-web/pull/24): **wicked-studio promoted to a first-class product** across the shared chrome — the Topbar ecosystem dropdown, Footer family links, and the SameGarden four-plane map now link the new deep-dive site at **ws.wickedagile.com** and the standalone repo (`mikeparcewski/wicked-studio`), replacing the old `wicked-crew/packages/studio` deep links.

Dependency re-pin — `package.json` + `package-lock.json` (`wicked-web` `61396e4` → `cf770de`); no site-content changes. Pages redeploy expected on merge.

Part of the combined family re-pin sweep (all five consumer sites + the new studio site start on this SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)