### PR TITLE
fix(events): catalog 6 wicked-core production events + 4-segment format validator (P9 soft findings)

### DIFF
--- a/scripts/_bus.py
+++ b/scripts/_bus.py
@@ -379,6 +379,41 @@ BUS_EVENT_MAP: Dict[str, Dict[str, str]] = {
         "subdomain": "qe.release",
         "description": "Release readiness verdict assessed against ledger evidence window",
     },
+    # wicked-core production events — emitted by the engine (cli_runner.rs + bus.rs).
+    # These are cross-domain events that garden consumers (mem/search) may subscribe to.
+    # Source constants: TASK_DISPATCHED, TASK_COMPLETED (cli_runner.rs);
+    #                   RUN_REQUESTED, RUN_LAUNCHED (bus.rs);
+    #                   GATE_EVAL_REQUESTED, GATE_EVAL_RESPONDED (cli_runner.rs).
+    "wicked.crew.task.dispatched": {
+        "domain": "wicked-core",
+        "subdomain": "crew.task",
+        "description": "A workflow unit has been dispatched to a CLI seat for execution (bus-as-truth handoff)",
+    },
+    "wicked.crew.task.completed": {
+        "domain": "wicked-core",
+        "subdomain": "crew.task",
+        "description": "A dispatched workflow unit has completed; carries verdict and captured output",
+    },
+    "wicked.crew.run.requested": {
+        "domain": "wicked-core",
+        "subdomain": "crew.run",
+        "description": "A new governed run has been requested via the bus (durable intent record)",
+    },
+    "wicked.crew.run.launched": {
+        "domain": "wicked-core",
+        "subdomain": "crew.run",
+        "description": "A requested run has been accepted and launched by the engine",
+    },
+    "wicked.gate.eval.requested": {
+        "domain": "wicked-core",
+        "subdomain": "gate.eval",
+        "description": "Gate evaluation published to the bus; the governed evaluator daemon is expected to respond (evaluator≠creator bus path)",
+    },
+    "wicked.gate.eval.responded": {
+        "domain": "wicked-core",
+        "subdomain": "gate.eval",
+        "description": "Governed evaluator daemon responded to a gate eval request (verdict carried in payload)",
+    },
 }
 
 # Payload deny-list — these fields must NEVER appear in bus payloads.

--- a/scripts/_validate_registry.py
+++ b/scripts/_validate_registry.py
@@ -119,6 +119,15 @@ _AUDIT_MARKER_EVENTS: Tuple[str, ...] = (
     # QE skill signals — fire-and-forget; consumed by ledger / dashboard tooling.
     "wicked.qe.scenario.authored",
     "wicked.qe.release.assessed",
+    # wicked-core production events — emitted by the engine, not by wicked-garden.
+    # These are catalogued in BUS_EVENT_MAP for subscriber discovery but have no
+    # projector handler in garden's daemon/projector.py (they're handled by crew/core).
+    "wicked.crew.task.dispatched",
+    "wicked.crew.task.completed",
+    "wicked.crew.run.requested",
+    "wicked.crew.run.launched",
+    "wicked.gate.eval.requested",
+    "wicked.gate.eval.responded",
 )
 
 # Reviewer values in gate-policy.json that are NOT subagent identifiers — they

--- a/scripts/_validate_registry.py
+++ b/scripts/_validate_registry.py
@@ -749,6 +749,22 @@ def check_bus_handlers(plugin_root: Path) -> List[Dict[str, Any]]:
         )
         return findings
 
+    # 4-segment format: wicked.<domain>.<noun>.<past-tense-verb>
+    _segment_re = re.compile(r"^wicked\.[a-z][a-z0-9_-]*\.[a-z][a-z0-9_-]*\.[a-z][a-z0-9_-]*$")
+    for evt in sorted(event_keys):
+        if not _segment_re.match(evt):
+            findings.append(
+                {
+                    "category": CAT_MALFORMED,
+                    "check": "bus.event_format",
+                    "target": evt,
+                    "detail": (
+                        "event key does not follow the canonical 4-segment format "
+                        "wicked.<domain>.<noun>.<verb> (SPEC: WICKED_GARDEN_BUS_EVENTS.md)"
+                    ),
+                }
+            )
+
     audit_marker = set(_AUDIT_MARKER_EVENTS)
     for evt in sorted(event_keys):
         if evt in audit_marker:

--- a/scripts/_validate_registry.py
+++ b/scripts/_validate_registry.py
@@ -751,7 +751,8 @@ def check_bus_handlers(plugin_root: Path) -> List[Dict[str, Any]]:
 
     # 4-segment format: wicked.<domain>.<noun>.<past-tense-verb>
     _segment_re = re.compile(r"^wicked\.[a-z][a-z0-9_-]*\.[a-z][a-z0-9_-]*\.[a-z][a-z0-9_-]*$")
-    for evt in sorted(event_keys):
+    sorted_events = sorted(event_keys)
+    for evt in sorted_events:
         if not _segment_re.match(evt):
             findings.append(
                 {
@@ -760,13 +761,13 @@ def check_bus_handlers(plugin_root: Path) -> List[Dict[str, Any]]:
                     "target": evt,
                     "detail": (
                         "event key does not follow the canonical 4-segment format "
-                        "wicked.<domain>.<noun>.<verb> (SPEC: WICKED_GARDEN_BUS_EVENTS.md)"
+                        "wicked.<domain>.<noun>.<past-tense-verb> (SPEC: WICKED_GARDEN_BUS_EVENTS.md)"
                     ),
                 }
             )
 
     audit_marker = set(_AUDIT_MARKER_EVENTS)
-    for evt in sorted(event_keys):
+    for evt in sorted_events:
         if evt in audit_marker:
             continue
         if evt in handler_keys:


### PR DESCRIPTION
## Summary

Two soft findings from the P9 adversarial review, addressed here:

**1. 6 wicked-core production events missing from `BUS_EVENT_MAP`**  
The garden event catalog was missing the events emitted by the wicked-core engine. Garden consumers (mem/search subscribers) couldn't catalogue these events. Added with source attribution:
- `wicked.crew.task.dispatched` / `wicked.crew.task.completed` — cli_runner.rs bus-path handoff
- `wicked.crew.run.requested` / `wicked.crew.run.launched` — bus.rs run lifecycle
- `wicked.gate.eval.requested` / `wicked.gate.eval.responded` — cli_runner.rs governed gate eval (evaluator≠creator bus path)

**2. No 4-segment format check in `check_bus_handlers()`**  
The validator checked handler coverage but never verified that event keys follow the canonical `wicked.<domain>.<noun>.<verb>` grammar. Added a regex pre-pass before the handler-coverage loop; malformed keys emit a `CAT_MALFORMED` `bus.event_format` finding with a SPEC reference.

## Test plan

- [x] New events follow 4-segment format (verified via the new format check)
- [x] `_AUDIT_MARKER_EVENTS` exclusions unaffected
- [ ] Wait 6-8 min for automated reviewer posts before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)