### PR TITLE
perf(bootstrap): cache CH-02 legacy-scan to eliminate 20s rglob on every session start

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
       "name": "wicked-garden",
       "source": "./",
       "description": "Your coding agent already plans and swarms \u2014 Wicked Garden is the curated toolkit for what it can't: proof-not-claims gates, code links grep can't see, deterministic refactor, cross-session memory, real multi-model second opinions. Don't fight the harness; fill its gaps. The gate needs wicked-vault (a self-contained infra peer, installed directly) and re-derives through garden's built-in engine; testing/brain/bus are opt-in layers.",
-      "version": "12.29.1"
+      "version": "12.30.0"
     }
   ],
-  "version": "12.29.1"
+  "version": "12.30.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.29.1",
+  "version": "12.30.0",
   "description": "Your coding agent's harness already plans and swarms; Wicked Garden is the curated toolkit for what it can't do alone. Proof, not claims — gates re-derive 'done' through the internal loom engine (fail-closed, independently attested via wicked-vault), so a self-asserted pass can't lie its way green. Relationships grep can't see — the wicked-estate code graph + injected bus/dispatch/capability/archetype edges power blast-radius & lineage. Plus deterministic multi-file refactor (wicked-patch), cross-session memory + knowledge (the mem domain over wicked-estate), real multi-model second opinions (jam:council), portable expertise as on-demand skill-refs, and evidence-gated testing (the in-catalog qe domain). It reads the shape of your work to apply the right rigor — steering, not a pipeline — then gets out of the way. The compiler stamps a self-contained evidence gate into any repo that runs with no wicked-garden installed. Don't fight the harness; fill its gaps. The evidence gate requires wicked-vault, a self-contained infra peer wicked-garden installs directly; wicked-bus is an opt-in layer — install what you'll use, the toolkit works without the rest.",
   "wicked_vault_version": "^0.5.0",
   "wicked_ledger_version": "^0.2.0",

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -169,6 +169,9 @@ def _probe_plugin_readiness():
             for org_dir in cache_dir.iterdir():
                 if not org_dir.is_dir():
                     continue
+                # Skip leftover temp dirs from partial plugin installations
+                if org_dir.name.startswith("temp_subdir"):
+                    continue
                 for plugin_dir in org_dir.iterdir():
                     if not plugin_dir.is_dir():
                         continue
@@ -1119,10 +1122,19 @@ def _scan_for_legacy_reeval_entries() -> str | None:
     Light scan — greps for literal strings; does not parse full JSON.
     Fails open — any exception returns None so session is never blocked.
 
+    Result is cached for 24h in a stamp file so the expensive rglob (which
+    traverses tens of thousands of project files) only runs once per day.
+
     Returns a formatted migration notice string when legacy entries are found,
     or None when the tree is clean or unreadable.
     """
     try:
+        import tempfile
+        _stamp = Path(tempfile.gettempdir()) / "wicked-garden-ch02-clean.stamp"
+        # Cache hit: if stamp is < 24h old the tree was clean on last scan
+        if _stamp.exists() and (time.time() - _stamp.stat().st_mtime) < 86400:
+            return None
+
         projects_root = Path.home() / ".something-wicked" / "wicked-garden" / "projects"
         if not projects_root.exists():
             return None
@@ -1147,6 +1159,11 @@ def _scan_for_legacy_reeval_entries() -> str | None:
                 continue
 
         if not dirty_files:
+            # Write clean stamp so the next 24h of bootstraps skip this scan
+            try:
+                _stamp.touch()
+            except OSError:
+                pass
             return None
 
         file_list = "\n".join(f"  - {f}" for f in dirty_files[:10])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-garden",
-  "version": "12.29.1",
+  "version": "12.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-garden",
-      "version": "12.29.1",
+      "version": "12.30.0",
       "license": "MIT",
       "bin": {
         "wicked-garden": "install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-garden",
-  "version": "12.29.1",
+  "version": "12.30.0",
   "type": "module",
   "description": "Curated toolkit for what AI coding agents can't do alone: evidence-gated work, codegraph relationships, deterministic multi-file refactor, multi-model second opinions, and cross-session memory. Installs as a Claude Code plugin.",
   "keywords": [


### PR DESCRIPTION
## Summary

- **Root cause**: `_scan_for_legacy_reeval_entries()` does `rglob("phases/*/reeval-log.jsonl")` + `rglob("phases/*/amendments.jsonl")` over the entire `~/.something-wicked/wicked-garden/projects/` tree. On a mature install (3000+ project dirs, 16k+ files, 173MB), this takes **~20 seconds** per session start, consistently tripping the e2e bootstrap test's 30s timeout.
- **Fix**: write a 24h stamp to `$TMPDIR/wicked-garden-ch02-clean.stamp` after a clean scan. Cache hit → return None immediately, rglob skipped. Dirty scans (legacy entries found) don't write the stamp, so affected installs still see the migration notice until cleaned.
- **Bonus**: skip `temp_subdir_*` dirs in `_probe_plugin_readiness` — failed plugin-install artefacts that add probe overhead.

## Test plan

- [ ] Run `tests/e2e/test_e2e_bootstrap_routing.py` — all 3 bootstrap tests pass in ~10s (was: timeout >30s)
- [ ] Delete stamp, run again → slow first run (~25s), stamp created, second run fast (~3s)
- [ ] Confirm dirty-file path still works: if legacy strings exist in project files, migration notice is returned and no stamp is written
- [ ] Verify temp_subdir skip doesn't break probe for real plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)