### PR TITLE
perf(bootstrap): cache CH-02 legacy-scan result to eliminate 20s rglob on session start

### DIFF
--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -1129,8 +1129,10 @@ def _scan_for_legacy_reeval_entries() -> str | None:
     or None when the tree is clean or unreadable.
     """
     try:
+        import getpass
         import tempfile
-        _stamp = Path(tempfile.gettempdir()) / "wicked-garden-ch02-clean.stamp"
+        _user = getpass.getuser()
+        _stamp = Path(tempfile.gettempdir()) / f"wicked-garden-ch02-clean-{_user}.stamp"
         # Cache hit: if stamp is < 24h old the tree was clean on last scan
         if _stamp.exists() and (time.time() - _stamp.stat().st_mtime) < 86400:
             return None

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -169,6 +169,9 @@ def _probe_plugin_readiness():
             for org_dir in cache_dir.iterdir():
                 if not org_dir.is_dir():
                     continue
+                # Skip leftover temp dirs from partial plugin installations
+                if org_dir.name.startswith("temp_subdir"):
+                    continue
                 for plugin_dir in org_dir.iterdir():
                     if not plugin_dir.is_dir():
                         continue
@@ -1119,10 +1122,19 @@ def _scan_for_legacy_reeval_entries() -> str | None:
     Light scan — greps for literal strings; does not parse full JSON.
     Fails open — any exception returns None so session is never blocked.
 
+    Result is cached for 24h in a stamp file so the expensive rglob (which
+    traverses tens of thousands of project files) only runs once per day.
+
     Returns a formatted migration notice string when legacy entries are found,
     or None when the tree is clean or unreadable.
     """
     try:
+        import tempfile
+        _stamp = Path(tempfile.gettempdir()) / "wicked-garden-ch02-clean.stamp"
+        # Cache hit: if stamp is < 24h old the tree was clean on last scan
+        if _stamp.exists() and (time.time() - _stamp.stat().st_mtime) < 86400:
+            return None
+
         projects_root = Path.home() / ".something-wicked" / "wicked-garden" / "projects"
         if not projects_root.exists():
             return None
@@ -1147,6 +1159,11 @@ def _scan_for_legacy_reeval_entries() -> str | None:
                 continue
 
         if not dirty_files:
+            # Write clean stamp so the next 24h of bootstraps skip this scan
+            try:
+                _stamp.touch()
+            except OSError:
+                pass
             return None
 
         file_list = "\n".join(f"  - {f}" for f in dirty_files[:10])

--- a/hooks/scripts/bootstrap.py
+++ b/hooks/scripts/bootstrap.py
@@ -1130,8 +1130,11 @@ def _scan_for_legacy_reeval_entries() -> str | None:
     """
     try:
         import getpass
+        import re
         import tempfile
-        _user = getpass.getuser()
+        _raw_user = getpass.getuser()
+        # Strip path separators and other unsafe chars (e.g. DOMAIN\user on Windows)
+        _user = re.sub(r"[^\w.-]", "_", _raw_user)
         _stamp = Path(tempfile.gettempdir()) / f"wicked-garden-ch02-clean-{_user}.stamp"
         # Cache hit: if stamp is < 24h old the tree was clean on last scan
         if _stamp.exists() and (time.time() - _stamp.stat().st_mtime) < 86400:


### PR DESCRIPTION
## Summary

- **Root cause**: `_scan_for_legacy_reeval_entries()` does `rglob("phases/*/reeval-log.jsonl")` over all of `~/.something-wicked/wicked-garden/projects/`. On a mature install (3000+ project dirs, 16k+ files), this takes **~20–25 seconds** per session start, tripping the e2e bootstrap test's 30s subprocess timeout.
- **Fix 1**: Write a 24h stamp to `$TMPDIR/wicked-garden-ch02-clean-$USER.stamp` after a clean scan. Cache hit → return None immediately, rglob skipped. Dirty scans (legacy entries found) don't write the stamp, so affected installs keep seeing the migration notice until cleaned.
- **Fix 2**: Stamp is user-scoped (`getpass.getuser()`) to prevent cross-user cache bleed on multi-user systems.
- **Fix 3**: Skip `temp_subdir_*` directories in `_probe_plugin_readiness` — these are failed plugin-install artefacts that accumulate in the Claude plugin cache and add unnecessary probe overhead.

## Performance impact

| Run | Before | After |
|-----|--------|-------|
| First (no stamp) | ~25s | ~25s |
| Subsequent (stamp < 24h) | ~25s | ~3s |

## Test plan

- [x] `tests/e2e/test_e2e_bootstrap_routing.py` — all 3 bootstrap tests pass
- [x] Full `tests/` suite: 1196 passed, 13 skipped, 0 failed
- [ ] Delete user-scoped stamp, verify first run writes it (slow), second run is fast (cache hit)
- [ ] Confirm dirty path: if legacy entries exist, no stamp written, migration notice shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)