### PR TITLE
fix(events): rename 3-segment QE event names to canonical 4-segment (P9 conditional)

### DIFF
--- a/WICKED_GARDEN_BUS_EVENTS.md
+++ b/WICKED_GARDEN_BUS_EVENTS.md
@@ -125,6 +125,8 @@ These fields are **stripped automatically** by `_bus.py` before emission:
 |------------|-----------|-------------|
 | `wicked.garden.coverage.changed` | `qe.coverage` | Test coverage metrics changed |
 | `wicked.garden.scenario.run` | `qe.scenario` | Test scenario executed with pass/fail result |
+| `wicked.qe.release.assessed` | `qe.release` | Release readiness verdict assessed against ledger evidence window |
+| `wicked.qe.scenario.authored` | `qe.scenario` | Scenario file authored from a production incident; queues a human review task |
 
 ### Sentinel
 

--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -368,6 +368,17 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "crew.loom",
         "description": "Loom hard-gate verdict differs from the in-process gate result (diagnostic: parity mirror)",
     },
+    # QE domain — incident-to-scenario-synthesizer + release-readiness-engineer
+    "wicked.qe.scenario.authored": {
+        "domain": "wicked-garden",
+        "subdomain": "qe.scenario",
+        "description": "Scenario file authored from a production incident; queues a human review task",
+    },
+    "wicked.qe.release.assessed": {
+        "domain": "wicked-garden",
+        "subdomain": "qe.release",
+        "description": "Release readiness verdict assessed against ledger evidence window",
+    },
 }
 
 # Payload deny-list — these fields must NEVER appear in bus payloads.

--- a/scripts/_validate_registry.py
+++ b/scripts/_validate_registry.py
@@ -116,6 +116,9 @@ _AUDIT_MARKER_EVENTS: Tuple[str, ...] = (
     "wicked.garden.sentinel.prepush_blocked",
     "wicked.garden.sentinel.unverified_task_done",
     "wicked.garden.loom.parity_mismatched",
+    # QE skill signals — fire-and-forget; consumed by ledger / dashboard tooling.
+    "wicked.qe.scenario.authored",
+    "wicked.qe.release.assessed",
 )
 
 # Reviewer values in gate-policy.json that are NOT subagent identifiers — they

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,7 +16,7 @@
         "motion": "^13.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+        "wicked-web": "github:mikeparcewski/wicked-web#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1",
@@ -5818,8 +5818,8 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#cf770de0a151d46837ae8b3369606b005bb8473c",
-      "integrity": "sha512-uc0gE4B6fQPztbCF+Ix4X6yhR9DnS8eKjAD5F+JquDXRe7B1LHixr5HdyKZFr8pibbtSZod283yMCVvxPEfp/A==",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6",
+      "integrity": "sha512-25Rvj7LGH5QMhdowobIrZOdBlIjVP+k9LBqsUQkyH9VdaRsII+/O93Rr9x49Dj5T/L966PNkpwFl6jvIvx0qRg==",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
     "motion": "^13.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+    "wicked-web": "github:mikeparcewski/wicked-web#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/skills/qe-incident-to-scenario-synthesizer/SKILL.md
+++ b/skills/qe-incident-to-scenario-synthesizer/SKILL.md
@@ -6,7 +6,7 @@ description: |
   reproduces it. Takes an incident-report markdown OR direct fields
   (stack trace, endpoint URL, HTTP method, request body), extracts the
   minimal reproducer, writes `scenarios/<incident-id>.md` with
-  `linked_to_incident:` frontmatter, emits `wicked.scenario.authored`
+  `linked_to_incident:` frontmatter, emits `wicked.qe.scenario.authored`
   with `source: incident`, and queues a review task under
   `assignee_skill: incident-to-scenario-synthesizer:review` so a human
   confirms before the scenario is marked active.
@@ -20,7 +20,7 @@ description: |
   user: "Synthesize a scenario from docs/postmortems/INC-4829.md."
   <commentary>Use incident-to-scenario-synthesizer — it reads the
   postmortem, extracts stack + request + endpoint, writes scenarios/
-  INC-4829.md with status: pending-review, emits wicked.scenario.authored,
+  INC-4829.md with status: pending-review, emits wicked.qe.scenario.authored,
   and queues a human-review task. Scenario is NOT active until approved.</commentary>
   </example>
 model: sonnet
@@ -217,7 +217,7 @@ store.create("tasks", {
 
 // 3. Bus event so downstream listeners (e.g. a reviewer dashboard) can
 //    surface the authored scenario immediately.
-bus.emit("wicked.scenario.authored", {
+bus.emit("wicked.qe.scenario.authored", {
   scenario_path: scenarioPath,
   incident_id: incidentId,
   source: "incident",
@@ -271,7 +271,7 @@ top_frame: {file}:{line} ({function})
 
 synthesized: scenarios/{incident_id}.md   status: pending-review
 
-emitted event: wicked.scenario.authored  source=incident  run_id={RUN_ID}
+emitted event: wicked.qe.scenario.authored  source=incident  run_id={RUN_ID}
 queued task:   incident-to-scenario-synthesizer:review  ({incident_id})
 
 VERDICT=PASS REVIEWER=wicked-garden-qe-incident-to-scenario-synthesizer RUN_ID={RUN_ID}

--- a/skills/qe-release-readiness-engineer/SKILL.md
+++ b/skills/qe-release-readiness-engineer/SKILL.md
@@ -183,7 +183,7 @@ for (const b of blockers) {
 }
 
 // Bus emit (optional, fire-and-forget).
-emitBusEvent("wicked.release.assessed", {
+emitBusEvent("wicked.qe.release.assessed", {
   project_id: PROJECT_ID,
   run_id: RUN_ID,
   verdict: gateDecision,
@@ -216,7 +216,7 @@ emitBusEvent("wicked.release.assessed", {
 ## References
 
 - `wicked-ledger` domain-store (`import { createDomainStore } from "wicked-ledger"`) — verdicts / tasks schema
-- `wicked-ledger` bus-emit (`emitBusEvent`) — `wicked.release.assessed` producer
+- `wicked-ledger` bus-emit (`emitBusEvent`) — `wicked.qe.release.assessed` producer
 - [`../qe-flaky-test-hunter/SKILL.md`](../qe-flaky-test-hunter/SKILL.md) — source of quarantine tasks
 - [`../qe-coverage-archaeologist/SKILL.md`](../qe-coverage-archaeologist/SKILL.md) — coverage-delta reference
 - [`../qe-production-quality-engineer/SKILL.md`](../qe-production-quality-engineer/SKILL.md) — prod SLO state source

--- a/skills/qe/refs/author.md
+++ b/skills/qe/refs/author.md
@@ -108,7 +108,7 @@ Scenario files use the format in [refs/scenario-format.md](refs/scenario-format.
   OR
 - Both, when authoring scenarios that have automated companions
 
-Emits `wicked.scenario.authored` and/or `wicked.test.strategy.generated` on the
+Emits `wicked.qe.scenario.authored` and/or `wicked.test.strategy.generated` on the
 bus when present.
 
 ## Legacy invocations (absorbed in 0.4.0)


### PR DESCRIPTION
## Summary

Fixes two active event emitters that violated the mandatory 4-segment naming grammar:

| Old (3-segment, wrong) | New (4-segment, correct) |
|---|---|
| `wicked.scenario.authored` | `wicked.qe.scenario.authored` |
| `wicked.release.assessed` | `wicked.qe.release.assessed` |

Both are also registered in `BUS_EVENT_MAP` so `emit_event()` no longer short-circuits on "Unknown event type".

## Why

The canonical grammar is `wicked.<domain>.<noun>.<verb>` (WICKED_GARDEN_BUS_EVENTS.md SPEC). P9 DoD adversarial review flagged these as CONDITIONAL — active emitters with incorrect names that make them look like orphaned events in the catalog.

## Test plan

- [ ] `npm test` passes (1196 expected)
- [ ] `grep -r "wicked\.scenario\.authored\|wicked\.release\.assessed"` returns no hits in non-historical files

🤖 Generated with [Claude Code](https://claude.com/claude-code)