### PR TITLE
fix(e2e): isolate BootstrapEndToEndTests from shared HOME state

### DIFF
--- a/tests/e2e/test_e2e_bootstrap_routing.py
+++ b/tests/e2e/test_e2e_bootstrap_routing.py
@@ -36,12 +36,22 @@ _ENV = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(_REPO)}
 
 
 class BootstrapEndToEndTests(unittest.TestCase):
+    def setUp(self):
+        # Isolated HOME so no other test's capability-registry state bleeds in
+        # (the regression tested by test_bootstrap_emits_no_unknown_capability_warnings
+        # is ordering-sensitive if the real HOME is shared — garden#1062).
+        self._home = configured_home()
+
+    def tearDown(self):
+        self._home.cleanup()
+
     def _run_bootstrap(self):
         payload = json.dumps({"hook_event_name": "SessionStart",
                               "cwd": str(_REPO), "session_id": "e2e-boot"})
+        env = {**_ENV, "HOME": self._home.name}
         return subprocess.run([sys.executable, str(_INVOKE), "bootstrap"],
                               input=payload, capture_output=True, text=True,
-                              env=_ENV, cwd=str(_REPO), timeout=30)
+                              env=env, cwd=str(_REPO), timeout=30)
 
     def test_bootstrap_returns_valid_json_and_does_not_crash(self):
         proc = self._run_bootstrap()


### PR DESCRIPTION
## Summary

- `test_bootstrap_emits_no_unknown_capability_warnings` was flaky because `_run_bootstrap()` used the real `HOME`, letting other tests' capability-registry state in `~/.something-wicked/wicked-garden/` bleed in
- Add `setUp`/`tearDown` to `BootstrapEndToEndTests` using the existing `configured_home()` helper to create an isolated tmp HOME per test
- Pass `"HOME": self._home.name` into the subprocess env so bootstrap sees a clean slate regardless of ordering

Fixes #1062

## Test plan

- [x] `pytest tests/e2e/test_e2e_bootstrap_routing.py::BootstrapEndToEndTests` — 3 passed, 0 flaky
- [x] All three bootstrap tests pass in isolation and when run after other e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn