### PR TITLE
chore(chrome): pin wicked-web bc1f547 — platform dropdown icon

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
     "motion": "^13.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+    "wicked-web": "github:mikeparcewski/wicked-web#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
Picks up wicked-web#25: replaces the apps-grid button icon on the platform dropdown with the four-plane architecture mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)